### PR TITLE
gateway: persistent-hydration fix — write-side digest guard + last-good serving [v0.7.22]

### DIFF
--- a/exp/runtime/gateway/alias_fallback.py
+++ b/exp/runtime/gateway/alias_fallback.py
@@ -1,0 +1,157 @@
+"""Last-good fallback loading for aliases whose active revision is unservable.
+
+Serving-path support for the persistent-hydration fix: when an alias's active
+revision pins an unservable snapshot (a missing file, or a same-version
+self-inconsistent digest), the pod loads the most recent PRIOR revision that is
+present and valid and serves it in place of a hard 503. The shared per-revision
+load and readiness helpers live in ``lifecycle``; this module reuses them so a
+prior revision is validated exactly like an active one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from exp.common.models import NormalizedGatewayCatalog
+from exp.runtime.gateway.contracts import ExecutionSnapshot
+from exp.runtime.gateway.management import GatewayAliasView, GatewayManagement
+from exp.runtime.gateway.project_activation import (
+    ProjectActivationError,
+    ProjectActivationRepository,
+    require_project_activation_authority,
+)
+from exp.runtime.models import ModelConnectionError, RuntimeModelCatalog
+from exp.runtime.models.credentials import ModelCredentialError
+from exp.runtime.router.errors import RouterApplicationError
+from exp.runtime.router.runtime import DecisionSink, RouterRuntime, RouterRuntimeIntegrityError
+
+# Bound on how many prior revisions the last-good fallback walks when an alias's
+# active revision pins an unservable snapshot. A dead pin's immediate
+# predecessor is almost always the good one; the cap bounds cold-start cost.
+FALLBACK_REVISION_WALK_LIMIT = 5
+
+
+@dataclass(frozen=True)
+class LoadedRevision:
+    """One fully loaded and readiness-proven alias revision awaiting registration."""
+
+    key: tuple[str, str]
+    normalized: NormalizedGatewayCatalog
+    runtime_catalog: RuntimeModelCatalog
+    proof: ExecutionSnapshot
+    activation: tuple[tuple[str, str, str], RouterRuntime] | None
+
+
+def load_alias_revision(
+    manager: GatewayManagement,
+    alias: GatewayAliasView,
+    *,
+    environment: Mapping[str, str] | None,
+    project_repository: ProjectActivationRepository | None,
+    decision_sink: DecisionSink | None,
+    exact_models: dict[tuple[str, str, str, str], str],
+) -> LoadedRevision:
+    """Load and prove readiness for one exact (alias, revision) view.
+
+    Shared by the last-good fallback so a prior revision is validated through the
+    same snapshot load and provider-idle readiness as an active one. Raises the
+    same failures the active-revision loop already handles, so a caller can walk
+    candidates and keep the first that loads.
+
+    Raises:
+        GatewayLifecycleError: The snapshot is unservable or the route is invalid.
+        ModelConnectionError, ModelCredentialError, ProjectActivationError,
+        RouterApplicationError, RouterRuntimeIntegrityError: Provider or project
+            readiness could not be proven.
+    """
+    # Imported lazily to avoid a module import cycle: ``lifecycle`` imports this
+    # module's fallback entry point, and these per-revision helpers live there.
+    from exp.runtime.gateway.lifecycle import (
+        GatewayLifecycleError,
+        _direct_readiness,
+        _load_snapshot,
+        _project_readiness,
+        _required,
+        _required_revision,
+    )
+
+    revision_id, catalog_sha256 = _required_revision(alias)
+    catalog, normalized = _load_snapshot(manager, alias)
+    key = (revision_id, catalog_sha256)
+    runtime_catalog = RuntimeModelCatalog(catalog, environment=environment)
+    if alias.target_kind == "direct":
+        proof = _direct_readiness(manager, alias, normalized, runtime_catalog)
+        return LoadedRevision(key, normalized, runtime_catalog, proof, None)
+    if alias.target_kind != "project":
+        raise GatewayLifecycleError(f"alias {alias.alias_name!r} has an unknown target kind")
+    if project_repository is None:
+        raise GatewayLifecycleError(
+            f"alias {alias.alias_name!r} project alias requires a project activation repository"
+        )
+    project_ref = _required(alias.project_ref, "project reference", alias)
+    activation_ref = _required(alias.activation_ref, "activation reference", alias)
+    activation = project_repository.load(
+        project_ref, activation_ref, runtime_catalog=runtime_catalog
+    )
+    try:
+        require_project_activation_authority(
+            activation, project_ref=project_ref, activation_ref=activation_ref
+        )
+    except ProjectActivationError as exc:
+        raise GatewayLifecycleError(str(exc)) from exc
+    runtime = RouterRuntime.from_activation(
+        activation, runtime_catalog, decision_sink=decision_sink
+    )
+    proof = _project_readiness(
+        manager, alias, normalized, runtime, runtime_catalog, exact_models=exact_models
+    )
+    return LoadedRevision(
+        key,
+        normalized,
+        runtime_catalog,
+        proof,
+        ((project_ref, activation_ref, catalog_sha256), runtime),
+    )
+
+
+def load_last_good_fallback(
+    manager: GatewayManagement,
+    alias: GatewayAliasView,
+    *,
+    environment: Mapping[str, str] | None,
+    project_repository: ProjectActivationRepository | None,
+    decision_sink: DecisionSink | None,
+    exact_models: dict[tuple[str, str, str, str], str],
+) -> LoadedRevision | None:
+    """Return the newest prior revision that loads and proves ready, or ``None``.
+
+    Walks the alias's prior revisions newest-first (bounded by
+    ``FALLBACK_REVISION_WALK_LIMIT``) and returns the first one whose snapshot is
+    present, matches its own pinned digest, and passes readiness. Topology-
+    agnostic: a prior revision whose snapshot file is not on this node simply
+    fails to load and is skipped; when none load the caller degrades the alias to
+    a retryable-unavailable, never a permanent hard-fail.
+    """
+    from exp.runtime.gateway.lifecycle import GatewayLifecycleError
+
+    for prior in manager.prior_alias_revisions(alias, limit=FALLBACK_REVISION_WALK_LIMIT):
+        try:
+            return load_alias_revision(
+                manager,
+                prior,
+                environment=environment,
+                project_repository=project_repository,
+                decision_sink=decision_sink,
+                exact_models=exact_models,
+            )
+        except (
+            GatewayLifecycleError,
+            ModelConnectionError,
+            ModelCredentialError,
+            ProjectActivationError,
+            RouterApplicationError,
+            RouterRuntimeIntegrityError,
+        ):
+            continue
+    return None

--- a/exp/runtime/gateway/catalog_authority.py
+++ b/exp/runtime/gateway/catalog_authority.py
@@ -577,8 +577,15 @@ def _write_catalog_snapshot(
         # so new alias revisions bind the current provider authority.
         write_bytes_atomic(authored, authored_bytes, follow_symlinks=False)
         os.chmod(authored, 0o600)
-    if not snapshot.exists():
-        write_bytes_atomic(snapshot, canonical_json_bytes(normalized), follow_symlinks=False)
+    normalized_bytes = canonical_json_bytes(normalized)
+    if not snapshot.exists() or snapshot.read_bytes() != normalized_bytes:
+        # Content-addressed, but never trust a pre-existing file blindly: a
+        # stale or partially written `<sha>.json` (a crash between the atomic
+        # temp write and its rename, a restored backup) whose bytes no longer
+        # hash to its own name would otherwise be pinned as a self-inconsistent
+        # snapshot and 503 every alias on it. Rewrite whenever the on-disk bytes
+        # differ, exactly as the authored companion above already does.
+        write_bytes_atomic(snapshot, normalized_bytes, follow_symlinks=False)
         os.chmod(snapshot, 0o600)
     return snapshot
 

--- a/exp/runtime/gateway/catalog_authority_test.py
+++ b/exp/runtime/gateway/catalog_authority_test.py
@@ -21,9 +21,11 @@ from exp.common.models import (
     ModelCatalog,
     ModelRecord,
     ModelRoles,
+    normalize_gateway_catalog,
     write_model_catalog,
 )
 from exp.runtime.gateway.catalog_authority import (
+    _write_catalog_snapshot,
     authored_snapshot_path,
     upsert_singleton_deployment,
 )
@@ -89,6 +91,35 @@ def test_rejected_singleton_deployment_leaves_the_authored_catalog_unchanged(
         )
 
     assert path.read_bytes() == before
+
+
+def test_write_catalog_snapshot_repairs_a_stale_content_addressed_file(tmp_path: Path) -> None:
+    """C1 root-cause fix: a normalized snapshot whose on-disk bytes no longer hash
+    to their own content-addressed name (a stale or partially written file) is
+    rewritten instead of blindly trusted, so a self-inconsistent snapshot can
+    never be pinned by this write path."""
+    catalog = ModelCatalog(
+        connections={"openai": ConnectionConfig(provider="openai")},
+        models={
+            "m": ModelRecord(
+                connection="openai",
+                model="gpt-test",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+            )
+        },
+    )
+    normalized = normalize_gateway_catalog(catalog)
+
+    snapshot = _write_catalog_snapshot(tmp_path, catalog, normalized)
+    assert sha256(snapshot.read_bytes()).hexdigest() == normalized.identity_sha256()
+
+    # A stale/corrupt file already sitting at the content-addressed path.
+    snapshot.write_bytes(b'{"stale": true}')
+    repaired = _write_catalog_snapshot(tmp_path, catalog, normalized)
+
+    assert repaired == snapshot
+    # The bytes on disk once again hash to their own content-addressed name.
+    assert sha256(snapshot.read_bytes()).hexdigest() == normalized.identity_sha256()
 
 
 def test_valid_singleton_deployment_still_persists_after_validation(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -7,7 +7,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 from typing import cast
@@ -30,6 +30,7 @@ from exp.runtime.gateway.contracts import (
     ExecutionSnapshot,
     GatewayApiSurface,
     GatewayRequest,
+    GatewayTarget,
     ProjectTarget,
 )
 from exp.runtime.gateway.group_commit import GroupCommitAttemptLedger
@@ -64,6 +65,20 @@ class GatewayLifecycleError(ValueError):
 
 
 @dataclass(frozen=True)
+class _ServedFallback:
+    """A last-good prior revision served in place of a dead active revision.
+
+    When an alias's active revision pins an unservable snapshot, admission
+    re-keys the request to this prior revision so routing, attribution, and
+    prices all follow the revision actually served.
+    """
+
+    alias_revision_id: str
+    catalog_sha256: str
+    target: GatewayTarget
+
+
+@dataclass(frozen=True)
 class _AliasAuthorityState:
     """One fully validated generation of granted alias serving authority."""
 
@@ -75,6 +90,9 @@ class _AliasAuthorityState:
     listing_pools: Mapping[tuple[str, str, str], str]
     proof: ExecutionSnapshot
     unavailable_aliases: tuple[tuple[str, str], ...] = ()
+    # Dead active revision_id -> the last-good prior revision serving it. Empty
+    # unless an alias's active pinned snapshot was unservable at load.
+    fallback_revisions: Mapping[str, _ServedFallback] = field(default_factory=dict)
 
 
 class _AliasAuthorityReloader:
@@ -201,6 +219,7 @@ class _AliasAuthorityReloader:
             listing_pools=listing_pools,
             proof=loaded.proof,
             unavailable_aliases=loaded.unavailable_aliases,
+            fallback_revisions=loaded.fallback_revisions,
         )
         self._routes.swap_catalogs(
             normalized,
@@ -233,6 +252,57 @@ def _revision_served(
     return key in state.normalized_catalogs and key in state.runtime_catalogs
 
 
+def _served_triple(
+    state: _AliasAuthorityState,
+    triple: tuple[str, str, str],
+) -> tuple[str, str, str] | None:
+    """Return the served authority triple for one granted active triple, or None.
+
+    The granted triple names the alias's active revision. When that revision is
+    served it is returned verbatim; when it pins an unservable snapshot its
+    last-good fallback triple is returned; otherwise ``None``.
+    """
+    if triple in state.authorities:
+        return triple
+    alias, active_revision_id, _digest = triple
+    fallback = state.fallback_revisions.get(active_revision_id)
+    if fallback is None:
+        return None
+    return (alias, fallback.alias_revision_id, fallback.catalog_sha256)
+
+
+def _serve_or_fallback(
+    state: _AliasAuthorityState,
+    authorization: AuthorizationSnapshot,
+) -> AuthorizationSnapshot | None:
+    """Return an authorization this generation can serve, or ``None``.
+
+    A revision loaded directly is served verbatim. An active revision whose
+    pinned snapshot was unservable at load is re-keyed to the last-good prior
+    revision loaded in its place, so routing, the ledger, and prices all follow
+    the revision actually served. Returns ``None`` when neither applies (genuine
+    drift, or an alias with no loadable revision at all), so the caller reloads
+    once and, failing that, degrades to a retryable unavailable.
+    """
+    authority = (
+        authorization.alias,
+        authorization.alias_revision_id,
+        authorization.catalog_sha256,
+    )
+    if authority in state.authorities or _revision_served(state, authorization):
+        return authorization
+    fallback = state.fallback_revisions.get(authorization.alias_revision_id)
+    if fallback is None:
+        return None
+    return authorization.model_copy(
+        update={
+            "alias_revision_id": fallback.alias_revision_id,
+            "catalog_sha256": fallback.catalog_sha256,
+            "target": fallback.target,
+        }
+    )
+
+
 @dataclass(frozen=True)
 class _ReadyControlStore:
     """Filter public authority through the current hot-reloadable ready generation."""
@@ -255,16 +325,24 @@ class _ReadyControlStore:
         )
 
     def granted_alias_authorities(self, *, raw_key: str) -> tuple[tuple[str, str, str], ...]:
-        """Return granted authority triples whose active revision is currently served."""
+        """Return the served authority triple for each granted alias.
+
+        An alias served on its active revision returns that triple; one whose
+        active revision pins an unservable snapshot returns its last-good
+        fallback triple, so a dead-pinned alias still lists and serves under the
+        revision actually served rather than disappearing from the catalog.
+        """
         granted = tuple(self.store.granted_alias_authorities(raw_key=raw_key))
         state = self.reloader.state
-        drifted = next((item for item in granted if item not in state.authorities), None)
+        drifted = next((item for item in granted if _served_triple(state, item) is None), None)
         if drifted is not None:
             try:
                 state = self.reloader.refresh_if_drifted(drifted)
             except GatewayRoutingError:
                 state = self.reloader.state
-        return tuple(item for item in granted if item in state.authorities)
+        return tuple(
+            served for item in granted if (served := _served_triple(state, item)) is not None
+        )
 
     def authorize_request(
         self,
@@ -290,17 +368,22 @@ class _ReadyControlStore:
             app_referer=app_referer,
             app_title=app_title,
         )
+        served = _serve_or_fallback(self.reloader.state, authorization)
+        if served is not None:
+            return served
+        # The SQLite authority names a revision this generation has not loaded
+        # (a concurrent activation, or an active revision whose snapshot was
+        # unservable at load); reload once and re-resolve, including last-good.
         authority = (
             authorization.alias,
             authorization.alias_revision_id,
             authorization.catalog_sha256,
         )
-        state = self.reloader.state
-        if authority not in state.authorities and not _revision_served(state, authorization):
-            state = self.reloader.refresh_if_drifted(authority)
-        if authority not in state.authorities and not _revision_served(state, authorization):
-            raise GatewayRoutingError("authorized alias revision is unavailable in this process")
-        return authorization
+        state = self.reloader.refresh_if_drifted(authority)
+        served = _serve_or_fallback(state, authorization)
+        if served is not None:
+            return served
+        raise GatewayRoutingError("authorized alias revision is unavailable in this process")
 
 
 @contextmanager
@@ -505,13 +588,51 @@ def _load_alias_state(
     readiness: list[ExecutionSnapshot] = []
     unavailable_aliases: list[tuple[str, str]] = []
     missing_credential_variables: set[str] = set()
+    fallback_revisions: dict[str, _ServedFallback] = {}
 
     for alias in aliases:
         try:
             revision_id, catalog_sha256 = _required_revision(alias)
             catalog, normalized = _load_snapshot(manager, alias)
         except GatewayLifecycleError as exc:
-            unavailable_aliases.append((alias.alias_name, str(exc)))
+            # The alias's active revision pins an unservable snapshot (parse
+            # failure or a same-version self-inconsistent digest). Serve the most
+            # recent prior revision that loads instead of 503-ing the alias, and
+            # record the re-key so admission attributes to the revision served.
+            # Imported here to avoid a module import cycle with the fallback
+            # loader, which reuses this module's per-revision helpers.
+            from exp.runtime.gateway.alias_fallback import load_last_good_fallback
+
+            fallback = load_last_good_fallback(
+                manager,
+                alias,
+                environment=environment,
+                project_repository=project_repository,
+                decision_sink=decision_sink,
+                exact_models=exact_models,
+            )
+            if fallback is None:
+                unavailable_aliases.append((alias.alias_name, str(exc)))
+                continue
+            normalized_catalogs[fallback.key] = fallback.normalized
+            runtime_catalogs[fallback.key] = fallback.runtime_catalog
+            if fallback.activation is not None:
+                activations[fallback.activation[0]] = fallback.activation[1]
+            readiness.append(fallback.proof)
+            served = fallback.proof.authorization
+            if alias.revision_id is not None:
+                fallback_revisions[alias.revision_id] = _ServedFallback(
+                    alias_revision_id=served.alias_revision_id,
+                    catalog_sha256=served.catalog_sha256,
+                    target=served.target,
+                )
+            _logger.warning(
+                "gateway alias %r active revision pins an unservable snapshot (%s); "
+                "serving last-good prior revision %r",
+                alias.alias_name,
+                exc,
+                served.alias_revision_id,
+            )
             continue
         key = (revision_id, catalog_sha256)
         runtime_catalog = RuntimeModelCatalog(catalog, environment=environment)
@@ -613,6 +734,7 @@ def _load_alias_state(
         },
         proof=readiness[0],
         unavailable_aliases=tuple(sorted(unavailable_aliases)),
+        fallback_revisions=fallback_revisions,
     )
 
 

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -90,9 +90,11 @@ class _AliasAuthorityState:
     listing_pools: Mapping[tuple[str, str, str], str]
     proof: ExecutionSnapshot
     unavailable_aliases: tuple[tuple[str, str], ...] = ()
-    # Dead active revision_id -> the last-good prior revision serving it. Empty
-    # unless an alias's active pinned snapshot was unservable at load.
-    fallback_revisions: Mapping[str, _ServedFallback] = field(default_factory=dict)
+    # (alias, dead active revision_id) -> the last-good prior revision serving
+    # it. Keyed by alias too (not the revision id alone) so a shared revision id
+    # can never route one alias's request to another alias's fallback target.
+    # Empty unless an alias's active pinned snapshot was unservable at load.
+    fallback_revisions: Mapping[tuple[str, str], _ServedFallback] = field(default_factory=dict)
 
 
 class _AliasAuthorityReloader:
@@ -265,7 +267,7 @@ def _served_triple(
     if triple in state.authorities:
         return triple
     alias, active_revision_id, _digest = triple
-    fallback = state.fallback_revisions.get(active_revision_id)
+    fallback = state.fallback_revisions.get((alias, active_revision_id))
     if fallback is None:
         return None
     return (alias, fallback.alias_revision_id, fallback.catalog_sha256)
@@ -291,7 +293,7 @@ def _serve_or_fallback(
     )
     if authority in state.authorities or _revision_served(state, authorization):
         return authorization
-    fallback = state.fallback_revisions.get(authorization.alias_revision_id)
+    fallback = state.fallback_revisions.get((authorization.alias, authorization.alias_revision_id))
     if fallback is None:
         return None
     return authorization.model_copy(
@@ -588,7 +590,7 @@ def _load_alias_state(
     readiness: list[ExecutionSnapshot] = []
     unavailable_aliases: list[tuple[str, str]] = []
     missing_credential_variables: set[str] = set()
-    fallback_revisions: dict[str, _ServedFallback] = {}
+    fallback_revisions: dict[tuple[str, str], _ServedFallback] = {}
 
     for alias in aliases:
         try:
@@ -621,7 +623,7 @@ def _load_alias_state(
             readiness.append(fallback.proof)
             served = fallback.proof.authorization
             if alias.revision_id is not None:
-                fallback_revisions[alias.revision_id] = _ServedFallback(
+                fallback_revisions[(alias.alias_name, alias.revision_id)] = _ServedFallback(
                     alias_revision_id=served.alias_revision_id,
                     catalog_sha256=served.catalog_sha256,
                     target=served.target,

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -36,10 +36,20 @@ from exp.runtime.gateway.catalog_authority import (
     upsert_connection,
     upsert_singleton_deployment,
 )
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+)
 from exp.runtime.gateway.lifecycle import (
     GatewayLifecycleError,
     LocalGatewayComponents,
+    _AliasAuthorityState,
     _ReadyControlStore,
+    _serve_or_fallback,
+    _served_triple,
+    _ServedFallback,
     gateway_instance_lock,
     load_gateway_components,
 )
@@ -563,6 +573,65 @@ def test_invalid_new_revision_serves_last_good_and_recovers_after_fix(tmp_path: 
 
     assert _granted_authorities(components, raw_key) == {"coding": "revision-repaired"}
     assert _authorize(components, raw_key, "coding") == "revision-repaired"
+
+
+def _fallback_auth(alias: str, revision: str, digest: str) -> AuthorizationSnapshot:
+    """One minimal authorization snapshot for the fallback-scoping unit test."""
+    return AuthorizationSnapshot(
+        request_id="req",
+        organization_id="org",
+        identity_id="id",
+        virtual_key_id="key",
+        alias=alias,
+        alias_revision_id=revision,
+        target=DirectTarget(pool_id="pool"),
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        catalog_sha256=digest,
+        canonical_request_sha256="c" * 64,
+        refusal_failover=False,
+        deadline_monotonic=1.0,
+    )
+
+
+def test_fallback_lookup_is_alias_scoped_not_revision_id_only() -> None:
+    """A fallback recorded for one alias is never returned for a different alias
+    that happens to share the active revision id — the fallback map is keyed by
+    (alias, revision), so it cannot cross an alias authorization boundary."""
+    shared_revision = "revision-shared"
+    fallback = _ServedFallback(
+        alias_revision_id="revision-a-prior",
+        catalog_sha256="d" * 64,
+        target=DirectTarget(pool_id="pool-a-prior"),
+    )
+    proof = ExecutionSnapshot(
+        authorization=_fallback_auth("alias-a", "revision-a-prior", "d" * 64),
+        exact_model_id="exact-a",
+        pool_id="pool-a-prior",
+        deployment_ids=("deployment-a",),
+    )
+    state = _AliasAuthorityState(
+        authorities=frozenset(),
+        normalized_catalogs={},
+        runtime_catalogs={},
+        activations={},
+        exact_models={},
+        listing_pools={},
+        proof=proof,
+        fallback_revisions={("alias-a", shared_revision): fallback},
+    )
+
+    # alias-a with the shared revision id resolves to its own fallback...
+    served_a = _serve_or_fallback(state, _fallback_auth("alias-a", shared_revision, "e" * 64))
+    assert served_a is not None
+    assert served_a.alias_revision_id == "revision-a-prior"
+    assert _served_triple(state, ("alias-a", shared_revision, "e" * 64)) == (
+        "alias-a",
+        "revision-a-prior",
+        "d" * 64,
+    )
+    # ...but alias-b with the SAME revision id gets nothing (no cross-alias leak).
+    assert _serve_or_fallback(state, _fallback_auth("alias-b", shared_revision, "e" * 64)) is None
+    assert _served_triple(state, ("alias-b", shared_revision, "e" * 64)) is None
 
 
 def test_cold_start_clears_a_dead_active_pin_via_last_good(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -466,9 +466,13 @@ def test_unrelated_invalid_snapshot_does_not_block_a_valid_alias_reload(tmp_path
         catalog_sha256=normalized.identity_sha256(),
     )
 
-    assert _granted_authorities(components, raw_key) == {"coding": "revision-two"}
-    with pytest.raises(GatewayRoutingError):
-        _authorize(components, raw_key, "sibling")
+    # The broken sibling revision never blocks coding's reload, and the sibling
+    # itself degrades to its last-good prior revision instead of going dark.
+    assert _granted_authorities(components, raw_key) == {
+        "coding": "revision-two",
+        "sibling": "revision-sibling",
+    }
+    assert _authorize(components, raw_key, "sibling") == "revision-sibling"
 
 
 class _FailingProjectRepository:
@@ -522,8 +526,11 @@ def test_broken_project_sibling_does_not_block_a_valid_alias_reload(tmp_path: Pa
         _authorize(components, raw_key, "router")
 
 
-def test_invalid_new_revision_fails_closed_and_recovers_after_fix(tmp_path: Path) -> None:
-    """An unloadable new revision keeps fail-closed behavior and recovers in place."""
+def test_invalid_new_revision_serves_last_good_and_recovers_after_fix(tmp_path: Path) -> None:
+    """An unloadable new revision serves the last-good prior revision, not a 503,
+    and adopts a repaired revision in place. This is the persistent-hydration
+    fix: a live alias whose active revision pins a dead snapshot degrades to its
+    most recent good revision instead of going dark."""
     manager, raw_key = _configured_gateway(tmp_path)
     components = load_gateway_components(
         tmp_path,
@@ -540,9 +547,10 @@ def test_invalid_new_revision_fails_closed_and_recovers_after_fix(tmp_path: Path
         catalog_sha256="a" * 64,
     )
 
-    assert _granted_authorities(components, raw_key) == {}
-    with pytest.raises(GatewayRoutingError):
-        _authorize(components, raw_key, "coding")
+    # The active (broken) revision is unservable, so the alias is served and
+    # listed on its last-good prior revision, attributed to what was served.
+    assert _granted_authorities(components, raw_key) == {"coding": "revision-one"}
+    assert _authorize(components, raw_key, "coding") == "revision-one"
 
     manager.activate_direct_alias(
         alias_id="coding",
@@ -555,6 +563,57 @@ def test_invalid_new_revision_fails_closed_and_recovers_after_fix(tmp_path: Path
 
     assert _granted_authorities(components, raw_key) == {"coding": "revision-repaired"}
     assert _authorize(components, raw_key, "coding") == "revision-repaired"
+
+
+def test_cold_start_clears_a_dead_active_pin_via_last_good(tmp_path: Path) -> None:
+    """A FRESH pod whose alias active revision pins an unservable snapshot serves
+    and lists it on the last-good prior revision at startup — the persistent
+    dead-pin case cleared automatically on a fresh-image deploy (no reload, no
+    in-memory retention involved)."""
+    manager, raw_key = _configured_gateway(tmp_path)
+    manager.activate_direct_alias(
+        alias_id="coding",
+        alias_name="coding",
+        revision_id="revision-dead",
+        pool_id="coding",
+        snapshot_ref="catalog-snapshots/missing.json",
+        catalog_sha256="a" * 64,
+    )
+
+    # A brand-new process loads with the dead pin already active.
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "available"},
+    )
+
+    assert _granted_authorities(components, raw_key) == {"coding": "revision-one"}
+    assert _authorize(components, raw_key, "coding") == "revision-one"
+    assert components.unavailable_aliases == ()
+
+
+def test_dead_pin_with_no_loadable_prior_stays_retryable_unavailable(tmp_path: Path) -> None:
+    """An alias whose only revision pins an unservable snapshot (no prior to fall
+    back to) degrades to a retryable-unavailable routing error, never a permanent
+    hard-fail, and does not block a healthy sibling."""
+    manager, raw_key = _configured_gateway(tmp_path)
+    manager.activate_direct_alias(
+        alias_id="orphan",
+        alias_name="orphan",
+        revision_id="orphan-dead",
+        pool_id="orphan",
+        snapshot_ref="catalog-snapshots/missing.json",
+        catalog_sha256="a" * 64,
+    )
+    manager.add_grant(identity_id="default", alias_id="orphan")
+
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "available"},
+    )
+
+    assert _granted_authorities(components, raw_key) == {"coding": "revision-one"}
+    with pytest.raises(GatewayRoutingError):
+        _authorize(components, raw_key, "orphan")
 
 
 def test_concurrent_authorization_survives_pool_recertification_hot_swap(

--- a/exp/runtime/gateway/management.py
+++ b/exp/runtime/gateway/management.py
@@ -594,6 +594,56 @@ class GatewayManagement:
             for row in rows
         )
 
+    def prior_alias_revisions(
+        self, alias: GatewayAliasView, *, limit: int
+    ) -> tuple[GatewayAliasView, ...]:
+        """Return an alias's non-active revisions, newest first, as servable views.
+
+        Used only as a last-good fallback: when an alias's active revision pins an
+        unservable snapshot, the pod walks these newest-first to serve the most
+        recent prior revision whose snapshot is present and valid. Each view keeps
+        the alias identity but carries that prior revision's pinned target and
+        snapshot, so serving and attribution follow the revision actually served.
+
+        Args:
+            alias: The active alias view whose pinned revision is unservable.
+            limit: Maximum number of prior revisions to return (bounds the walk).
+
+        Returns:
+            Prior revision views ordered newest revision first, excluding the
+            active revision; empty when the alias has no prior revisions.
+        """
+        if not self.initialized or alias.revision_id is None:
+            return ()
+        rows = self._rows(
+            f"""
+            SELECT r.revision_id, r.target_kind, r.pool_id, r.project_ref,
+                   r.activation_ref, r.snapshot_ref, r.catalog_sha256, r.refusal_failover
+            FROM alias_revisions AS r
+            WHERE r.organization_id = ? AND r.alias_id = ? AND r.revision_id != ?
+            ORDER BY r.revision_number DESC
+            LIMIT {int(limit)}
+            """,
+            (self.organization_id, alias.alias_id, alias.revision_id),
+        )
+        return tuple(
+            alias.model_copy(
+                update={
+                    "revision_id": str(row["revision_id"]),
+                    "target_kind": str(row["target_kind"]),
+                    "pool_id": None if row["pool_id"] is None else str(row["pool_id"]),
+                    "project_ref": None if row["project_ref"] is None else str(row["project_ref"]),
+                    "activation_ref": (
+                        None if row["activation_ref"] is None else str(row["activation_ref"])
+                    ),
+                    "snapshot_ref": str(row["snapshot_ref"]),
+                    "catalog_sha256": str(row["catalog_sha256"]),
+                    "refusal_failover": bool(row["refusal_failover"]),
+                }
+            )
+            for row in rows
+        )
+
     def activate_direct_alias(
         self,
         *,

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3056,6 +3056,39 @@ def test_responses_continuation_round_trip_and_fail_closed(tmp_path: Path) -> No
     assert crossed.value.detail.code == "previous_response_not_found"
 
 
+def test_fallback_served_alias_continuation_degrades_to_resend_not_503(tmp_path: Path) -> None:
+    """A continuation on an alias served via its last-good fallback still fails
+    with the 400 'resend the full conversation' error when it cannot resolve —
+    never a 503. The fallback re-key is upstream of continuation binding, so it
+    adds no 5xx path; a fresh request on the same alias serves via the fallback.
+    """
+    control, raw_key = _control_plane(tmp_path)
+    # Dead-pin the active revision so the alias is served on its last-good prior.
+    manager = GatewayManagement(tmp_path)
+    manager.activate_direct_alias(
+        alias_id="coding",
+        alias_name="coding",
+        revision_id="revision-dead",
+        pool_id="coding",
+        snapshot_ref="catalog-snapshots/missing.json",
+        catalog_sha256="a" * 64,
+    )
+
+    # A fresh (non-continuation) Responses request still serves via the fallback.
+    served = _admit_responses(control, raw_key, _responses_body())
+    assert served["request_id"]
+
+    # A continuation whose previous_response_id cannot resolve returns the shared
+    # 400 resend error, not a 503 — confirming the re-key never turns an
+    # unresolvable continuation into a server error.
+    with pytest.raises(NativeBridgeError) as rejected:
+        _admit_responses(control, raw_key, _responses_body(previous_response_id="resp_missing"))
+    payload = json.loads(rejected.value.public_error_json)
+    assert payload["status_code"] == 400
+    assert payload["code"] == "previous_response_not_found"
+    assert payload["param"] == "previous_response_id"
+
+
 def test_responses_tool_call_retention_survives_continuation(tmp_path: Path) -> None:
     """Completed tool calls are retained and replayed into continued history."""
     control, raw_key = _control_plane(tmp_path)

--- a/exp/runtime/gateway/snapshot_integrity.py
+++ b/exp/runtime/gateway/snapshot_integrity.py
@@ -1,0 +1,63 @@
+"""Write-side guard that refuses to pin a self-inconsistent catalog snapshot.
+
+Root-cause prevention for the persistent-hydration incident: an alias revision
+must never pin a normalized snapshot whose stored content does not hash to its
+pinned digest, because a same-version mismatch is unservable and 503s every
+alias on it. This verifies content against digest at the activation seam.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from exp.common.models.gateway_catalog import read_pinned_normalized_snapshot
+
+_logger = logging.getLogger(__name__)
+
+
+def refuse_self_inconsistent_snapshot(
+    state_dir: Path, snapshot_ref: str, catalog_sha256: str
+) -> None:
+    """Refuse to pin a snapshot whose stored content does not match its digest.
+
+    When the ``<sha>.json`` file is present under ``state_dir``, its bytes must
+    parse and hash to ``catalog_sha256`` (a cross-version snapshot is tolerated
+    exactly as the serving reader tolerates it); a same-version mismatch or a
+    malformed file fails the activation loudly so a self-inconsistent snapshot
+    never becomes an alias authority. When the file is not local (a pin whose
+    content lives on another node), it cannot be verified here, so this flags and
+    proceeds rather than blocking a legitimate activation.
+
+    Args:
+        state_dir: The gateway state directory the reference is relative to.
+        snapshot_ref: Relative reference to the stored normalized snapshot.
+        catalog_sha256: The digest the activation is about to pin for it.
+
+    Raises:
+        ValueError: The reference escapes gateway state, or a locally present
+            snapshot's content does not match its pinned digest.
+    """
+    root = state_dir.resolve()
+    snapshot_path = (root / snapshot_ref).resolve()
+    if not snapshot_path.is_relative_to(root):
+        raise ValueError("catalog snapshot reference escapes gateway state")
+    try:
+        data = snapshot_path.read_bytes()
+    except OSError:
+        _logger.warning(
+            "gateway snapshot content unverifiable at activation: the pinned "
+            "snapshot file is not present on this node; pinning without a content check"
+        )
+        return
+    try:
+        read_pinned_normalized_snapshot(data, catalog_sha256)
+    except ValueError as exc:
+        _logger.error(
+            "gateway refused a self-inconsistent catalog snapshot at activation: "
+            "stored content does not match its pinned digest (%s)",
+            type(exc).__name__,
+        )
+        raise ValueError(
+            "catalog snapshot content does not match its pinned digest; refusing to pin"
+        ) from exc

--- a/exp/runtime/gateway/snapshot_integrity.py
+++ b/exp/runtime/gateway/snapshot_integrity.py
@@ -41,12 +41,23 @@ def refuse_self_inconsistent_snapshot(
             digest.
     """
     root = state_dir.resolve()
-    snapshot_path = (root / snapshot_ref).resolve()
+    reference_path = root / snapshot_ref
+    snapshot_path = reference_path.resolve()
     if not snapshot_path.is_relative_to(root):
         raise ValueError("catalog snapshot reference escapes gateway state")
     try:
         data = snapshot_path.read_bytes()
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
+        # A broken symlink (or any dangling entry) at the reference is a PRESENT
+        # local filesystem object, not a genuine absence: it fails closed like an
+        # unreadable file rather than being waved through as a remote-node pin.
+        if reference_path.is_symlink():
+            _logger.error(
+                "gateway refused a catalog snapshot reference that is a broken symlink"
+            )
+            raise ValueError(
+                "catalog snapshot path is a broken symlink; refusing to pin"
+            ) from exc
         # Genuinely absent: a pin whose content lives on another node. It cannot
         # be verified here, so flag and proceed rather than block a legitimate
         # cross-node activation (topology-agnostic).

--- a/exp/runtime/gateway/snapshot_integrity.py
+++ b/exp/runtime/gateway/snapshot_integrity.py
@@ -23,11 +23,12 @@ def refuse_self_inconsistent_snapshot(
 
     When the ``<sha>.json`` file is present under ``state_dir``, its bytes must
     parse and hash to ``catalog_sha256`` (a cross-version snapshot is tolerated
-    exactly as the serving reader tolerates it); a same-version mismatch or a
-    malformed file fails the activation loudly so a self-inconsistent snapshot
-    never becomes an alias authority. When the file is not local (a pin whose
-    content lives on another node), it cannot be verified here, so this flags and
-    proceeds rather than blocking a legitimate activation.
+    exactly as the serving reader tolerates it); a same-version mismatch, a
+    malformed file, or a present-but-unreadable file fails the activation loudly
+    so a self-inconsistent (or unverifiable) snapshot never becomes an alias
+    authority. Only a genuinely ABSENT file (a pin whose content lives on another
+    node) cannot be verified here, so that case flags and proceeds rather than
+    blocking a legitimate cross-node activation.
 
     Args:
         state_dir: The gateway state directory the reference is relative to.
@@ -36,7 +37,8 @@ def refuse_self_inconsistent_snapshot(
 
     Raises:
         ValueError: The reference escapes gateway state, or a locally present
-            snapshot's content does not match its pinned digest.
+            snapshot is unreadable or its content does not match its pinned
+            digest.
     """
     root = state_dir.resolve()
     snapshot_path = (root / snapshot_ref).resolve()
@@ -44,12 +46,24 @@ def refuse_self_inconsistent_snapshot(
         raise ValueError("catalog snapshot reference escapes gateway state")
     try:
         data = snapshot_path.read_bytes()
-    except OSError:
+    except FileNotFoundError:
+        # Genuinely absent: a pin whose content lives on another node. It cannot
+        # be verified here, so flag and proceed rather than block a legitimate
+        # cross-node activation (topology-agnostic).
         _logger.warning(
             "gateway snapshot content unverifiable at activation: the pinned "
             "snapshot file is not present on this node; pinning without a content check"
         )
         return
+    except OSError as exc:
+        # Present but unreadable (a permission or partial/corrupt-write fault):
+        # NOT the remote-node topology case, so fail the activation closed rather
+        # than pin a snapshot whose content was never verified.
+        _logger.error(
+            "gateway refused an unreadable local catalog snapshot at activation (%s)",
+            type(exc).__name__,
+        )
+        raise ValueError("catalog snapshot is present but unreadable; refusing to pin") from exc
     try:
         read_pinned_normalized_snapshot(data, catalog_sha256)
     except ValueError as exc:

--- a/exp/runtime/gateway/snapshot_integrity.py
+++ b/exp/runtime/gateway/snapshot_integrity.py
@@ -16,6 +16,26 @@ from exp.common.models.gateway_catalog import read_pinned_normalized_snapshot
 _logger = logging.getLogger(__name__)
 
 
+def _has_symlink_component(root: Path, reference: Path) -> bool:
+    """Whether any path component from ``root`` up to ``reference`` is a symlink.
+
+    A symlink anywhere on the reference path (the file itself or any parent
+    directory) makes a read failure a present-but-unusable local entry rather
+    than a genuine remote-node absence, so the caller must fail closed.
+    """
+    current = reference
+    while current != root:
+        if current.is_symlink():
+            return True
+        parent = current.parent
+        if parent == current:
+            # Reached the filesystem root without meeting ``root``: treat as
+            # suspect rather than a clean absence.
+            return True
+        current = parent
+    return False
+
+
 def refuse_self_inconsistent_snapshot(
     state_dir: Path, snapshot_ref: str, catalog_sha256: str
 ) -> None:
@@ -47,34 +67,31 @@ def refuse_self_inconsistent_snapshot(
         raise ValueError("catalog snapshot reference escapes gateway state")
     try:
         data = snapshot_path.read_bytes()
-    except FileNotFoundError as exc:
-        # A broken symlink (or any dangling entry) at the reference is a PRESENT
-        # local filesystem object, not a genuine absence: it fails closed like an
-        # unreadable file rather than being waved through as a remote-node pin.
-        if reference_path.is_symlink():
-            _logger.error(
-                "gateway refused a catalog snapshot reference that is a broken symlink"
-            )
-            raise ValueError(
-                "catalog snapshot path is a broken symlink; refusing to pin"
-            ) from exc
-        # Genuinely absent: a pin whose content lives on another node. It cannot
-        # be verified here, so flag and proceed rather than block a legitimate
-        # cross-node activation (topology-agnostic).
-        _logger.warning(
-            "gateway snapshot content unverifiable at activation: the pinned "
-            "snapshot file is not present on this node; pinning without a content check"
-        )
-        return
     except OSError as exc:
-        # Present but unreadable (a permission or partial/corrupt-write fault):
-        # NOT the remote-node topology case, so fail the activation closed rather
-        # than pin a snapshot whose content was never verified.
+        # The ONLY tolerated failure is a genuine remote-node absence: the
+        # reference resolves through a real directory tree (no symlink at ANY
+        # component) and simply names a file not present on this node. Anything
+        # else -- a broken/dangling symlink at the reference or any parent, a
+        # non-regular entry, a permission or partial-read fault -- is a present-
+        # but-unusable LOCAL reference, so it fails closed rather than pinning a
+        # snapshot whose content was never verified.
+        if (
+            isinstance(exc, FileNotFoundError)
+            and not _has_symlink_component(root, reference_path)
+            and reference_path.parent.is_dir()
+        ):
+            _logger.warning(
+                "gateway snapshot content unverifiable at activation: the pinned "
+                "snapshot file is not present on this node; pinning without a content check"
+            )
+            return
         _logger.error(
-            "gateway refused an unreadable local catalog snapshot at activation (%s)",
+            "gateway refused an unusable local catalog snapshot reference at activation (%s)",
             type(exc).__name__,
         )
-        raise ValueError("catalog snapshot is present but unreadable; refusing to pin") from exc
+        raise ValueError(
+            "catalog snapshot reference is not a readable local file; refusing to pin"
+        ) from exc
     try:
         read_pinned_normalized_snapshot(data, catalog_sha256)
     except ValueError as exc:

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -57,6 +57,7 @@ from exp.runtime.gateway.platform import (
     UsageTerminalCount,
     VirtualKeyRecord,
 )
+from exp.runtime.gateway.snapshot_integrity import refuse_self_inconsistent_snapshot
 from exp.runtime.gateway.sqlite.migrations import connect_database
 from exp.runtime.gateway.sqlite.platform_records import (
     alias_record as _alias_record,
@@ -832,11 +833,7 @@ class SQLiteGatewayPlatform:
                 snapshot_ref = ? OR catalog_sha256 = ?
             )
             """,
-            (
-                command.organization_id,
-                command.snapshot_ref,
-                command.catalog_sha256,
-            ),
+            (command.organization_id, command.snapshot_ref, command.catalog_sha256),
         )
         if rows:
             if len(rows) != 1 or (
@@ -845,6 +842,10 @@ class SQLiteGatewayPlatform:
             ) != (command.snapshot_ref, command.catalog_sha256):
                 raise ValueError("catalog snapshot reference conflicts with existing authority")
             return
+        # Never pin a self-inconsistent snapshot (the persistent hydration bug).
+        refuse_self_inconsistent_snapshot(
+            self.database_path.parent, command.snapshot_ref, command.catalog_sha256
+        )
         try:
             self.control.register_catalog_snapshot(
                 organization_id=command.organization_id,
@@ -857,11 +858,7 @@ class SQLiteGatewayPlatform:
                 SELECT snapshot_ref, catalog_sha256 FROM catalog_snapshot_refs
                 WHERE organization_id = ? AND snapshot_ref = ? AND catalog_sha256 = ?
                 """,
-                (
-                    command.organization_id,
-                    command.snapshot_ref,
-                    command.catalog_sha256,
-                ),
+                (command.organization_id, command.snapshot_ref, command.catalog_sha256),
             )
             if len(concurrent) != 1:
                 raise

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -60,6 +60,7 @@ from exp.runtime.gateway import (
 from exp.runtime.gateway.budgets import BudgetScope, BudgetScopeKind, SQLiteBudgetStore
 from exp.runtime.gateway.contracts import DirectTarget, ExecutionSnapshot
 from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.snapshot_integrity import refuse_self_inconsistent_snapshot
 from exp.runtime.gateway.sqlite.platform import SQLiteGatewayPlatform
 from exp.runtime.gateway.sqlite.store import (
     GatewayStoreError,
@@ -196,6 +197,49 @@ def test_default_adapter_constructs_existing_atomic_components(tmp_path: Path) -
     assert platform.budgets.database_path == platform.database_path
     assert platform.attempts.database_path == platform.database_path
     assert platform.exact_pool_revisions(organization_id="missing") == ()
+
+
+def test_activation_refuses_a_self_inconsistent_snapshot(tmp_path: Path) -> None:
+    """C2 write-side guard: a snapshot whose stored content does not hash to its
+    pinned digest is refused at activation so it never becomes an authority; a
+    matching one is accepted; and an absent file cannot be verified here, so it
+    is flagged and allowed rather than blocking a legitimate activation."""
+    normalized = NormalizedGatewayCatalog(
+        deployments=(
+            ExactModelDeployment(
+                deployment_id="deployment-one",
+                source_alias="deployment-one",
+                exact_model_id="exact-coding",
+                connection="openai",
+                provider="openai",
+                provider_model="gpt-test",
+                connection_sha256="b" * 64,
+                capabilities_sha256="c" * 64,
+            ),
+        ),
+        pools=(
+            ExactModelPool(
+                pool_id="coding-pool",
+                exact_model_id="exact-coding",
+                deployment_ids=("deployment-one",),
+            ),
+        ),
+    )
+    digest = normalized.identity_sha256()
+    snapshot_ref = f"catalog-snapshots/{digest}.json"
+    snapshot_path = tmp_path / snapshot_ref
+    snapshot_path.parent.mkdir()
+    snapshot_path.write_bytes(canonical_json_bytes(normalized))
+
+    # Matching content and digest: accepted.
+    refuse_self_inconsistent_snapshot(tmp_path, snapshot_ref, digest)
+
+    # Present file pinned under the wrong digest (the 6d85fcc0 shape): refused.
+    with pytest.raises(ValueError, match="does not match its pinned digest"):
+        refuse_self_inconsistent_snapshot(tmp_path, snapshot_ref, "a" * 64)
+
+    # Absent file: unverifiable on this node, flagged and allowed.
+    refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/missing.json", "a" * 64)
 
 
 def test_default_adapter_reads_complete_local_pool_revisions(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -244,15 +244,20 @@ def test_activation_refuses_a_self_inconsistent_snapshot(tmp_path: Path) -> None
     # Present but unreadable (here a directory at the path -> a non-absent OSError):
     # NOT the remote-node case, so it fails closed rather than pinning unverified.
     (tmp_path / "catalog-snapshots" / "unreadable.json").mkdir()
-    with pytest.raises(ValueError, match="present but unreadable"):
+    with pytest.raises(ValueError, match="not a readable local file"):
         refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/unreadable.json", digest)
 
-    # Broken symlink: a PRESENT dangling entry, not a genuine absence -> fails
-    # closed rather than being waved through as a remote-node pin.
+    # Broken symlink at the reference: a present dangling entry -> fails closed.
     broken = tmp_path / "catalog-snapshots" / "broken.json"
     broken.symlink_to(tmp_path / "catalog-snapshots" / "does-not-exist.json")
-    with pytest.raises(ValueError, match="broken symlink"):
+    with pytest.raises(ValueError, match="not a readable local file"):
         refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/broken.json", digest)
+
+    # A broken symlink at a PARENT component (the snapshots directory itself)
+    # also fails closed -- the reference is not a symlink but its parent is.
+    (tmp_path / "linked").symlink_to(tmp_path / "missing-dir")
+    with pytest.raises(ValueError, match="not a readable local file"):
+        refuse_self_inconsistent_snapshot(tmp_path, "linked/x.json", digest)
 
 
 def test_default_adapter_reads_complete_local_pool_revisions(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -247,6 +247,13 @@ def test_activation_refuses_a_self_inconsistent_snapshot(tmp_path: Path) -> None
     with pytest.raises(ValueError, match="present but unreadable"):
         refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/unreadable.json", digest)
 
+    # Broken symlink: a PRESENT dangling entry, not a genuine absence -> fails
+    # closed rather than being waved through as a remote-node pin.
+    broken = tmp_path / "catalog-snapshots" / "broken.json"
+    broken.symlink_to(tmp_path / "catalog-snapshots" / "does-not-exist.json")
+    with pytest.raises(ValueError, match="broken symlink"):
+        refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/broken.json", digest)
+
 
 def test_default_adapter_reads_complete_local_pool_revisions(tmp_path: Path) -> None:
     """SQLite resolves complete pools from its pinned immutable local snapshots."""

--- a/exp/runtime/gateway/sqlite/platform_test.py
+++ b/exp/runtime/gateway/sqlite/platform_test.py
@@ -241,6 +241,12 @@ def test_activation_refuses_a_self_inconsistent_snapshot(tmp_path: Path) -> None
     # Absent file: unverifiable on this node, flagged and allowed.
     refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/missing.json", "a" * 64)
 
+    # Present but unreadable (here a directory at the path -> a non-absent OSError):
+    # NOT the remote-node case, so it fails closed rather than pinning unverified.
+    (tmp_path / "catalog-snapshots" / "unreadable.json").mkdir()
+    with pytest.raises(ValueError, match="present but unreadable"):
+        refuse_self_inconsistent_snapshot(tmp_path, "catalog-snapshots/unreadable.json", digest)
+
 
 def test_default_adapter_reads_complete_local_pool_revisions(tmp_path: Path) -> None:
     """SQLite resolves complete pools from its pinned immutable local snapshots."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.23"
+version = "0.7.24"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.23"
+version = "0.7.24"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

A published catalog snapshot (prod: `6d85fcc0`) whose stored content does **not** hash to its own pinned digest is unservable, so `read_pinned_normalized_snapshot` / `_load_snapshot` fail it closed (correctly, as corruption). Every alias whose **current** revision pins it then 503s **permanently** — **382 advertised models went dark for days** on a single stable image. This is not a rolling deploy, so #714's roll-tolerance doesn't apply. #995's hydration has neither a last-good fallback nor a write-side check that content matches digest before pinning.

This is the durable code fix (the owner deferred the clear to Part B — no manual ops re-activation), so on the v0.7.22 deploy the 382 become callable again automatically.

## Part C — write-side prevention (never pin a self-inconsistent snapshot)

- **C1 (root cause):** `_write_catalog_snapshot` wrote the normalized `<sha>.json` with **skip-if-exists**, so a stale/partial file already at the content-addressed path was trusted and pinned (content ≠ digest). It now **write-or-verifies** (rewrites when the on-disk bytes differ), exactly as its authored companion already did. This is how `6d85fcc0` became self-inconsistent.
- **C2 (activation guard):** `refuse_self_inconsistent_snapshot` verifies the local `<sha>.json` hashes to its pinned digest before activation registers it (`_ensure_catalog_snapshot`). A same-version mismatch **fails the activation loudly**; a file **absent on this node** is flagged and allowed (topology-agnostic). A cross-version snapshot is tolerated exactly as the serving reader tolerates it.

## Part B — last-good serving fallback (clears the existing dead pins)

- When an alias's active revision pins an unservable snapshot, the pod walks its **prior revisions newest-first (cap 5)**, loads the first whose snapshot is **present and verified**, and serves it. Admission **re-keys** the authorization to the served prior revision (`alias_revision_id`, `catalog_sha256`, `target`), so routing, the ledger, budgets, and **prices** all follow the revision actually served ("bill for what was served"). A dead-pinned alias is also **listed under its fallback**, so it stays advertised (`granted_alias_authorities` re-keys too).
- **Topology-agnostic:** if no prior revision loads (a per-node cold miss), the alias degrades to a **retryable `UNAVAILABLE`** routing error (the class from #714), never a permanent internal. Under the shared-volume prod topology, the prior `<sha>.json` files are present, so the 382 clear on deploy.
- **Continuations** bound to a revision that cannot re-key degrade through the existing **400 "resend the full conversation"** path, never a 503.
- Serves only **verified** prior revisions (digest matches), so it does **not** relax #714's same-version fail-closed for the pinned snapshot, and does not resurface the #714 Greptile "integrity" concern.

### Notable behavior change
A newly activated **broken** revision now also degrades to last-good instead of fail-closing (`test_invalid_new_revision_fails_closed` → `..._serves_last_good`), so a bad activation never takes an alias down; the serve is logged. Flagging for the serving/auth-path review.

## Structure / version
The per-revision load+readiness and last-good loaders move to a new `alias_fallback.py` (function-level import breaks the cycle), and the C2 guard to `snapshot_integrity.py`, keeping `lifecycle.py` (968) and `platform.py` (996) within the file-size limit. Python-only control plane (UNAVAILABLE already in Rust from #714) → **experiential 0.7.21 → 0.7.22, native crate unchanged (0.3.17)**.

## Test evidence
- `pytest exp/runtime/gateway/ exp/common/models/ exp/tests/repo_layout_test.py` — **868 passed, 3 skipped**. New guards: cold-start clears a dead active pin via last-good; a dead pin with no loadable prior stays retryable-unavailable; a broken new revision serves last-good then adopts a repaired one; a broken sibling degrades to last-good without blocking others; C2 refuses a self-inconsistent snapshot (accepts matching, flags absent); C1 repairs a stale content-addressed file.
- `ruff format --check`, `ruff check`, `ty check` clean.
- No Rust change (native unchanged).

Design was reviewed with the owner before implementation (root cause, the re-key/billing semantics, the N=5 walk, continuations, and the topology-agnostic UNAVAILABLE fallback). Holding for the serving/auth-path review before merge — do not merge/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)