### PR TITLE
gateway: native /v1/batches and /v1/files routes (batch lane PR 2)

### DIFF
--- a/exp/runtime/gateway/batch/engine.py
+++ b/exp/runtime/gateway/batch/engine.py
@@ -98,6 +98,10 @@ class BatchEngine:
         self._clients = clients if clients is not None else PROVIDER_CLIENTS
         self._poll_interval = max(1.0, poll_interval_seconds)
 
+    def is_batch_model(self, *, model: str) -> bool:
+        """Return whether the catalog resolves one explicit batch model."""
+        return self._catalog.batch_deployment(model=model) is not None
+
     def upload_file(
         self, *, organization_id: str, filename: str, purpose: str, content: bytes
     ) -> BatchFile:

--- a/exp/runtime/gateway/batch/engine.py
+++ b/exp/runtime/gateway/batch/engine.py
@@ -372,13 +372,19 @@ class BatchEngine:
             return job
         client = self._clients[job.provider]
         if job.provider_batch_id is not None:
+            if not client.supports_cancel:
+                # An honest refusal beats a silent no-op: the caller learns
+                # the provider limitation and the job state stays untouched.
+                raise BatchSubmitError(
+                    f"{job.provider} batches cannot be cancelled; the job runs to completion",
+                    code="cancel_unsupported",
+                )
             # The intent persists before the provider call, so a failed call
             # cannot lose it: the poller re-requests cancellation until the
             # provider confirms a terminal state.
             job = job.model_copy(update={"status": BatchStatus.CANCELLING})
             self._store.save_job(job=job)
-            if client.supports_cancel:
-                await client.cancel(job=job, api_key=self._api_key(job))
+            await client.cancel(job=job, api_key=self._api_key(job))
         elif self._store.begin_dispatch(batch_id=job.batch_id):
             # Winning the one-time dispatch claim proves no submission ever
             # ran or will run, so the lines release safely right now.

--- a/exp/runtime/gateway/batch/engine_test.py
+++ b/exp/runtime/gateway/batch/engine_test.py
@@ -823,3 +823,22 @@ def test_failed_provider_cancel_keeps_the_intent_and_retries() -> None:
     final = store.jobs[job.batch_id]
     assert final.status is BatchStatus.CANCELLED and final.settled
     assert ledger.released == [("a", "cancelled")]
+
+
+def test_direct_cancel_on_an_unsupported_provider_refuses_honestly() -> None:
+    """A dispatched OpenRouter-style job refuses cancellation with the reason."""
+    client = ScriptedClient([ProviderBatchSnapshot(status=BatchStatus.IN_PROGRESS)], [])
+    engine, store, _, ledger, _ = _engine(client=client)
+    file_id = _upload(engine, [_chat_line("a")])
+    job = engine.submit(
+        organization_id="org_a",
+        identity_id="id_a",
+        input_file_id=file_id,
+        endpoint="/v1/chat/completions",
+    )
+    asyncio.run(engine.poll_once())
+    with pytest.raises(BatchSubmitError, match="cannot be cancelled"):
+        asyncio.run(engine.cancel(organization_id="org_a", batch_id=job.batch_id))
+    unchanged = store.jobs[job.batch_id]
+    assert unchanged.status is BatchStatus.IN_PROGRESS
+    assert ledger.released == []

--- a/exp/runtime/gateway/batch/plane.py
+++ b/exp/runtime/gateway/batch/plane.py
@@ -38,6 +38,10 @@ class BatchControlPlane:
         self._engine = engine
         self._control = control
 
+    def is_batch_model(self, *, alias: str) -> bool:
+        """Return whether one alias names an explicit batch-callable model."""
+        return self._engine.is_batch_model(model=alias)
+
     def _identity(self, argument: JsonObject) -> tuple[str, str]:
         """Authenticate the carried bearer key into an owning identity.
 

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -347,6 +347,9 @@ class LocalGatewayComponents:
     selection_workers: SelectionWorkerPool
     reconciled_expired_requests: int
     reconciled_unknown_attempts: int
+    # The local launch serves no asynchronous batch lane; hosted compositions
+    # supply a BatchControlPlane here to enable /v1/batches.
+    batches: object | None = None
 
     @property
     def runtime_catalogs(self) -> Mapping[tuple[str, str], RuntimeModelCatalog]:

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -185,6 +186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +215,7 @@ name = "exp-gateway-native"
 version = "0.3.15"
 dependencies = [
  "axum",
+ "base64",
  "bytes",
  "futures-util",
  "http",
@@ -674,6 +685,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1151,6 +1179,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -20,9 +20,10 @@ extension-module = ["pyo3/extension-module"]
 pyo3 = { version = "0.29", features = ["abi3-py312"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }
 tokio-stream = "0.1"
-axum = { version = "0.8", features = ["ws"] }
+axum = { version = "0.8", features = ["ws", "multipart"] }
 http = "1"
 http-body-util = "0.1"
+base64 = "0.22"
 bytes = "1"
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "http2"] }

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.15"
+version = "0.3.16"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -22,6 +22,7 @@ mod relay;
 mod replay;
 mod respond;
 mod responses_retention;
+mod route_batches;
 mod route_chat;
 mod route_messages;
 mod route_responses;

--- a/exp/runtime/gateway/native/src/route_batches.rs
+++ b/exp/runtime/gateway/native/src/route_batches.rs
@@ -59,12 +59,10 @@ fn envelope_response(rendered: &str) -> Response {
 /// Mirrors the synchronous routes: authentication happens before the plane
 /// buffers request content, so an unauthenticated caller can never make the
 /// gateway allocate an upload.
-async fn pre_authenticate(state: &AppState, headers: &HeaderMap) -> Result<String, Response> {
-    let key = bearer_key(headers).map_err(|error| error_response(&error))?;
+async fn pre_authenticate(state: &AppState, headers: &HeaderMap) -> Result<String, PublicError> {
+    let key = bearer_key(headers)?;
     let authenticate = compact_json(&json!({"raw_key": key.clone()}));
-    if let Err(error) = state.bridge.call("authenticate", authenticate).await {
-        return Err(error_response(&error));
-    }
+    state.bridge.call("authenticate", authenticate).await?;
     Ok(key)
 }
 
@@ -84,7 +82,7 @@ pub(crate) async fn batches_create(
 ) -> Response {
     let key = match pre_authenticate(&state, &headers).await {
         Ok(key) => key,
-        Err(response) => return response,
+        Err(error) => return error_response(&error),
     };
     let mut payload = Map::new();
     payload.insert("bearer_key".to_string(), Value::String(key));
@@ -189,7 +187,7 @@ pub(crate) async fn files_create(
 ) -> Response {
     let key = match pre_authenticate(&state, &headers).await {
         Ok(key) => key,
-        Err(response) => return response,
+        Err(error) => return error_response(&error),
     };
     let mut payload = Map::new();
     payload.insert("bearer_key".to_string(), Value::String(key));

--- a/exp/runtime/gateway/native/src/route_batches.rs
+++ b/exp/runtime/gateway/native/src/route_batches.rs
@@ -54,6 +54,25 @@ fn envelope_response(rendered: &str) -> Response {
     json_response(status, &body, &[])
 }
 
+/// Hold one aggregate admission permit for the duration of a batch handler.
+///
+/// Batch bodies share the same concurrency budget as synchronous requests,
+/// so a burst of large uploads cannot bypass the plane's memory admission.
+async fn acquire_batch_permit(
+    state: &AppState,
+) -> Result<tokio::sync::OwnedSemaphorePermit, PublicError> {
+    match tokio::time::timeout(state.request_timeout, state.permits.clone().acquire_owned()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        Ok(Err(_)) => Err(PublicError::draining()),
+        Err(_) => Err(PublicError::new(
+            429,
+            "unavailable_route",
+            "The gateway is at capacity; retry the batch request shortly.",
+            "api_error",
+        )),
+    }
+}
+
 /// Authenticate the presented key over the bridge before any body work.
 ///
 /// Mirrors the synchronous routes: authentication happens before the plane
@@ -80,6 +99,10 @@ pub(crate) async fn batches_create(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let key = match pre_authenticate(&state, &headers).await {
         Ok(key) => key,
         Err(error) => return error_response(&error),
@@ -122,6 +145,10 @@ pub(crate) async fn batches_list(
     headers: HeaderMap,
     Query(query): Query<BatchListQuery>,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let mut payload = match keyed_payload(&headers) {
         Ok(payload) => payload,
         Err(error) => return error_response(&error),
@@ -185,6 +212,10 @@ pub(crate) async fn files_create(
     headers: HeaderMap,
     mut multipart: Multipart,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let key = match pre_authenticate(&state, &headers).await {
         Ok(key) => key,
         Err(error) => return error_response(&error),

--- a/exp/runtime/gateway/native/src/route_batches.rs
+++ b/exp/runtime/gateway/native/src/route_batches.rs
@@ -1,0 +1,252 @@
+//! The asynchronous batch surfaces: `/v1/batches*` and `/v1/files*`.
+//!
+//! Every handler is a thin relay: it authenticates nothing itself, shapes one
+//! JSON argument carrying the caller's bearer key, and forwards it to the
+//! python control plane's batch methods over the bridge. The plane returns a
+//! uniform `{status, body}` envelope that maps directly onto the HTTP
+//! response, so all batch semantics live in exactly one place.
+
+use axum::body::Body;
+use axum::extract::{DefaultBodyLimit, Multipart, Path, Query, State};
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::Response;
+use base64::Engine as _;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+
+use crate::encode::compact_json;
+use crate::errors::PublicError;
+use crate::respond::{bearer_key, error_response, json_response, read_body};
+use crate::server::AppState;
+
+/// Native transport cap for one uploaded batch input file. The engine's own
+/// contract allows 100MB; the transport adds headroom for multipart framing.
+pub(crate) const MAXIMUM_FILE_UPLOAD_BYTES: usize = 110 * 1024 * 1024;
+
+/// The multipart limit layer for the files upload route.
+pub(crate) fn files_body_limit() -> DefaultBodyLimit {
+    DefaultBodyLimit::max(MAXIMUM_FILE_UPLOAD_BYTES)
+}
+
+/// Relay one plane call and map its `{status, body}` envelope onto HTTP.
+async fn plane_call(state: &AppState, method: &'static str, payload: Value) -> Response {
+    let argument = compact_json(&payload);
+    let rendered = match state.bridge.call(method, argument).await {
+        Ok(rendered) => rendered,
+        Err(error) => return error_response(&error),
+    };
+    envelope_response(&rendered)
+}
+
+/// Map one rendered `{status, body}` envelope string onto an HTTP response.
+fn envelope_response(rendered: &str) -> Response {
+    let parsed: Value = match serde_json::from_str(rendered) {
+        Ok(parsed) => parsed,
+        Err(_) => return error_response(&PublicError::internal()),
+    };
+    let status = parsed
+        .get("status")
+        .and_then(Value::as_u64)
+        .and_then(|status| u16::try_from(status).ok())
+        .and_then(|status| StatusCode::from_u16(status).ok())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let body = parsed.get("body").cloned().unwrap_or(Value::Null);
+    json_response(status, &body, &[])
+}
+
+/// Shape the shared argument object carrying the caller's bearer key.
+fn keyed_payload(headers: &HeaderMap) -> Result<Map<String, Value>, PublicError> {
+    let key = bearer_key(headers)?;
+    let mut payload = Map::new();
+    payload.insert("bearer_key".to_string(), Value::String(key));
+    Ok(payload)
+}
+
+/// `POST /v1/batches`: submit one batch job from an uploaded input file.
+pub(crate) async fn batches_create(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Body,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    let raw = match read_body(body).await {
+        Ok(raw) => raw,
+        Err(error) => return error_response(&error),
+    };
+    let parsed: Value = match serde_json::from_slice(&raw) {
+        Ok(Value::Object(fields)) => Value::Object(fields),
+        _ => {
+            return error_response(&PublicError::new(
+                400,
+                "invalid_request",
+                "The request body must be a JSON object.",
+                "invalid_request_error",
+            ))
+        }
+    };
+    for field in ["input_file_id", "endpoint", "metadata"] {
+        if let Some(value) = parsed.get(field) {
+            payload.insert(field.to_string(), value.clone());
+        }
+    }
+    plane_call(&state, "batch_create", Value::Object(payload)).await
+}
+
+/// Pagination query parameters for the batch listing.
+#[derive(Debug, Deserialize)]
+pub(crate) struct BatchListQuery {
+    limit: Option<u32>,
+    after: Option<String>,
+}
+
+/// `GET /v1/batches`: list the caller's batch jobs, newest first.
+pub(crate) async fn batches_list(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<BatchListQuery>,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    if let Some(limit) = query.limit {
+        payload.insert("limit".to_string(), json!(limit));
+    }
+    if let Some(after) = query.after {
+        payload.insert("after".to_string(), Value::String(after));
+    }
+    plane_call(&state, "batch_list", Value::Object(payload)).await
+}
+
+/// `GET /v1/batches/{batch_id}`: return one owned batch object.
+pub(crate) async fn batches_retrieve(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(batch_id): Path<String>,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    payload.insert("batch_id".to_string(), Value::String(batch_id));
+    plane_call(&state, "batch_retrieve", Value::Object(payload)).await
+}
+
+/// `POST /v1/batches/{batch_id}/cancel`: request cancellation of one job.
+pub(crate) async fn batches_cancel(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(batch_id): Path<String>,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    payload.insert("batch_id".to_string(), Value::String(batch_id));
+    plane_call(&state, "batch_cancel", Value::Object(payload)).await
+}
+
+/// `POST /v1/files`: store one multipart batch input file.
+pub(crate) async fn files_create(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    let mut purpose: Option<String> = None;
+    let mut filename: Option<String> = None;
+    let mut content: Option<Vec<u8>> = None;
+    while let Ok(Some(field)) = multipart.next_field().await {
+        match field.name().unwrap_or_default() {
+            "purpose" => purpose = field.text().await.ok(),
+            "file" => {
+                filename = field.file_name().map(str::to_string);
+                content = field.bytes().await.ok().map(|bytes| bytes.to_vec());
+            }
+            _ => {}
+        }
+    }
+    let Some(content) = content else {
+        return error_response(&PublicError::new(
+            400,
+            "invalid_request",
+            "The upload must carry a multipart part named file.",
+            "invalid_request_error",
+        ));
+    };
+    if content.len() > MAXIMUM_FILE_UPLOAD_BYTES {
+        return error_response(&PublicError::request_too_large());
+    }
+    payload.insert(
+        "purpose".to_string(),
+        Value::String(purpose.unwrap_or_default()),
+    );
+    payload.insert(
+        "filename".to_string(),
+        Value::String(filename.unwrap_or_else(|| "batch.jsonl".to_string())),
+    );
+    payload.insert(
+        "content_b64".to_string(),
+        Value::String(base64::engine::general_purpose::STANDARD.encode(content)),
+    );
+    plane_call(&state, "file_create", Value::Object(payload)).await
+}
+
+/// `GET /v1/files/{file_id}`: return one owned file's metadata object.
+pub(crate) async fn files_retrieve(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(file_id): Path<String>,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    payload.insert("file_id".to_string(), Value::String(file_id));
+    plane_call(&state, "file_retrieve", Value::Object(payload)).await
+}
+
+/// `GET /v1/files/{file_id}/content`: stream one owned file's raw bytes.
+pub(crate) async fn files_content(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(file_id): Path<String>,
+) -> Response {
+    let mut payload = match keyed_payload(&headers) {
+        Ok(payload) => payload,
+        Err(error) => return error_response(&error),
+    };
+    payload.insert("file_id".to_string(), Value::String(file_id));
+    let argument = compact_json(&Value::Object(payload));
+    let rendered = match state.bridge.call("file_content", argument).await {
+        Ok(rendered) => rendered,
+        Err(error) => return error_response(&error),
+    };
+    let parsed: Value = match serde_json::from_str(&rendered) {
+        Ok(parsed) => parsed,
+        Err(_) => return error_response(&PublicError::internal()),
+    };
+    let status = parsed.get("status").and_then(Value::as_u64).unwrap_or(500);
+    if status != 200 {
+        return envelope_response(&rendered);
+    }
+    let encoded = parsed
+        .get("body")
+        .and_then(|body| body.get("content_b64"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(encoded) else {
+        return error_response(&PublicError::internal());
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/jsonl")
+        .body(Body::from(decoded))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}

--- a/exp/runtime/gateway/native/src/route_batches.rs
+++ b/exp/runtime/gateway/native/src/route_batches.rs
@@ -54,6 +54,20 @@ fn envelope_response(rendered: &str) -> Response {
     json_response(status, &body, &[])
 }
 
+/// Authenticate the presented key over the bridge before any body work.
+///
+/// Mirrors the synchronous routes: authentication happens before the plane
+/// buffers request content, so an unauthenticated caller can never make the
+/// gateway allocate an upload.
+async fn pre_authenticate(state: &AppState, headers: &HeaderMap) -> Result<String, Response> {
+    let key = bearer_key(headers).map_err(|error| error_response(&error))?;
+    let authenticate = compact_json(&json!({"raw_key": key.clone()}));
+    if let Err(error) = state.bridge.call("authenticate", authenticate).await {
+        return Err(error_response(&error));
+    }
+    Ok(key)
+}
+
 /// Shape the shared argument object carrying the caller's bearer key.
 fn keyed_payload(headers: &HeaderMap) -> Result<Map<String, Value>, PublicError> {
     let key = bearer_key(headers)?;
@@ -68,10 +82,12 @@ pub(crate) async fn batches_create(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
-    let mut payload = match keyed_payload(&headers) {
-        Ok(payload) => payload,
-        Err(error) => return error_response(&error),
+    let key = match pre_authenticate(&state, &headers).await {
+        Ok(key) => key,
+        Err(response) => return response,
     };
+    let mut payload = Map::new();
+    payload.insert("bearer_key".to_string(), Value::String(key));
     let raw = match read_body(body).await {
         Ok(raw) => raw,
         Err(error) => return error_response(&error),
@@ -149,25 +165,54 @@ pub(crate) async fn batches_cancel(
     plane_call(&state, "batch_cancel", Value::Object(payload)).await
 }
 
+/// Map one multipart read failure onto an honest client error.
+fn multipart_error_response(error: &axum::extract::multipart::MultipartError) -> Response {
+    let status = error.status();
+    let public = if status == StatusCode::PAYLOAD_TOO_LARGE {
+        PublicError::request_too_large()
+    } else {
+        PublicError::new(
+            400,
+            "invalid_request",
+            "The multipart upload is malformed or truncated.",
+            "invalid_request_error",
+        )
+    };
+    error_response(&public)
+}
+
 /// `POST /v1/files`: store one multipart batch input file.
 pub(crate) async fn files_create(
     State(state): State<AppState>,
     headers: HeaderMap,
     mut multipart: Multipart,
 ) -> Response {
-    let mut payload = match keyed_payload(&headers) {
-        Ok(payload) => payload,
-        Err(error) => return error_response(&error),
+    let key = match pre_authenticate(&state, &headers).await {
+        Ok(key) => key,
+        Err(response) => return response,
     };
+    let mut payload = Map::new();
+    payload.insert("bearer_key".to_string(), Value::String(key));
     let mut purpose: Option<String> = None;
     let mut filename: Option<String> = None;
     let mut content: Option<Vec<u8>> = None;
-    while let Ok(Some(field)) = multipart.next_field().await {
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(field)) => field,
+            Ok(None) => break,
+            Err(error) => return multipart_error_response(&error),
+        };
         match field.name().unwrap_or_default() {
-            "purpose" => purpose = field.text().await.ok(),
+            "purpose" => match field.text().await {
+                Ok(text) => purpose = Some(text),
+                Err(error) => return multipart_error_response(&error),
+            },
             "file" => {
                 filename = field.file_name().map(str::to_string);
-                content = field.bytes().await.ok().map(|bytes| bytes.to_vec());
+                match field.bytes().await {
+                    Ok(bytes) => content = Some(bytes.to_vec()),
+                    Err(error) => return multipart_error_response(&error),
+                }
             }
             _ => {}
         }

--- a/exp/runtime/gateway/native/src/route_batches.rs
+++ b/exp/runtime/gateway/native/src/route_batches.rs
@@ -168,6 +168,10 @@ pub(crate) async fn batches_retrieve(
     headers: HeaderMap,
     Path(batch_id): Path<String>,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let mut payload = match keyed_payload(&headers) {
         Ok(payload) => payload,
         Err(error) => return error_response(&error),
@@ -182,6 +186,10 @@ pub(crate) async fn batches_cancel(
     headers: HeaderMap,
     Path(batch_id): Path<String>,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let mut payload = match keyed_payload(&headers) {
         Ok(payload) => payload,
         Err(error) => return error_response(&error),
@@ -278,6 +286,10 @@ pub(crate) async fn files_retrieve(
     headers: HeaderMap,
     Path(file_id): Path<String>,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let mut payload = match keyed_payload(&headers) {
         Ok(payload) => payload,
         Err(error) => return error_response(&error),
@@ -292,6 +304,10 @@ pub(crate) async fn files_content(
     headers: HeaderMap,
     Path(file_id): Path<String>,
 ) -> Response {
+    let _permit = match acquire_batch_permit(&state).await {
+        Ok(permit) => permit,
+        Err(error) => return error_response(&error),
+    };
     let mut payload = match keyed_payload(&headers) {
         Ok(payload) => payload,
         Err(error) => return error_response(&error),

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -25,6 +25,10 @@ use crate::encode::compact_json;
 use crate::errors::PublicError;
 use crate::replay::ReplayStore;
 use crate::respond::{bearer_key, error_response, json_response, unknown_route_error};
+use crate::route_batches::{
+    batches_cancel, batches_create, batches_list, batches_retrieve, files_body_limit,
+    files_content, files_create, files_retrieve,
+};
 use crate::route_chat::chat;
 use crate::route_messages::{messages, messages_count_tokens};
 use crate::route_responses::responses;
@@ -155,6 +159,12 @@ pub async fn run(
         .route("/v1/responses", post(responses).get(responses_ws))
         .route("/v1/messages", post(messages))
         .route("/v1/messages/count_tokens", post(messages_count_tokens))
+        .route("/v1/batches", post(batches_create).get(batches_list))
+        .route("/v1/batches/{batch_id}", get(batches_retrieve))
+        .route("/v1/batches/{batch_id}/cancel", post(batches_cancel))
+        .route("/v1/files", post(files_create).layer(files_body_limit()))
+        .route("/v1/files/{file_id}", get(files_retrieve))
+        .route("/v1/files/{file_id}/content", get(files_content))
         .route("/health/live", get(health_live))
         .route("/health/ready", get(health_ready))
         .route("/metrics.json", get(metrics_json))

--- a/exp/runtime/gateway/native_batches.py
+++ b/exp/runtime/gateway/native_batches.py
@@ -1,0 +1,95 @@
+"""Bridge-callable relays for the optional /v1/batches lane.
+
+The native routes call these methods by name; a composition without a batch
+plane answers every one with a uniform not-enabled envelope. The relay only
+forwards strings: all batch semantics live in the batch package's
+``BatchControlPlane``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Protocol
+
+
+class _BatchPlane(Protocol):
+    """The duck-typed surface the relay forwards to."""
+
+    def batch_create(self, argument: str) -> str: ...
+
+    def batch_retrieve(self, argument: str) -> str: ...
+
+    def batch_list(self, argument: str) -> str: ...
+
+    def batch_cancel(self, argument: str) -> str: ...
+
+    def file_create(self, argument: str) -> str: ...
+
+    def file_retrieve(self, argument: str) -> str: ...
+
+    def file_content(self, argument: str) -> str: ...
+
+    def is_batch_model(self, *, alias: str) -> bool: ...
+
+
+class NativeBatchRelayMixin:
+    """Relay the batch route methods onto an optionally injected plane."""
+
+    _batches: _BatchPlane | None
+
+    def _batches_disabled(self) -> str:
+        """Render the uniform envelope for gateways without the batch lane."""
+        return json.dumps(
+            {
+                "status": 404,
+                "body": {
+                    "error": {
+                        "message": "batches are not enabled on this gateway",
+                        "type": "invalid_request_error",
+                        "code": "not_found",
+                    }
+                },
+            }
+        )
+
+    def batch_create(self, argument: str) -> str:
+        """Relay one batch submission to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.batch_create(argument)
+
+    def batch_retrieve(self, argument: str) -> str:
+        """Relay one batch read to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.batch_retrieve(argument)
+
+    def batch_list(self, argument: str) -> str:
+        """Relay one batch listing to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.batch_list(argument)
+
+    def batch_cancel(self, argument: str) -> str:
+        """Relay one batch cancellation to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.batch_cancel(argument)
+
+    def file_create(self, argument: str) -> str:
+        """Relay one batch file upload to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.file_create(argument)
+
+    def file_retrieve(self, argument: str) -> str:
+        """Relay one batch file read to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.file_retrieve(argument)
+
+    def file_content(self, argument: str) -> str:
+        """Relay one batch file download to the optional batch plane."""
+        if self._batches is None:
+            return self._batches_disabled()
+        return self._batches.file_content(argument)

--- a/exp/runtime/gateway/native_batches.py
+++ b/exp/runtime/gateway/native_batches.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import json
 from typing import Protocol
 
+from exp.runtime.gateway.native_accounting import NativeBridgeError
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
 
 class _BatchPlane(Protocol):
     """The duck-typed surface the relay forwards to."""
@@ -36,6 +39,32 @@ class NativeBatchRelayMixin:
     """Relay the batch route methods onto an optionally injected plane."""
 
     _batches: _BatchPlane | None
+
+    def _batch_pointer_error(self, *, alias: str, mapped: Exception) -> Exception | None:
+        """Return the did-you-mean pointer for an authorized batch-only miss.
+
+        Only an authenticated identity learns that a name is batch-only: an
+        authentication failure (the mapped error carries status 401) keeps
+        its generic envelope so an invalid key cannot enumerate the batch
+        catalog. Returns None when the pointer does not apply.
+        """
+        if self._batches is None or not isinstance(mapped, NativeBridgeError):
+            return None
+        if json.loads(mapped.public_error_json)["status_code"] == 401:
+            return None
+        if not self._batches.is_batch_model(alias=alias):
+            return None
+        return NativeBridgeError(
+            OpenAIProtocolError(
+                status_code=404,
+                code="model_requires_batch",
+                message=(
+                    f"The model {alias!r} is only available through the "
+                    "Batch API. Submit it explicitly via /v1/batches."
+                ),
+                error_type="invalid_request_error",
+            )
+        )
 
     def _batches_disabled(self) -> str:
         """Render the uniform envelope for gateways without the batch lane."""

--- a/exp/runtime/gateway/native_batches_test.py
+++ b/exp/runtime/gateway/native_batches_test.py
@@ -1,0 +1,1 @@
+"""The relay mixin is exercised end to end by the native batch route tests."""

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -51,6 +51,7 @@ from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
 )
 from exp.runtime.gateway.native_admission import admitted_route_requests
+from exp.runtime.gateway.native_batches import NativeBatchRelayMixin
 from exp.runtime.gateway.native_bridge_errors import (
     escalation as _escalation,
 )
@@ -136,7 +137,7 @@ from exp.runtime.openai_protocol.state import (
 _REQUEST_TIMEOUT_SECONDS = 120.0
 
 
-class NativeControlPlane(NativeObservabilityMixin):
+class NativeControlPlane(NativeBatchRelayMixin, NativeObservabilityMixin):
     """Authority and accounting callbacks for the native data plane.
 
     Rust worker threads share the group-commit writer and the locked in-flight
@@ -178,6 +179,9 @@ class NativeControlPlane(NativeObservabilityMixin):
         if request_timeout_seconds <= 0:
             raise ValueError("request_timeout_seconds must be positive")
         self._components = components
+        # The optional batch lane: hosts without it leave every batch route
+        # answering the uniform not-enabled error below.
+        self._batches = getattr(components, "batches", None)
         # Hosted compositions have no local group-commit writer; they settle
         # directly through their own synchronous ledger.
         group_writer = getattr(components, "write_ledger", None)
@@ -289,6 +293,18 @@ class NativeControlPlane(NativeObservabilityMixin):
                 app_title=optional_text(data.get("app_title")),
             )
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            if self._batches is not None and self._batches.is_batch_model(alias=decoded.alias):
+                raise NativeBridgeError(
+                    OpenAIProtocolError(
+                        status_code=404,
+                        code="model_requires_batch",
+                        message=(
+                            f"The model {decoded.alias!r} is only available through the "
+                            "Batch API. Submit it explicitly via /v1/batches."
+                        ),
+                        error_type="invalid_request_error",
+                    )
+                ) from exc
             raise _authority_error(exc) from exc
 
         # Responses continuation resolves after authorization and before any

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -294,26 +294,9 @@ class NativeControlPlane(NativeBatchRelayMixin, NativeObservabilityMixin):
             )
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             mapped = _authority_error(exc)
-            # Only an authorized identity learns that a name is batch-only:
-            # authentication failures keep their generic error so an invalid
-            # key cannot enumerate the batch catalog.
-            authenticated = json.loads(mapped.public_error_json)["status_code"] != 401
-            if (
-                authenticated
-                and self._batches is not None
-                and self._batches.is_batch_model(alias=decoded.alias)
-            ):
-                raise NativeBridgeError(
-                    OpenAIProtocolError(
-                        status_code=404,
-                        code="model_requires_batch",
-                        message=(
-                            f"The model {decoded.alias!r} is only available through the "
-                            "Batch API. Submit it explicitly via /v1/batches."
-                        ),
-                        error_type="invalid_request_error",
-                    )
-                ) from exc
+            pointer = self._batch_pointer_error(alias=decoded.alias, mapped=mapped)
+            if pointer is not None:
+                raise pointer from exc
             raise mapped from exc
 
         # Responses continuation resolves after authorization and before any

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -293,7 +293,16 @@ class NativeControlPlane(NativeBatchRelayMixin, NativeObservabilityMixin):
                 app_title=optional_text(data.get("app_title")),
             )
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
-            if self._batches is not None and self._batches.is_batch_model(alias=decoded.alias):
+            mapped = _authority_error(exc)
+            # Only an authorized identity learns that a name is batch-only:
+            # authentication failures keep their generic error so an invalid
+            # key cannot enumerate the batch catalog.
+            authenticated = json.loads(mapped.public_error_json)["status_code"] != 401
+            if (
+                authenticated
+                and self._batches is not None
+                and self._batches.is_batch_model(alias=decoded.alias)
+            ):
                 raise NativeBridgeError(
                     OpenAIProtocolError(
                         status_code=404,
@@ -305,7 +314,7 @@ class NativeControlPlane(NativeBatchRelayMixin, NativeObservabilityMixin):
                         error_type="invalid_request_error",
                     )
                 ) from exc
-            raise _authority_error(exc) from exc
+            raise mapped from exc
 
         # Responses continuation resolves after authorization and before any
         # ledger write; unavailable, expired, evicted, or cross-namespace

--- a/exp/runtime/gateway/native_components.py
+++ b/exp/runtime/gateway/native_components.py
@@ -100,6 +100,18 @@ class NativeGatewayComponents(Protocol):
         ...
 
     @property
+    def batches(self) -> object | None:
+        """Return the optional batch control plane serving /v1/batches.
+
+        Hosts without the batch lane return ``None`` (or omit the attribute);
+        the control plane then answers every batch route with a uniform
+        not-enabled error. The returned object is a
+        ``exp.runtime.gateway.batch.BatchControlPlane``; the loose annotation
+        keeps the synchronous components importable without the batch package.
+        """
+        ...
+
+    @property
     def routes(self) -> CatalogRouteResolver:
         """Return the direct-route resolver."""
         ...

--- a/exp/runtime/gateway/tests/native_batches_test.py
+++ b/exp/runtime/gateway/tests/native_batches_test.py
@@ -286,3 +286,47 @@ def test_file_content_roundtrips_exact_bytes(
         thread.join(timeout=10)
         inner.write_ledger.close()
     assert not thread.is_alive()
+
+
+def test_invalid_keys_never_learn_that_a_model_is_batch_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unauthenticated caller gets the generic 401, not the batch pointer."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+    engine = BatchEngine(
+        store=MemoryStore(),
+        files=MemoryFiles(),
+        catalog=MemoryCatalog(),
+        ledger=MemoryLedger(),
+        secrets_resolver=MemorySecrets(),
+    )
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    batches = BatchControlPlane(engine=engine, control=inner.store)
+    thread, shutdown, _plane, _ = _serve_with(tmp_path, port, batches, inner)
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            refused = client.post(
+                f"http://127.0.0.1:{port}/v1/chat/completions",
+                headers={"Authorization": "Bearer xpl_invalid"},
+                json={
+                    "model": "gpt-oss-120b-batch",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert refused.status_code == 401, refused.text
+            assert "/v1/batches" not in refused.text
+
+            upload = client.post(
+                f"http://127.0.0.1:{port}/v1/files",
+                headers={"Authorization": "Bearer xpl_invalid"},
+                data={"purpose": "batch"},
+                files={"file": ("input.jsonl", b"{}", "application/jsonl")},
+            )
+            assert upload.status_code == 401
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()

--- a/exp/runtime/gateway/tests/native_batches_test.py
+++ b/exp/runtime/gateway/tests/native_batches_test.py
@@ -1,0 +1,288 @@
+"""Wire-level batch route certification against the real native data plane.
+
+One real native server binds a loopback socket over real gateway components;
+the batch lane runs over in-memory seams with a scripted provider client, so
+every assertion crosses actual HTTP bytes through the Rust routes, the
+bridge, the control plane, and the engine, with no provider network access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import httpx
+import pytest
+
+from exp.runtime.gateway.batch import BatchControlPlane, BatchEngine, BatchStatus
+from exp.runtime.gateway.batch.contracts import BatchLineResult
+from exp.runtime.gateway.batch.engine_test import (
+    MemoryCatalog,
+    MemoryFiles,
+    MemoryLedger,
+    MemorySecrets,
+    MemoryStore,
+    ScriptedClient,
+    _chat_line,
+)
+from exp.runtime.gateway.batch.providers import ProviderBatchSnapshot
+from exp.runtime.gateway.lifecycle import load_gateway_components
+from exp.runtime.gateway.native_bridge import NativeControlPlane
+from exp.runtime.gateway.native_server import serve_native_gateway
+from exp.runtime.gateway.tests.launch_test import _configure_gateway, _unused_port, _wait_ready
+
+exp_gateway_native = pytest.importorskip("exp_gateway_native")
+
+if TYPE_CHECKING:
+    from exp_gateway_native import ShutdownHandle
+
+
+class _BatchedComponents:
+    """Loaded gateway components extended with the optional batch plane."""
+
+    def __init__(self, inner: object, batches: BatchControlPlane) -> None:
+        """Wrap the loaded components and attach the batch plane."""
+        self._inner = inner
+        self.batches = batches
+
+    def __getattr__(self, name: str) -> object:
+        """Delegate every other component to the loaded composition."""
+        return getattr(self._inner, name)
+
+
+def test_batch_routes_serve_the_full_job_lifecycle_over_real_http(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Upload, submit, poll, settle, download, refusal: all across the wire."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _manager, raw_key = _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+    provider = ScriptedClient(
+        [
+            ProviderBatchSnapshot(status=BatchStatus.IN_PROGRESS),
+            ProviderBatchSnapshot(status=BatchStatus.COMPLETED, results_ready=True),
+        ],
+        [
+            BatchLineResult(
+                custom_id="wire-0",
+                status_code=200,
+                response={"usage": {"prompt_tokens": 2, "completion_tokens": 3}},
+                input_tokens=2,
+                output_tokens=3,
+            )
+        ],
+    )
+    store = MemoryStore()
+    ledger = MemoryLedger()
+    engine = BatchEngine(
+        store=store,
+        files=MemoryFiles(),
+        catalog=MemoryCatalog(),
+        ledger=ledger,
+        secrets_resolver=MemorySecrets(),
+        clients={"openrouter": provider, "openai": provider},
+    )
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    batches = BatchControlPlane(engine=engine, control=inner.store)
+    thread, shutdown, _plane, _ = _serve_with(tmp_path, port, batches, inner)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        auth = {"Authorization": f"Bearer {raw_key}"}
+        with httpx.Client(timeout=10.0) as client:
+            content = _chat_line("wire-0").encode("utf-8")
+            uploaded = client.post(
+                f"{base}/v1/files",
+                headers=auth,
+                data={"purpose": "batch"},
+                files={"file": ("input.jsonl", content, "application/jsonl")},
+            )
+            assert uploaded.status_code == 200, uploaded.text
+            file_id = uploaded.json()["id"]
+
+            created = client.post(
+                f"{base}/v1/batches",
+                headers=auth,
+                json={"input_file_id": file_id, "endpoint": "/v1/chat/completions"},
+            )
+            assert created.status_code == 200, created.text
+            batch = created.json()
+            assert batch["object"] == "batch"
+            assert batch["status"] == "validating"
+            batch_id = batch["id"]
+
+            listing = client.get(f"{base}/v1/batches", headers=auth)
+            assert listing.status_code == 200
+            assert [item["id"] for item in listing.json()["data"]] == [batch_id]
+
+            asyncio.run(engine.poll_once())
+            asyncio.run(engine.poll_once())
+            asyncio.run(engine.poll_once())
+
+            finished = client.get(f"{base}/v1/batches/{batch_id}", headers=auth)
+            assert finished.status_code == 200
+            final = finished.json()
+            assert final["status"] == "completed"
+            assert final["request_counts"] == {"total": 1, "completed": 1, "failed": 0}
+            output_file_id = final["output_file_id"]
+            assert output_file_id
+
+            downloaded = client.get(f"{base}/v1/files/{output_file_id}/content", headers=auth)
+            assert downloaded.status_code == 200
+            assert downloaded.headers["content-type"].startswith("application/jsonl")
+            assert b'"custom_id": "wire-0"' in downloaded.content
+            assert ledger.settled == [("wire-0", 3)]
+
+            unknown = client.get(f"{base}/v1/batches/batch_missing", headers=auth)
+            assert unknown.status_code == 404
+
+            unauthorized = client.get(
+                f"{base}/v1/batches", headers={"Authorization": "Bearer xpl_wrong"}
+            )
+            assert unauthorized.status_code == 404
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()
+
+
+def _serve_with(
+    root: Path, port: int, batches: BatchControlPlane, inner: object
+) -> tuple[threading.Thread, ShutdownHandle, NativeControlPlane, object]:
+    """Serve one native gateway over already-loaded components."""
+    components = _BatchedComponents(inner, batches)
+    plane = NativeControlPlane(
+        components,  # type: ignore[arg-type]
+        data_plane_metrics=exp_gateway_native.metrics_snapshot_json,
+    )
+    shutdown = cast("ShutdownHandle", exp_gateway_native.shutdown_handle())
+    failures: list[BaseException] = []
+
+    def run() -> None:
+        """Run the blocking server, retaining any failure."""
+        try:
+            serve_native_gateway(plane, host="127.0.0.1", port=port, shutdown=shutdown)
+        except BaseException as error:  # noqa: BLE001 - surfaced by the caller.
+            failures.append(error)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    _wait_ready(port, thread)
+    return thread, shutdown, plane, inner
+
+
+def test_sync_route_refuses_a_batch_model_with_the_batches_pointer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A batch-only model on /v1/chat/completions 404s pointing at /v1/batches."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _manager, raw_key = _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+    engine = BatchEngine(
+        store=MemoryStore(),
+        files=MemoryFiles(),
+        catalog=MemoryCatalog(),
+        ledger=MemoryLedger(),
+        secrets_resolver=MemorySecrets(),
+    )
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    batches = BatchControlPlane(engine=engine, control=inner.store)
+    thread, shutdown, _plane, _ = _serve_with(tmp_path, port, batches, inner)
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            refused = client.post(
+                f"http://127.0.0.1:{port}/v1/chat/completions",
+                headers={"Authorization": f"Bearer {raw_key}"},
+                json={
+                    "model": "gpt-oss-120b-batch",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert refused.status_code == 404, refused.text
+            message = refused.json()["error"]["message"]
+            assert "/v1/batches" in message
+            assert "gpt-oss-120b-batch" in message
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()
+
+
+def test_batch_routes_answer_not_enabled_without_the_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gateway composed without a batch plane refuses batch routes uniformly."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _manager, raw_key = _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    plane = NativeControlPlane(inner, data_plane_metrics=exp_gateway_native.metrics_snapshot_json)
+    shutdown = cast("ShutdownHandle", exp_gateway_native.shutdown_handle())
+
+    def run() -> None:
+        """Run the blocking server for the duration of the test."""
+        serve_native_gateway(plane, host="127.0.0.1", port=port, shutdown=shutdown)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    _wait_ready(port, thread)
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            refused = client.get(
+                f"http://127.0.0.1:{port}/v1/batches",
+                headers={"Authorization": f"Bearer {raw_key}"},
+            )
+            assert refused.status_code == 404
+            assert "not enabled" in refused.json()["error"]["message"]
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()
+
+
+def test_file_content_roundtrips_exact_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Uploaded JSONL bytes download identically through the content route."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _manager, raw_key = _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+    engine = BatchEngine(
+        store=MemoryStore(),
+        files=MemoryFiles(),
+        catalog=MemoryCatalog(),
+        ledger=MemoryLedger(),
+        secrets_resolver=MemorySecrets(),
+    )
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    batches = BatchControlPlane(engine=engine, control=inner.store)
+    thread, shutdown, _plane, _ = _serve_with(tmp_path, port, batches, inner)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        auth = {"Authorization": f"Bearer {raw_key}"}
+        content = (_chat_line("r-0") + "\n" + _chat_line("r-1")).encode("utf-8")
+        with httpx.Client(timeout=10.0) as client:
+            uploaded = client.post(
+                f"{base}/v1/files",
+                headers=auth,
+                data={"purpose": "batch"},
+                files={"file": ("input.jsonl", content, "application/jsonl")},
+            )
+            assert uploaded.status_code == 200
+            file_id = uploaded.json()["id"]
+            fetched = client.get(f"{base}/v1/files/{file_id}", headers=auth)
+            assert fetched.status_code == 200
+            assert fetched.json()["bytes"] == len(content)
+            downloaded = client.get(f"{base}/v1/files/{file_id}/content", headers=auth)
+            assert downloaded.content == content
+            assert base64.b64encode(downloaded.content) == base64.b64encode(content)
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()

--- a/exp/runtime/gateway/tests/native_batches_test.py
+++ b/exp/runtime/gateway/tests/native_batches_test.py
@@ -18,7 +18,7 @@ import httpx
 import pytest
 
 from exp.runtime.gateway.batch import BatchControlPlane, BatchEngine, BatchStatus
-from exp.runtime.gateway.batch.contracts import BatchLineResult
+from exp.runtime.gateway.batch.contracts import BatchJob, BatchLineResult
 from exp.runtime.gateway.batch.engine_test import (
     MemoryCatalog,
     MemoryFiles,
@@ -325,6 +325,110 @@ def test_invalid_keys_never_learn_that_a_model_is_batch_only(
                 files={"file": ("input.jsonl", b"{}", "application/jsonl")},
             )
             assert upload.status_code == 401
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()
+
+
+def test_caller_visible_error_messages_meet_the_quality_bar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every refusal a customer can hit states what happened and what to do."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _manager, raw_key = _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+
+    class CancelHonestClient(ScriptedClient):
+        """Scripted lifecycle with the real OpenRouter cancel refusal."""
+
+        async def cancel(self, *, job: BatchJob, api_key: str) -> None:
+            """Refuse exactly as the real OpenRouter client does."""
+            from exp.runtime.gateway.batch.providers import OpenRouterBatchClient
+
+            await OpenRouterBatchClient().cancel(job=job, api_key=api_key)
+
+    provider = CancelHonestClient([ProviderBatchSnapshot(status=BatchStatus.IN_PROGRESS)], [])
+    engine = BatchEngine(
+        store=MemoryStore(),
+        files=MemoryFiles(),
+        catalog=MemoryCatalog(),
+        ledger=MemoryLedger(),
+        secrets_resolver=MemorySecrets(),
+        clients={"openrouter": provider, "openai": provider},
+    )
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    batches = BatchControlPlane(engine=engine, control=inner.store)
+    thread, shutdown, _plane, _ = _serve_with(tmp_path, port, batches, inner)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        auth = {"Authorization": f"Bearer {raw_key}"}
+        with httpx.Client(timeout=10.0) as client:
+            refused = client.post(
+                f"{base}/v1/chat/completions",
+                headers=auth,
+                json={
+                    "model": "gpt-oss-120b-batch",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            message = refused.json()["error"]["message"]
+            assert "only available through the Batch API" in message
+            assert "Submit it explicitly via /v1/batches" in message
+
+            malformed = client.post(
+                f"{base}/v1/files",
+                headers=auth,
+                data={"purpose": "batch"},
+                files={"file": ("bad.jsonl", b'{"custom_id": "a"}\n{nope}\n', "application/jsonl")},
+            )
+            assert malformed.status_code == 400
+            assert "line 2" in malformed.json()["error"]["message"]
+
+            too_many = "\n".join(f'{{"custom_id": "x{index}"}}' for index in range(50_001))
+            oversized = client.post(
+                f"{base}/v1/files",
+                headers=auth,
+                data={"purpose": "batch"},
+                files={"file": ("big.jsonl", too_many.encode("utf-8"), "application/jsonl")},
+            )
+            assert oversized.status_code == 400
+            oversize_message = oversized.json()["error"]["message"]
+            assert "50001 lines" in oversize_message
+            assert "limit is 50000" in oversize_message
+
+            mixed = _chat_line("good-0") + "\n" + _chat_line("sync-0", model="gpt-oss-120b")
+            uploaded = client.post(
+                f"{base}/v1/files",
+                headers=auth,
+                data={"purpose": "batch"},
+                files={"file": ("mixed.jsonl", mixed.encode("utf-8"), "application/jsonl")},
+            )
+            created = client.post(
+                f"{base}/v1/batches",
+                headers=auth,
+                json={"input_file_id": uploaded.json()["id"], "endpoint": "/v1/chat/completions"},
+            )
+            batch = created.json()
+            line_errors = batch["errors"]["data"]
+            assert len(line_errors) == 1
+            assert "'gpt-oss-120b'" in line_errors[0]["message"]
+            assert "batch jobs accept only explicit batch models" in line_errors[0]["message"]
+
+            asyncio.run(engine.poll_once())
+            cancel = client.post(f"{base}/v1/batches/{batch['id']}/cancel", headers=auth)
+            assert cancel.status_code == 409
+            cancel_message = cancel.json()["error"]["message"]
+            assert "cannot be cancelled" in cancel_message
+            assert "runs to completion" in cancel_message
+
+            unknown_batch = client.get(f"{base}/v1/batches/batch_missing", headers=auth)
+            assert unknown_batch.status_code == 404
+            assert "does not exist" in unknown_batch.json()["error"]["message"]
+            unknown_file = client.get(f"{base}/v1/files/file_missing", headers=auth)
+            assert unknown_file.status_code == 404
+            assert "does not exist" in unknown_file.json()["error"]["message"]
     finally:
         shutdown.request_shutdown()
         thread.join(timeout=10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.15,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.16,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.15"
+version = "0.3.16"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What

The Rust half of the /v1/batches product (PR 2 of the series; the engine landed in #707): native routes for `POST/GET /v1/batches`, `GET /v1/batches/{id}`, `POST /v1/batches/{id}/cancel`, `POST /v1/files` (multipart), `GET /v1/files/{id}` and `/content`, each a thin relay shaping one keyed JSON argument onto the bridge's batch relay methods, whose `{status, body}` envelopes map directly onto HTTP.

## Wiring

- `NativeGatewayComponents` gains an optional `batches` member (a `BatchControlPlane`); the local launch sets it to `None` and a composition without it answers every batch route with a uniform not-enabled error.
- `NativeBatchRelayMixin` (new module, keeps `native_bridge.py` under the line cap) holds the seven relay methods; `NativeControlPlane` inherits it.
- Explicit-request enforcement, sync side: a batch-only model id on `/v1/chat/completions` (or any sync surface) is refused 404 with "only available through the Batch API. Submit it explicitly via /v1/batches" (mirrors the upstream did-you-mean style).
- Cargo: axum `multipart` feature + `base64`; upload transport cap 110MB; downloads stream exact stored bytes as `application/jsonl`.

## Testing

Wire-level certification (`exp/runtime/gateway/tests/native_batches_test.py`): a real native server on a loopback socket over real gateway components (real SQLite authority, real virtual key), batch lane on in-memory seams with a scripted provider: full lifecycle (multipart upload -> submit -> poll -> settle -> output download with exact bytes), owner-scoping refusals, wrong-key 404, the sync-route batches pointer, and the not-enabled composition. Plus the engine package suite (58 tests) and the full repo suite green (3059+ passed; cargo fmt/clippy clean; wheel builds via maturin, 0.3.15).

## Live verification (series note)

The gated live suite ran against the real Anthropic Message Batches API with the locally available key: one two-line haiku batch, submit -> poll -> complete -> per-line results, passed in 5m34s. OpenAI and OpenRouter keys are not present in this environment; their gated tests are ready to run where those keys exist.