### PR TITLE
gateway: accept Copilot's hardcoded no-op values (n:1, truncation:disabled, implicit cache mode)

### DIFF
--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -52,6 +52,9 @@ CHAT_MANIFEST = CompatibilityManifest(
         _field("reasoning_effort", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
         _field("top_k", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "top_k"),
         _field("logprobs", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "logprobs"),
+        # Accepted only at its no-op default of 1 (the wire model enforces
+        # the value): Copilot hardcodes n:1 on every Chat request.
+        _field("n", CompatibilityDisposition.SUPPORTED),
         _field("top_logprobs", CompatibilityDisposition.UNSUPPORTED),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
         # End-user attribution / cache hints (OpenAI spec). Accepted and recorded
@@ -71,7 +74,6 @@ CHAT_MANIFEST = CompatibilityManifest(
                 "logit_bias",
                 "modalities",
                 "moderation",
-                "n",
                 "prediction",
                 "presence_penalty",
                 "prompt_cache_options",
@@ -121,6 +123,13 @@ RESPONSES_MANIFEST = CompatibilityManifest(
         _field("reasoning", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
         _field("top_k", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "top_k"),
         _field("top_logprobs", CompatibilityDisposition.UNSUPPORTED),
+        # Accepted only at their no-op values (the wire models enforce them):
+        # Copilot hardcodes truncation:"disabled" and
+        # prompt_cache_options:{"mode":"implicit"} on every Responses request,
+        # and both describe exactly the behavior this gateway already serves
+        # (context is never truncated; served routes cache implicitly).
+        _field("truncation", CompatibilityDisposition.SUPPORTED),
+        _field("prompt_cache_options", CompatibilityDisposition.SUPPORTED),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
         # End-user attribution / cache hints (OpenAI spec), same handling as the
         # Chat surface: accepted and recorded gateway-side, never forwarded.
@@ -136,11 +145,9 @@ RESPONSES_MANIFEST = CompatibilityManifest(
                 "max_tool_calls",
                 "moderation",
                 "prompt",
-                "prompt_cache_options",
                 "prompt_cache_retention",
                 "service_tier",
                 "stream_options",
-                "truncation",
             )
         ),
     ),

--- a/exp/runtime/openai_protocol/manifest_test.py
+++ b/exp/runtime/openai_protocol/manifest_test.py
@@ -48,7 +48,12 @@ def test_manifests_classify_explicit_exclusions() -> None:
     chat = disposition_map(CHAT_MANIFEST)
     responses = disposition_map(RESPONSES_MANIFEST)
     assert chat["audio"] == CompatibilityDisposition.UNSUPPORTED
-    assert chat["n"] == CompatibilityDisposition.UNSUPPORTED
+    # Value-constrained acceptances: the wire models admit only the no-op
+    # values Copilot hardcodes (n:1, truncation:"disabled",
+    # prompt_cache_options:{"mode":"implicit"}).
+    assert chat["n"] == CompatibilityDisposition.SUPPORTED
+    assert responses["truncation"] == CompatibilityDisposition.SUPPORTED
+    assert responses["prompt_cache_options"] == CompatibilityDisposition.SUPPORTED
     assert chat["logprobs"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED
     assert chat["top_logprobs"] == CompatibilityDisposition.UNSUPPORTED
     assert chat["top_k"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -598,6 +598,17 @@ def _validation_protocol_error(error: ValidationError) -> OpenAIProtocolError:
         for detail in details:
             if detail["type"] == "value_error":
                 return invalid_field(param, detail["msg"].removeprefix("Value error, ") + ".")
+    for detail in details:
+        # A field validator's own wording states this gateway's exact value
+        # constraint (only our wire models raise these, so the text is
+        # display-safe and never echoes the caller's value).
+        if detail["type"] == "value_error":
+            return invalid_field(
+                param,
+                f"Invalid value for {param!r}: "
+                + detail["msg"].removeprefix("Value error, ")
+                + ".",
+            )
     return invalid_field(param, _shape_message(param, details))
 
 

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -246,11 +246,6 @@ def test_responses_decoder_rejects_conflicting_reasoning_summary_aliases() -> No
     ("decoder", "payload", "param"),
     (
         (
-            decode_chat,
-            {"model": "coding", "messages": [{"role": "user", "content": "x"}], "n": 2},
-            "n",
-        ),
-        (
             decode_responses,
             {"model": "coding", "input": "x", "background": True},
             "background",
@@ -2374,3 +2369,92 @@ def test_responses_surface_defines_no_video_part() -> None:
                 ],
             }
         )
+
+
+def test_copilot_hardcoded_no_op_values_decode_on_both_openai_surfaces() -> None:
+    """The exact VS Code Copilot custom-endpoint shapes decode end to end.
+
+    Wire-captured from VS Code 1.136 (2026-09-02): Copilot hardcodes ``n: 1``
+    (with ``stream_options.include_usage``, ``temperature: 0.1``,
+    ``top_p: 1``) on every Chat request and ``truncation: "disabled"`` plus
+    ``prompt_cache_options: {"mode": "implicit"}`` on every Responses
+    request; each rejection blocked the whole lane. The values are accepted
+    as already satisfied (this gateway serves one completion, never
+    truncates, and caches implicitly on served routes), never forwarded, and
+    disclose nothing because nothing is ignored.
+    """
+    chat = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "temperature": 0.1,
+            "top_p": 1,
+            "n": 1,
+        }
+    )
+    assert chat.request.temperature == 0.1
+    assert chat.request.include_usage is True
+    assert chat.request.ignored_parameters == ()
+    assert "n" not in chat.request.model_dump(mode="json")
+
+    responses = decode_responses(
+        {
+            "model": "coding",
+            "input": "hello",
+            "truncation": "disabled",
+            "prompt_cache_options": {"mode": "implicit"},
+        }
+    )
+    assert responses.request.ignored_parameters == ()
+    dumped = responses.request.model_dump(mode="json")
+    assert "truncation" not in dumped
+    assert "prompt_cache_options" not in dumped
+
+
+@pytest.mark.parametrize(
+    ("decoder", "payload", "param", "fragment"),
+    (
+        (
+            decode_chat,
+            {"model": "coding", "messages": [{"role": "user", "content": "x"}], "n": 2},
+            "n",
+            "default of 1",
+        ),
+        (
+            decode_responses,
+            {"model": "coding", "input": "x", "truncation": "auto"},
+            "truncation",
+            "never truncates",
+        ),
+        (
+            decode_responses,
+            {"model": "coding", "input": "x", "prompt_cache_options": {"mode": "explicit"}},
+            "prompt_cache_options.mode",
+            "implicit",
+        ),
+        (
+            decode_responses,
+            {
+                "model": "coding",
+                "input": "x",
+                "prompt_cache_options": {"mode": "implicit", "ttl": "5m"},
+            },
+            "prompt_cache_options.ttl",
+            "",
+        ),
+    ),
+)
+def test_non_default_values_of_accepted_no_op_fields_stay_named_rejections(
+    decoder: Callable[[JsonObject], DecodedGatewayRequest],
+    payload: JsonObject,
+    param: str,
+    fragment: str,
+) -> None:
+    """Only the semantically satisfied value of each field is accepted."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decoder(payload)
+    assert captured.value.detail.code == "invalid_parameter"
+    assert captured.value.detail.param == param
+    assert fragment in captured.value.detail.message

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -322,6 +322,26 @@ class _ChatRequest(_WireModel):
     max_tokens: int | None = Field(default=None, gt=0)
     max_completion_tokens: int | None = Field(default=None, gt=0)
     stop: str | tuple[str, ...] | None = None
+    n: int | None = None
+    """Completion-count selector, accepted only at its no-op default of 1.
+
+    VS Code Copilot's custom-endpoint provider hardcodes ``n: 1`` on every
+    Chat request (wire-captured 2026-09-02); this gateway serves exactly one
+    completion per request, so 1 is accepted as already satisfied and any
+    other value stays a named rejection.
+    """
+
+    @field_validator("n")
+    @classmethod
+    def _require_single_completion(cls, value: int | None) -> int | None:
+        """Accept the completion count only as already satisfied."""
+        if value is not None and value != 1:
+            raise ValueError(
+                "supported only at its default of 1: this gateway serves "
+                "exactly one completion per request"
+            )
+        return value
+
     temperature: float | None = Field(default=None, ge=0, le=2)
     top_p: float | None = Field(default=None, ge=0, le=1)
     top_k: int | None = Field(default=None, ge=0)
@@ -574,6 +594,20 @@ _ResponsesOutputItem = Annotated[
 _ResponsesInputItem = _ResponseMessage | _ResponsesOutputItem
 
 
+class _PromptCacheOptions(_WireModel):
+    """Responses prompt-cache selector, accepted only in its implicit mode.
+
+    VS Code Copilot's custom-endpoint provider hardcodes
+    ``{"mode": "implicit"}`` on every Responses request (wire-captured
+    2026-09-02). Implicit prefix caching is exactly what served routes
+    already do, so the value is accepted as already satisfied; any other
+    mode names behavior this gateway does not provide and stays a closed
+    rejection.
+    """
+
+    mode: Literal["implicit"]
+
+
 class _ResponsesRequest(_WireModel):
     """Closed gateway Responses request profile."""
 
@@ -593,6 +627,25 @@ class _ResponsesRequest(_WireModel):
     top_logprobs: int | None = Field(default=None, ge=0, le=20)
     reasoning: _ResponseReasoning | None = None
     text: _ResponseText | None = None
+    truncation: str | None = Field(default=None, max_length=64)
+    """Context-truncation selector, accepted only at its no-op default.
+
+    VS Code Copilot's custom-endpoint provider hardcodes
+    ``truncation: "disabled"`` on every Responses request (wire-captured
+    2026-09-02). This gateway never truncates context, so "disabled" is
+    accepted as already satisfied; "auto" asks for dropping context the
+    gateway does not implement and stays a closed rejection.
+    """
+
+    @field_validator("truncation")
+    @classmethod
+    def _require_no_truncation(cls, value: str | None) -> str | None:
+        """Accept the truncation selector only as already satisfied."""
+        if value is not None and value != "disabled":
+            raise ValueError("supported only as 'disabled': this gateway never truncates context")
+        return value
+
+    prompt_cache_options: _PromptCacheOptions | None = None
     stream: bool = False
     client_metadata: JsonObject | None = None
     metadata: JsonObject = Field(default_factory=dict)


### PR DESCRIPTION
## Problem (verified customer-lane blocker: VS Code Copilot BYOK)

Copilot's "Custom Endpoint" provider (wire-captured from VS Code 1.136, curl-reproducible on prod) hardcodes three request fields the gateway 400s, blocking its chat-completions and responses lanes entirely (the messages lane already serves end to end):

1. `/v1/chat/completions` + `n: 1` → "The parameter 'n' is not supported by this gateway profile"
2. `/v1/responses` + `prompt_cache_options: {"mode": "implicit"}` → same class
3. `/v1/responses` + `truncation: "disabled"` → same class

All three were engine-side manifest `UNSUPPORTED` entries (not platform admission), confirmed by code and by replay.

## Fix: accept-the-no-op-value, fail-closed otherwise (the temperature [1,1] pattern)

- **`n`**: accepted iff `== 1` — the gateway serves exactly one completion per request, so 1 is already satisfied. `n: 2` stays a named rejection: `Invalid value for 'n': supported only at its default of 1: this gateway serves exactly one completion per request.`
- **`truncation`**: accepted iff `== "disabled"` — the gateway never truncates context. `"auto"` stays rejected with the constraint stated.
- **`prompt_cache_options`**: accepted iff exactly `{"mode": "implicit"}` (closed model: unknown modes and extra keys reject by name) — implicit prefix caching is exactly what served routes already do.

None of the values are forwarded upstream, and none disclose through `ignored_parameters`: nothing is ignored, the requested behavior is already delivered. The manifests move the three fields from `UNSUPPORTED` to `SUPPORTED` with the wire models enforcing the values, keeping the drift gates satisfied. As a small #671 improvement, `value_error` 400s on the OpenAI surfaces now carry the field validator's own constraint wording (previously a bare "Invalid value for 'n'.").

## Tests

- The exact captured Copilot payload shapes pinned on both surfaces (chat: `n:1` + `stream_options.include_usage` + `temperature: 0.1` + `top_p: 1`; responses: `truncation: "disabled"` + `prompt_cache_options: {"mode": "implicit"}`), asserting decode success, no disclosures, and no canonical-contract leakage.
- Named-rejection matrix for every non-default value (`n: 2`, `truncation: "auto"`, `mode: "explicit"`, extra cache-option keys).
- Three existing pins updated: the manifest exclusion assertions and the two `n: 2` rejection tests (still 400 with `param: "n"`, now `invalid_parameter` with the constraint message).

## Live verification (locally served native gateway, house keys)

- Chat lane, full Copilot shape on an OpenAI-routed alias (`gpt-4o-mini`): streams 200 with usage.
- Responses lane, full Copilot shape: 200 (`COPILOT_RESP_OK`).

Two adjacent pre-existing behaviors surfaced during live testing, both known policy and out of scope here: on adaptive-generation Anthropic routes Copilot's `temperature: 0.1` still rejects per the [1,1] constraint, and on `claude-haiku-4-5` the provider itself rejects `temperature` and `top_p` together. Copilot BYOK targets OpenAI-family routes where the full shape serves.

## Gates

- ruff format / check, ty: clean
- Full `uv run pytest -q` on the committed tree: 3262 passed, 6 skipped
- Python-only; no crate change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
