### PR TITLE
release: bump version to 0.7.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.22"
+version = "0.7.23"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.22"
+version = "0.7.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bumps the package version from 0.7.22 to 0.7.23 (pyproject.toml + uv.lock, version line only).

Covers everything merged since the 0.7.22 bump (#719), currently #718 (raw embedding primitives with input-token usage).

Note: v0.7.22 was bumped in #719 but its GitHub release was never published, so PyPI is still at 0.7.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)