### PR TITLE
release: bump version to 0.7.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.22"
+version = "0.7.23"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.22"
+version = "0.7.23"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Mechanical bump 0.7.22 → 0.7.23 (pyproject + uv.lock together — the lockfile records the project's own version and the w16 evidence gate fails closed on a dirty tree otherwise).

v0.7.22 was tagged at its bump commit (19:06 yesterday) before three PRs merged:
- #729 — accept Copilot's hardcoded no-op values (n:1, truncation:disabled, implicit cache mode); unblocks VS Code Copilot BYOK chat-completions/responses lanes
- #724 — video input across Chat decoding, Gemini/Bedrock/OpenAI-compatible encoding
- #726 — preserve cache_write_input_tokens in combine_economics

0.7.23 is the first tag carrying them; native crate is at 0.3.19 on main (0.3.18 is the latest published — this release publishes 0.3.19). Platform pin PR follows wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)