### PR TITLE
gateway: drop unservable efforts with disclosure and dispatch cache-capable rungs first

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -281,9 +281,16 @@ controls narrow the waterfall to the rungs that preserve every exact value
 capability preflight plus payload build. Only when zero rungs survive does the
 capability-preservation policy (`exp/runtime/models/providers/capability_policy.py`) attempt one
 minimal COERCE-WITH-DISCLOSURE: a reasoning effort snaps to the nearest level any rung supports
-on the canonical ladder (ties prefer the lower level), an explicit `none` on a route with no
-reasoning support drops (the model already delivers what `none` asks for), and `strict: true`
-tools degrade to best-effort schemas. Every coercion is disclosed in `path->effective` form
+on the canonical ladder (ties prefer the lower level), ANY effort on a route with no reasoning
+support at all drops (first-party clients pin effort globally, so a named rejection made whole
+sessions unusable against non-reasoning models the provider itself serves fine without the
+parameter; the Messages surface's verbatim `output_config.effort` is stripped with it so the
+dropped value reaches the provider through no channel), and `strict: true` tools degrade to
+best-effort schemas. On `maximize_cache` pools, a cache-marked request dispatches
+marker-honoring (Anthropic Messages) rungs before marker-dropping wires, stably within each
+group, so a shim rung can no longer silently bill every turn's full context uncached while the
+native rung stands ready; routes narrowing to only marker-dropping wires keep disclosing the
+dropped markers. Every coercion is disclosed in `path->effective` form
 through `ignored_parameters`, logged, and counted in the `admission_parameter_coercions`
 metric; nothing coercible keeps the first rung's own field-scoped rejection.
 The per-deployment `capability_parity` export joins catalog declarations with the engine's

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -785,6 +785,7 @@ def _configured_gateway(
     *,
     base_url: str = "http://127.0.0.1:9/v1",
     capabilities: ModelCapabilities | None = None,
+    provider: str = "openai-compatible",
 ) -> tuple[GatewayManagement, str]:
     """Create one explicit direct alias, identity, grant, and key in real SQLite."""
     manager = GatewayManagement(root)
@@ -793,8 +794,9 @@ def _configured_gateway(
         root,
         name="provider-main",
         connection=ConnectionConfig(
-            provider="openai-compatible",
-            base_url=base_url,
+            provider=provider,
+            # Fixed-origin providers (anthropic and friends) reject a base_url.
+            base_url=None if provider == "anthropic" else base_url,
             api_key_env="TEST_PROVIDER_KEY",
         ),
         replace=False,

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -18,7 +18,11 @@ import logging
 
 from exp.runtime.gateway.contracts import AuthorizationSnapshot, GatewayRequest
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
-from exp.runtime.gateway.native_execution import select_route_deployments
+from exp.runtime.gateway.native_execution import (
+    reorder_route_deployments,
+    request_carries_cache_markers,
+    select_route_deployments,
+)
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.models.providers import preflight_gateway_request
 from exp.runtime.models.providers.base import GatewayWireProfile
@@ -169,7 +173,47 @@ def admitted_route_requests(
                 )
             }
         )
+    route, resolved_wires = _prefer_cache_capable_rungs(route, resolved_wires, provider_request)
     return route, resolved_wires, public_request, provider_request
+
+
+def _prefer_cache_capable_rungs(
+    route: GatewayRoute,
+    resolved_wires: _ResolvedWires,
+    provider_request: GatewayRequest,
+) -> tuple[GatewayRoute, _ResolvedWires]:
+    """Dispatch marker-honoring rungs first on cache-preserving pools.
+
+    Under ``maximize_cache`` a cache-marked request must never start on a
+    wire that structurally drops its markers while a marker-honoring rung
+    stands ready: the pool's whole policy is prefix-cache preservation, and
+    a marker-dropping first rung silently bills every turn's full context
+    uncached (measured ~10x on a large system prompt). The reorder is
+    stable within each group, so certified order still breaks ties, and a
+    route that narrowing left with NO marker-honoring rung is unchanged
+    here: the dropped markers are already disclosed through the
+    ``cache_control`` ``ignored_parameters`` entries. ``maximize_availability``
+    pools keep their certified order untouched.
+    """
+    if route.snapshot.failover_mode != "maximize_cache":
+        return route, resolved_wires
+    if len(resolved_wires) < 2 or not request_carries_cache_markers(provider_request):
+        return route, resolved_wires
+    marker_capable = tuple(
+        index
+        for index, (profile, _client) in enumerate(resolved_wires)
+        if profile.dialect == "anthropic_messages"
+    )
+    if not marker_capable or len(marker_capable) == len(resolved_wires):
+        return route, resolved_wires
+    order = (
+        *marker_capable,
+        *(index for index in range(len(resolved_wires)) if index not in marker_capable),
+    )
+    return (
+        reorder_route_deployments(route, order),
+        tuple(resolved_wires[index] for index in order),
+    )
 
 
 def _candidate_serves(

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -1,1 +1,134 @@
-"""Admission coercion behavior is exercised end to end in native_bridge_test.py."""
+"""Rung-preference units; admission coercions are exercised e2e in native_bridge_test.py."""
+
+from typing import Literal, cast
+
+from exp.common.models.catalog import GatewayDeploymentMetadata
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+)
+from exp.runtime.gateway.native_admission import _prefer_cache_capable_rungs
+from exp.runtime.gateway.native_dispatch import NativeWireClient
+from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.models.providers.base import GatewayWireProfile
+
+
+def _deployment(deployment_id: str) -> ExactModelDeployment:
+    """Build one exact deployment for rung-preference tests."""
+    return ExactModelDeployment(
+        deployment_id=deployment_id,
+        source_alias=deployment_id,
+        exact_model_id="exact-one",
+        connection=f"connection-{deployment_id}",
+        provider="openai-compatible",
+        provider_model="provider-model",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        gateway=GatewayDeploymentMetadata(),
+    )
+
+
+def _mixed_route(failover_mode: str) -> GatewayRoute:
+    """Build one two-rung route whose FIRST rung drops cache markers."""
+    deployments = (_deployment("shim"), _deployment("native"))
+    authorization = AuthorizationSnapshot(
+        request_id="request-one",
+        organization_id="organization-one",
+        identity_id="identity-one",
+        virtual_key_id="key-one",
+        alias="public-model",
+        alias_revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        surface=GatewayApiSurface.MESSAGES,
+        catalog_sha256="a" * 64,
+        canonical_request_sha256="d" * 64,
+        deadline_monotonic=1.0,
+    )
+    return GatewayRoute(
+        snapshot=ExecutionSnapshot(
+            authorization=authorization,
+            exact_model_id="exact-one",
+            pool_id="pool-one",
+            deployment_ids=tuple(item.deployment_id for item in deployments),
+            failover_mode=cast(Literal["maximize_availability", "maximize_cache"], failover_mode),
+        ),
+        deployment=deployments[0],
+        fallback_deployments=deployments[1:],
+        route_reason="direct",
+    )
+
+
+def _wires() -> tuple[tuple[GatewayWireProfile, NativeWireClient], ...]:
+    """Pair one marker-dropping and one marker-honoring rung, shim first."""
+    shim = GatewayWireProfile(dialect="openai_compatible", url="https://shim.test")
+    native = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    client = cast(NativeWireClient, object())
+    return ((shim, client), (native, client))
+
+
+def _marked_request() -> GatewayRequest:
+    """Build one Messages request carrying a system cache marker."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(
+                role="system",
+                content="cached prompt",
+                provider_text_blocks=(
+                    {
+                        "type": "text",
+                        "text": "cached prompt",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ),
+            ),
+            GatewayMessage(role="user", content="hi"),
+        ),
+    )
+
+
+def test_cache_marked_requests_dispatch_marker_honoring_rungs_first() -> None:
+    """maximize_cache pools put the marker-carrying wire ahead of the shim.
+
+    The haiku-4.5 incident shape: a certified waterfall paired a native
+    Anthropic rung with an aggregator shim, and every marked session that
+    dispatched on the shim billed its full context uncached (~10x). The
+    pool's whole policy is prefix-cache preservation, so the marker-honoring
+    rung dispatches first; certified order still decides everything else.
+    """
+    route, wires = _prefer_cache_capable_rungs(
+        _mixed_route("maximize_cache"), _wires(), _marked_request()
+    )
+    assert route.deployment.deployment_id == "native"
+    assert tuple(item.deployment_id for item in route.fallback_deployments) == ("shim",)
+    assert wires[0][0].dialect == "anthropic_messages"
+
+    # A markerless request keeps the certified order.
+    plain = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hi"),),
+    )
+    route, wires = _prefer_cache_capable_rungs(_mixed_route("maximize_cache"), _wires(), plain)
+    assert route.deployment.deployment_id == "shim"
+
+    # maximize_availability pools keep their certified order untouched.
+    route, wires = _prefer_cache_capable_rungs(
+        _mixed_route("maximize_availability"), _wires(), _marked_request()
+    )
+    assert route.deployment.deployment_id == "shim"
+
+    # A route with no marker-honoring rung (or only such rungs) is unchanged;
+    # the dropped markers are disclosed elsewhere.
+    client = cast(NativeWireClient, object())
+    shim = (GatewayWireProfile(dialect="openai_compatible", url="https://shim.test"), client)
+    route, wires = _prefer_cache_capable_rungs(
+        _mixed_route("maximize_cache"),
+        (shim, shim),
+        _marked_request(),
+    )
+    assert route.deployment.deployment_id == "shim"

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -203,19 +203,20 @@ def _admit(
     raw_key: str,
     body: str,
     *,
+    surface: str | None = None,
     idempotency_key: str | None = None,
     client_request_id: str | None = None,
 ) -> JsonObject:
     """Run one admission call and decode its JSON response."""
-    argument = json.dumps(
-        {
-            "raw_key": raw_key,
-            "body": body,
-            "idempotency_key": idempotency_key,
-            "client_request_id": client_request_id,
-        }
-    )
-    return json.loads(control.admit(argument))
+    payload: JsonObject = {
+        "raw_key": raw_key,
+        "body": body,
+        "idempotency_key": idempotency_key,
+        "client_request_id": client_request_id,
+    }
+    if surface is not None:
+        payload["surface"] = surface
+    return json.loads(control.admit(json.dumps(payload)))
 
 
 def _claim_scope(
@@ -2937,21 +2938,23 @@ def test_responses_admission_is_native_with_envelope_and_payload(tmp_path: Path)
     assert report["totals"]["requests"] == 1
 
 
-def test_responses_admission_rejects_unsupported_reasoning_effort(tmp_path: Path) -> None:
-    """Native admission returns the same local parameter error before Rust dispatch."""
+def test_responses_admission_drops_effort_on_a_reasoning_less_route(tmp_path: Path) -> None:
+    """A Responses effort on a zero-reasoning route serves without it, disclosed.
+
+    This surface previously answered the named 400; the owner-approved drop
+    policy (2026-09-01) serves the request effortless instead, because a
+    zero-reasoning route cannot honor any depth and first-party clients pin
+    effort globally.
+    """
     control, raw_key = _control_plane(tmp_path)
     payload = json.loads(_responses_body())
     payload["reasoning"] = {"effort": "high"}
 
-    with pytest.raises(NativeBridgeError) as raised:
-        _admit_responses(control, raw_key, json.dumps(payload))
-
-    error = json.loads(raised.value.public_error_json)
-    assert error["status_code"] == 400
-    assert error["code"] == "unsupported_parameter"
-    assert error["error_type"] == "invalid_request_error"
-    assert error["param"] == "reasoning.effort"
-    assert "not supported by this model route" in error["message"]
+    admission = _flatten_started(control, _admit_responses(control, raw_key, json.dumps(payload)))
+    assert admission["ignored_parameters"] == ["reasoning_effort"]
+    upstream = admission["upstream_payload"]
+    assert isinstance(upstream, dict)
+    assert "reasoning" not in upstream
 
 
 def test_responses_continuation_round_trip_and_fail_closed(tmp_path: Path) -> None:
@@ -4329,16 +4332,17 @@ def test_strict_tools_degrade_with_disclosure_when_no_rung_declares_them(
     assert control_plane["admission_parameter_coercions"] == 1
 
 
-def test_effort_none_drops_with_disclosure_on_a_reasoning_less_route(
+def test_any_effort_drops_with_disclosure_on_a_reasoning_less_route(
     tmp_path: Path,
 ) -> None:
-    """reasoning_effort none is satisfied by a non-reasoning route.
+    """Every effort level is dropped with disclosure by a non-reasoning route.
 
-    The kimi-k3 shape: a route whose rungs declare no reasoning support
-    rejected the parameter wholesale. An explicit 'none' now drops with
-    disclosure (the model already does exactly what none asks for), while a
-    real effort stays the named rejection because deleting the feature is
-    not a nearest supported level.
+    The kimi-k3 shape dropped only an explicit 'none'; the haiku-4.5 shape
+    proved a real effort must drop too. First-party clients pin effort
+    globally (Claude Code sends its configured effortLevel to every model),
+    so a named rejection made whole sessions unusable against non-reasoning
+    models the provider itself serves fine without the parameter (owner
+    decision, 2026-09-01).
     """
     control, raw_key = _control_plane(tmp_path)
 
@@ -4352,21 +4356,61 @@ def test_effort_none_drops_with_disclosure_on_a_reasoning_less_route(
             }
         )
 
-    admission = _flatten_started(control, _admit(control, raw_key, chat_body("none")))
+    for attempt, effort in enumerate(("none", "high"), start=1):
+        admission = _flatten_started(control, _admit(control, raw_key, chat_body(effort)))
+        assert admission["ignored_parameters"] == ["reasoning_effort"], effort
+        upstream = admission["upstream_payload"]
+        assert isinstance(upstream, dict)
+        assert "reasoning_effort" not in upstream
+        assert "reasoning" not in upstream
+        control_plane = cast("JsonObject", control.metrics_snapshot()["control_plane"])
+        assert control_plane["admission_parameter_coercions"] == attempt
+
+
+def test_effort_carrying_marked_request_serves_native_with_caching_intact(
+    tmp_path: Path,
+) -> None:
+    """The haiku-4.5 regression: effort drops, cache markers reach the wire.
+
+    A Claude Code session pinning effortLevel against a non-reasoning
+    Anthropic model must serve on the native rung with its prompt-cache
+    markers preserved and the dropped effort disclosed, not 400 and not
+    narrow onto a marker-dropping shim.
+    """
+    root = tmp_path / "anthropic-root"
+    root.mkdir()
+    _manager, raw_key = _configured_gateway(root, provider="anthropic")
+    components = load_gateway_components(
+        root,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    control = NativeControlPlane(components, request_timeout_seconds=120.0)
+    body = json.dumps(
+        {
+            "model": "coding",
+            "max_tokens": 32,
+            "system": [
+                {"type": "text", "text": "You are terse."},
+                {
+                    "type": "text",
+                    "text": "Big cached block.",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+            "messages": [{"role": "user", "content": "hi"}],
+            "output_config": {"effort": "high"},
+        }
+    )
+    admission = _flatten_started(control, _admit(control, raw_key, body, surface="messages"))
     assert admission["ignored_parameters"] == ["reasoning_effort"]
     upstream = admission["upstream_payload"]
     assert isinstance(upstream, dict)
+    # The dropped effort reaches the provider through NO channel.
+    assert "output_config" not in upstream
     assert "reasoning_effort" not in upstream
-    assert "reasoning" not in upstream
-    control_plane = cast("JsonObject", control.metrics_snapshot()["control_plane"])
-    assert control_plane["admission_parameter_coercions"] == 1
-
-    with pytest.raises(NativeBridgeError) as raised:
-        _admit(control, raw_key, chat_body("high"))
-    payload = json.loads(raised.value.public_error_json)
-    assert payload["status_code"] == 400
-    assert payload["param"] == "reasoning_effort"
-    assert payload["code"] == "unsupported_parameter"
+    # The cache markers survive to the native wire, block structure intact.
+    system = cast("list[JsonObject]", upstream["system"])
+    assert system[-1]["cache_control"] == {"type": "ephemeral"}
 
 
 def _web_search_fixture_json() -> str:

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -469,6 +469,63 @@ def select_route_deployments(
     )
 
 
+def request_carries_cache_markers(request: GatewayRequest) -> bool:
+    """Whether any prompt-cache marker rides this request.
+
+    Markers live on the top-level automatic carrier, tool definitions,
+    assistant tool calls, message text runs, and tool-result breakpoints;
+    every one of them is honored only by the Anthropic Messages wire.
+    """
+    return (
+        request.provider_cache_control is not None
+        or any(tool.cache_control is not None for tool in request.tools)
+        or any(
+            message.provider_text_blocks
+            or message.cache_control is not None
+            or any(call.cache_control is not None for call in message.tool_calls)
+            for message in request.messages
+        )
+    )
+
+
+def reorder_route_deployments(
+    route: GatewayRoute,
+    order: tuple[int, ...],
+) -> GatewayRoute:
+    """Return the route with its deployments in the given permutation.
+
+    Unlike :func:`select_route_deployments` this changes dispatch order
+    without narrowing: ``order`` must be a permutation of every current
+    deployment index.
+
+    Args:
+        route: Frozen ordered deployment route selected for the request.
+        order: Permutation of ``range(len(route.deployments))``.
+
+    Returns:
+        The original route when the order is unchanged, otherwise a new
+        execution snapshot naming the same deployments in dispatch order.
+
+    Raises:
+        ValueError: The order is not a permutation of the route.
+    """
+    deployments = route.deployments
+    if sorted(order) != list(range(len(deployments))):
+        raise ValueError("route reorder requires a permutation of every deployment")
+    if order == tuple(range(len(deployments))):
+        return route
+    selected = tuple(deployments[index] for index in order)
+    return GatewayRoute(
+        snapshot=route.snapshot.model_copy(
+            update={"deployment_ids": tuple(item.deployment_id for item in selected)}
+        ),
+        deployment=selected[0],
+        fallback_deployments=selected[1:],
+        route_reason=route.route_reason,
+        fallback_reason=route.fallback_reason,
+    )
+
+
 def deployment_wire_entry(
     route: GatewayRoute,
     deployment: ExactModelDeployment,

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -15,6 +15,7 @@ from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayFailure,
     GatewayFailureClass,
+    GatewayRequest,
 )
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.native_execution import (
@@ -511,3 +512,76 @@ def test_native_serving_blockers_name_reasoning_wire_contract_conflicts(
     assert len(blockers) == 1
     assert blockers[0].startswith("reasoning: ")
     assert "invalid reasoning wire contract" in blockers[0]
+
+
+def test_route_reorder_permutes_dispatch_order_and_rejects_non_permutations() -> None:
+    """Reordering changes dispatch order over exactly the same deployments."""
+    from exp.runtime.gateway.native_execution import reorder_route_deployments
+
+    route = _route()
+    unchanged = reorder_route_deployments(route, (0, 1, 2))
+    assert unchanged is route
+    rotated = reorder_route_deployments(route, (2, 0, 1))
+    assert rotated.deployment.deployment_id == "three"
+    assert tuple(item.deployment_id for item in rotated.fallback_deployments) == ("one", "two")
+    assert rotated.snapshot.deployment_ids == ("three", "one", "two")
+    assert rotated.route_reason == route.route_reason
+    with pytest.raises(ValueError, match="permutation"):
+        reorder_route_deployments(route, (0, 1))
+    with pytest.raises(ValueError, match="permutation"):
+        reorder_route_deployments(route, (0, 1, 1))
+
+
+def test_cache_marker_predicate_sees_every_marker_carrier() -> None:
+    """Each cache-marker position makes the request marker-carrying."""
+    from exp.common.models.model import ToolCall
+    from exp.runtime.gateway.contracts import GatewayMessage, GatewayToolDefinition
+    from exp.runtime.gateway.native_execution import request_carries_cache_markers
+
+    def request(**updates: object) -> GatewayRequest:
+        base = GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=(GatewayMessage(role="user", content="hi"),),
+        )
+        return base.model_copy(update=updates)
+
+    assert request_carries_cache_markers(request()) is False
+    assert request_carries_cache_markers(request(provider_cache_control={"type": "ephemeral"}))
+    assert request_carries_cache_markers(
+        request(
+            tools=(
+                GatewayToolDefinition(
+                    name="bash",
+                    parameters={"type": "object"},
+                    cache_control={"type": "ephemeral"},
+                ),
+            )
+        )
+    )
+    marked_text = GatewayMessage(
+        role="user",
+        content="hi",
+        provider_text_blocks=(
+            {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}},
+        ),
+    )
+    assert request_carries_cache_markers(request(messages=(marked_text,)))
+    marked_tool_result = GatewayMessage(
+        role="tool",
+        content="ok",
+        tool_call_id="call-1",
+        cache_control={"type": "ephemeral"},
+    )
+    assert request_carries_cache_markers(request(messages=(marked_tool_result,)))
+    marked_call = GatewayMessage(
+        role="assistant",
+        tool_calls=(
+            ToolCall(
+                call_id="call-1",
+                name="bash",
+                arguments={},
+                cache_control={"type": "ephemeral"},
+            ),
+        ),
+    )
+    assert request_carries_cache_markers(request(messages=(marked_call,)))

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -893,10 +893,17 @@ def test_protocol_and_key_failures_are_anthropic_shaped(engine: _ServingEngine) 
     assert count_tokens.json()["error"]["type"] == "not_found_error"
 
 
-def test_native_rejects_unsupported_reasoning_effort_with_the_public_field_error(
+def test_native_serves_an_effort_on_a_reasoning_less_route_by_dropping_it(
     engine: _ServingEngine,
 ) -> None:
-    """The native plane returns the local field error before any provider dispatch."""
+    """An effort on a zero-reasoning route serves without it, end to end.
+
+    This surface previously answered a named 400 before any dispatch; the
+    owner-approved drop policy (2026-09-01) serves the request effortless
+    with the drop disclosed through admission accounting, because
+    first-party clients pin effort globally and a zero-reasoning route
+    cannot honor any depth.
+    """
     payload = {
         "model": "coding",
         "input": "hello",
@@ -909,20 +916,9 @@ def test_native_rejects_unsupported_reasoning_effort_with_the_public_field_error
         json=payload,
         timeout=10.0,
     )
-
-    expected = {
-        "error": {
-            "message": (
-                "The parameter 'reasoning.effort' is not supported by this model route. "
-                "Remove the field or choose a different model."
-            ),
-            "type": "invalid_request_error",
-            "param": "reasoning.effort",
-            "code": "unsupported_parameter",
-        }
-    }
-    assert native.status_code == 400
-    assert native.json() == expected
+    assert native.status_code == 200
+    body = native.json()
+    assert body["status"] == "completed"
 
 
 def test_native_rejects_unsupported_sampling_with_the_public_field_error(

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -40,7 +40,7 @@ STRICT_TOOLS_DISCLOSURE = "tools.strict->false"
 """Disclosure recorded when strict tools degrade to best-effort schemas."""
 
 EFFORT_DROP_DISCLOSURE = "reasoning_effort"
-"""Disclosure recorded when a no-reasoning route drops an explicit 'none'."""
+"""Disclosure recorded when a zero-reasoning route drops the caller effort."""
 
 
 @dataclass(frozen=True)
@@ -62,11 +62,14 @@ def coerce_generation_parameters(
     Only substitutions whose semantics survive are offered: a reasoning
     effort snaps to the nearest level any rung supports on the canonical
     ladder (ties prefer the lower level, so a coercion never spends more
-    than requested), and an explicit ``none`` on a route with no reasoning
-    support at all is dropped, because a non-reasoning model already delivers
-    exactly what ``none`` asks for. A request whose effort exceeds a
-    zero-reasoning route stays a named rejection: deleting the feature is
-    not a nearest level.
+    than requested), and ANY effort on a route with no reasoning support at
+    all is dropped with disclosure. A zero-reasoning route cannot honor any
+    depth, so the only serviceable semantic is the model's sole behavior,
+    and first-party clients pin effort globally (Claude Code sends its
+    configured effortLevel to every model), so a named rejection here makes
+    whole sessions unusable against non-reasoning models the provider
+    itself serves fine without the parameter (owner decision, 2026-09-01;
+    previously only an explicit ``none`` dropped).
 
     Args:
         profiles: Ordered wire profiles for every live route deployment.
@@ -87,9 +90,18 @@ def coerce_generation_parameters(
     for profile in profiles:
         ladder.update(profile_reasoning_efforts(profile))
     if not ladder:
-        if request.reasoning_effort != "none":
-            return None
-        dropped_request = request.model_copy(update={"reasoning_effort": None})
+        updates: dict[str, object] = {"reasoning_effort": None}
+        if request.provider_output_config is not None:
+            # The Messages surface carries the same effort verbatim inside
+            # output_config; a dropped effort must not reach the provider
+            # through that channel (the provider rejects it by name).
+            remaining = {
+                key: value
+                for key, value in request.provider_output_config.items()
+                if key != "effort"
+            }
+            updates["provider_output_config"] = remaining or None
+        dropped_request = request.model_copy(update=updates)
         if admits is not None and not admits(dropped_request):
             return None
         return RequestCoercion(

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -87,17 +87,43 @@ def test_effort_snap_skips_levels_that_admit_no_rung() -> None:
     assert coercion.disclosures == ("reasoning_effort->high",)
 
 
-def test_effort_none_drops_on_a_route_with_no_reasoning_at_all() -> None:
-    """A non-reasoning route already delivers what 'none' asks for."""
-    bare = GatewayWireProfile(dialect="openai_compatible", url="https://provider.test")
-    coercion = coerce_generation_parameters((bare,), _request(reasoning_effort="none"))
-    assert coercion is not None
-    assert coercion.request.reasoning_effort is None
-    assert coercion.disclosures == ("reasoning_effort",)
+def test_any_effort_drops_on_a_route_with_no_reasoning_at_all() -> None:
+    """A zero-reasoning route serves the request without its effort, disclosed.
 
-    # Any real effort on a zero-reasoning route stays a named rejection:
-    # deleting the feature is not a nearest level.
-    assert coerce_generation_parameters((bare,), _request(reasoning_effort="high")) is None
+    First-party clients pin effort globally (Claude Code sends its
+    configured effortLevel to every model), so a named rejection here made
+    whole sessions unusable against non-reasoning models the provider
+    itself serves fine without the parameter (owner decision, 2026-09-01).
+    """
+    bare = GatewayWireProfile(dialect="openai_compatible", url="https://provider.test")
+    for effort in ("none", "high", "xhigh"):
+        coercion = coerce_generation_parameters((bare,), _request(reasoning_effort=effort))
+        assert coercion is not None, effort
+        assert coercion.request.reasoning_effort is None
+        assert coercion.disclosures == ("reasoning_effort",)
+
+    # The Messages surface carries the same effort inside output_config; the
+    # drop strips exactly that key so nothing effort-shaped reaches a
+    # provider that rejects it by name, while other verbatim keys survive.
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    marked = _request(reasoning_effort="high").model_copy(
+        update={
+            "surface": GatewayApiSurface.MESSAGES,
+            "provider_output_config": {"effort": "high", "format": {"type": "text"}},
+        }
+    )
+    coercion = coerce_generation_parameters((anthropic,), marked)
+    assert coercion is not None
+    assert coercion.request.provider_output_config == {"format": {"type": "text"}}
+    effort_only = _request(reasoning_effort="high").model_copy(
+        update={
+            "surface": GatewayApiSurface.MESSAGES,
+            "provider_output_config": {"effort": "high"},
+        }
+    )
+    coercion = coerce_generation_parameters((anthropic,), effort_only)
+    assert coercion is not None
+    assert coercion.request.provider_output_config is None
 
 
 def test_portable_effort_is_never_snapped() -> None:


### PR DESCRIPTION
## What (owner-greenlit policy pair, 0.7.20 train)

Two admission-policy changes from the haiku-4.5 uncached-billing incident, both approved by the owner 2026-09-01:

### 1. Effort drop-with-disclosure on zero-reasoning routes

`coerce_generation_parameters` previously dropped only an explicit `none`; ANY real effort on a route with no reasoning support answered a named 400 ("deleting the feature is not a nearest level"). But first-party clients pin effort globally — Claude Code sends its configured `effortLevel` to every model — so that 400 made whole sessions unusable against non-reasoning models the provider itself serves fine without the parameter. Now every effort drops with the existing `reasoning_effort` disclosure and coercion metrics when the route's effort ladder is empty. The Messages surface's verbatim `output_config.effort` is stripped in the same coercion, so the dropped value reaches the provider through **no** channel (Anthropic rejects it by name: "This model does not support the effort parameter", verified live on haiku).

The regression test demanded in the greenlight is pinned e2e on an anthropic-rung control plane: an effort-carrying, cache-marked Messages request on a zero-effort route serves with `ignored_parameters == ["reasoning_effort"]`, no `output_config` upstream, and the system cache markers intact on the wire. This composes with the platform catalog truth fix (#1083): post-both, effort-carrying Claude Code haiku traffic serves NATIVE with caching.

### 2. `maximize_cache` marker-honoring dispatch preference

The incident's other half: exact-preservation narrowing kept an aggregator shim (whose catalog over-claimed effort support) while dropping the honest native rung, and the shim's OpenAI-compatible wire structurally drops Anthropic cache markers — every turn billed full context uncached (~10x, measured 27.5k input/turn on prod). New rule, scoped to `maximize_cache` pools (whose entire policy is prefix-cache preservation): a cache-marked request dispatches marker-honoring (`anthropic_messages`) rungs before marker-dropping wires, stably within each group so certified order still breaks ties. `maximize_availability` pools and markerless requests keep their certified order untouched, and a route narrowed to only marker-dropping wires keeps disclosing the dropped markers through the existing `cache_control` `ignored_parameters` entries.

Implementation: a `reorder_route_deployments` permutation helper beside `select_route_deployments` (which deliberately forbids reorder), a `request_carries_cache_markers` predicate covering every marker carrier, and one `_prefer_cache_capable_rungs` hook at the end of `admitted_route_requests`, so the Rust waterfall receives the already-ordered route.

## Behavior changes to pinned tests

Three tests pinned the old named-rejection behavior and now pin the new policy: the chat/Responses admission effort rejections (both now serve with disclosure) and the live-engine Responses 400 (now 200). `_configured_gateway` gained a `provider` parameter so the regression seeds a real anthropic-dialect rung.

## Live acceptance (the original haiku demand, house key)

A locally served native gateway on **discovery-derived** `claude-haiku-4-5` (which previously answered the named 400 to every effort-carrying request):

- `output_config.effort: high` request: 200, served effortless with disclosure.
- Real two-turn Claude Code CLI session: both turns serve; turn 1 `cache_creation_input_tokens=47528`, turn 2 `cache_read_input_tokens=47528`, `input_tokens=10` per turn.

## Gates

- ruff format / check, ty: clean
- Full `uv run pytest -q` on the committed tree: 3094 passed, 5 skipped
- Python-only; no crate change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
