### PR TITLE
fix(models): preserve cache_write_input_tokens in combine_economics aggregation

### DIFF
--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -140,17 +140,22 @@ def _sum_usage(values: Sequence[Usage]) -> Usage:
         values: Usage records reported by the aggregated operations.
 
     Returns:
-        Summed input and output tokens, with cached input tokens summed only when every
-        record reports them.
+        Summed input and output tokens, with cached and cache-write input tokens
+        summed only when every record reports them.
     """
     cached = tuple(value.cached_input_tokens for value in values)
     cached_total: int | None = None
     if all(item is not None for item in cached):
         cached_total = sum(item for item in cached if item is not None)
+    written = tuple(value.cache_write_input_tokens for value in values)
+    written_total: int | None = None
+    if all(item is not None for item in written):
+        written_total = sum(item for item in written if item is not None)
     return Usage(
         input_tokens=sum(value.input_tokens for value in values),
         output_tokens=sum(value.output_tokens for value in values),
         cached_input_tokens=cached_total,
+        cache_write_input_tokens=written_total,
     )
 
 

--- a/exp/common/models/model_test.py
+++ b/exp/common/models/model_test.py
@@ -309,6 +309,102 @@ def test_combine_economics_sums_present_usage_and_complete_measurements() -> Non
     assert combine_economics(()) == OperationEconomics()
 
 
+def test_combine_economics_preserves_cache_write_when_every_record_reports_it() -> None:
+    """Aggregated usage keeps cache-write counts only when every record carries them."""
+    first = OperationEconomics(
+        usage=Usage(
+            input_tokens=100,
+            output_tokens=10,
+            cached_input_tokens=20,
+            cache_write_input_tokens=30,
+        ),
+        cost_usd=NumericMeasurement(value=0.2, provenance="observed"),
+        latency_seconds=NumericMeasurement(value=0.4, provenance="observed"),
+    )
+    second = OperationEconomics(
+        usage=Usage(
+            input_tokens=50,
+            output_tokens=5,
+            cached_input_tokens=10,
+            cache_write_input_tokens=15,
+        ),
+        cost_usd=NumericMeasurement(value=0.1, provenance="observed"),
+        latency_seconds=NumericMeasurement(value=0.2, provenance="observed"),
+    )
+    partial = OperationEconomics(
+        usage=Usage(input_tokens=20, output_tokens=2, cached_input_tokens=5),
+        cost_usd=NumericMeasurement(value=0.05, provenance="observed"),
+    )
+
+    complete = combine_economics((first, second))
+    mixed = combine_economics((first, partial))
+    zero_write = combine_economics(
+        (
+            OperationEconomics(
+                usage=Usage(
+                    input_tokens=10,
+                    output_tokens=1,
+                    cached_input_tokens=2,
+                    cache_write_input_tokens=0,
+                ),
+            ),
+            OperationEconomics(
+                usage=Usage(
+                    input_tokens=10,
+                    output_tokens=1,
+                    cached_input_tokens=3,
+                    cache_write_input_tokens=0,
+                ),
+            ),
+        )
+    )
+
+    assert complete.usage == Usage(
+        input_tokens=150,
+        output_tokens=15,
+        cached_input_tokens=30,
+        cache_write_input_tokens=45,
+    )
+    assert mixed.usage == Usage(
+        input_tokens=120,
+        output_tokens=12,
+        cached_input_tokens=25,
+        cache_write_input_tokens=None,
+    )
+    assert zero_write.usage == Usage(
+        input_tokens=20,
+        output_tokens=2,
+        cached_input_tokens=5,
+        cache_write_input_tokens=0,
+    )
+    assert zero_write.usage is not None
+    assert zero_write.usage.cache_write_input_tokens == 0
+
+
+def test_combine_economics_cache_write_partial_mode_keeps_only_complete_subset() -> None:
+    """Partial aggregation keeps cache-write totals only from the present subset."""
+    priced = OperationEconomics(
+        usage=Usage(
+            input_tokens=10,
+            output_tokens=2,
+            cached_input_tokens=4,
+            cache_write_input_tokens=2,
+        ),
+        cost_usd=NumericMeasurement(value=0.5, provenance="observed"),
+    )
+    unmetered = OperationEconomics()
+
+    strict = combine_economics((priced, unmetered))
+    relaxed = combine_economics((priced, unmetered), require_complete_usage=False)
+    empty_relaxed = combine_economics((unmetered,), require_complete_usage=False)
+
+    assert strict.usage is None
+    assert relaxed.usage == priced.usage
+    assert relaxed.usage is not None
+    assert relaxed.usage.cache_write_input_tokens == 2
+    assert empty_relaxed.usage is None
+
+
 def test_unknown_support_flags_change_the_frozen_capability_identity_digest() -> None:
     """Unknown tool and embedding support hash as their own tri-state value.
 


### PR DESCRIPTION
### Summary

`_sum_usage` in `exp/common/models/model.py:136` dropped `cache_write_input_tokens` on every aggregated `Usage`, silently under-billing router economics, evaluation reports and `usage_html` when per-operation usage was combined via `combine_economics`. The single-operation pricing fix in #697 (`reconcile_completion_economics` at `pricing.py:361`) does not touch aggregation.

### Fix

- Sum `cache_write_input_tokens` only when every record reports it, mirroring the existing `cached_input_tokens` contract.
- Keep 0 as a valid total (distinct from `None` when some record lacks the field).
- Update the module docstring for `_sum_usage`.

### Tests

- `test_combine_economics_preserves_cache_write_when_every_record_reports_it` – complete sum (150/15/30/45), mixed case where `cached` is complete but `written` is partial (120/12/25/None), and zero-write total.
- `test_combine_economics_cache_write_partial_mode_keeps_only_complete_subset` – strict vs `require_complete_usage=False` handling.

### Verification

- `uv run ruff check .` – All checks passed
- `uv run ruff format --check .` – 758 files formatted
- `uv run pytest exp/common/models/model_test.py -q` – 17 passed
- `uv run pytest exp/common/models/ -q` – 195 passed
- `uv run pytest exp/runtime/router/ -q` – 131 passed

### Not a duplicate

Open issue #694 and open PR #697 are single-operation cache-write concerns. This PR fixes the orthogonal aggregation path (`model.py:136` `_sum_usage`) which that PR never touches. Evidence: `grep -n cache_write exp/common/models/model.py` previously returned only the field definition (80) with zero handling in `_sum_usage`.