### PR TITLE
gateway: recover a Gemini stream that emits content then ends abnormally (v0.7.25)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.19"
+version = "0.3.20"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.19"
+version = "0.3.20"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -355,6 +355,44 @@ impl Normalizer {
         events
     }
 
+    /// Recover a Gemini stream that emitted content and then terminated
+    /// *abnormally* — a broken transport read, a malformed frame, or a decoder
+    /// error — rather than closing cleanly. `on_stream_end` covers the clean
+    /// end (last content frame, then EOF, no terminal frame); this covers the
+    /// abnormal end, where the underlying failure would otherwise discard a
+    /// real partial answer.
+    ///
+    /// Scoped to Gemini: Gemini uniquely ends legitimate turns without a
+    /// terminal frame, so a break after content is far more likely a
+    /// truncated-but-usable answer than corruption. When content was already
+    /// emitted, synthesize an `Incomplete` terminal (folding last-seen usage)
+    /// so the caller receives the partial content with an early-termination
+    /// finish reason and a retryable settlement (`incomplete`, not `failed`),
+    /// and the delivered tokens still bill. Before any content there is nothing
+    /// to preserve, so reclassify the abnormal end as a retryable transport
+    /// failure (retry same deployment, then fail over) instead of a hard
+    /// malformed reject. Any non-Gemini dialect, or a stream already terminated,
+    /// keeps the original failure unchanged.
+    pub fn recover_abnormal_end(&mut self, failure: Failure) -> Result<Vec<Event>, Failure> {
+        if self.terminal || self.dialect != Dialect::GeminiGenerateContent {
+            return Err(failure);
+        }
+        if !self.emitted_output {
+            return Err(Failure::new(
+                FailureClass::Transport,
+                "provider transport failed; retry the request",
+            )
+            .with_retry(true, true));
+        }
+        let mut events = Vec::new();
+        if let Some(usage) = self.usage.take() {
+            events.push(Event::Usage(usage));
+        }
+        events.push(Event::Incomplete);
+        self.terminal = true;
+        Ok(events)
+    }
+
     /// Feed one decoded SSE frame; a terminal event ends the stream.
     pub fn feed(&mut self, frame: &SseEvent) -> Result<Vec<Event>, Failure> {
         if self.terminal {
@@ -389,12 +427,14 @@ pub fn drain_stream_fixture(dialect: Dialect, chunks: &[Vec<u8>]) -> (Vec<Value>
     for chunk in chunks {
         let frames = match decoder.feed(chunk) {
             Ok(frames) => frames,
-            Err(message) => return (simplified, Some(malformed(&message))),
+            Err(message) => {
+                return recover_or_report(&mut normalizer, simplified, malformed(&message))
+            }
         };
         for frame in frames {
             match normalizer.feed(&frame) {
                 Ok(events) => simplified.extend(events.iter().map(simplified_event)),
-                Err(failure) => return (simplified, Some(failure)),
+                Err(failure) => return recover_or_report(&mut normalizer, simplified, failure),
             }
             if normalizer.saw_terminal() {
                 return (simplified, None);
@@ -404,10 +444,10 @@ pub fn drain_stream_fixture(dialect: Dialect, chunks: &[Vec<u8>]) -> (Vec<Value>
     match decoder.finish() {
         Ok(Some(frame)) => match normalizer.feed(&frame) {
             Ok(events) => simplified.extend(events.iter().map(simplified_event)),
-            Err(failure) => return (simplified, Some(failure)),
+            Err(failure) => return recover_or_report(&mut normalizer, simplified, failure),
         },
         Ok(None) => {}
-        Err(message) => return (simplified, Some(malformed(&message))),
+        Err(message) => return recover_or_report(&mut normalizer, simplified, malformed(&message)),
     }
     if normalizer.saw_terminal() {
         return (simplified, None);
@@ -422,5 +462,107 @@ pub fn drain_stream_fixture(dialect: Dialect, chunks: &[Vec<u8>]) -> (Vec<Value>
     match normalizer.stream_ended() {
         Ok(()) => (simplified, None),
         Err(failure) => (simplified, Some(failure)),
+    }
+}
+
+/// Mirror the relay's abnormal-end handling for the fixture drive loop: route a
+/// terminating failure through `recover_abnormal_end`, appending any recovered
+/// terminal to the collected events, and report the (possibly reclassified)
+/// failure when recovery does not apply. Keeps the fixture drain a faithful
+/// mirror of `UpstreamRelay::next_event`.
+fn recover_or_report(
+    normalizer: &mut Normalizer,
+    mut simplified: Vec<Value>,
+    failure: Failure,
+) -> (Vec<Value>, Option<Failure>) {
+    match normalizer.recover_abnormal_end(failure) {
+        Ok(events) => {
+            simplified.extend(events.iter().map(simplified_event));
+            (simplified, None)
+        }
+        Err(failure) => (simplified, Some(failure)),
+    }
+}
+
+#[cfg(test)]
+mod recover_abnormal_end_tests {
+    use super::*;
+
+    fn feed_text(normalizer: &mut Normalizer, text: &str) {
+        let frame = SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "candidates": [{"content": {"parts": [{"text": text}]}}]
+            })
+            .to_string(),
+        };
+        let events = normalizer.feed(&frame).expect("content frame normalizes");
+        assert!(events.iter().any(Event::is_output_token));
+    }
+
+    fn incoming() -> Failure {
+        Failure::new(FailureClass::MalformedResponse, "boom").with_retry(false, true)
+    }
+
+    #[test]
+    fn gemini_after_content_recovers_incomplete_and_folds_usage() {
+        let mut normalizer = Normalizer::new(Dialect::GeminiGenerateContent);
+        feed_text(&mut normalizer, "hi");
+        normalizer.usage = Some(Usage {
+            input_tokens: Some(5),
+            output_tokens: Some(2),
+            ..Usage::default()
+        });
+        let recovered = normalizer
+            .recover_abnormal_end(incoming())
+            .expect("a partial answer recovers instead of failing");
+        assert!(matches!(recovered.first(), Some(Event::Usage(_))));
+        assert!(matches!(recovered.last(), Some(Event::Incomplete)));
+        assert!(normalizer.saw_terminal());
+    }
+
+    #[test]
+    fn gemini_before_content_reclassifies_to_retryable_transport() {
+        let mut normalizer = Normalizer::new(Dialect::GeminiGenerateContent);
+        let failure = normalizer
+            .recover_abnormal_end(incoming())
+            .expect_err("nothing to salvage before content");
+        assert_eq!(failure.failure_class, FailureClass::Transport);
+        assert!(failure.retryable_same_deployment);
+        assert!(failure.failover_eligible);
+        assert!(!normalizer.saw_terminal());
+    }
+
+    #[test]
+    fn non_gemini_keeps_the_original_failure_even_after_content() {
+        // Recovery is scoped to Gemini; an OpenAI-compatible stream that emitted
+        // content and then broke keeps its original malformed classification.
+        let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+        let frame = SseEvent {
+            event: None,
+            data: serde_json::json!({"choices": [{"delta": {"content": "hi"}}]}).to_string(),
+        };
+        normalizer.feed(&frame).expect("content normalizes");
+        let failure = normalizer
+            .recover_abnormal_end(incoming())
+            .expect_err("non-gemini keeps the original failure");
+        assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+        assert!(!normalizer.saw_terminal());
+    }
+
+    #[test]
+    fn an_already_terminal_stream_keeps_the_original_failure() {
+        let mut normalizer = Normalizer::new(Dialect::GeminiGenerateContent);
+        feed_text(&mut normalizer, "hi");
+        let terminal = SseEvent {
+            event: None,
+            data: serde_json::json!({"candidates": [{"finishReason": "STOP"}]}).to_string(),
+        };
+        normalizer.feed(&terminal).expect("terminal normalizes");
+        assert!(normalizer.saw_terminal());
+        let failure = normalizer
+            .recover_abnormal_end(incoming())
+            .expect_err("a terminated stream does not re-recover");
+        assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
     }
 }

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -373,7 +373,15 @@ impl Normalizer {
     /// failure (retry same deployment, then fail over) instead of a hard
     /// malformed reject. Any non-Gemini dialect, or a stream already terminated,
     /// keeps the original failure unchanged.
+    ///
+    /// A retained-output overflow is never recovered: it is a deliberate gateway
+    /// limit (`provider_output_too_large`), not a provider abnormality, so
+    /// converting it to `Incomplete` would deliver and bill an over-limit partial
+    /// instead of surfacing the overflow — regardless of dialect or content.
     pub fn recover_abnormal_end(&mut self, failure: Failure) -> Result<Vec<Event>, Failure> {
+        if failure.safe_message == OUTPUT_OVERFLOW_MESSAGE {
+            return Err(failure);
+        }
         if self.terminal || self.dialect != Dialect::GeminiGenerateContent {
             return Err(failure);
         }
@@ -519,6 +527,22 @@ mod recover_abnormal_end_tests {
         assert!(matches!(recovered.first(), Some(Event::Usage(_))));
         assert!(matches!(recovered.last(), Some(Event::Incomplete)));
         assert!(normalizer.saw_terminal());
+    }
+
+    #[test]
+    fn an_output_overflow_is_never_recovered_even_after_content() {
+        // The retained-output ceiling is a deliberate gateway limit: a Gemini
+        // stream that emitted content and then overflowed must still surface
+        // `provider_output_too_large`, not be delivered and billed as a partial.
+        let mut normalizer = Normalizer::new(Dialect::GeminiGenerateContent);
+        feed_text(&mut normalizer, "hi");
+        let overflow = Failure::new(FailureClass::ProviderInternal, OUTPUT_OVERFLOW_MESSAGE);
+        let failure = normalizer
+            .recover_abnormal_end(overflow)
+            .expect_err("an overflow is not an abnormal end to salvage");
+        assert_eq!(failure.safe_message, OUTPUT_OVERFLOW_MESSAGE);
+        assert_eq!(failure.failure_class, FailureClass::ProviderInternal);
+        assert!(!normalizer.saw_terminal());
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -313,41 +313,40 @@ mod gemini_tests {
     }
 
     #[test]
-    fn gemini_malformed_frames_fail_the_stream() {
-        // A non-text text part fails, exactly like the python mapper.
-        let bad_text = [sse(
-            &json!({"candidates": [{"content": {"parts": [{"text": 5}]}}]}),
-        )];
-        let refs: Vec<&[u8]> = bad_text.iter().map(Vec::as_slice).collect();
-        let (_, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
-        assert_eq!(
-            failure.expect("must fail").failure_class,
-            FailureClass::MalformedResponse
-        );
+    fn gemini_malformed_frame_before_content_is_a_retryable_abnormal_end() {
+        // A malformed frame arriving before any content is a Gemini abnormal
+        // end with nothing to salvage: there is no partial answer, so it is
+        // reclassified from a hard malformed reject to a retryable transport
+        // failure (retry the lane, then fail over) rather than being accepted.
+        // The frames are still rejected — none is silently taken as content.
+        let cases: [Value; 3] = [
+            // A non-text text part (python: parts.text must be a string).
+            json!({"candidates": [{"content": {"parts": [{"text": 5}]}}]}),
+            // Null function-call args (python: args must decode to a dict).
+            json!({"candidates": [{"content": {"parts": [
+                {"functionCall": {"name": "x", "args": null}}
+            ]}}]}),
+            // Two candidates in one frame.
+            json!({"candidates": [{}, {}]}),
+        ];
+        for payload in &cases {
+            let chunk = sse(payload);
+            let refs: Vec<&[u8]> = [chunk.as_slice()].to_vec();
+            let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+            assert!(events.is_empty(), "a rejected frame emits no content");
+            let failure = failure.expect("a malformed pre-content frame must not succeed");
+            assert_eq!(failure.failure_class, FailureClass::Transport);
+            assert!(failure.retryable_same_deployment);
+            assert!(failure.failover_eligible);
+        }
+    }
 
-        // Null function-call args fail (python: args must decode to a dict).
-        let bad_args = [sse(&json!({"candidates": [{"content": {"parts": [
-            {"functionCall": {"name": "x", "args": null}}
-        ]}}]}))];
-        let refs: Vec<&[u8]> = bad_args.iter().map(Vec::as_slice).collect();
-        let (_, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
-        assert_eq!(
-            failure.expect("must fail").failure_class,
-            FailureClass::MalformedResponse
-        );
-
-        // Two candidates in one frame fail.
-        let two = [sse(&json!({"candidates": [{}, {}]}))];
-        let refs: Vec<&[u8]> = two.iter().map(Vec::as_slice).collect();
-        let (_, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
-        assert_eq!(
-            failure.expect("must fail").failure_class,
-            FailureClass::MalformedResponse
-        );
-
+    #[test]
+    fn gemini_usage_only_close_without_content_still_fails_malformed() {
         // A stream that closes having emitted NO content at all (here only a
-        // usage-only trailer) still fails malformed: there is no real answer to
-        // complete, so the clean-end tolerance does not apply.
+        // usage-only trailer, then a clean EOF) still fails malformed: there is
+        // no real answer to complete, so the clean-end tolerance does not apply
+        // and the abnormal-end recovery never engages (nothing terminated it).
         let empty = [sse(&json!({
             "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 0},
         }))];
@@ -357,6 +356,40 @@ mod gemini_tests {
         assert_eq!(
             failure.expect("must fail").failure_class,
             FailureClass::MalformedResponse
+        );
+    }
+
+    #[test]
+    fn gemini_malformed_frame_after_content_recovers_as_incomplete() {
+        // Content emitted, then a structurally malformed frame: the real answer
+        // is preserved and the turn ends `incomplete` (an early-termination
+        // finish reason), never discarded as malformed. Last-seen usage is
+        // folded so delivered tokens still bill at settle.
+        let chunks = [
+            sse(&json!({"candidates": [{"content": {"parts": [{"text": "partial"}]}}]})),
+            sse(&json!({"usageMetadata": {"promptTokenCount": 9, "candidatesTokenCount": 3}})),
+            // A non-text text part after content: malformed mid-stream frame.
+            sse(&json!({"candidates": [{"content": {"parts": [{"text": 5}]}}]})),
+        ];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(
+            failure.is_none(),
+            "a partial answer is recovered, not failed"
+        );
+        assert_eq!(
+            events,
+            vec![
+                json!({"kind": "text_delta", "text": "partial"}),
+                json!({
+                    "kind": "usage",
+                    "input_tokens": 9,
+                    "output_tokens": 3,
+                    "cached_input_tokens": 0,
+                    "reasoning_tokens": null,
+                }),
+                json!({"kind": "incomplete"}),
+            ]
         );
     }
 

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -205,6 +205,18 @@ impl UpstreamRelay {
         self.first_token_at
     }
 
+    /// Route an abnormal stream termination through the normalizer's recovery.
+    /// The relay is done either way, so mark EOF; when recovery applies (a
+    /// Gemini stream that emitted content) the synthesized terminal is buffered
+    /// for the caller to drain, otherwise the (possibly reclassified) failure
+    /// propagates. See `Normalizer::recover_abnormal_end`.
+    fn recover_or_fail(&mut self, failure: Failure) -> Result<(), Failure> {
+        self.eof = true;
+        let events = self.normalizer.recover_abnormal_end(failure)?;
+        self.pending.extend(events);
+        Ok(())
+    }
+
     /// Yield the next normalized event. `Ok(None)` means the upstream closed
     /// without a terminal event (the caller synthesizes that failure); a
     /// stream whose terminal was already yielded returns `Ok(None)` too, but
@@ -242,24 +254,45 @@ impl UpstreamRelay {
             let chunk = match tokio::time::timeout(bound, self.stream.next()).await {
                 Ok(Some(Ok(chunk))) => chunk,
                 Ok(Some(Err(_))) => {
-                    return Err(Failure::new(
-                        FailureClass::Transport,
-                        "provider transport failed; retry the request",
-                    )
-                    .with_retry(true, true))
+                    // A transport break mid-stream: recover a Gemini partial as
+                    // Incomplete, otherwise surface the retryable transport
+                    // failure. Pre-content it stays a retryable transport error
+                    // either way.
+                    self.recover_or_fail(
+                        Failure::new(
+                            FailureClass::Transport,
+                            "provider transport failed; retry the request",
+                        )
+                        .with_retry(true, true),
+                    )?;
+                    continue;
                 }
                 Ok(None) => {
                     self.eof = true;
                     // Recover a final unterminated SSE frame at EOF, exactly
                     // like the python decoder, so a provider that omits the
                     // closing blank line still settles by its terminal event.
-                    let tail = self.decoder.finish().map_err(|message| {
-                        Failure::new(FailureClass::MalformedResponse, &message)
-                            .with_retry(false, true)
-                    })?;
+                    // A malformed trailing frame, or a normalizer that rejects
+                    // it, is an abnormal end: recover a Gemini partial as
+                    // Incomplete instead of discarding the answer.
+                    let tail = match self.decoder.finish() {
+                        Ok(tail) => tail,
+                        Err(message) => {
+                            self.recover_or_fail(
+                                Failure::new(FailureClass::MalformedResponse, &message)
+                                    .with_retry(false, true),
+                            )?;
+                            continue;
+                        }
+                    };
                     if let Some(frame) = tail {
-                        let events = self.normalizer.feed(&frame)?;
-                        self.pending.extend(events);
+                        match self.normalizer.feed(&frame) {
+                            Ok(events) => self.pending.extend(events),
+                            Err(failure) => {
+                                self.recover_or_fail(failure)?;
+                                continue;
+                            }
+                        }
                     }
                     // A Gemini stream may end cleanly after its last content
                     // frame without a finishReason frame; synthesize the
@@ -288,12 +321,28 @@ impl UpstreamRelay {
                     .record(request_started.elapsed());
                 self.first_byte_recorded = true;
             }
-            let frames = self.decoder.feed(&chunk).map_err(|message| {
-                Failure::new(FailureClass::MalformedResponse, &message).with_retry(false, true)
-            })?;
+            // A malformed frame, or a normalizer that rejects one, is an
+            // abnormal end: recover a Gemini partial as Incomplete, otherwise
+            // surface the failure. Recovery buffers a terminal and marks EOF,
+            // so stop draining this chunk and let the outer loop yield it.
+            let frames = match self.decoder.feed(&chunk) {
+                Ok(frames) => frames,
+                Err(message) => {
+                    self.recover_or_fail(
+                        Failure::new(FailureClass::MalformedResponse, &message)
+                            .with_retry(false, true),
+                    )?;
+                    continue;
+                }
+            };
             for frame in frames {
-                let events = self.normalizer.feed(&frame)?;
-                self.pending.extend(events);
+                match self.normalizer.feed(&frame) {
+                    Ok(events) => self.pending.extend(events),
+                    Err(failure) => {
+                        self.recover_or_fail(failure)?;
+                        break;
+                    }
+                }
             }
         }
     }
@@ -395,6 +444,61 @@ mod tests {
         // A stalled lane is skipped, not redialed: redialing it would only
         // stall again for another window.
         assert!(!failure.retryable_same_deployment);
+    }
+
+    #[tokio::test]
+    async fn a_gemini_partial_then_abnormal_frame_ends_incomplete_not_failed() {
+        // A Gemini content frame, its usage, then a structurally malformed frame
+        // (a non-string text part). The relay must route the abnormal end
+        // through recovery: yield the content, fold the usage, and end on an
+        // Incomplete terminal instead of surfacing the malformed failure.
+        let frames = vec![
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"partial\"}]}}]}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"usageMetadata\":{\"promptTokenCount\":9,\"candidatesTokenCount\":3}}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":5}]}}]}\n\n",
+            )),
+        ];
+        let mut relay = UpstreamRelay::from_stream(
+            stream::iter(frames).boxed(),
+            Dialect::GeminiGenerateContent,
+            Instant::now() + Duration::from_secs(5),
+        );
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let per_chunk = Duration::from_secs(5);
+        let mut seen: Vec<Event> = Vec::new();
+        loop {
+            let event = relay
+                .next_event(deadline, per_chunk, Instant::now())
+                .await
+                .expect("recovery yields events, never the malformed failure");
+            match event {
+                Some(event) => {
+                    let terminal = event.is_terminal();
+                    seen.push(event);
+                    if terminal {
+                        break;
+                    }
+                }
+                None => panic!("the recovered terminal must arrive before EOF"),
+            }
+        }
+        assert!(
+            matches!(seen.first(), Some(Event::TextDelta(text)) if text == "partial"),
+            "the partial content is delivered"
+        );
+        assert!(
+            seen.iter().any(|event| matches!(event, Event::Usage(_))),
+            "last-seen usage is folded so delivered tokens bill"
+        );
+        assert!(
+            matches!(seen.last(), Some(Event::Incomplete)),
+            "the turn ends incomplete, not failed"
+        );
     }
 
     #[tokio::test]

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -247,6 +247,46 @@ def test_native_gemini_normalizer_fails_streams_that_produced_no_content() -> No
     assert failure["failure_class"] == "malformed_response"
 
 
+def test_native_gemini_normalizer_recovers_a_partial_before_an_abnormal_frame() -> None:
+    """Content, then a structurally malformed frame: the partial answer is kept
+    and the turn ends `incomplete` (an early-termination finish reason) with the
+    last-seen usage folded, never discarded as malformed. Gemini uniquely ends
+    legitimate turns abnormally, so a break after content is a truncated answer,
+    not corruption."""
+    chunks = (
+        _sse({"candidates": [{"content": {"parts": [{"text": "partial"}]}}]}),
+        _sse({"usageMetadata": {"promptTokenCount": 9, "candidatesTokenCount": 3}}),
+        # A non-string text part after content: malformed mid-stream frame.
+        _sse({"candidates": [{"content": {"parts": [{"text": 5}]}}]}),
+    )
+    result = _native_normalized("gemini_generate_content", chunks)
+    assert result["failure"] is None
+    assert result["events"] == [
+        {"kind": "text_delta", "text": "partial"},
+        {
+            "kind": "usage",
+            "input_tokens": 9,
+            "output_tokens": 3,
+            "cached_input_tokens": 0,
+            "reasoning_tokens": None,
+        },
+        {"kind": "incomplete"},
+    ]
+
+
+def test_native_gemini_normalizer_reclassifies_a_pre_content_abnormal_frame() -> None:
+    """A malformed frame before any content is a Gemini abnormal end with
+    nothing to salvage: it is reclassified from a hard malformed reject to a
+    retryable transport failure (retry the lane, then fail over), and no content
+    is emitted."""
+    chunk = _sse({"candidates": [{"content": {"parts": [{"text": 5}]}}]})
+    result = _native_normalized("gemini_generate_content", (chunk,))
+    assert result["events"] == []
+    failure = result["failure"]
+    assert isinstance(failure, dict)
+    assert failure["failure_class"] == "transport"
+
+
 def _eventstream_message(name: str, payload: JsonObject, *, exception: bool = False) -> bytes:
     """Encode one AWS event-stream message the way Bedrock frames its stream.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.24"
+version = "0.7.25"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.19,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.20,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.19"
+version = "0.3.20"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.24"
+version = "0.7.25"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What

A Gemini stream that emits ≥1 content token and then terminates **abnormally** was discarded as `malformed_response`, throwing away a real partial answer. #708 already tolerates Gemini's *clean* abnormal close (last content frame, then EOF, no `finishReason` frame → `Completed`). This covers the genuinely abnormal end: a broken transport read, a malformed frame, or a decoder error mid-stream or at EOF.

## How

- `Normalizer::recover_abnormal_end(failure)` (dialects.rs), scoped to Gemini:
  - **content already emitted** → synthesize an `Incomplete` terminal, folding last-seen usage. The caller gets the partial content + an early-termination finish reason (`length` / `max_tokens` / `incomplete`), a **retryable** settlement, and delivered tokens still bill.
  - **before any content** → nothing to salvage, so reclassify the abnormal end from a hard `malformed_response` reject to a **retryable transport** failure (`with_retry(true, true)`: retry the lane, then fail over).
  - **non-Gemini dialect, or already-terminal** → original failure unchanged.
- `UpstreamRelay::next_event` routes all four abnormal-termination sites through `recover_or_fail`:
  1. mid-stream transport error (`Ok(Some(Err(_)))`)
  2. EOF trailing-frame decoder error (`decoder.finish()`)
  3. mid-stream decoder error (`decoder.feed()`)
  4. mid-stream/EOF normalizer error (`normalizer.feed()`)
- `drain_stream_fixture` mirrors the same recovery so golden + Python parity fixtures exercise the real path.
- **Excluded on purpose:** the mid-stream *timeout* path. A stall is not an end; salvaging it would truncate a slow-but-live stream.

## Confirmations (requested)

1. **Ledger status `incomplete`, not `failed`.** `Event::Incomplete` → `settle_stream_end` → `guard.settle("incomplete", …)` (respond.rs:258). Verified.
2. **Flushed usage reaches settle and bills delivered tokens.** Recovery emits `Usage` before `Incomplete`; the streaming drive loop `track_event`s the `Usage` into `usage` and passes it to `settle_stream_end` (route_chat.rs:855,899); non-streaming `collect_committed` finds the terminal in the returned events. Verified.

## ⚠️ Behavior change to flag for the serving-path pass

Routing the **pre-content** malformed-frame paths through recovery means a **pre-content malformed Gemini frame** now classifies as **retryable transport** instead of `malformed_response`. It already failed over (`with_retry(false, true)`); the only delta is it now also permits **one same-deployment redial**. Three assertions in `gemini_malformed_frames_fail_the_stream` move to the new classification (split into `gemini_malformed_frame_before_content_is_a_retryable_abnormal_end` + `gemini_usage_only_close_without_content_still_fails_malformed`). This follows the approved "pre-content → retryable Transport, scoped to Gemini abnormal-end"; calling it out explicitly since it changes an existing parity contract.

## Tests

- Rust: `recover_abnormal_end` unit tests (after-content → incomplete+usage; before-content → transport; non-Gemini passthrough; already-terminal passthrough); relay end-to-end (`a_gemini_partial_then_abnormal_frame_ends_incomplete_not_failed`); golden `gemini_malformed_frame_after_content_recovers_as_incomplete`. 138 native lib tests green.
- Python parity: `test_native_gemini_normalizer_recovers_a_partial_before_an_abnormal_frame`, `…_reclassifies_a_pre_content_abnormal_frame`. Full parity file green (12).
- `cargo fmt` / `cargo clippy` clean; `ruff format`/`ruff check`/`ty check` clean on touched Python.

## Version

Native 0.3.19 → 0.3.20, engine 0.7.24 → 0.7.25, floor bumped in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)