### PR TITLE
gateway/embeddings: EMBEDDINGS surface, contract, decode, and manifest

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -57,6 +57,7 @@ class GatewayApiSurface(StrEnum):
     CHAT_COMPLETIONS = "chat_completions"
     RESPONSES = "responses"
     MESSAGES = "messages"
+    EMBEDDINGS = "embeddings"
 
 
 class GatewayToolDefinition(ContractModel):

--- a/exp/runtime/gateway/embeddings_contracts.py
+++ b/exp/runtime/gateway/embeddings_contracts.py
@@ -1,0 +1,48 @@
+"""Canonical embeddings request contract, parallel to the chat ``GatewayRequest``."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+from exp.common.core.artifacts import ContractModel
+from exp.runtime.gateway.contracts import GatewayApiSurface
+
+
+class EmbeddingsRequest(ContractModel):
+    """Canonical, provider-neutral embeddings request.
+
+    Deliberately parallel to :class:`~exp.runtime.gateway.contracts.GatewayRequest`
+    rather than a mode of it: the embeddings surface is message-less and
+    non-streaming, while ``GatewayRequest`` hard-requires ``messages`` and is
+    admitted stream-only. Reusing that contract would have forced either a
+    message-less exception or a stream-forced embeddings dispatch, so the two
+    surfaces stay separate. It lives in its own module so the already
+    line-budgeted ``contracts`` module carries only the shared enum member.
+    """
+
+    surface: Literal[GatewayApiSurface.EMBEDDINGS] = GatewayApiSurface.EMBEDDINGS
+    inputs: tuple[str, ...] = Field(min_length=1)
+    dimensions: int | None = Field(default=None, gt=0)
+    encoding_format: Literal["float", "base64"] | None = None
+    user: str | None = Field(default=None, max_length=1024)
+    """End-user attribution from the OpenAI ``user`` field: content-free and never a credential."""
+
+    @field_validator("inputs")
+    @classmethod
+    def _require_nonempty_inputs(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        """Reject empty input strings, mirroring the provider's own rejection.
+
+        Args:
+            value: Ordered visible text inputs to embed.
+
+        Returns:
+            The unchanged validated inputs.
+
+        Raises:
+            ValueError: An input string is empty.
+        """
+        if any(not text for text in value):
+            raise ValueError("embedding inputs must not be empty strings")
+        return value

--- a/exp/runtime/gateway/embeddings_contracts_test.py
+++ b/exp/runtime/gateway/embeddings_contracts_test.py
@@ -1,0 +1,30 @@
+"""Tests for the canonical embeddings request contract."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from exp.runtime.gateway.contracts import GatewayApiSurface
+from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest
+
+
+def test_embeddings_request_is_message_less_and_defaults_optionals() -> None:
+    """The parallel embeddings contract needs only inputs and pins its surface."""
+    request = EmbeddingsRequest(inputs=("hello",))
+
+    assert request.surface == GatewayApiSurface.EMBEDDINGS
+    assert request.inputs == ("hello",)
+    assert request.dimensions is None
+    assert request.encoding_format is None
+    assert request.user is None
+
+
+def test_embeddings_request_rejects_empty_input_sets() -> None:
+    """An empty input list or an empty input string is invalid at the contract boundary."""
+    with pytest.raises(ValidationError, match="at least 1 item"):
+        EmbeddingsRequest(inputs=())
+    with pytest.raises(ValidationError, match="must not be empty"):
+        EmbeddingsRequest(inputs=("ok", ""))
+    with pytest.raises(ValidationError, match="greater than 0"):
+        EmbeddingsRequest(inputs=("ok",), dimensions=0)

--- a/exp/runtime/gateway/native_decode.py
+++ b/exp/runtime/gateway/native_decode.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 
+from exp.common.core.artifacts import JsonObject
 from exp.runtime.anthropic_protocol.requests import decode_messages
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 from exp.runtime.openai_protocol.requests import (
+    DecodedEmbeddingsRequest,
     DecodedGatewayRequest,
     decode_chat,
+    decode_embeddings,
     decode_responses,
 )
 
@@ -55,6 +58,47 @@ def decode_native_body(
         NativeDecodeError: The body is not JSON, not an object, or fails
             shared protocol validation.
     """
+    payload = _load_object_body(body)
+    try:
+        if surface == "messages":
+            return decode_messages(payload, anthropic_beta=anthropic_beta)
+        decoder = decode_responses if surface == "responses" else decode_chat
+        return decoder(
+            payload,
+            idempotency_key=idempotency_key,
+            client_request_id=client_request_id,
+        )
+    except OpenAIProtocolError as exc:
+        raise NativeDecodeError(exc) from exc
+
+
+def decode_native_embeddings_body(body: str) -> DecodedEmbeddingsRequest:
+    """Decode one raw ``/embeddings`` body with the shared embeddings decoder.
+
+    The embeddings surface is message-less and non-streaming, so it decodes
+    through its own entrypoint rather than the chat/responses/messages
+    dispatch above. Keyed replay is a future add, so no idempotency header is
+    threaded here.
+
+    Args:
+        body: Raw request body text.
+
+    Returns:
+        The public alias and canonical embeddings request.
+
+    Raises:
+        NativeDecodeError: The body is not JSON, not an object, or fails shared
+            protocol validation.
+    """
+    payload = _load_object_body(body)
+    try:
+        return decode_embeddings(payload)
+    except OpenAIProtocolError as exc:
+        raise NativeDecodeError(exc) from exc
+
+
+def _load_object_body(body: str) -> JsonObject:
+    """Parse one raw request body into a JSON object or raise the public error."""
     try:
         payload = json.loads(body)
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
@@ -73,14 +117,4 @@ def decode_native_body(
                 message="Request body must be a JSON object. Re-encode the payload and resend.",
             )
         )
-    try:
-        if surface == "messages":
-            return decode_messages(payload, anthropic_beta=anthropic_beta)
-        decoder = decode_responses if surface == "responses" else decode_chat
-        return decoder(
-            payload,
-            idempotency_key=idempotency_key,
-            client_request_id=client_request_id,
-        )
-    except OpenAIProtocolError as exc:
-        raise NativeDecodeError(exc) from exc
+    return payload

--- a/exp/runtime/gateway/native_decode_test.py
+++ b/exp/runtime/gateway/native_decode_test.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_body
+from exp.runtime.gateway.contracts import GatewayApiSurface
+from exp.runtime.gateway.native_decode import (
+    NativeDecodeError,
+    decode_native_body,
+    decode_native_embeddings_body,
+)
 
 
 def test_decode_native_body_accepts_chat_and_responses() -> None:
@@ -40,3 +45,23 @@ def test_messages_surface_threads_the_caller_beta_header() -> None:
     )
     assert decoded.request.provider_beta_tokens == ("context-1m-2025-08-07",)
     assert decoded.request.ignored_parameters == ("anthropic-beta.claude-code-20250219",)
+
+
+def test_decode_native_embeddings_body_accepts_the_embeddings_surface() -> None:
+    """The embeddings surface decodes through its own message-less entrypoint."""
+    decoded = decode_native_embeddings_body('{"model":"text-embedding-3-small","input":"hi"}')
+
+    assert decoded.alias == "text-embedding-3-small"
+    assert decoded.request.surface == GatewayApiSurface.EMBEDDINGS
+    assert decoded.request.inputs == ("hi",)
+
+
+def test_decode_native_embeddings_body_rejects_malformed_bodies() -> None:
+    """Invalid JSON and non-object bodies keep the shared public error shapes."""
+    with pytest.raises(NativeDecodeError) as invalid_json:
+        decode_native_embeddings_body("{not json")
+    assert invalid_json.value.error.detail.code == "invalid_json"
+
+    with pytest.raises(NativeDecodeError) as not_object:
+        decode_native_embeddings_body("[]")
+    assert not_object.value.error.status_code == 400

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -239,6 +239,27 @@ caching natively, and non-Anthropic routes disclose the omission through
 """
 
 
+EMBEDDINGS_MANIFEST = CompatibilityManifest(
+    schema_version=1,
+    surface=GatewayApiSurface.EMBEDDINGS,
+    fields=(
+        *(
+            _field(path, CompatibilityDisposition.SUPPORTED)
+            for path in (
+                "model",
+                "input",
+                "dimensions",
+                "encoding_format",
+            )
+        ),
+        # End-user attribution (OpenAI spec): accepted and recorded gateway-side,
+        # never forwarded to the provider. The embeddings body carries no
+        # safety_identifier / prompt_cache_key, so `user` is the only one.
+        _field("user", CompatibilityDisposition.METADATA_ONLY),
+    ),
+)
+
+
 def disposition_map(manifest: CompatibilityManifest) -> dict[str, CompatibilityDisposition]:
     """Index one manifest by exact top-level request field.
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Collection, Sequence
 from typing import Literal, cast
 
+from openai.types import EmbeddingCreateParams
 from openai.types.chat.completion_create_params import CompletionCreateParams
 from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import (
@@ -39,6 +40,7 @@ from exp.runtime.gateway.contracts import (
     SealedReasoningContentBlock,
     StructuredTextFormat,
 )
+from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest
 from exp.runtime.gateway.reasoning_carrier import (
     FIREWORKS_REASONING_CONTENT_PREFIX,
     parse_reasoning_content_carrier,
@@ -49,6 +51,7 @@ from exp.runtime.openai_protocol.cache_control import (
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
+    EMBEDDINGS_MANIFEST,
     RESPONSES_MANIFEST,
     disposition_map,
 )
@@ -71,6 +74,7 @@ from exp.runtime.openai_protocol.wire_models import (
     _ContentPart,
     _CustomToolCall,
     _CustomToolCallOutput,
+    _EmbeddingsRequest,
     _FunctionCall,
     _Message,
     _ResponseFunctionCall,
@@ -85,6 +89,9 @@ from exp.runtime.openai_protocol.wire_models import (
 
 _CHAT_OFFICIAL = TypeAdapter(CompletionCreateParams)
 _RESPONSES_OFFICIAL = TypeAdapter(ResponseCreateParams)
+# Parametrized to object so the invariant TypeAdapter matches _validate_official;
+# EmbeddingCreateParams is a single TypedDict, unlike the union-typed chat/responses params.
+_EMBEDDINGS_OFFICIAL: TypeAdapter[object] = TypeAdapter[object](EmbeddingCreateParams)
 _TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 
 
@@ -94,6 +101,17 @@ class DecodedGatewayRequest(ContractModel):
     alias: str = Field(min_length=1, max_length=256)
     request: GatewayRequest
     developer_messages_param: str | None = None
+
+
+class DecodedEmbeddingsRequest(ContractModel):
+    """Public alias plus its canonical embeddings request.
+
+    Distinct from :class:`DecodedGatewayRequest` because the embeddings surface
+    carries its own message-less, non-streaming request contract.
+    """
+
+    alias: str = Field(min_length=1, max_length=256)
+    request: EmbeddingsRequest
 
 
 def _without_chat_reasoning_content(payload: JsonObject) -> JsonObject:
@@ -196,6 +214,38 @@ def decode_chat(
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
     return DecodedGatewayRequest(alias=request.model, request=canonical)
+
+
+def decode_embeddings(payload: JsonObject) -> DecodedEmbeddingsRequest:
+    """Decode one Embeddings body into the canonical embeddings surface.
+
+    The embeddings surface has no idempotency protocol yet: keyed replay is a
+    future add, so an inbound ``Idempotency-Key`` header is ignored upstream
+    rather than keying this decode (which therefore takes no header arguments).
+
+    Args:
+        payload: Parsed JSON request body.
+
+    Returns:
+        Public alias and canonical embeddings request.
+
+    Raises:
+        OpenAIProtocolError: The body is invalid, unknown, or unsupported.
+    """
+    _validate_manifest(payload, EMBEDDINGS_MANIFEST)
+    _validate_official(_EMBEDDINGS_OFFICIAL, payload)
+    request = _validate_wire(_EmbeddingsRequest, payload)
+    inputs = (request.input,) if isinstance(request.input, str) else request.input
+    try:
+        canonical = EmbeddingsRequest(
+            inputs=inputs,
+            dimensions=request.dimensions,
+            encoding_format=request.encoding_format,
+            user=request.user,
+        )
+    except ValidationError as exc:
+        raise _validation_protocol_error(exc) from exc
+    return DecodedEmbeddingsRequest(alias=request.model, request=canonical)
 
 
 def decode_responses(

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -21,6 +21,7 @@ from exp.runtime.openai_protocol.model_adapter import model_request
 from exp.runtime.openai_protocol.requests import (
     DecodedGatewayRequest,
     decode_chat,
+    decode_embeddings,
     decode_responses,
 )
 
@@ -1948,3 +1949,65 @@ def test_a_malformed_function_tool_declaration_still_fails_closed() -> None:
         )
     assert rejection.value.status_code == 400
     assert "tools" in (rejection.value.detail.param or "")
+
+
+def test_embeddings_decoder_preserves_supported_fields() -> None:
+    """Embeddings conversion keeps the alias, inputs, dimensions, encoding, and attribution."""
+    decoded = decode_embeddings(
+        {
+            "model": "text-embedding-3-small",
+            "input": "hello world",
+            "dimensions": 256,
+            "encoding_format": "float",
+            "user": "end-user-7",
+        }
+    )
+
+    assert decoded.alias == "text-embedding-3-small"
+    assert decoded.request.surface == GatewayApiSurface.EMBEDDINGS
+    assert decoded.request.inputs == ("hello world",)
+    assert decoded.request.dimensions == 256
+    assert decoded.request.encoding_format == "float"
+    assert decoded.request.user == "end-user-7"
+
+
+def test_embeddings_decoder_accepts_a_list_of_inputs() -> None:
+    """An array of texts decodes in order with defaults for the optional fields."""
+    decoded = decode_embeddings({"model": "m", "input": ["first", "second"]})
+
+    assert decoded.request.inputs == ("first", "second")
+    assert decoded.request.dimensions is None
+    assert decoded.request.encoding_format is None
+    assert decoded.request.user is None
+
+
+def test_embeddings_decoder_rejects_unknown_and_streaming_fields() -> None:
+    """A field outside the closed embeddings manifest is a named 400, never silently dropped."""
+    with pytest.raises(OpenAIProtocolError) as rejection:
+        decode_embeddings({"model": "m", "input": "x", "stream": True})
+    assert rejection.value.status_code == 400
+    assert "stream" in rejection.value.detail.message
+
+
+def test_embeddings_decoder_rejects_token_array_input() -> None:
+    """Pre-tokenized id arrays pass official validation but this text surface rejects them."""
+    with pytest.raises(OpenAIProtocolError) as rejection:
+        decode_embeddings({"model": "m", "input": [1, 2, 3]})
+    assert rejection.value.status_code == 400
+    assert "input" in (rejection.value.detail.param or "")
+
+
+def test_embeddings_decoder_rejects_empty_and_malformed_inputs() -> None:
+    """Empty strings, an empty array, a missing input, and bad options each fail with a param."""
+    cases: tuple[tuple[JsonObject, str], ...] = (
+        ({"model": "m", "input": ""}, "input"),
+        ({"model": "m", "input": []}, "input"),
+        ({"model": "m"}, "input"),
+        ({"model": "m", "input": "x", "dimensions": 0}, "dimensions"),
+        ({"model": "m", "input": "x", "encoding_format": "weird"}, "encoding_format"),
+    )
+    for payload, param in cases:
+        with pytest.raises(OpenAIProtocolError) as rejection:
+            decode_embeddings(payload)
+        assert rejection.value.status_code == 400
+        assert param in (rejection.value.detail.param or "")

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -269,6 +269,36 @@ class _ChatRequest(_WireModel):
         return self
 
 
+class _EmbeddingsRequest(_WireModel):
+    """Closed gateway embeddings request profile.
+
+    ``input`` narrows the official OpenAI union to text only: the token-array
+    forms (``list[int]`` / ``list[list[int]]``) pass official validation but
+    are rejected here with a field-specific 400, since this surface serves
+    visible text, not pre-tokenized ids.
+    """
+
+    model: str = Field(min_length=1, max_length=256)
+    input: str | tuple[str, ...]
+    dimensions: int | None = Field(default=None, gt=0)
+    encoding_format: Literal["float", "base64"] | None = None
+    user: str | None = Field(default=None, max_length=1024)
+
+    @field_validator("input")
+    @classmethod
+    def _require_nonempty_input(cls, value: str | tuple[str, ...]) -> str | tuple[str, ...]:
+        """Reject empty text, an empty array, or empty array members."""
+        if isinstance(value, str):
+            if not value:
+                raise ValueError("input must not be an empty string")
+            return value
+        if not value:
+            raise ValueError("input must not be an empty array")
+        if any(not text for text in value):
+            raise ValueError("input array must not contain empty strings")
+        return value
+
+
 class _ResponseTool(_WireModel):
     """Responses API function tool declaration."""
 


### PR DESCRIPTION
Second PR in the `/v1/embeddings` serving-surface series (dispatch design approved: Option B, Rust buffered data-plane path). Adds the request-decoding surface only — no dispatch/route wiring. Independent of PR1 (#718); disjoint files, no symbol dependency, based on `main`.

## What
- **`GatewayApiSurface.EMBEDDINGS`**. No exhaustive `match`/`assert_never` over the surface enum exists, so the new member is safe.
- **`EmbeddingsRequest`** — a PARALLEL canonical contract, deliberately not a mode of `GatewayRequest`. `GatewayRequest` hard-requires `messages(min_length=1)` and admission forces stream-only; embeddings are message-less and non-streaming, so reusing it would force a message-less exception or a stream-forced dispatch. This is the architectural fork the team approved.
- **`EMBEDDINGS_MANIFEST`** — closed compatibility manifest (`model`/`input`/`dimensions`/`encoding_format` SUPPORTED, `user` METADATA_ONLY). Any field outside it (e.g. `stream`) is a named 400, never silently dropped.
- **`_EmbeddingsRequest`** wire model — narrows the official OpenAI `input` union to text only; token-array forms (`list[int]`/`list[list[int]]`) pass official validation but are rejected here with a field-specific 400.
- **`decode_embeddings` + `DecodedEmbeddingsRequest`**, and a dedicated **`decode_native_embeddings_body`** entrypoint.

## Two decisions worth a look
1. **Dedicated native entrypoint, not a `decode_native_body` branch.** The checklist said "branch in native_decode.py"; I added a separate typed `decode_native_embeddings_body` (sharing a `_load_object_body` helper) instead of widening `decode_native_body`'s `DecodedGatewayRequest` return into a union. Keeps each return type precise (type invariance); PR3's `admit_embeddings` calls it directly.
2. **No idempotency threading.** Keyed replay is deferred (approved), so `decode_embeddings` takes no header args; an inbound `Idempotency-Key` is ignored upstream in PR3, never rejected.

## Testing
- Decode: string + list happy paths; unknown/streaming, token-array, empty-string, empty-array, missing-input, `dimensions=0`, bad-`encoding_format` rejections each with the right `param`.
- Contract: message-less defaults, pinned surface, empty-input rejection.
- Native entrypoint: happy path + invalid-JSON + non-object.
- `ruff`/`ty` clean; full gateway package regression green (692 passed, 3 DB-skipped).

Do not merge without team-lead go-ahead. No version bump (surface/decode only; the engine version + native bump happen in PR3, the dispatch PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)