### PR TITLE
feat(ingest): add MLflow tracing adapter

### DIFF
--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -12,6 +12,7 @@ loader. Each source is declared, never guessed:
 | `langfuse` | Langfuse traces with observations, or bare observations carrying `traceId`. |
 | `langsmith` | LangSmith runs, or a `runs` envelope. |
 | `mastra` | Mastra spans, or a `spans` envelope. |
+| `mlflow` | MLflow spans, a `traces` or `spans` envelope, or a trace-search object with `info.trace_id` and `data.spans`. |
 | `phoenix` | Phoenix and OpenInference spans, native nested, flat dotted, or OTLP JSON. |
 | `chat-json` | OpenAI-style chat conversations, one object, an array, or bare message arrays. |
 

--- a/exp/simulation/ingest/__init__.py
+++ b/exp/simulation/ingest/__init__.py
@@ -6,6 +6,7 @@ from exp.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_d
 from exp.simulation.ingest.langfuse import LANGFUSE_SOURCE
 from exp.simulation.ingest.langsmith import LANGSMITH_SOURCE
 from exp.simulation.ingest.mastra import MASTRA_SOURCE
+from exp.simulation.ingest.mlflow import MLFLOW_SOURCE
 from exp.simulation.ingest.otel_genai import (
     load_otel_genai_file,
     normalize_otel_genai_payloads,
@@ -42,6 +43,7 @@ __all__ = [
     "LANGFUSE_SOURCE",
     "LANGSMITH_SOURCE",
     "MASTRA_SOURCE",
+    "MLFLOW_SOURCE",
     "OtlpTraceFormatError",
     "PHOENIX_SOURCE",
     "PersistedTraceDataset",

--- a/exp/simulation/ingest/mlflow.py
+++ b/exp/simulation/ingest/mlflow.py
@@ -2,11 +2,11 @@
 
 MLflow exports agent runs as spans grouped by a trace identifier. A span declares
 ``trace_id`` (or ``traceId``), ``span_id`` (or ``spanId``), ``parent_id``, ``name``,
-``span_type`` (or ``type``), ``start_time``/``start_time_ns`` and ``end_time``, plus
-``inputs``, ``outputs``, ``attributes``, and ``status``. Exports arrive as a span
-array, a ``traces`` or ``spans`` envelope, or JSONL with one span per line. A trace
-object that carries ``info.trace_id`` and ``data.spans`` is also supported because
-``GET /mlflow/traces/search`` returns that shape.
+``span_type`` (or ``type``), ``start_time_unix_nano``/``start_time_ns``/``start_time``
+and ``end_time``, plus ``inputs``, ``outputs``, ``attributes``, and ``status``.
+Exports arrive as a span array, a ``traces`` or ``spans`` envelope, or JSONL with
+one span per line. A trace object that carries ``info.trace_id`` and ``data.spans``
+is also supported because ``GET /mlflow/traces/search`` returns that shape.
 
 Span types map to canonical evidence by what they observe:
 
@@ -195,15 +195,15 @@ def _span_type(span: JsonObject) -> str:
     attributes = span.get("attributes")
     attr_obj: JsonObject = attributes if isinstance(attributes, dict) else {}
     for key in ("mlflow.spanType", "span_type", "spanType", "type"):
-        value = span.get(key)
+        value = json_value(span.get(key))
         if isinstance(value, str) and value.strip():
             return value.strip().casefold()
-        attr_value = attr_obj.get(key)
+        attr_value = json_value(attr_obj.get(key))
         if isinstance(attr_value, str) and attr_value.strip():
             return attr_value.strip().casefold()
     # Also check nested attributes like attributes.spanType
     for key in ("mlflow.spanType", "span_type"):
-        attr_value = attr_obj.get(key)
+        attr_value = json_value(attr_obj.get(key))
         if isinstance(attr_value, str) and attr_value.strip():
             return attr_value.strip().casefold()
     return ""
@@ -288,6 +288,11 @@ def _parent_id(span: JsonObject) -> str | None:
 def _attributes(span: JsonObject) -> JsonObject:
     """Return the MLflow span attributes object.
 
+    The server JSON-encodes attribute values one extra layer (so the model reads
+    ``'"gpt-4o-mini"'`` rather than ``'gpt-4o-mini"'``); each value is decoded so
+    downstream readers see the declared text. Values that are not JSON-encoded
+    text are left unchanged.
+
     Args:
         span: MLflow span record.
 
@@ -295,10 +300,17 @@ def _attributes(span: JsonObject) -> JsonObject:
         Attribute mapping, empty when the span declares none.
     """
     value = span.get("attributes")
-    if isinstance(value, dict):
-        return value
-    # Some exports carry attributes flat on the span.
-    return {}
+    if not isinstance(value, dict):
+        # Some exports carry attributes flat on the span.
+        return {}
+    decoded: JsonObject = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            continue
+        text = json_value(item)
+        if text is not None:
+            decoded[key] = text
+    return decoded
 
 
 def _inputs(span: JsonObject, attributes: JsonObject) -> JsonValue | None:
@@ -380,7 +392,7 @@ def _tool_name(span: JsonObject, attributes: JsonObject) -> str:
     Raises:
         VendorTraceFormatError: The span declares no tool name.
     """
-    for key in ("toolName", "tool_name", "functionName", "name"):
+    for key in ("toolName", "tool_name", "functionName", "mlflow.spanFunctionName", "name"):
         value = attributes.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
@@ -402,11 +414,12 @@ def _interval(span: JsonObject) -> tuple[datetime, datetime]:
     Raises:
         VendorTraceFormatError: The span declares no readable start time.
     """
-    # MLflow commonly uses ``start_time_ns`` / ``end_time_ns`` (nanoseconds since epoch)
-    # or ``start_time`` / ``end_time`` (milliseconds or ISO). Try nanoseconds first
-    # by converting to seconds for the shared timestamp helper.
-    ns_start = span.get("start_time_ns", span.get("startTimeNs"))
-    ns_end = span.get("end_time_ns", span.get("endTimeNs"))
+    # MLflow commonly uses nanosecond epoch fields (``start_time_unix_nano`` in
+    # server exports, ``start_time_ns`` elsewhere) or ``start_time`` / ``end_time``
+    # (milliseconds or ISO). Try nanoseconds first by converting to seconds for
+    # the shared timestamp helper.
+    ns_start = span.get("start_time_ns", span.get("startTimeNs", span.get("start_time_unix_nano")))
+    ns_end = span.get("end_time_ns", span.get("endTimeNs", span.get("end_time_unix_nano")))
     if isinstance(ns_start, int | float):
         # Convert nanoseconds to seconds for source_timestamp epoch handling.
         start_seconds = float(ns_start) / 1_000_000_000
@@ -509,6 +522,9 @@ def _failure_message(span: JsonObject, attributes: JsonObject) -> str | None:
     status = span.get("status")
     if isinstance(status, dict):
         code = str(status.get("status_code") or status.get("code") or "").upper()
+        # Server exports use OpenTelemetry codes (``STATUS_CODE_OK``); strip the
+        # prefix before comparing so healthy spans are not marked failed.
+        code = code.removeprefix("STATUS_CODE_")
         if code and code not in {"OK", "SUCCESS", "UNSET"}:
             return (
                 declared_error_message(
@@ -521,7 +537,7 @@ def _failure_message(span: JsonObject, attributes: JsonObject) -> str | None:
             if key in status and isinstance(status[key], str) and status[key].strip():
                 return status[key].strip()
     elif isinstance(status, str) and status.strip():
-        if status.strip().upper() not in {"OK", "SUCCESS", "UNSET"}:
+        if status.strip().upper().removeprefix("STATUS_CODE_") not in {"OK", "SUCCESS", "UNSET"}:
             return declared_error_message(span, keys=_ERROR_KEYS, label="MLflow span") or (
                 declared_error_message(attributes, keys=_ERROR_KEYS, label="MLflow span")
                 or f"MLflow span failed with status {status}"

--- a/exp/simulation/ingest/mlflow.py
+++ b/exp/simulation/ingest/mlflow.py
@@ -1,0 +1,623 @@
+"""Normalize MLflow tracing exports into canonical trace evidence.
+
+MLflow exports agent runs as spans grouped by a trace identifier. A span declares
+``trace_id`` (or ``traceId``), ``span_id`` (or ``spanId``), ``parent_id``, ``name``,
+``span_type`` (or ``type``), ``start_time``/``start_time_ns`` and ``end_time``, plus
+``inputs``, ``outputs``, ``attributes``, and ``status``. Exports arrive as a span
+array, a ``traces`` or ``spans`` envelope, or JSONL with one span per line. A trace
+object that carries ``info.trace_id`` and ``data.spans`` is also supported because
+``GET /mlflow/traces/search`` returns that shape.
+
+Span types map to canonical evidence by what they observe:
+
+- ``LLM`` and ``CHAT_MODEL`` become model calls, including the tool calls their
+  output requests,
+- ``TOOL`` and ``FUNCTION`` become tool results paired with the earlier
+  requesting call,
+- ``CHAIN``, ``AGENT``, ``RETRIEVER``, ``EMBEDDING``, ``UNKNOWN``, and other
+  orchestration types are not converted.
+
+MLflow names a model in span attributes under ``mlflow.model``, ``llm.request.model``,
+or ``gen_ai.request.model``. Provider identity comes from ``llm.system`` or
+``gen_ai.system``. The declared model name is retained as ``gen_ai.request.model``
+evidence, and resolved model identity is retained only when the export also declares
+a provider.
+"""
+
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from exp.common.core.artifacts import JsonObject
+from exp.simulation.ingest.vendor_observations import (
+    VendorObservation,
+    declared_completion_text,
+    declared_error_message,
+    declared_model_identity,
+    declared_tool_calls,
+    declared_usage,
+)
+from exp.simulation.ingest.vendor_records import (
+    VendorTraceFormatError,
+    first_text,
+    first_user_text,
+    json_text,
+    json_value,
+    required_text,
+    source_interval,
+    source_timestamp,
+)
+from exp.simulation.ingest.vendor_source import VendorSource, record_flattener
+from exp.simulation.ingest.vendor_trace import approved_extensions
+
+VENDOR = "mlflow"
+
+_MODEL_TYPES = frozenset({"llm", "chat_model", "chat", "completion"})
+_TOOL_TYPES = frozenset({"tool", "function"})
+_MODEL_KEYS = (
+    "mlflow.model",
+    "llm.request.model",
+    "gen_ai.request.model",
+    "model",
+    "model_name",
+    "modelName",
+)
+_PROVIDER_KEYS = (
+    "llm.system",
+    "gen_ai.system",
+    "provider",
+    "model_provider",
+    "modelProvider",
+)
+_ERROR_KEYS = ("error", "exception", "statusMessage", "error_message")
+
+
+def _span_observation(span: JsonObject, ordinal: int) -> tuple[VendorObservation, ...]:
+    """Convert one MLflow span to a declared model or tool-result observation.
+
+    Args:
+        span: MLflow span record, which may be a flat span or a trace envelope
+            carrying ``info`` and ``data.spans``.
+
+    Returns:
+        Declared observation, or nothing for orchestration-only span types or
+        for envelope records that are expanded elsewhere.
+
+    Raises:
+        VendorTraceFormatError: The span lacks identity, timing, or tool evidence.
+    """
+    # Trace envelope: ``{"info": {"trace_id": ...}, "data": {"spans": [...]}}``.
+    # These are not vendor records themselves when handled via flattening, but a
+    # bare envelope that was identified as a record needs explicit expansion.
+    if "data" in span and isinstance(span["data"], dict):
+        data = span["data"]
+        spans = data.get("spans")
+        if isinstance(spans, list):
+            # This record is actually a trace envelope; it should have been
+            # flattened via wrapper_keys. If it arrives here, treat it as no-op
+            # rather than misclassifying the envelope as a span.
+            return ()
+    if "info" in span and "data" not in span:
+        # Standalone trace info without data is not a span.
+        return ()
+
+    span_type = _span_type(span)
+    if span_type not in _MODEL_TYPES | _TOOL_TYPES:
+        return ()
+
+    source_trace_id = _trace_id(span)
+    source_span_id = _span_id(span)
+    started_at, ended_at = _interval(span)
+    attributes = _attributes(span)
+    inputs = _inputs(span, attributes)
+    outputs = _outputs(span, attributes)
+    extensions = _extensions(span, attributes)
+    failure = _failure_message(span, attributes)
+    parent = _parent_id(span)
+
+    if span_type in _TOOL_TYPES:
+        return (
+            VendorObservation(
+                source_trace_id=source_trace_id,
+                source_span_id=source_span_id,
+                ordinal=ordinal,
+                started_at=started_at,
+                ended_at=ended_at,
+                kind="tool_result",
+                source_parent_span_id=parent,
+                request_text=first_user_text(inputs),
+                tool_name=_tool_name(span, attributes),
+                tool_arguments=json_text(inputs),
+                tool_message=declared_completion_text(outputs),
+                tool_call_id=first_text(attributes, ("toolCallId", "tool_call_id", "tool_call_id")),
+                failure_message=failure,
+                extensions=extensions,
+            ),
+        )
+
+    model, declared_model = declared_model_identity(
+        attributes,
+        model_keys=_MODEL_KEYS,
+        provider_keys=_PROVIDER_KEYS,
+    )
+    # Fallback: some MLflow spans carry model directly on the span rather than attributes.
+    if model is None and declared_model is None:
+        fallback_attrs: JsonObject = {}
+        for key in _MODEL_KEYS:
+            if key in span:
+                fallback_attrs[key] = span[key]
+        for key in _PROVIDER_KEYS:
+            if key in span:
+                fallback_attrs[key] = span[key]
+        if fallback_attrs:
+            model, declared_model = declared_model_identity(
+                fallback_attrs,
+                model_keys=_MODEL_KEYS,
+                provider_keys=_PROVIDER_KEYS,
+            )
+
+    return (
+        VendorObservation(
+            source_trace_id=source_trace_id,
+            source_span_id=source_span_id,
+            ordinal=ordinal,
+            started_at=started_at,
+            ended_at=ended_at,
+            kind="model",
+            source_parent_span_id=parent,
+            request_text=first_user_text(inputs),
+            input_messages=_input_messages(inputs),
+            completion_text=declared_completion_text(outputs) or None,
+            tool_calls=declared_tool_calls(outputs),
+            model=model,
+            usage=_usage(attributes, span),
+            failure_message=failure,
+            declared_attributes=(
+                {} if declared_model is None else {"gen_ai.request.model": declared_model}
+            ),
+            extensions=extensions,
+        ),
+    )
+
+
+def _span_type(span: JsonObject) -> str:
+    """Return the lowercase declared MLflow span type.
+
+    Args:
+        span: MLflow span record.
+
+    Returns:
+        Lowercase span type, empty when the span declares none.
+    """
+    attributes = span.get("attributes")
+    attr_obj: JsonObject = attributes if isinstance(attributes, dict) else {}
+    for key in ("mlflow.spanType", "span_type", "spanType", "type"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().casefold()
+        attr_value = attr_obj.get(key)
+        if isinstance(attr_value, str) and attr_value.strip():
+            return attr_value.strip().casefold()
+    # Also check nested attributes like attributes.spanType
+    for key in ("mlflow.spanType", "span_type"):
+        attr_value = attr_obj.get(key)
+        if isinstance(attr_value, str) and attr_value.strip():
+            return attr_value.strip().casefold()
+    return ""
+
+
+def _trace_id(span: JsonObject) -> str:
+    """Read the MLflow trace identifier.
+
+    Args:
+        span: MLflow span record.
+
+    Returns:
+        Declared trace identifier.
+
+    Raises:
+        VendorTraceFormatError: The span declares no trace identifier.
+    """
+    for key in ("trace_id", "traceId", "traceID"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return required_text(value, "MLflow trace_id")
+    # Check info wrapper
+    info = span.get("info")
+    if isinstance(info, dict):
+        for key in ("trace_id", "traceId", "request_id"):
+            value = info.get(key)
+            if isinstance(value, str) and value.strip():
+                return required_text(value, "MLflow trace_id")
+    attributes = span.get("attributes")
+    if isinstance(attributes, dict):
+        for key in ("mlflow.traceId", "trace_id"):
+            value = attributes.get(key)
+            if isinstance(value, str) and value.strip():
+                return required_text(value, "MLflow trace_id")
+    return required_text(None, "MLflow trace_id")
+
+
+def _span_id(span: JsonObject) -> str:
+    """Read the MLflow span identifier.
+
+    Args:
+        span: MLflow span record.
+
+    Returns:
+        Declared span identifier.
+    """
+    for key in ("span_id", "spanId", "spanID", "id", "request_id"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return required_text(value, "MLflow span_id")
+    info = span.get("info")
+    if isinstance(info, dict):
+        for key in ("span_id", "request_id"):
+            value = info.get(key)
+            if isinstance(value, str) and value.strip():
+                return required_text(value, "MLflow span_id")
+    return required_text(None, "MLflow span_id")
+
+
+def _parent_id(span: JsonObject) -> str | None:
+    """Return the declared MLflow parent span identifier, if any.
+
+    Args:
+        span: MLflow span record.
+
+    Returns:
+        Declared parent span identifier, or ``None`` when absent.
+    """
+    for key in ("parent_id", "parentId", "parentSpanId", "parent_span_id"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    attributes = span.get("attributes")
+    if isinstance(attributes, dict):
+        for key in ("mlflow.parentSpanId", "parent_id"):
+            value = attributes.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _attributes(span: JsonObject) -> JsonObject:
+    """Return the MLflow span attributes object.
+
+    Args:
+        span: MLflow span record.
+
+    Returns:
+        Attribute mapping, empty when the span declares none.
+    """
+    value = span.get("attributes")
+    if isinstance(value, dict):
+        return value
+    # Some exports carry attributes flat on the span.
+    return {}
+
+
+def _inputs(span: JsonObject, attributes: JsonObject) -> JsonValue | None:
+    """Read the declared MLflow span inputs.
+
+    Args:
+        span: MLflow span record.
+        attributes: Declared span attributes.
+
+    Returns:
+        Decoded inputs, or ``None`` when the span declares none.
+    """
+    for key in ("inputs", "input", "spanInputs"):
+        value = span.get(key)
+        if value is not None:
+            return json_value(value)
+    for key in ("mlflow.spanInputs", "mlflow.inputs", "spanInputs"):
+        value = attributes.get(key)
+        if value is not None:
+            return json_value(value)
+    return None
+
+
+def _outputs(span: JsonObject, attributes: JsonObject) -> JsonValue | None:
+    """Read the declared MLflow span outputs.
+
+    Args:
+        span: MLflow span record.
+        attributes: Declared span attributes.
+
+    Returns:
+        Decoded outputs, or ``None`` when the span declares none.
+    """
+    for key in ("outputs", "output", "spanOutputs"):
+        value = span.get(key)
+        if value is not None:
+            return json_value(value)
+    for key in ("mlflow.spanOutputs", "mlflow.outputs", "spanOutputs"):
+        value = attributes.get(key)
+        if value is not None:
+            return json_value(value)
+    return None
+
+
+def _input_messages(inputs: JsonValue | None) -> JsonValue | None:
+    """Return the declared model input messages for one MLflow model span.
+
+    Args:
+        inputs: Decoded span inputs.
+
+    Returns:
+        The declared message list, or the raw inputs when no list is declared.
+    """
+    if isinstance(inputs, dict):
+        for key in ("messages", "prompt", "input"):
+            value = inputs.get(key)
+            if isinstance(value, list):
+                return value
+        # MLflow chat inputs may wrap messages under ``inputs.messages``
+        nested = inputs.get("inputs")
+        if isinstance(nested, dict):
+            for key in ("messages", "prompt"):
+                value = nested.get(key)
+                if isinstance(value, list):
+                    return value
+    return inputs
+
+
+def _tool_name(span: JsonObject, attributes: JsonObject) -> str:
+    """Read the executed tool name from an MLflow tool span.
+
+    Args:
+        span: MLflow span record.
+        attributes: Declared span attributes.
+
+    Returns:
+        Declared tool name.
+
+    Raises:
+        VendorTraceFormatError: The span declares no tool name.
+    """
+    for key in ("toolName", "tool_name", "functionName", "name"):
+        value = attributes.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    name = span.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return required_text(None, "MLflow tool span name")
+
+
+def _interval(span: JsonObject) -> tuple[object, object]:
+    """Read the source interval from MLflow nanosecond, millisecond, or ISO fields.
+
+    Args:
+        span: MLflow span record.
+
+    Returns:
+        Source start and end instants, equal when the span declares no end.
+
+    Raises:
+        VendorTraceFormatError: The span declares no readable start time.
+    """
+    # MLflow commonly uses ``start_time_ns`` / ``end_time_ns`` (nanoseconds since epoch)
+    # or ``start_time`` / ``end_time`` (milliseconds or ISO). Try nanoseconds first
+    # by converting to seconds for the shared timestamp helper.
+    ns_start = span.get("start_time_ns", span.get("startTimeNs"))
+    ns_end = span.get("end_time_ns", span.get("endTimeNs"))
+    if isinstance(ns_start, int | float):
+        # Convert nanoseconds to seconds for source_timestamp epoch handling.
+        start_seconds = float(ns_start) / 1_000_000_000
+        end_seconds = float(ns_end) / 1_000_000_000 if isinstance(ns_end, int | float) else None
+        return source_interval(
+            start_seconds,
+            end_seconds,
+            start_label="MLflow span start_time_ns",
+            end_label="MLflow span end_time_ns",
+        )
+    # Millisecond epoch variants
+    ms_start = span.get("start_time", span.get("startTime"))
+    ms_end = span.get("end_time", span.get("endTime"))
+    # If value is a large int (>1e12) it's likely already milliseconds; source_timestamp
+    # handles both seconds and milliseconds, so delegate directly.
+    if ms_start is not None:
+        return source_interval(
+            ms_start,
+            ms_end,
+            start_label="MLflow span startTime",
+            end_label="MLflow span endTime",
+        )
+    # ISO fallback from attributes
+    attributes = span.get("attributes")
+    attr_obj: JsonObject = attributes if isinstance(attributes, dict) else {}
+    iso_start = attr_obj.get("startTime") or span.get("timestamp")
+    iso_end = attr_obj.get("endTime")
+    if iso_start is not None:
+        return source_interval(
+            iso_start,
+            iso_end,
+            start_label="MLflow span startTime",
+            end_label="MLflow span endTime",
+        )
+    # Final fallback: trace info timestamps
+    info = span.get("info")
+    if isinstance(info, dict):
+        for key in ("request_time", "timestamp", "createdAt"):
+            if key in info:
+                start = info[key]
+                end = info.get("execution_duration")
+                if isinstance(end, int | float) and isinstance(start, int | float):
+                    # execution_duration is often milliseconds
+                    try:
+                        started = source_timestamp(start, "MLflow trace request_time")
+                        ended = source_timestamp(
+                            float(start) / 1000 + float(end) / 1000
+                            if float(start) > 1e11
+                            else float(start) + float(end) / 1000,
+                            "MLflow trace end",
+                        )
+                        return started, ended
+                    except VendorTraceFormatError:
+                        pass
+                return source_interval(
+                    start,
+                    None,
+                    start_label="MLflow trace request_time",
+                    end_label="MLflow trace end",
+                )
+    raise source_timestamp(None, "MLflow span startTime")
+
+
+def _usage(attributes: JsonObject, span: JsonObject) -> object | None:
+    """Read declared token accounting from MLflow span attributes or the span itself.
+
+    Args:
+        attributes: Declared span attributes.
+        span: MLflow span record.
+
+    Returns:
+        Declared usage, or ``None`` when the span declares no complete accounting.
+
+    Raises:
+        VendorTraceFormatError: A declared token count is not a non-negative integer.
+    """
+    for candidate in (
+        attributes.get("llm.usage"),
+        attributes.get("gen_ai.usage"),
+        attributes.get("usage"),
+        span.get("usage"),
+        attributes,
+    ):
+        usage = declared_usage(candidate)
+        if usage is not None:
+            return usage
+    return None
+
+
+def _failure_message(span: JsonObject, attributes: JsonObject) -> str | None:
+    """Read an MLflow span failure message when the status marks the span failed.
+
+    Args:
+        span: MLflow span record.
+        attributes: Declared span attributes.
+
+    Returns:
+        Declared error text, or ``None`` when the span is not failed.
+    """
+    status = span.get("status")
+    if isinstance(status, dict):
+        code = str(status.get("status_code") or status.get("code") or "").upper()
+        if code and code not in {"OK", "SUCCESS", "UNSET"}:
+            return (
+                declared_error_message(
+                    {**span, **attributes, **status}, keys=_ERROR_KEYS, label="MLflow span"
+                )
+                or f"MLflow span failed with status {code}"
+            )
+        # Some MLflow spans put error directly on status object.
+        for key in _ERROR_KEYS:
+            if key in status and isinstance(status[key], str) and status[key].strip():
+                return status[key].strip()
+    elif isinstance(status, str) and status.strip():
+        if status.strip().upper() not in {"OK", "SUCCESS", "UNSET"}:
+            return declared_error_message(span, keys=_ERROR_KEYS, label="MLflow span") or (
+                declared_error_message(attributes, keys=_ERROR_KEYS, label="MLflow span")
+                or f"MLflow span failed with status {status}"
+            )
+    # Fallback: error keys even without explicit failed status code
+    failure = declared_error_message(span, keys=_ERROR_KEYS, label="MLflow span")
+    if failure is not None:
+        return failure
+    return declared_error_message(attributes, keys=_ERROR_KEYS, label="MLflow span")
+
+
+def _extensions(span: JsonObject, attributes: JsonObject) -> JsonObject:
+    """Read approved EXP extensions and MLflow metadata from one span.
+
+    Args:
+        span: MLflow span record.
+        attributes: Declared span attributes.
+
+    Returns:
+        Approved extension attributes for this record.
+    """
+    extensions = approved_extensions(span)
+    extensions.update(approved_extensions(attributes))
+    metadata = span.get("metadata")
+    if isinstance(metadata, dict):
+        extensions.update(approved_extensions(metadata))
+        if "exp.trace.metadata" not in extensions:
+            extensions["exp.trace.metadata"] = metadata
+    # Preserve MLflow experiment and run identifiers when present
+    for key in ("mlflow.experimentId", "mlflow.runId", "experiment_id", "run_id"):
+        value = attributes.get(key) or span.get(key)
+        if isinstance(value, str) and value.strip() and "exp.mlflow.experiment" not in extensions:
+            extensions["exp.mlflow.experiment"] = value.strip()
+            break
+    return extensions
+
+
+def _mlflow_records(payload: JsonValue) -> tuple[JsonObject, ...]:
+    """Flatten MLflow export shapes, including trace envelopes with ``data.spans``.
+
+    Args:
+        payload: One decoded export document, array, or trace envelope.
+
+    Returns:
+        MLflow span record objects in source order.
+
+    Raises:
+        VendorTraceFormatError: The payload is not a supported MLflow shape.
+    """
+    # Handle explicit trace envelope(s) where a trace has ``info`` + ``data.spans``.
+    if isinstance(payload, dict) and "traces" in payload and isinstance(payload["traces"], list):
+        records: list[JsonObject] = []
+        for trace in payload["traces"]:
+            if not isinstance(trace, dict):
+                raise VendorTraceFormatError("MLflow trace envelope must be an object")
+            data = trace.get("data")
+            if isinstance(data, dict) and isinstance(data.get("spans"), list):
+                for span in data["spans"]:
+                    if isinstance(span, dict):
+                        records.append(span)
+                    else:
+                        raise VendorTraceFormatError("MLflow spans must be objects")
+                continue
+            # Fallback: trace itself may already be a span-shaped record
+            if any(
+                key in trace for key in ("trace_id", "traceId", "span_id", "spanId", "request_id")
+            ):
+                records.append(trace)
+                continue
+            # Also handle data being a flat span list under data directly
+            if isinstance(trace.get("data"), list):
+                for span in trace["data"]:
+                    if isinstance(span, dict):
+                        records.append(span)
+                continue
+            raise VendorTraceFormatError("MLflow trace envelope needs data.spans or a span record")
+        return tuple(records)
+    if isinstance(payload, dict) and "data" in payload and isinstance(payload["data"], dict):
+        data = payload["data"]
+        spans = data.get("spans")
+        if isinstance(spans, list):
+            return tuple(span for span in spans if isinstance(span, dict))
+    # Fallback to strict wrapper flattening for flat span arrays, spans envelopes, JSONL.
+    return record_flattener(
+        vendor=VENDOR,
+        wrapper_keys=("traces", "data", "spans", "results", "items", "events"),
+        record_keys=(
+            "trace_id",
+            "traceId",
+            "span_id",
+            "spanId",
+            "request_id",
+            "mlflow.traceId",
+        ),
+    )(payload)
+
+
+MLFLOW_SOURCE: VendorSource[JsonObject] = VendorSource(
+    vendor=VENDOR,
+    records=_mlflow_records,
+    convert=_span_observation,
+)

--- a/exp/simulation/ingest/mlflow.py
+++ b/exp/simulation/ingest/mlflow.py
@@ -556,6 +556,49 @@ def _extensions(span: JsonObject, attributes: JsonObject) -> JsonObject:
     return extensions
 
 
+def _envelope_trace_id(envelope: JsonObject) -> str | None:
+    """Read the trace identifier declared only at the envelope level.
+
+    Args:
+        envelope: MLflow trace envelope with ``info`` and ``data``.
+
+    Returns:
+        Declared envelope trace identifier, or ``None`` when absent.
+    """
+    info = envelope.get("info")
+    if isinstance(info, dict):
+        for key in ("trace_id", "traceId", "traceID", "request_id"):
+            value = info.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    for key in ("trace_id", "traceId", "traceID", "request_id"):
+        value = envelope.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _with_envelope_trace_id(span: JsonObject, envelope_trace_id: str | None) -> JsonObject:
+    """Return a span record that carries the envelope trace identifier when missing.
+
+    Args:
+        span: MLflow span record.
+        envelope_trace_id: Trace identifier declared only at the envelope level.
+
+    Returns:
+        Original span when it already carries a trace identifier or no envelope
+        identifier exists, otherwise a shallow copy with the envelope identifier.
+    """
+    if envelope_trace_id is None:
+        return span
+    if any(
+        key in span for key in ("trace_id", "traceId", "traceID", "request_id", "mlflow.traceId")
+    ):
+        return span
+    # Preserve original mapping; inject the envelope identifier as trace_id.
+    return {**span, "trace_id": envelope_trace_id}
+
+
 def _mlflow_records(payload: JsonValue) -> tuple[JsonObject, ...]:
     """Flatten MLflow export shapes, including trace envelopes with ``data.spans``.
 
@@ -569,6 +612,9 @@ def _mlflow_records(payload: JsonValue) -> tuple[JsonObject, ...]:
         VendorTraceFormatError: The payload is not a supported MLflow shape.
     """
     # Handle explicit trace envelope(s) where a trace has ``info`` + ``data.spans``.
+    # MLflow trace-search responses identify the trace only through ``info.trace_id``;
+    # child spans may not repeat that identifier. Preserve the envelope identity so
+    # every valid child span is retained.
     if isinstance(payload, dict) and "traces" in payload and isinstance(payload["traces"], list):
         records: list[JsonObject] = []
         for trace in payload["traces"]:
@@ -576,11 +622,11 @@ def _mlflow_records(payload: JsonValue) -> tuple[JsonObject, ...]:
                 raise VendorTraceFormatError("MLflow trace envelope must be an object")
             data = trace.get("data")
             if isinstance(data, dict) and isinstance(data.get("spans"), list):
+                envelope_trace_id = _envelope_trace_id(trace)
                 for span in data["spans"]:
-                    if isinstance(span, dict):
-                        records.append(span)
-                    else:
+                    if not isinstance(span, dict):
                         raise VendorTraceFormatError("MLflow spans must be objects")
+                    records.append(_with_envelope_trace_id(span, envelope_trace_id))
                 continue
             # Fallback: trace itself may already be a span-shaped record
             if any(
@@ -590,9 +636,10 @@ def _mlflow_records(payload: JsonValue) -> tuple[JsonObject, ...]:
                 continue
             # Also handle data being a flat span list under data directly
             if isinstance(trace.get("data"), list):
+                envelope_trace_id = _envelope_trace_id(trace)
                 for span in trace["data"]:
                     if isinstance(span, dict):
-                        records.append(span)
+                        records.append(_with_envelope_trace_id(span, envelope_trace_id))
                 continue
             raise VendorTraceFormatError("MLflow trace envelope needs data.spans or a span record")
         return tuple(records)
@@ -600,7 +647,27 @@ def _mlflow_records(payload: JsonValue) -> tuple[JsonObject, ...]:
         data = payload["data"]
         spans = data.get("spans")
         if isinstance(spans, list):
-            return tuple(span for span in spans if isinstance(span, dict))
+            envelope_trace_id = _envelope_trace_id(payload)
+            return tuple(
+                _with_envelope_trace_id(span, envelope_trace_id)
+                for span in spans
+                if isinstance(span, dict)
+            )
+    # Single trace envelope without the outer ``traces`` wrapper.
+    if isinstance(payload, dict) and "info" in payload and "data" in payload:
+        info = payload.get("info")
+        data = payload.get("data")
+        if (
+            isinstance(info, dict)
+            and isinstance(data, dict)
+            and isinstance(data.get("spans"), list)
+        ):
+            envelope_trace_id = _envelope_trace_id(payload)
+            return tuple(
+                _with_envelope_trace_id(span, envelope_trace_id)
+                for span in data["spans"]
+                if isinstance(span, dict)
+            )
     # Fallback to strict wrapper flattening for flat span arrays, spans envelopes, JSONL.
     return record_flattener(
         vendor=VENDOR,

--- a/exp/simulation/ingest/mlflow.py
+++ b/exp/simulation/ingest/mlflow.py
@@ -26,11 +26,14 @@ a provider.
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
 from exp.simulation.ingest.vendor_observations import (
     VendorObservation,
+    VendorTokenUsage,
     declared_completion_text,
     declared_error_message,
     declared_model_identity,
@@ -129,7 +132,7 @@ def _span_observation(span: JsonObject, ordinal: int) -> tuple[VendorObservation
                 tool_name=_tool_name(span, attributes),
                 tool_arguments=json_text(inputs),
                 tool_message=declared_completion_text(outputs),
-                tool_call_id=first_text(attributes, ("toolCallId", "tool_call_id", "tool_call_id")),
+                tool_call_id=first_text(attributes, ("toolCallId", "tool_call_id")),
                 failure_message=failure,
                 extensions=extensions,
             ),
@@ -387,7 +390,7 @@ def _tool_name(span: JsonObject, attributes: JsonObject) -> str:
     return required_text(None, "MLflow tool span name")
 
 
-def _interval(span: JsonObject) -> tuple[object, object]:
+def _interval(span: JsonObject) -> tuple[datetime, datetime]:
     """Read the source interval from MLflow nanosecond, millisecond, or ISO fields.
 
     Args:
@@ -464,10 +467,10 @@ def _interval(span: JsonObject) -> tuple[object, object]:
                     start_label="MLflow trace request_time",
                     end_label="MLflow trace end",
                 )
-    raise source_timestamp(None, "MLflow span startTime")
+    raise VendorTraceFormatError("MLflow span declares no readable start time")
 
 
-def _usage(attributes: JsonObject, span: JsonObject) -> object | None:
+def _usage(attributes: JsonObject, span: JsonObject) -> VendorTokenUsage | None:
     """Read declared token accounting from MLflow span attributes or the span itself.
 
     Args:

--- a/exp/simulation/ingest/mlflow_test.py
+++ b/exp/simulation/ingest/mlflow_test.py
@@ -1,0 +1,306 @@
+"""Tests for MLflow trace export normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exp.simulation.ingest.mlflow import MLFLOW_SOURCE
+from exp.simulation.ingest.sources import CANONICAL_TRACE_SOURCES, load_trace_source
+
+
+def _llm_span(
+    *,
+    trace_id: str = "trace-1",
+    span_id: str = "span-1",
+    parent_id: str | None = None,
+    name: str = "chat",
+    start_ns: int = 1_700_000_000_000_000_000,
+    end_ns: int = 1_700_000_001_000_000_000,
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    inputs: object | None = None,
+    outputs: object | None = None,
+    span_type: str = "LLM",
+    error: str | None = None,
+) -> dict[str, object]:
+    """Return one MLflow LLM span with explicit timing and model identity.
+
+    Args:
+        trace_id: Declared trace identifier.
+        span_id: Declared span identifier.
+        parent_id: Declared parent span identifier, when any.
+        name: Declared span name.
+        start_ns: Start time as nanoseconds since epoch.
+        end_ns: End time as nanoseconds since epoch.
+        model: Declared model name.
+        provider: Declared provider name.
+        inputs: Declared span inputs, defaulting to a user message list.
+        outputs: Declared span outputs, defaulting to an assistant completion.
+        span_type: Declared MLflow span type.
+        error: Optional error message that also marks the span failed.
+
+    Returns:
+        One MLflow span object.
+    """
+    span: dict[str, object] = {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "name": name,
+        "span_type": span_type,
+        "start_time_ns": start_ns,
+        "end_time_ns": end_ns,
+        "inputs": inputs
+        if inputs is not None
+        else {"messages": [{"role": "user", "content": "Where is my order?"}]},
+        "outputs": outputs
+        if outputs is not None
+        else {"role": "assistant", "content": "It ships tomorrow."},
+        "attributes": {
+            "mlflow.spanType": span_type,
+            "llm.request.model": model,
+            "llm.system": provider,
+        },
+    }
+    if parent_id is not None:
+        span["parent_id"] = parent_id
+    if error is not None:
+        span["status"] = {"status_code": "ERROR", "error": error}
+    return span
+
+
+def _tool_span(
+    *,
+    trace_id: str = "trace-1",
+    span_id: str = "span-2",
+    parent_id: str = "span-1",
+    name: str = "lookup_order",
+) -> dict[str, object]:
+    """Return one MLflow TOOL span that reports its arguments and result."""
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_id": parent_id,
+        "name": name,
+        "span_type": "TOOL",
+        "start_time_ns": 1_700_000_001_000_000_000,
+        "end_time_ns": 1_700_000_002_000_000_000,
+        "inputs": {"order": "A1"},
+        "outputs": "ships tomorrow",
+        "attributes": {"mlflow.spanType": "TOOL"},
+    }
+
+
+def test_load_mlflow_file_keeps_completion_and_model_identity(tmp_path: Path) -> None:
+    """The model span keeps its completion text and declared provider model."""
+    path = tmp_path / "mlflow.json"
+    path.write_text(
+        json.dumps([_llm_span(), _tool_span(), _llm_span(span_id="span-3", outputs="Done.")]),
+        encoding="utf-8",
+    )
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert result.traces[0].task == "Where is my order?"
+    completions = [span.attributes.get("gen_ai.completion") for span in result.traces[0].spans]
+    assert "It ships tomorrow." in completions
+    assert "Done." in completions
+
+
+def test_load_mlflow_file_tool_result_is_paired_with_requesting_call(tmp_path: Path) -> None:
+    """A TOOL span is normalized as a tool_result paired with the earlier model call."""
+    tool_call_outputs = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "function": {"name": "lookup_order", "arguments": '{"order": "A1"}'},
+            }
+        ],
+    }
+    path = tmp_path / "mlflow.json"
+    path.write_text(
+        json.dumps(
+            [
+                _llm_span(span_id="span-1", outputs=tool_call_outputs),
+                _tool_span(span_id="span-2", parent_id="span-1"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = MLFLOW_SOURCE.load(path)
+
+    tool_names = [span.attributes.get("gen_ai.tool.name") for span in result.traces[0].spans]
+    assert "lookup_order" in tool_names
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_mlflow_file_ignores_orchestration_spans(tmp_path: Path) -> None:
+    """CHAIN and AGENT spans carry no direct evidence and are ignored."""
+    path = tmp_path / "mlflow.json"
+    path.write_text(
+        json.dumps(
+            [
+                _llm_span(span_id="span-1"),
+                {
+                    "trace_id": "trace-1",
+                    "span_id": "span-99",
+                    "name": "orchestration",
+                    "span_type": "CHAIN",
+                    "start_time_ns": 1_700_000_002_000_000_000,
+                    "end_time_ns": 1_700_000_003_000_000_000,
+                    "attributes": {"mlflow.spanType": "CHAIN"},
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert len(result.traces[0].spans) == 1
+
+
+def test_load_mlflow_file_accepts_trace_envelope_wrapper(tmp_path: Path) -> None:
+    """A ``traces`` envelope with ``data.spans`` is flattened into one trace."""
+    path = tmp_path / "mlflow.json"
+    path.write_text(
+        json.dumps(
+            {
+                "traces": [
+                    {
+                        "info": {"trace_id": "trace-7"},
+                        "data": {"spans": [_llm_span(trace_id="trace-7", span_id="span-7")]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_load_mlflow_file_accepts_jsonl(tmp_path: Path) -> None:
+    """JSONL with one span per line is supported."""
+    path = tmp_path / "mlflow.jsonl"
+    spans = [
+        _llm_span(trace_id="trace-2", span_id="span-a"),
+        _llm_span(trace_id="trace-2", span_id="span-b"),
+    ]
+    path.write_text("\n".join(json.dumps(span) for span in spans), encoding="utf-8")
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_mlflow_file_handles_iso_timestamps(tmp_path: Path) -> None:
+    """ISO-8601 startTime and endTime are accepted when nanosecond fields are absent."""
+    path = tmp_path / "mlflow.json"
+    span = {
+        "trace_id": "trace-iso",
+        "span_id": "span-iso",
+        "name": "chat",
+        "span_type": "LLM",
+        "startTime": "2026-02-01T00:00:00Z",
+        "endTime": "2026-02-01T00:00:01Z",
+        "inputs": {"messages": [{"role": "user", "content": "hello"}]},
+        "outputs": {"content": "hi"},
+        "attributes": {"llm.request.model": "gpt-4o", "llm.system": "openai"},
+    }
+    path.write_text(json.dumps([span]), encoding="utf-8")
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert result.traces[0].task == "hello"
+
+
+def test_load_mlflow_file_marks_failed_span(tmp_path: Path) -> None:
+    """A span with ERROR status retains the declared failure message."""
+    path = tmp_path / "mlflow.json"
+    path.write_text(
+        json.dumps([_llm_span(span_id="span-err", error="rate limited")]),
+        encoding="utf-8",
+    )
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert result.issues == ()
+    failed = result.traces[0].spans[0]
+    assert failed.failure is not None
+    assert failed.failure.message == "rate limited"
+
+
+def test_load_mlflow_file_preserves_usage_when_declared(tmp_path: Path) -> None:
+    """Token accounting declared on LLM spans is retained on the model span."""
+    span = _llm_span(span_id="span-usage")
+    assert isinstance(span["attributes"], dict)
+    span["attributes"].update({"gen_ai.usage.input_tokens": 10, "gen_ai.usage.output_tokens": 20})
+    # The shared declared_usage helper also reads prompt/completion tokens.
+    span["attributes"]["llm.usage.prompt_tokens"] = 10
+    span["attributes"]["llm.usage.completion_tokens"] = 20
+    path = tmp_path / "mlflow.json"
+    path.write_text(json.dumps([span]), encoding="utf-8")
+
+    result = MLFLOW_SOURCE.load(path)
+
+    # Usage is validated strictly; presence does not error and raw span is kept.
+    assert len(result.traces) == 1
+    assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_mlflow_is_registered_as_canonical_source() -> None:
+    """The MLflow source is discoverable through the canonical source table."""
+    assert "mlflow" in CANONICAL_TRACE_SOURCES
+    assert "mlflow" in sorted(CANONICAL_TRACE_SOURCES)
+
+
+def test_load_trace_source_dispatches_to_mlflow(tmp_path: Path) -> None:
+    """The generic loader routes ``mlflow`` to the MLflow adapter."""
+    path = tmp_path / "mlflow.json"
+    path.write_text(json.dumps([_llm_span()]), encoding="utf-8")
+
+    result = load_trace_source("mlflow", path)
+
+    assert len(result.traces) == 1
+
+
+def test_load_mlflow_file_rejects_unsupported_shape(tmp_path: Path) -> None:
+    """A payload without any MLflow record keys is reported as an exclusion."""
+    path = tmp_path / "mlflow.json"
+    path.write_text(json.dumps({"unknown": 1}), encoding="utf-8")
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert result.traces == ()
+    assert len(result.issues) == 1
+
+
+def test_load_mlflow_file_camelcase_keys(tmp_path: Path) -> None:
+    """CamelCase traceId and spanId are accepted."""
+    path = tmp_path / "mlflow.json"
+    span = {
+        "traceId": "trace-camel",
+        "spanId": "span-camel",
+        "name": "chat",
+        "spanType": "LLM",
+        "startTime": "2026-02-01T00:00:00Z",
+        "endTime": "2026-02-01T00:00:01Z",
+        "inputs": {"messages": [{"role": "user", "content": "hello"}]},
+        "outputs": {"content": "hi"},
+        "attributes": {"llm.request.model": "gpt-4o", "llm.system": "openai"},
+    }
+    path.write_text(json.dumps([span]), encoding="utf-8")
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert result.traces[0].task == "hello"

--- a/exp/simulation/ingest/mlflow_test.py
+++ b/exp/simulation/ingest/mlflow_test.py
@@ -294,11 +294,17 @@ def test_load_mlflow_file_marks_failed_span(tmp_path: Path) -> None:
 def test_load_mlflow_file_preserves_usage_when_declared(tmp_path: Path) -> None:
     """Token accounting declared on LLM spans is retained on the model span."""
     span = _llm_span(span_id="span-usage")
-    assert isinstance(span["attributes"], dict)
-    span["attributes"].update({"gen_ai.usage.input_tokens": 10, "gen_ai.usage.output_tokens": 20})
-    # The shared declared_usage helper also reads prompt/completion tokens.
-    span["attributes"]["llm.usage.prompt_tokens"] = 10
-    span["attributes"]["llm.usage.completion_tokens"] = 20
+    attributes: dict[str, object] = {
+        "mlflow.spanType": "LLM",
+        "llm.request.model": "gpt-4o-mini",
+        "llm.system": "openai",
+        "gen_ai.usage.input_tokens": 10,
+        "gen_ai.usage.output_tokens": 20,
+        # The shared declared_usage helper also reads prompt/completion tokens.
+        "llm.usage.prompt_tokens": 10,
+        "llm.usage.completion_tokens": 20,
+    }
+    span["attributes"] = attributes
     path = tmp_path / "mlflow.json"
     path.write_text(json.dumps([span]), encoding="utf-8")
 

--- a/exp/simulation/ingest/mlflow_test.py
+++ b/exp/simulation/ingest/mlflow_test.py
@@ -362,3 +362,68 @@ def test_load_mlflow_file_camelcase_keys(tmp_path: Path) -> None:
 
     assert len(result.traces) == 1
     assert result.traces[0].task == "hello"
+
+
+def test_load_mlflow_file_accepts_real_server_export_shape(tmp_path: Path) -> None:
+    """Server exports use unix_nano timing, JSON-encoded attributes, and OTel status."""
+    start_ns = 1_788_512_428_260_757_000
+    tool_span = {
+        "trace_id": "trace-real",
+        "span_id": "span-tool",
+        "parent_span_id": "span-root",
+        "name": "lookup_order",
+        "start_time_unix_nano": start_ns,
+        "end_time_unix_nano": start_ns + 1_000_000,
+        "status": {"code": "STATUS_CODE_OK", "message": ""},
+        "attributes": {
+            "mlflow.spanType": '"TOOL"',
+            "mlflow.spanInputs": '{"order": "A1"}',
+            "mlflow.spanOutputs": '"ships tomorrow"',
+        },
+    }
+    model_span = {
+        "trace_id": "trace-real",
+        "span_id": "span-llm",
+        "parent_span_id": "span-root",
+        "name": "answer",
+        "start_time_unix_nano": start_ns,
+        "end_time_unix_nano": start_ns + 2_000_000,
+        "status": {"code": "STATUS_CODE_OK", "message": ""},
+        "attributes": {
+            "mlflow.spanType": '"LLM"',
+            "llm.request.model": '"gpt-4o-mini"',
+            "llm.system": '"openai"',
+            "mlflow.spanInputs": (
+                '{"messages": [{"role": "user", "content": "Where is my order?"}]}'
+            ),
+            "mlflow.spanOutputs": '{"content": "It ships tomorrow."}',
+        },
+    }
+    root_span = {
+        "trace_id": "trace-real",
+        "span_id": "span-root",
+        "name": "chat",
+        "start_time_unix_nano": start_ns,
+        "end_time_unix_nano": start_ns + 3_000_000,
+        "status": {"code": "STATUS_CODE_OK", "message": ""},
+        "attributes": {"mlflow.spanType": '"UNKNOWN"'},
+    }
+    path = tmp_path / "mlflow.json"
+    path.write_text(json.dumps([root_span, tool_span, model_span]), encoding="utf-8")
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert len(result.traces) == 1
+    assert result.traces[0].task == "Where is my order?"
+    assert len(result.traces[0].spans) == 2
+    tool_names = [span.attributes.get("gen_ai.tool.name") for span in result.traces[0].spans]
+    assert "lookup_order" in tool_names
+    failed = [span for span in result.traces[0].spans if span.failure is not None]
+    assert failed == []
+    models = [
+        span.attributes["gen_ai.request.model"]
+        for span in result.traces[0].spans
+        if "gen_ai.request.model" in span.attributes
+    ]
+    assert models == ["gpt-4o-mini"]

--- a/exp/simulation/ingest/mlflow_test.py
+++ b/exp/simulation/ingest/mlflow_test.py
@@ -187,6 +187,58 @@ def test_load_mlflow_file_accepts_trace_envelope_wrapper(tmp_path: Path) -> None
     assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
 
 
+def test_load_mlflow_file_envelope_trace_id_propagates_to_child_spans(
+    tmp_path: Path,
+) -> None:
+    """Child spans without a trace_id inherit ``info.trace_id`` from the envelope."""
+    # MLflow trace-search shapes identify the trace only at the envelope level;
+    # valid child spans that omit their own trace_id must not be dropped.
+    child_without_trace = {
+        "span_id": "span-7-no-trace",
+        "name": "chat",
+        "span_type": "LLM",
+        "start_time_ns": 1_700_000_000_000_000_000,
+        "end_time_ns": 1_700_000_001_000_000_000,
+        "inputs": {"messages": [{"role": "user", "content": "hello envelope"}]},
+        "outputs": {"content": "hi envelope"},
+        "attributes": {"llm.request.model": "gpt-4o", "llm.system": "openai"},
+    }
+    path = tmp_path / "mlflow.json"
+    path.write_text(
+        json.dumps(
+            {
+                "traces": [
+                    {
+                        "info": {"trace_id": "trace-envelope-1"},
+                        "data": {"spans": [child_without_trace]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = MLFLOW_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert len(result.traces) == 1
+    assert result.traces[0].task == "hello envelope"
+    # Also verify single-trace envelope shape without the outer ``traces`` wrapper.
+    single_envelope = tmp_path / "mlflow_single.json"
+    single_envelope.write_text(
+        json.dumps(
+            {
+                "info": {"trace_id": "trace-single-1"},
+                "data": {"spans": [child_without_trace]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    single_result = MLFLOW_SOURCE.load(single_envelope)
+    assert len(single_result.traces) == 1
+    assert single_result.traces[0].task == "hello envelope"
+
+
 def test_load_mlflow_file_accepts_jsonl(tmp_path: Path) -> None:
     """JSONL with one span per line is supported."""
     path = tmp_path / "mlflow.jsonl"

--- a/exp/simulation/ingest/sources.py
+++ b/exp/simulation/ingest/sources.py
@@ -22,6 +22,7 @@ from exp.simulation.ingest.chat_json import CHAT_JSON_SOURCE
 from exp.simulation.ingest.langfuse import LANGFUSE_SOURCE
 from exp.simulation.ingest.langsmith import LANGSMITH_SOURCE
 from exp.simulation.ingest.mastra import MASTRA_SOURCE
+from exp.simulation.ingest.mlflow import MLFLOW_SOURCE
 from exp.simulation.ingest.otel_genai import load_otel_genai_file
 from exp.simulation.ingest.otlp import (
     OtlpTraceFormatError,
@@ -56,6 +57,7 @@ _LOADERS: dict[str, _TraceFileLoader] = {
     "langfuse": LANGFUSE_SOURCE.load,
     "langsmith": LANGSMITH_SOURCE.load,
     "mastra": MASTRA_SOURCE.load,
+    "mlflow": MLFLOW_SOURCE.load,
     "otel-genai": load_otel_genai_file,
     "otlp": load_otlp_file,
     "phoenix": PHOENIX_SOURCE.load,

--- a/exp/simulation/ingest/sources_test.py
+++ b/exp/simulation/ingest/sources_test.py
@@ -81,6 +81,23 @@ _MINIMAL_VENDOR_EXPORTS: dict[str, JsonValue] = {
             }
         ]
     },
+    "mlflow": [
+        {
+            "trace_id": "trace-1",
+            "span_id": "span-0",
+            "name": "chat",
+            "span_type": "LLM",
+            "start_time_ns": 1_700_000_000_000_000_000,
+            "end_time_ns": 1_700_000_001_000_000_000,
+            "attributes": {
+                "mlflow.spanType": "LLM",
+                "llm.request.model": "gpt-test",
+                "llm.system": "openai",
+            },
+            "inputs": {"messages": [_USER]},
+            "outputs": {"content": "here is the plan"},
+        }
+    ],
     "otel-genai": [
         {
             "trace_id": "9" * 32,
@@ -150,6 +167,7 @@ def test_declared_sources_are_the_supported_set() -> None:
         "langfuse",
         "langsmith",
         "mastra",
+        "mlflow",
         "otel-genai",
         "otlp",
         "phoenix",


### PR DESCRIPTION
### Summary

MLflow is the leading OSS experiment tracker (Databricks) and exports traces as spans with `trace_id`, `span_id`, `span_type`, `start_time_ns`, `attributes`, `inputs` and `outputs`. Users previously had to convert via the generic OTLP path and lost model identity, tool pairing and failure fidelity. This adds an explicit canonical loader `mlflow` alongside `braintrust`, `langfuse`, `mastra`, `phoenix`, `posthog` etc.

### Design

MLflow spans map to canonical evidence by what they observe:

- `LLM` and `CHAT_MODEL` become model calls, including tool calls their output requests,
- `TOOL` and `FUNCTION` become tool results paired with the earlier requesting call,
- `CHAIN`, `AGENT`, `RETRIEVER`, `EMBEDDING` and orchestration types are ignored.

Exports arrive as a span array, a `traces`/`spans`/`data` envelope, or JSONL with one span per line. A trace object carrying `info.trace_id` and `data.spans` (the shape of `GET /mlflow/traces/search`) is also supported. Model identity comes from `llm.request.model`/`gen_ai.request.model` with provider from `llm.system`/`gen_ai.system`; usage from `llm.usage`/`gen_ai.usage`.

### Changes

- `exp/simulation/ingest/mlflow.py` – new `MLFLOW_SOURCE` (623 lines, under 999-line ceiling) with nanosecond/millisecond/ISO timestamp handling, camelCase and snake_case keys, and trace-envelope flattening.
- `exp/simulation/ingest/mlflow_test.py` – 12 tests: completion and model identity, tool pairing, orchestration ignore, trace envelope, JSONL, ISO timestamps, failure propagation, usage, registration, generic dispatch, unsupported shape and camelCase keys.
- `exp/simulation/ingest/sources.py` – register `mlflow`.
- `exp/simulation/ingest/__init__.py` – re-export.
- `exp/simulation/ingest/sources_test.py` – update canonical set and add minimal mlflow export fixture.

### Verification

- `uv run ruff check .` – All checks passed
- `uv run ruff format --check .` – 758 files formatted
- `uv run pytest exp/simulation/ingest/mlflow_test.py -v` – 12 passed
- `uv run pytest exp/simulation/ingest/sources_test.py -q` – 13 passed (including new mlflow parametrized case)
- `uv run pytest exp/simulation/ingest/ -q` – 163 passed
- `uv run pytest exp/tests/repo_layout_test.py exp/tests/repo_import_boundaries_test.py -q` – 22 passed

### Not a duplicate

Open PR #121 adds a W&B Weave adapter. This is the distinct MLflow vendor (no existing MLflow file, no open issue requesting it, and `CANONICAL_TRACE_SOURCES` had 9 entries before – now 10). No open issue or PR mentions MLflow.