### PR TITLE
release: bump version to 0.7.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.20"
+version = "0.7.21"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.20"
+version = "0.7.21"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Mechanical version bump 0.7.20 → 0.7.21.

**Why a new version immediately after 0.7.20:** the v0.7.20 tag was cut at the bump commit (5c37a4b7, 14:32) before three PRs merged the same afternoon:
- #715 — anthropic point-release generation contract (fixes the live fable-5.1 effort 400)
- #714 — catalog snapshot roll-safety (forward-compat reader + UNAVAILABLE)
- #710 — Responses non-function tool declarations carried verbatim on native rungs

0.7.21 is the first tag that contains them. Native crate is already at 0.3.17 with the floor raised on main (no change needed here). Platform pin PR follows once wheels publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)