### PR TITLE
anthropic: resolve point releases to their generation contract (fix fable-5.1 effort 400)

### DIFF
--- a/exp/common/models/discovery_test.py
+++ b/exp/common/models/discovery_test.py
@@ -218,3 +218,28 @@ def test_connection_names_and_aliases_are_readable_and_collision_safe() -> None:
     assert (
         derive_model_alias("gemini", "models/gemini-3.5-flash", frozenset()) == "gemini-3-5-flash"
     )
+
+
+def test_anthropic_point_release_resolves_a_reasoning_route_without_prices() -> None:
+    """A freshly launched point release must not degrade to a non-reasoning route.
+
+    claude-fable-5-1 reached production as a non-reasoning route (every
+    effort-carrying Claude Code request got a named 400) because the bare
+    listing entry resolved no metadata. With the explicit 5.1 record the
+    route carries its full verified contract; a future unrecorded minor
+    (sonnet-5-2 here) still inherits the generation's controls while its
+    prices stay unknown so priced lanes fail closed.
+    """
+    recorded = resolve_discovered_model(
+        DiscoveredModel(provider="anthropic", model="claude-fable-5-1")
+    )
+    assert recorded.capabilities.supports_reasoning is True
+    assert recorded.capabilities.supports_top_k is False
+    assert recorded.capabilities.input_cost_per_million_tokens_usd == 10.0
+    assert recorded.capabilities.cached_input_cost_per_million_tokens_usd == 0.25
+
+    inherited = resolve_discovered_model(
+        DiscoveredModel(provider="anthropic", model="claude-sonnet-5-2")
+    )
+    assert inherited.capabilities.supports_reasoning is True
+    assert inherited.capabilities.input_cost_per_million_tokens_usd is None

--- a/exp/common/models/known_models.py
+++ b/exp/common/models/known_models.py
@@ -14,7 +14,7 @@ zero means the provider documents no separate charge for that cache operation.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 _SNAPSHOT_SUFFIX_PATTERN = re.compile(r"(?:[-@]\d{8}|-\d{4}-\d{2}-\d{2}|-latest)$")
@@ -487,6 +487,29 @@ _OPENAI_MODELS: dict[str, KnownModel] = {
 }
 
 _ANTHROPIC_MODELS: dict[str, KnownModel] = {
+    # Verified live 2026-09-01: claude-fable-5-1 keeps claude-fable-5's exact
+    # generation contract (adaptive-only thinking, low..max efforts,
+    # temperature pinned to 1, top_p floor 0.99, top_k rejected; 1M input,
+    # 128k output per the Models API) but discounts cache reads to 0.025x
+    # ($0.25/MTok), so its prices are recorded explicitly, never inherited.
+    "claude-fable-5-1": _anthropic_chat(
+        input_usd=10.0,
+        cached_input_usd=0.25,
+        cache_write_usd=12.5,
+        output_usd=50.0,
+        context_window_tokens=1_000_000,
+        maximum_output_tokens=128_000,
+        adaptive_reasoning=True,
+    ),
+    "claude-mythos-5-1": _anthropic_chat(
+        input_usd=10.0,
+        cached_input_usd=0.25,
+        cache_write_usd=12.5,
+        output_usd=50.0,
+        context_window_tokens=1_000_000,
+        maximum_output_tokens=128_000,
+        adaptive_reasoning=True,
+    ),
     "claude-fable-5": _anthropic_chat(
         input_usd=10.0,
         cached_input_usd=1.0,
@@ -622,8 +645,47 @@ def canonical_model_id(provider: str, model: str) -> str:
     return _SNAPSHOT_SUFFIX_PATTERN.sub("", identity)
 
 
+_ANTHROPIC_POINT_RELEASE_PATTERN = re.compile(r"^(?P<generation>.+-\d+)-\d+$")
+
+
+def _anthropic_generation_contract(identity: str) -> KnownModel | None:
+    """Inherit generation controls, never prices, for an unrecorded point release.
+
+    The matching rule: an Anthropic id of the form ``<generation>-<minor>``
+    whose ``<generation>`` (itself ending in a digit) is a recorded model
+    inherits that generation's wire contract. Point releases keep their
+    generation's exact controls (claude-fable-5-1 launched with
+    claude-fable-5's thinking, effort, and sampling rules, verified live
+    2026-09-01) but not necessarily its prices (5.1 discounts cache reads
+    4x versus 5), so every price field is cleared: the point release stays
+    servable with the right reasoning contract the day it launches, while
+    priced lanes keep failing closed until its real prices are recorded.
+    ``claude-haiku-4-5`` never falls through here: its would-be generation
+    ``claude-haiku-4`` is not a recorded model.
+    """
+    match = _ANTHROPIC_POINT_RELEASE_PATTERN.match(identity)
+    if match is None:
+        return None
+    generation = _ANTHROPIC_MODELS.get(match.group("generation"))
+    if generation is None:
+        return None
+    return replace(
+        generation,
+        input_cost_per_million_tokens_usd=None,
+        output_cost_per_million_tokens_usd=None,
+        cached_input_cost_per_million_tokens_usd=None,
+        cache_write_cost_per_million_tokens_usd=None,
+    )
+
+
 def known_model_metadata(provider: str, model: str) -> KnownModel | None:
     """Look up verified metadata for one provider model.
+
+    Anthropic point releases resolve through
+    :func:`_anthropic_generation_contract` when no exact record exists, so a
+    newly launched minor version (5.1, 5.2, ...) inherits its generation's
+    wire contract instead of degrading to a non-reasoning route; prices
+    never inherit.
 
     Args:
         provider: Setup provider kind such as ``openai`` or ``anthropic``.
@@ -635,7 +697,11 @@ def known_model_metadata(provider: str, model: str) -> KnownModel | None:
     models = _KNOWN_MODELS.get(provider)
     if models is None:
         return None
-    return models.get(canonical_model_id(provider, model))
+    identity = canonical_model_id(provider, model)
+    known = models.get(identity)
+    if known is None and provider == "anthropic":
+        return _anthropic_generation_contract(identity)
+    return known
 
 
 _RECOMMENDED_MODELS: dict[

--- a/exp/common/models/known_models_test.py
+++ b/exp/common/models/known_models_test.py
@@ -267,3 +267,99 @@ def test_recommendation_ranks_are_explicit_per_provider_and_role() -> None:
     assert recommended_model_rank("anthropic", "claude-sonnet-5", "judge") == 0
     assert recommended_model_rank("gemini", "models/gemini-3.6-flash", "router_candidate") == 0
     assert recommended_model_rank("openai", "gpt-5.4-mini", "world_model") is None
+
+
+def test_claude_fable_5_1_is_recorded_with_its_verified_launch_contract() -> None:
+    """The 5.1 launch entry pins the live-verified contract and prices.
+
+    A real Claude Code session against claude-fable-5-1 was answered with
+    "The parameter 'reasoning_effort' is not supported by this model route"
+    because the id resolved no metadata and the route derived as
+    non-reasoning. The contract below was verified live 2026-09-01,
+    including the 0.025x cache-read discount that forbids inheriting
+    claude-fable-5's prices.
+    """
+    known = known_model_metadata("anthropic", "claude-fable-5-1")
+    assert known is not None
+    assert known.supports_reasoning_effort is True
+    assert known.minimum_temperature == 1.0
+    assert known.maximum_temperature == 1.0
+    assert known.supports_top_k is False
+    assert known.context_window_tokens == 1_000_000
+    assert known.maximum_output_tokens == 128_000
+    assert known.input_cost_per_million_tokens_usd == 10.0
+    assert known.output_cost_per_million_tokens_usd == 50.0
+    assert known.cached_input_cost_per_million_tokens_usd == 0.25
+    assert known.cache_write_cost_per_million_tokens_usd == 12.5
+    mythos = known_model_metadata("anthropic", "claude-mythos-5-1")
+    assert mythos is not None and mythos.cached_input_cost_per_million_tokens_usd == 0.25
+
+
+def test_anthropic_point_releases_inherit_generation_controls_never_prices() -> None:
+    """An unrecorded minor version keeps its generation's wire contract.
+
+    The matching rule: ``<generation>-<minor>`` resolves the recorded
+    ``<generation>`` with every price cleared, so a newly launched point
+    release serves with the right reasoning contract while priced lanes
+    keep failing closed until its prices are recorded. A new GENERATION
+    inherits nothing and must be a deliberate table addition.
+    """
+    inherited = known_model_metadata("anthropic", "claude-sonnet-5-2")
+    assert inherited is not None
+    assert inherited.supports_reasoning_effort is True
+    assert inherited.minimum_temperature == 1.0
+    assert inherited.input_cost_per_million_tokens_usd is None
+    assert inherited.output_cost_per_million_tokens_usd is None
+    assert inherited.cached_input_cost_per_million_tokens_usd is None
+    assert inherited.cache_write_cost_per_million_tokens_usd is None
+    # A dated snapshot of a point release resolves the same way.
+    dated = known_model_metadata("anthropic", "claude-sonnet-5-2-20270101")
+    assert dated is not None and dated.supports_reasoning_effort is True
+    # A new generation is a deliberate decision, never an inheritance.
+    assert known_model_metadata("anthropic", "claude-fable-6") is None
+    # Real two-segment model ids never fall through to a bogus generation.
+    haiku = known_model_metadata("anthropic", "claude-haiku-4-5")
+    assert haiku is not None and haiku.input_cost_per_million_tokens_usd == 1.0
+
+
+# The exact /v1/models listing served to a plain key, captured 2026-09-01
+# (the claude-fable-5-1 launch). The drift gate below turns the next launch
+# into a loud decision instead of a customer-facing reasoning_effort 400.
+ANTHROPIC_LIVE_LISTING_2026_09_01 = (
+    "claude-fable-5-1",
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-opus-4-5-20251101",
+    "claude-haiku-4-5-20251001",
+    "claude-sonnet-4-5-20250929",
+)
+
+
+def test_every_served_anthropic_listing_id_resolves_a_generation_contract() -> None:
+    """Every id Anthropic serves must resolve metadata, by name.
+
+    When this fails, a launched model is reaching customers with no
+    recorded contract: add its generation entry (or explicit point-release
+    entry with verified prices) to ``_ANTHROPIC_MODELS`` now. Silent drift
+    here is how paying customers become the first detector (claude-fable-5-1
+    shipped as a non-reasoning route for exactly this reason).
+    """
+    unresolved = [
+        wire_id
+        for wire_id in ANTHROPIC_LIVE_LISTING_2026_09_01
+        if known_model_metadata("anthropic", wire_id) is None
+    ]
+    assert not unresolved, (
+        f"Anthropic serves ids with no recorded generation contract: {unresolved}. "
+        "Record each in _ANTHROPIC_MODELS (verified prices, or the generation "
+        "entry a point release should inherit) before customers hit it."
+    )
+    # The adaptive generation must resolve WITH its reasoning contract.
+    for wire_id in ("claude-fable-5-1", "claude-fable-5", "claude-opus-5", "claude-sonnet-5"):
+        known = known_model_metadata("anthropic", wire_id)
+        assert known is not None and known.supports_reasoning_effort is True, wire_id

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -149,6 +149,13 @@ def supported_reasoning_efforts(
     return tuple(effort for effort in _EFFORT_ORDER if effort in supported)
 
 
+# Family entries are GENERATION PREFIXES matched as substrings of the
+# normalized model id (dots and underscores become hyphens), so point
+# releases inherit their generation's contract by construction:
+# claude-fable-5-1 matches "claude-fable-5" (verified live 2026-09-01, the
+# 5.1 launch). A NEW generation (claude-fable-6) matches nothing and must be
+# added here deliberately; the known-models drift gate fails by name when a
+# served Anthropic listing id resolves no generation contract.
 _ANTHROPIC_ADAPTIVE_ONLY_FAMILIES = (
     "claude-fable-5",
     "claude-mythos-5",

--- a/exp/runtime/models/providers/reasoning_compat_test.py
+++ b/exp/runtime/models/providers/reasoning_compat_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from exp.runtime.models.providers.errors import UnsupportedReasoningEffortError
 from exp.runtime.models.providers.reasoning_compat import (
+    anthropic_adaptive_only_thinking,
     anthropic_reasoning_effort,
     default_reasoning_effort,
     gemini_thinking_level,
@@ -146,3 +147,21 @@ def test_adaptive_only_thinking_families_match_the_live_api_boundary() -> None:
         assert anthropic_adaptive_only_thinking(model), model
     for model in ("claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5", "claude-haiku-4.5"):
         assert not anthropic_adaptive_only_thinking(model), model
+
+
+def test_anthropic_point_releases_inherit_their_generation_effort_contract() -> None:
+    """Generation prefixes match point releases by construction.
+
+    claude-fable-5-1 (launched 2026-09-01, verified live: adaptive-only
+    thinking, efforts low through max with ultra rejected by name) must
+    resolve claude-fable-5's family without a table edit, and so must the
+    next minor.
+    """
+    for model_id in ("claude-fable-5-1", "claude-fable-5.1", "claude-sonnet-5-2"):
+        assert anthropic_adaptive_only_thinking(model_id) is True, model_id
+        assert anthropic_reasoning_effort(model_id, "xhigh") == "xhigh"
+        assert anthropic_reasoning_effort(model_id, "max") == "max"
+    with pytest.raises(UnsupportedReasoningEffortError):
+        anthropic_reasoning_effort("claude-fable-5-1", "ultra")
+    # Pre-adaptive families stay budgeted.
+    assert anthropic_adaptive_only_thinking("claude-haiku-4-5") is False


### PR DESCRIPTION
## Problem

`claude-fable-5.1` launched (wire id `claude-fable-5-1`) and real Claude Code sessions against it 400 with "The parameter 'reasoning_effort' is not supported by this model route" — the owner's config carries `effortLevel: high`, so every session sends effort. Adaptive thinking, tools, and caching all serve fine on 5.1 through the gateway; only effort-carrying requests died.

## Root cause

Not the effort tables: `reasoning_compat`'s family lists are generation prefixes matched on the normalized id, so `claude-fable-5-1` already matched `claude-fable-5`. The fall-through is `known_model_metadata`: the table is exact-keyed (only dated snapshot suffixes strip), so the new id resolved no record, `resolve_discovered_model` derived `supports_reasoning=False`, the catalog shipped a non-reasoning route, and route admission rejected `reasoning_effort` by name. The same lookup also gates the Azure-Foundry Anthropic wire detection, so 5.1 on Azure would have routed to the wrong wire too.

## Live verification (house key, 2026-09-01)

- Models API record for `claude-fable-5-1`: 1M `max_input_tokens`, 128k `max_tokens`, efforts low/medium/high/xhigh/max, thinking `adaptive` supported / `enabled` unsupported.
- Probes: every listed effort 200; `ultra` rejected by name; `thinking.enabled+budget` and `thinking.disabled` both 400; `temperature` only at 1.0; `top_p` at 0.99 accepted, 1.0 rejected (identical to fable-5); `top_k` rejected. The contract is exactly fable-5's.
- Pricing (published table): $10 in / $50 out / $12.50 5m-cache-write, and a **new 0.025x cache-read discount ($0.25/MTok versus fable-5's $1)** — which is why the fix never inherits prices.

## Fix

1. **Explicit records** for `claude-fable-5-1` and `claude-mythos-5-1` with the verified contract and published prices.
2. **The generation rule** (the real fix): `known_model_metadata` now resolves an unrecorded Anthropic point release — `<generation>-<minor>` whose `<generation>` is a recorded model — to that generation's wire contract with **every price field cleared**. The next minor (5.2) launches servable with the right reasoning contract on day one, while priced lanes keep failing closed until its real prices are recorded. A new generation (`claude-fable-6`) inherits nothing and stays a deliberate table decision. `claude-haiku-4-5` never falls through (its would-be generation `claude-haiku-4` is not a recorded model). The rule is documented at the fallback and at the `reasoning_compat` family tables (whose prefix matching is the same rule for the effort/thinking contract).
3. **Drift gate**: the exact live `/v1/models` listing (captured 2026-09-01, the 5.1 launch) is pinned, and the test fails by name when any served Anthropic id resolves no generation contract — "silent drift here is how paying customers become the first detector" now applies to model launches too. Discovery-seam tests prove a point release resolves a reasoning route and that inherited records carry no prices.

## E2E

A locally served native gateway seeded with **discovery-derived** capabilities for `claude-fable-5-1` (the exact production path, no manual capability overrides): an `output_config.effort: high` request serves 200, and a real Claude Code CLI session completes (`FABLE51_OK`). Before the fix this exact setup produces the named 400.

## Gates

- ruff format / check, ty: clean
- Full `uv run pytest -q` on the committed tree: 3070 passed, 5 skipped
- Python-only (no crate change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
