### PR TITLE
release: bump version to 0.7.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.19"
+version = "0.7.20"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.19"
+version = "0.7.20"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Release cut for the batch lane: engine package (#707) + native /v1/batches and /v1/files routes (#711, native 0.3.16). Follows the #709 release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)