### PR TITLE
gateway: serve POST /v1/embeddings natively (OpenAI-wire, input-only billing)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -18,6 +18,11 @@ It serves:
   upgrade answers 426, the status the Codex client maps to its HTTP fallback)
 - `POST /v1/messages` (the Anthropic Messages API; `POST /v1/messages/count_tokens` answers an
   explicit Anthropic-shaped refusal because the gateway has no tokenizer authority)
+- `POST /v1/embeddings` (the OpenAI Embeddings API: message-less and never streamed; served
+  only by aliases whose catalog capabilities declare `supports_embeddings` on an OpenAI-wire
+  connection, billed on the provider's reported `prompt_tokens` with no output leg, and
+  returned with the provider's exact vectors in `float` or `base64` form; an inbound
+  `Idempotency-Key` is ignored because the surface has no replay protocol)
 - `GET /health/live` and `GET /health/ready`
 - `GET /usage` and `GET /usage.json`
 

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -21,7 +21,11 @@ from exp.common.models.gateway_catalog import (
 )
 from exp.runtime.gateway.auth import utc_text
 from exp.runtime.gateway.contracts import GatewayRequest
-from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest, ServingRequest
+from exp.runtime.gateway.embeddings_contracts import (
+    EmbeddingsRequest,
+    ServingRequest,
+    embeddings_input_ceiling_micro_usd,
+)
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.replay_identity import provider_replay_authority
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
@@ -538,38 +542,20 @@ def maximum_attempt_cost_micro_usd(
 ) -> int | None:
     """Return a conservative integer micro-USD ceiling for one physical call.
 
-    Dispatches on the serving surface: chat/responses/messages price an input
-    and an output leg, while embeddings price an input leg only (no output, no
-    provider replay carriers). Both reserve against the canonical byte length,
-    which never undercounts tokens, so the ceiling stays a hard upper bound and
-    a single call can never breach its budget; settlement charges actual tokens.
+    Chat/responses/messages price an input and an output leg; embeddings price an
+    input leg only. Both bound input by canonical byte length (never undercounts).
     """
     match request:
         case EmbeddingsRequest():
-            return _embeddings_attempt_cost_micro_usd(request, deployment)
+            return embeddings_input_ceiling_micro_usd(
+                request,
+                input_rate=deployment.gateway.prices.input_micro_usd_per_million_tokens,
+                maximum=MAXIMUM_MICRO_USD,
+            )
         case GatewayRequest():
             return _completion_attempt_cost_micro_usd(request, deployment)
         case _:  # pragma: no cover - exhaustive over the ServingRequest union.
             assert_never(request)
-
-
-def _embeddings_attempt_cost_micro_usd(
-    request: EmbeddingsRequest,
-    deployment: ExactModelDeployment,
-) -> int | None:
-    """Return a conservative input-only micro-USD ceiling for one embeddings call.
-
-    Embeddings have no output leg and carry no excluded provider input, so the
-    request's canonical UTF-8 byte length is the whole input upper bound and
-    only the input rate applies. A missing input rate unprices the route and
-    fails closed (``None``), matching the completion path's price discipline.
-    """
-    input_tokens = len(canonical_json_bytes(request))
-    input_rate = deployment.gateway.prices.input_micro_usd_per_million_tokens
-    if input_rate is None:
-        return None
-    maximum = (input_tokens * input_rate + 999_999) // 1_000_000
-    return maximum if maximum <= MAXIMUM_MICRO_USD else None
 
 
 def _completion_attempt_cost_micro_usd(

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
+from typing import assert_never
 
 from pydantic import Field, model_validator
 
@@ -20,6 +21,7 @@ from exp.common.models.gateway_catalog import (
 )
 from exp.runtime.gateway.auth import utc_text
 from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest, ServingRequest
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.replay_identity import provider_replay_authority
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
@@ -531,10 +533,50 @@ def budget_period_start(period: str) -> str:
 
 
 def maximum_attempt_cost_micro_usd(
-    request: GatewayRequest,
+    request: ServingRequest,
     deployment: ExactModelDeployment,
 ) -> int | None:
     """Return a conservative integer micro-USD ceiling for one physical call.
+
+    Dispatches on the serving surface: chat/responses/messages price an input
+    and an output leg, while embeddings price an input leg only (no output, no
+    provider replay carriers). Both reserve against the canonical byte length,
+    which never undercounts tokens, so the ceiling stays a hard upper bound and
+    a single call can never breach its budget; settlement charges actual tokens.
+    """
+    match request:
+        case EmbeddingsRequest():
+            return _embeddings_attempt_cost_micro_usd(request, deployment)
+        case GatewayRequest():
+            return _completion_attempt_cost_micro_usd(request, deployment)
+        case _:  # pragma: no cover - exhaustive over the ServingRequest union.
+            assert_never(request)
+
+
+def _embeddings_attempt_cost_micro_usd(
+    request: EmbeddingsRequest,
+    deployment: ExactModelDeployment,
+) -> int | None:
+    """Return a conservative input-only micro-USD ceiling for one embeddings call.
+
+    Embeddings have no output leg and carry no excluded provider input, so the
+    request's canonical UTF-8 byte length is the whole input upper bound and
+    only the input rate applies. A missing input rate unprices the route and
+    fails closed (``None``), matching the completion path's price discipline.
+    """
+    input_tokens = len(canonical_json_bytes(request))
+    input_rate = deployment.gateway.prices.input_micro_usd_per_million_tokens
+    if input_rate is None:
+        return None
+    maximum = (input_tokens * input_rate + 999_999) // 1_000_000
+    return maximum if maximum <= MAXIMUM_MICRO_USD else None
+
+
+def _completion_attempt_cost_micro_usd(
+    request: GatewayRequest,
+    deployment: ExactModelDeployment,
+) -> int | None:
+    """Return a conservative integer micro-USD ceiling for one chat/responses call.
 
     Canonical UTF-8 bytes conservatively upper-bound input tokens. The caller's output ceiling
     wins when present, then the frozen deployment limit, then a reservation-only default bounded

--- a/exp/runtime/gateway/embeddings_contracts.py
+++ b/exp/runtime/gateway/embeddings_contracts.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import Field, field_validator
 
-from exp.common.core.artifacts import ContractModel
+from exp.common.core.artifacts import ContractModel, canonical_json_bytes
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayRequest
 
 
@@ -56,3 +56,22 @@ union so a chat-assuming reader cannot duck-type onto an embeddings request and
 touch an absent leg (messages, output tokens): ``ty`` enumerates every reader
 that must now handle the embeddings arm, and each branches exhaustively.
 """
+
+
+def embeddings_input_ceiling_micro_usd(
+    request: EmbeddingsRequest,
+    *,
+    input_rate: int | None,
+    maximum: int,
+) -> int | None:
+    """Return the conservative input-only reservation ceiling for one embeddings call.
+
+    The canonical UTF-8 byte length upper-bounds the input tokens (there is no
+    output leg and no excluded provider carrier), so only the input rate
+    applies. A missing rate unprices the route (``None``), and a ceiling above
+    ``maximum`` is likewise unpriceable, matching the completion path.
+    """
+    if input_rate is None:
+        return None
+    ceiling = (len(canonical_json_bytes(request)) * input_rate + 999_999) // 1_000_000
+    return ceiling if ceiling <= maximum else None

--- a/exp/runtime/gateway/embeddings_contracts.py
+++ b/exp/runtime/gateway/embeddings_contracts.py
@@ -29,6 +29,19 @@ class EmbeddingsRequest(ContractModel):
     user: str | None = Field(default=None, max_length=1024)
     """End-user attribution from the OpenAI ``user`` field: content-free and never a credential."""
 
+    @property
+    def attribution_label(self) -> str | None:
+        """The end-user attribution label, per the OpenAI spec.
+
+        The embeddings body carries only the ``user`` field (no
+        ``safety_identifier``), so the label is exactly that field; hosts read
+        it off every serving request at accept, whichever surface it came in on.
+
+        Returns:
+            The attribution label, or ``None`` when the caller sent no ``user``.
+        """
+        return self.user
+
     @field_validator("inputs")
     @classmethod
     def _require_nonempty_inputs(cls, value: tuple[str, ...]) -> tuple[str, ...]:

--- a/exp/runtime/gateway/embeddings_contracts.py
+++ b/exp/runtime/gateway/embeddings_contracts.py
@@ -7,7 +7,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 
 from exp.common.core.artifacts import ContractModel
-from exp.runtime.gateway.contracts import GatewayApiSurface
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayRequest
 
 
 class EmbeddingsRequest(ContractModel):
@@ -46,3 +46,13 @@ class EmbeddingsRequest(ContractModel):
         if any(not text for text in value):
             raise ValueError("embedding inputs must not be empty strings")
         return value
+
+
+ServingRequest = GatewayRequest | EmbeddingsRequest
+"""One admitted serving request across every public surface.
+
+The money, auth, and accounting seams widen from ``GatewayRequest`` to this
+union so a chat-assuming reader cannot duck-type onto an embeddings request and
+touch an absent leg (messages, output tokens): ``ty`` enumerates every reader
+that must now handle the embeddings arm, and each branches exhaustively.
+"""

--- a/exp/runtime/gateway/embeddings_contracts_test.py
+++ b/exp/runtime/gateway/embeddings_contracts_test.py
@@ -28,3 +28,9 @@ def test_embeddings_request_rejects_empty_input_sets() -> None:
         EmbeddingsRequest(inputs=("ok", ""))
     with pytest.raises(ValidationError, match="greater than 0"):
         EmbeddingsRequest(inputs=("ok",), dimensions=0)
+
+
+def test_embeddings_request_attributes_the_end_user_from_the_user_field() -> None:
+    """``attribution_label`` mirrors the chat contract: the ``user`` field or nothing."""
+    assert EmbeddingsRequest(inputs=("hi",)).attribution_label is None
+    assert EmbeddingsRequest(inputs=("hi",), user="tenant-7").attribution_label == "tenant-7"

--- a/exp/runtime/gateway/interfaces.py
+++ b/exp/runtime/gateway/interfaces.py
@@ -17,6 +17,7 @@ from exp.runtime.gateway.contracts import (
     ProjectSelection,
     ProjectTarget,
 )
+from exp.runtime.gateway.embeddings_contracts import ServingRequest
 
 
 class GatewayControlStore(Protocol):
@@ -35,7 +36,7 @@ class GatewayControlStore(Protocol):
         *,
         raw_key: str,
         alias: str,
-        request: GatewayRequest,
+        request: ServingRequest,
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -29,10 +29,10 @@ from exp.runtime.gateway.contracts import (
     DirectTarget,
     ExecutionSnapshot,
     GatewayApiSurface,
-    GatewayRequest,
     GatewayTarget,
     ProjectTarget,
 )
+from exp.runtime.gateway.embeddings_contracts import ServingRequest
 from exp.runtime.gateway.group_commit import GroupCommitAttemptLedger
 from exp.runtime.gateway.interfaces import GatewayControlStore, ProjectTargetResolver
 from exp.runtime.gateway.ledger import SQLiteAttemptLedger
@@ -351,7 +351,7 @@ class _ReadyControlStore:
         *,
         raw_key: str,
         alias: str,
-        request: GatewayRequest,
+        request: ServingRequest,
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.20"
+version = "0.3.21"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.20"
+version = "0.3.21"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -24,6 +24,7 @@ mod respond;
 mod responses_retention;
 mod route_batches;
 mod route_chat;
+mod route_embeddings;
 mod route_messages;
 mod route_responses;
 mod route_responses_ws;

--- a/exp/runtime/gateway/native/src/route_embeddings.rs
+++ b/exp/runtime/gateway/native/src/route_embeddings.rs
@@ -295,42 +295,54 @@ async fn dispatch(
             true,
         ));
     }
-    let bytes = match tokio::time::timeout(remaining(deadline).min(phase_timeout), response.bytes())
+    let bytes = read_bounded_body(response, deadline, phase_timeout)
         .await
-    {
-        Ok(Ok(bytes)) => bytes,
-        Ok(Err(_)) => {
-            return Err((
-                Failure::new(
-                    FailureClass::Transport,
-                    "provider connection failed while sending the embeddings response",
-                )
-                .with_retry(true, true),
-                true,
-            ))
-        }
-        Err(_) => {
-            return Err((
-                Failure::new(
-                    FailureClass::Timeout,
-                    "provider did not finish the embeddings response in time",
-                )
-                .with_retry(false, true),
-                true,
-            ))
-        }
-    };
-    if bytes.len() > MAXIMUM_RETAINED_OUTPUT_BYTES {
-        return Err((
-            Failure::new(FailureClass::MalformedResponse, OUTPUT_OVERFLOW_MESSAGE),
-            true,
-        ));
-    }
+        .map_err(|failure| (failure, true))?;
     let payload: Value = match serde_json::from_slice(&bytes) {
         Ok(payload) => payload,
         Err(_) => return Err((malformed("embeddings response is not JSON"), true)),
     };
     public_embeddings(payload, admission).map_err(|failure| (failure, true))
+}
+
+/// Read one successful provider body chunk by chunk under the retained-output
+/// cap, so an upstream that omits `Content-Length` cannot make the gateway
+/// buffer an unbounded answer before the size check runs. Each chunk read is
+/// bounded by the deployment's transport timeout and the request deadline.
+async fn read_bounded_body(
+    mut response: reqwest::Response,
+    deadline: Instant,
+    phase_timeout: Duration,
+) -> Result<Vec<u8>, Failure> {
+    let mut body: Vec<u8> = Vec::new();
+    loop {
+        let bound = remaining(deadline).min(phase_timeout);
+        let chunk = match tokio::time::timeout(bound, response.chunk()).await {
+            Ok(Ok(Some(chunk))) => chunk,
+            Ok(Ok(None)) => return Ok(body),
+            Ok(Err(_)) => {
+                return Err(Failure::new(
+                    FailureClass::Transport,
+                    "provider connection failed while sending the embeddings response",
+                )
+                .with_retry(true, true))
+            }
+            Err(_) => {
+                return Err(Failure::new(
+                    FailureClass::Timeout,
+                    "provider did not finish the embeddings response in time",
+                )
+                .with_retry(false, true))
+            }
+        };
+        if body.len() + chunk.len() > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(Failure::new(
+                FailureClass::MalformedResponse,
+                OUTPUT_OVERFLOW_MESSAGE,
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
 }
 
 /// A provider answer the gateway cannot bill or relay; never retried on the

--- a/exp/runtime/gateway/native/src/route_embeddings.rs
+++ b/exp/runtime/gateway/native/src/route_embeddings.rs
@@ -1,0 +1,518 @@
+//! The native embeddings surface: the `POST /v1/embeddings` handler.
+//!
+//! Embeddings are message-less and never stream, so the surface skips the
+//! relay, replay, and reasoning machinery entirely: admission returns one
+//! fully built OpenAI-wire `/embeddings` payload per certified deployment, the
+//! ladder below reserves each physical attempt through `start_attempt`,
+//! POSTs the payload, buffers the JSON answer, validates it against the
+//! request (one vector per input, a reported `prompt_tokens`), and settles the
+//! winning attempt with input-only usage. Failures walk the same
+//! same-deployment/failover ladder as chat under the control plane's
+//! deployment-health and budget authority. An inbound `Idempotency-Key` is
+//! ignored: the surface has no replay protocol yet, and keying it here would
+//! share the chat replay namespace.
+
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Response;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+
+use crate::admission::{acquire_permit, new_guard, wire_drift_response};
+use crate::dialects::{Dialect, MAXIMUM_RETAINED_OUTPUT_BYTES, OUTPUT_OVERFLOW_MESSAGE};
+use crate::encode::compact_json;
+use crate::errors::{Failure, FailureClass, PublicError};
+use crate::events::Usage;
+use crate::metrics::{classify_escalation, METRICS};
+use crate::relay::{collection_public_error, remaining};
+use crate::respond::{
+    bearer_key, error_response, escalation_error, json_response, latin1_header, read_body,
+};
+use crate::server::AppState;
+use crate::settlement::AttemptGuard;
+use crate::upstream::open_stream;
+use crate::waterfall::{successor_possible, DeploymentWire, RoutePolicy, StartResponse};
+
+/// The wire configuration returned by one successful embeddings admission.
+#[derive(Debug, Clone, Deserialize)]
+struct EmbeddingsAdmission {
+    request_id: String,
+    alias: String,
+    alias_revision_id: String,
+    exact_model_id: String,
+    route_reason: String,
+    route: Vec<DeploymentWire>,
+    /// Number of input strings; the provider must answer with exactly this
+    /// many vectors.
+    input_count: usize,
+    maximum_total_attempts: u32,
+    maximum_same_deployment_attempts: u32,
+}
+
+impl EmbeddingsAdmission {
+    fn policy(&self) -> RoutePolicy {
+        RoutePolicy {
+            maximum_total_attempts: self.maximum_total_attempts.max(1),
+            maximum_same_deployment_attempts: self.maximum_same_deployment_attempts.max(1),
+            refusal_failover: false,
+        }
+    }
+}
+
+/// One validated provider answer: the public body and its billable usage.
+struct Served {
+    depth: usize,
+    body: Value,
+    usage: Usage,
+}
+
+pub(crate) async fn embeddings(
+    State(state): State<AppState>,
+    request: axum::extract::Request,
+) -> Response {
+    state.handled_requests.fetch_add(1, Ordering::Relaxed);
+    let started = Instant::now();
+    let deadline = started + state.request_timeout;
+    let (parts, raw_body) = request.into_parts();
+    let headers = parts.headers;
+    let body = match read_body(raw_body).await {
+        Ok(body) => body,
+        Err(error) => return error_response(&error),
+    };
+    let raw_key = match bearer_key(&headers) {
+        Ok(key) => key,
+        Err(error) => return error_response(&error),
+    };
+    let authenticate = compact_json(&json!({"raw_key": raw_key}));
+    if let Err(error) = state.bridge.call("authenticate", authenticate).await {
+        return error_response(&error);
+    }
+    let body_text = match String::from_utf8(body.to_vec()) {
+        Ok(text) => text,
+        Err(_) => return error_response(&PublicError::invalid_json()),
+    };
+    let client_request_id = latin1_header(&headers, "x-client-request-id");
+
+    let admit_argument = compact_json(&json!({"raw_key": raw_key, "body": body_text}));
+    let admission_text = match state.bridge.call("admit_embeddings", admit_argument).await {
+        Ok(text) => text,
+        Err(error) => return error_response(&error),
+    };
+    let admission_value: Value = match serde_json::from_str(&admission_text) {
+        Ok(value) => value,
+        Err(_) => return error_response(&PublicError::internal()),
+    };
+    if let Some(reason) = admission_value.get("escalate") {
+        METRICS.record_escalation(classify_escalation(reason.as_str().unwrap_or_default()));
+        // The accepted request is already finalized control-plane side;
+        // startup validation guarantees native servability, so fail closed.
+        return error_response(&escalation_error());
+    }
+    let admission: EmbeddingsAdmission = match serde_json::from_value(admission_value.clone()) {
+        Ok(admission) => admission,
+        Err(_) => return wire_drift_response(&state, &admission_value, started).await,
+    };
+    let mut guard = new_guard(&state, admission.request_id.clone(), started);
+    let permit = match acquire_permit(&state, &mut guard, deadline).await {
+        Ok(permit) => permit,
+        Err(response) => return *response,
+    };
+    let _permit = permit;
+
+    match run_ladder(&state, &admission, &raw_key, &mut guard, deadline).await {
+        Err(error) => error_response(&error),
+        Ok(served) => {
+            if !guard
+                .settle("completed", Some(&served.usage), &[], None, true)
+                .await
+            {
+                // The ledger never learned the outcome; the caller must not
+                // receive vectors the gateway cannot account for.
+                return error_response(&PublicError::internal());
+            }
+            let response_headers = served_headers(&admission, served.depth, client_request_id);
+            json_response(StatusCode::OK, &served.body, &response_headers)
+        }
+    }
+}
+
+/// Walk the certified ladder to one validated provider answer or the public
+/// error of the exhausting failure. Every reserved attempt settles exactly
+/// once through `guard`; on `Ok` the winning attempt is still open for the
+/// caller's finalizing settlement.
+async fn run_ladder(
+    state: &AppState,
+    admission: &EmbeddingsAdmission,
+    raw_key: &str,
+    guard: &mut AttemptGuard,
+    deadline: Instant,
+) -> Result<Served, PublicError> {
+    let policy = admission.policy();
+    let mut total_attempts: u32 = 0;
+    let mut counts: Vec<u32> = vec![0; admission.route.len()];
+    let mut current_depth: Option<usize> = None;
+    let mut last_failure: Option<Failure> = None;
+    loop {
+        let argument = compact_json(&json!({
+            "request_id": admission.request_id,
+            "raw_key": raw_key,
+            "attempt_ordinal": total_attempts,
+            "current_depth": current_depth,
+            "failure": last_failure.as_ref().map(|failure| json!({
+                "failure_class": failure.failure_class.as_str(),
+                "safe_message": failure.safe_message,
+                "retryable_same_deployment": failure.retryable_same_deployment,
+                "failover_eligible": failure.failover_eligible,
+                "rejected_parameter": failure.rejected_parameter,
+                "provider_detail": failure.provider_detail,
+            })),
+        }));
+        let started_text = match state.bridge.call("start_attempt", argument).await {
+            Ok(text) => text,
+            Err(error) => {
+                // The control plane finalized the request before raising.
+                guard.disarm_finalized("failed");
+                return Err(error);
+            }
+        };
+        let started: StartResponse = match serde_json::from_str(&started_text) {
+            Ok(started) => started,
+            Err(_) => {
+                guard
+                    .abandon(&Failure::new(
+                        FailureClass::Internal,
+                        "gateway attempt wire contract failed",
+                    ))
+                    .await;
+                return Err(PublicError::internal());
+            }
+        };
+        if started.exhausted {
+            guard.disarm_finalized("failed");
+            let failure = started.failure.or(last_failure).unwrap_or_else(|| {
+                Failure::new(
+                    FailureClass::ProviderInternal,
+                    "all exact-model deployments are unavailable",
+                )
+            });
+            return Err(collection_public_error(&failure.boundary()));
+        }
+        let (Some(attempt_id), Some(depth)) = (started.attempt_id, started.route_depth) else {
+            guard
+                .abandon(&Failure::new(
+                    FailureClass::Internal,
+                    "gateway attempt wire contract failed",
+                ))
+                .await;
+            return Err(PublicError::internal());
+        };
+        let Some(wire) = admission.route.get(depth) else {
+            guard.rebind(attempt_id);
+            let failure = Failure::new(
+                FailureClass::Internal,
+                "gateway attempt wire contract failed",
+            );
+            guard
+                .settle("failed", None, &[], Some(&failure), true)
+                .await;
+            return Err(PublicError::internal());
+        };
+        if current_depth == Some(depth) {
+            METRICS.record_open_retry();
+        }
+        guard.rebind(attempt_id);
+        total_attempts += 1;
+        counts[depth] += 1;
+        match dispatch(&state.http, wire, deadline, admission).await {
+            Ok((body, usage)) => return Ok(Served { depth, body, usage }),
+            Err((failure, opened)) => {
+                if opened {
+                    guard.mark_opened();
+                }
+                let boundary = failure.clone().boundary();
+                let possible = successor_possible(
+                    policy,
+                    admission.route.len(),
+                    deadline,
+                    total_attempts,
+                    counts[depth],
+                    depth,
+                    &failure,
+                    false,
+                );
+                if !guard
+                    .settle("failed", None, &[], Some(&boundary), !possible)
+                    .await
+                {
+                    return Err(PublicError::internal());
+                }
+                if possible {
+                    current_depth = Some(depth);
+                    last_failure = Some(failure);
+                    continue;
+                }
+                return Err(collection_public_error(&boundary));
+            }
+        }
+    }
+}
+
+/// POST one admitted payload and validate the buffered answer. The error
+/// carries whether the provider dispatch opened (for deployment-health
+/// recording); a rejected open never opened.
+async fn dispatch(
+    http: &reqwest::Client,
+    wire: &DeploymentWire,
+    deadline: Instant,
+    admission: &EmbeddingsAdmission,
+) -> Result<(Value, Usage), (Failure, bool)> {
+    let phase_timeout = Duration::from_secs_f64(wire.timeout_seconds.max(0.001));
+    let bound = remaining(deadline).min(phase_timeout);
+    // Every embeddings wire is the OpenAI `/embeddings` shape, whichever chat
+    // dialect the connection speaks, so client-error attribution reads the
+    // OpenAI error envelope.
+    let response = open_stream(
+        http,
+        &wire.url,
+        &wire.headers,
+        &wire.idempotency_key,
+        &wire.upstream_payload,
+        None,
+        bound,
+        Dialect::OpenAiCompatible,
+    )
+    .await
+    .map_err(|failure| (failure, false))?;
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAXIMUM_RETAINED_OUTPUT_BYTES as u64)
+    {
+        return Err((
+            Failure::new(FailureClass::MalformedResponse, OUTPUT_OVERFLOW_MESSAGE),
+            true,
+        ));
+    }
+    let bytes = match tokio::time::timeout(remaining(deadline).min(phase_timeout), response.bytes())
+        .await
+    {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(_)) => {
+            return Err((
+                Failure::new(
+                    FailureClass::Transport,
+                    "provider connection failed while sending the embeddings response",
+                )
+                .with_retry(true, true),
+                true,
+            ))
+        }
+        Err(_) => {
+            return Err((
+                Failure::new(
+                    FailureClass::Timeout,
+                    "provider did not finish the embeddings response in time",
+                )
+                .with_retry(false, true),
+                true,
+            ))
+        }
+    };
+    if bytes.len() > MAXIMUM_RETAINED_OUTPUT_BYTES {
+        return Err((
+            Failure::new(FailureClass::MalformedResponse, OUTPUT_OVERFLOW_MESSAGE),
+            true,
+        ));
+    }
+    let payload: Value = match serde_json::from_slice(&bytes) {
+        Ok(payload) => payload,
+        Err(_) => return Err((malformed("embeddings response is not JSON"), true)),
+    };
+    public_embeddings(payload, admission).map_err(|failure| (failure, true))
+}
+
+/// A provider answer the gateway cannot bill or relay; never retried on the
+/// same deployment, eligible for a certified fallback.
+fn malformed(reason: &str) -> Failure {
+    Failure::new(FailureClass::MalformedResponse, reason).with_retry(false, true)
+}
+
+/// Validate one provider `/embeddings` body against the admitted request and
+/// rebuild it as the public answer: exactly one vector per input, in input
+/// order, the public alias as `model`, and the billed `prompt_tokens`.
+/// Vectors pass through untouched (`float` arrays or `base64` strings), so the
+/// caller receives the provider's exact values.
+fn public_embeddings(
+    payload: Value,
+    admission: &EmbeddingsAdmission,
+) -> Result<(Value, Usage), Failure> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| malformed("embeddings response is not an object"))?;
+    let data = object
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| malformed("embeddings response omitted the data array"))?;
+    if data.len() != admission.input_count {
+        return Err(malformed(
+            "embeddings response count does not match the request input count",
+        ));
+    }
+    let mut ordered: Vec<Option<Value>> = vec![None; admission.input_count];
+    for (position, item) in data.iter().enumerate() {
+        let entry = item
+            .as_object()
+            .ok_or_else(|| malformed("embeddings response item is not an object"))?;
+        let index = match entry.get("index") {
+            None => position,
+            Some(value) => value
+                .as_u64()
+                .and_then(|index| usize::try_from(index).ok())
+                .ok_or_else(|| malformed("embeddings response index is not an integer"))?,
+        };
+        if index >= admission.input_count || ordered[index].is_some() {
+            return Err(malformed(
+                "embeddings response indexes are not unique input indexes",
+            ));
+        }
+        let vector = entry
+            .get("embedding")
+            .filter(|vector| vector.is_array() || vector.is_string())
+            .ok_or_else(|| malformed("embeddings response item omitted its vector"))?;
+        ordered[index] = Some(json!({
+            "object": "embedding",
+            "index": index,
+            "embedding": vector,
+        }));
+    }
+    let data: Vec<Value> = ordered
+        .into_iter()
+        .map(|item| item.ok_or_else(|| malformed("embeddings response omitted an input index")))
+        .collect::<Result<_, _>>()?;
+    // The surface bills on this count, so an omitted or malformed
+    // prompt_tokens is a malformed response, never a zero.
+    let prompt_tokens = object
+        .get("usage")
+        .and_then(Value::as_object)
+        .and_then(|usage| usage.get("prompt_tokens"))
+        .and_then(Value::as_u64)
+        .ok_or_else(|| malformed("embeddings response omitted usage.prompt_tokens"))?;
+    let mut public = Map::new();
+    public.insert("object".to_string(), Value::from("list"));
+    public.insert("data".to_string(), Value::Array(data));
+    public.insert("model".to_string(), Value::from(admission.alias.as_str()));
+    public.insert(
+        "usage".to_string(),
+        json!({"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens}),
+    );
+    let usage = Usage {
+        input_tokens: Some(prompt_tokens),
+        output_tokens: Some(0),
+        cached_input_tokens: None,
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    Ok((Value::Object(public), usage))
+}
+
+/// The gateway identity headers of one served embeddings response: the
+/// commit-independent and commit-dependent sets the chat surface emits.
+fn served_headers(
+    admission: &EmbeddingsAdmission,
+    depth: usize,
+    client_request_id: Option<String>,
+) -> Vec<(String, String)> {
+    let (provider, deployment_id) = admission
+        .route
+        .get(depth)
+        .map(|wire| (wire.provider.clone(), wire.deployment_id.clone()))
+        .unwrap_or_default();
+    let mut headers = vec![
+        ("x-request-id".to_string(), admission.request_id.clone()),
+        ("x-gateway-alias".to_string(), admission.alias.clone()),
+        (
+            "x-gateway-alias-revision".to_string(),
+            admission.alias_revision_id.clone(),
+        ),
+        (
+            "x-gateway-canonical-model".to_string(),
+            admission.exact_model_id.clone(),
+        ),
+        ("x-gateway-provider".to_string(), provider),
+        ("x-gateway-deployment".to_string(), deployment_id),
+        ("x-gateway-route-depth".to_string(), depth.to_string()),
+        (
+            "x-gateway-route-reason".to_string(),
+            admission.route_reason.clone(),
+        ),
+    ];
+    if let Some(value) = client_request_id {
+        headers.push(("x-client-request-id".to_string(), value));
+    }
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admission(input_count: usize) -> EmbeddingsAdmission {
+        EmbeddingsAdmission {
+            request_id: "request-1".to_string(),
+            alias: "embedder".to_string(),
+            alias_revision_id: "revision-one".to_string(),
+            exact_model_id: "model-exact".to_string(),
+            route_reason: "direct".to_string(),
+            route: Vec::new(),
+            input_count,
+            maximum_total_attempts: 8,
+            maximum_same_deployment_attempts: 2,
+        }
+    }
+
+    #[test]
+    fn provider_answer_is_reordered_relabeled_and_billed_on_prompt_tokens() {
+        let payload = json!({
+            "object": "list",
+            "model": "provider-model-exact",
+            "data": [
+                {"object": "embedding", "index": 1, "embedding": [0.5, 0.5]},
+                {"object": "embedding", "index": 0, "embedding": "AACAPwAAAAA="},
+            ],
+            "usage": {"prompt_tokens": 7, "total_tokens": 7},
+        });
+        let (body, usage) = public_embeddings(payload, &admission(2)).expect("valid answer");
+        assert_eq!(
+            body,
+            json!({
+                "object": "list",
+                "data": [
+                    {"object": "embedding", "index": 0, "embedding": "AACAPwAAAAA="},
+                    {"object": "embedding", "index": 1, "embedding": [0.5, 0.5]},
+                ],
+                "model": "embedder",
+                "usage": {"prompt_tokens": 7, "total_tokens": 7},
+            })
+        );
+        assert_eq!(usage.input_tokens, Some(7));
+        assert_eq!(usage.output_tokens, Some(0));
+    }
+
+    #[test]
+    fn count_mismatch_duplicate_index_and_missing_usage_are_malformed() {
+        let short = json!({"data": [{"embedding": [1.0]}], "usage": {"prompt_tokens": 1}});
+        let duplicated = json!({
+            "data": [{"index": 0, "embedding": [1.0]}, {"index": 0, "embedding": [1.0]}],
+            "usage": {"prompt_tokens": 1},
+        });
+        let unbilled = json!({"data": [{"embedding": [1.0]}, {"embedding": [2.0]}]});
+        for payload in [short, duplicated, unbilled] {
+            let failure = public_embeddings(payload, &admission(2)).expect_err("malformed");
+            assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+            assert!(failure.failover_eligible);
+            assert!(!failure.retryable_same_deployment);
+        }
+    }
+}

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -30,6 +30,7 @@ use crate::route_batches::{
     files_content, files_create, files_retrieve,
 };
 use crate::route_chat::chat;
+use crate::route_embeddings::embeddings;
 use crate::route_messages::{messages, messages_count_tokens};
 use crate::route_responses::responses;
 use crate::route_responses_ws::responses_ws;
@@ -156,6 +157,7 @@ pub async fn run(
         .route("/v1/models", get(models))
         .route("/v1/models/{model_id}", get(model_detail))
         .route("/v1/chat/completions", post(chat))
+        .route("/v1/embeddings", post(embeddings))
         .route("/v1/responses", post(responses).get(responses_ws))
         .route("/v1/messages", post(messages))
         .route("/v1/messages/count_tokens", post(messages_count_tokens))

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -194,15 +194,15 @@ fn is_semantic(event: &Event) -> bool {
 
 /// The control plane's answer to one `start_attempt` callback.
 #[derive(Debug, Deserialize)]
-struct StartResponse {
+pub(crate) struct StartResponse {
     #[serde(default)]
-    attempt_id: Option<String>,
+    pub(crate) attempt_id: Option<String>,
     #[serde(default)]
-    route_depth: Option<usize>,
+    pub(crate) route_depth: Option<usize>,
     #[serde(default)]
-    exhausted: bool,
+    pub(crate) exhausted: bool,
     #[serde(default)]
-    failure: Option<Failure>,
+    pub(crate) failure: Option<Failure>,
 }
 
 /// Whether the classified failure leaves any successor dispatch possible
@@ -210,7 +210,7 @@ struct StartResponse {
 /// control plane re-checks with health and budget state and may still answer
 /// with exhaustion.
 #[allow(clippy::too_many_arguments)]
-fn successor_possible(
+pub(crate) fn successor_possible(
     policy: RoutePolicy,
     route_length: usize,
     deadline: Instant,

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -17,13 +17,15 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 
-from exp.runtime.gateway.contracts import AuthorizationSnapshot, GatewayRequest
+from exp.runtime.gateway.contracts import AuthorizationSnapshot, DirectTarget, GatewayRequest
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_execution import (
     reorder_route_deployments,
     request_carries_cache_markers,
     select_route_deployments,
 )
+from exp.runtime.gateway.native_responses import ContinuationContext
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.models.providers import preflight_gateway_request
 from exp.runtime.models.providers.base import GatewayWireProfile
@@ -44,6 +46,7 @@ from exp.runtime.models.providers.streaming_requests import (
     dialect_stream_payload,
     route_generation_parameter_requests,
 )
+from exp.runtime.openai_protocol.state import ProtocolNamespace, episode_namespace
 
 _logger = logging.getLogger(__name__)
 
@@ -390,4 +393,51 @@ def record_admission_coercions(
         "(disclosed through ignored_parameters)",
         authorization.alias,
         ", ".join(disclosures),
+    )
+
+
+def resolve_admission_route(
+    components: NativeGatewayComponents,
+    authorization: AuthorizationSnapshot,
+    request: GatewayRequest,
+    *,
+    continuation: ContinuationContext | None = None,
+) -> GatewayRoute:
+    """Resolve one direct or project route without an event loop.
+
+    Direct pools resolve entirely inside frozen in-memory catalogs. Project
+    targets run frozen learned selection synchronously on this worker thread
+    through the shared selection seam and episode identity derivation, so
+    there is exactly one policy execution path. A Responses continuation
+    carries its original turn's episode key, so a continued request joins the
+    same selection episode instead of re-running request-time embedding for a
+    fresh one. Request-time embedding failure falls back to the frozen
+    conservative baseline inside the shared runtime, and neither path mutates
+    policy or evidence.
+    """
+    if isinstance(authorization.target, DirectTarget):
+        return components.routes.resolve_direct(authorization)
+    if continuation is not None:
+        episode = (
+            authorization.organization_id,
+            authorization.identity_id,
+            authorization.alias_revision_id,
+            continuation.episode_key,
+        )
+    else:
+        episode = episode_namespace(
+            namespace=ProtocolNamespace(
+                organization_id=authorization.organization_id,
+                identity_id=authorization.identity_id,
+                alias_revision_id=authorization.alias_revision_id,
+            ),
+            # The session-scoped correlation id is the stronger affinity
+            # scope; a per-operation idempotency key only pins retries.
+            caller_episode_key=request.client_request_id or request.idempotency_key,
+            request_id=authorization.request_id,
+        )
+    return components.routes.resolve_project_blocking(
+        authorization=authorization,
+        request=request,
+        episode_namespace=episode,
     )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -765,6 +765,12 @@ class NativeControlPlane(NativeBatchRelayMixin, NativeObservabilityMixin):
             authority = entry.reasoning_carrier_authorities[route_depth]
             if authority is None or authority.reasoning_route_sha256 != route_sha256:
                 raise ValueError("reasoning carrier route differs from the active attempt")
+            # Reasoning carriers exist only on the message-bearing completion
+            # surfaces; the embeddings dispatch never seals one, so a non-chat
+            # request reaching here is a fail-loud contract violation, not a
+            # silent access of an absent ``messages`` leg.
+            if not isinstance(entry.request, GatewayRequest):
+                raise ValueError("reasoning carrier is not valid for this request surface")
             carrier = seal_reasoning_content(
                 authority,
                 issuing_request_id=request_id,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -51,7 +51,7 @@ from exp.runtime.gateway.native_accounting import (
 from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
 )
-from exp.runtime.gateway.native_admission import admitted_route_requests
+from exp.runtime.gateway.native_admission import admitted_route_requests, resolve_admission_route
 from exp.runtime.gateway.native_batches import NativeBatchRelayMixin
 from exp.runtime.gateway.native_bridge_errors import (
     escalation as _escalation,
@@ -132,7 +132,6 @@ from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
 from exp.runtime.openai_protocol.state import (
     BoundedContinuationStore,
     ProtocolNamespace,
-    episode_namespace,
     replay_key,
 )
 
@@ -766,10 +765,7 @@ class NativeControlPlane(NativeBatchRelayMixin, NativeEmbeddingsMixin, NativeObs
             authority = entry.reasoning_carrier_authorities[route_depth]
             if authority is None or authority.reasoning_route_sha256 != route_sha256:
                 raise ValueError("reasoning carrier route differs from the active attempt")
-            # Reasoning carriers exist only on the message-bearing completion
-            # surfaces; the embeddings dispatch never seals one, so a non-chat
-            # request reaching here is a fail-loud contract violation, not a
-            # silent access of an absent ``messages`` leg.
+            # Carriers exist only on message-bearing surfaces: fail loud, never duck-type.
             if not isinstance(entry.request, GatewayRequest):
                 raise ValueError("reasoning carrier is not valid for this request surface")
             carrier = seal_reasoning_content(
@@ -964,42 +960,7 @@ class NativeControlPlane(NativeBatchRelayMixin, NativeEmbeddingsMixin, NativeObs
         *,
         continuation: ContinuationContext | None = None,
     ) -> GatewayRoute:
-        """Resolve one direct or project route without an event loop.
-
-        Direct pools resolve entirely inside frozen in-memory catalogs.
-        Project targets run frozen learned selection synchronously on this
-        worker thread through the shared selection seam and episode identity
-        derivation, so there is exactly one policy execution path. A
-        Responses continuation carries its original turn's episode key, so a
-        continued request joins the same selection episode instead of
-        re-running request-time embedding for a fresh one. Request-time
-        embedding failure falls back to the frozen conservative baseline
-        inside the shared runtime, and neither path mutates policy or
-        evidence.
-        """
-        if isinstance(authorization.target, DirectTarget):
-            return self._components.routes.resolve_direct(authorization)
-        if continuation is not None:
-            episode = (
-                authorization.organization_id,
-                authorization.identity_id,
-                authorization.alias_revision_id,
-                continuation.episode_key,
-            )
-        else:
-            episode = episode_namespace(
-                namespace=ProtocolNamespace(
-                    organization_id=authorization.organization_id,
-                    identity_id=authorization.identity_id,
-                    alias_revision_id=authorization.alias_revision_id,
-                ),
-                # The session-scoped correlation id is the stronger affinity
-                # scope; a per-operation idempotency key only pins retries.
-                caller_episode_key=request.client_request_id or request.idempotency_key,
-                request_id=authorization.request_id,
-            )
-        return self._components.routes.resolve_project_blocking(
-            authorization=authorization,
-            request=request,
-            episode_namespace=episode,
+        """Resolve one direct or project route; see ``resolve_admission_route``."""
+        return resolve_admission_route(
+            self._components, authorization, request, continuation=continuation
         )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -74,6 +74,7 @@ from exp.runtime.gateway.native_continuation import (
 )
 from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_body
 from exp.runtime.gateway.native_dispatch import dispatch_signature_headers, frozen_dispatch
+from exp.runtime.gateway.native_embeddings import NativeEmbeddingsMixin
 from exp.runtime.gateway.native_execution import (
     MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
     MAXIMUM_TOTAL_ATTEMPTS,
@@ -138,7 +139,7 @@ from exp.runtime.openai_protocol.state import (
 _REQUEST_TIMEOUT_SECONDS = 120.0
 
 
-class NativeControlPlane(NativeBatchRelayMixin, NativeObservabilityMixin):
+class NativeControlPlane(NativeBatchRelayMixin, NativeEmbeddingsMixin, NativeObservabilityMixin):
     """Authority and accounting callbacks for the native data plane.
 
     Rust worker threads share the group-commit writer and the locked in-flight

--- a/exp/runtime/gateway/native_embeddings.py
+++ b/exp/runtime/gateway/native_embeddings.py
@@ -1,0 +1,277 @@
+"""Embeddings admission for the native data plane.
+
+The embeddings surface reuses the chat surface's authority, ledger, route
+resolution, deployment-health, and reservation seams unchanged, and differs
+only in what it admits: a message-less, non-streaming request that dispatches
+one buffered OpenAI-wire ``/embeddings`` POST per attempt. This module holds
+that admission so the already line-budgeted ``native_bridge`` carries only the
+boundary method.
+
+Deliberately absent on day one (each is a documented follow-up, not an
+oversight): keyed replay (an inbound ``Idempotency-Key`` is ignored, never
+keyed), input guardrails (the guardrail engine reads chat messages), project
+targets (learned selection embeds the chat prompt), and body-signing dialects
+(Bedrock has no OpenAI embeddings wire).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import replace
+from typing import Protocol
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    GatewayFailure,
+    GatewayFailureClass,
+)
+from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest
+from exp.runtime.gateway.guardrails.client import assert_not_internal_classification
+from exp.runtime.gateway.native_accounting import (
+    NativeAttemptAccounting,
+    NativeBridgeError,
+    authority_error,
+    gateway_updating_failure,
+    record_dead_admission_rungs,
+)
+from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
+from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_embeddings_body
+from exp.runtime.gateway.native_execution import (
+    MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
+    MAXIMUM_TOTAL_ATTEMPTS,
+    InflightRequest,
+    NativeDialectUnavailableError,
+    deployment_wire_entry,
+    dispatchable_route_profiles,
+    select_route_deployments,
+)
+from exp.runtime.gateway.routing import GatewayRoutingError
+from exp.runtime.models.providers import require_gateway_provider
+from exp.runtime.models.providers.openai_compatible import openai_embedding_request
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+
+class _EmbeddingsPlane(Protocol):
+    """The control-plane state the embeddings admission reads and writes."""
+
+    _components: NativeGatewayComponents
+    _accounting: NativeAttemptAccounting
+    _write_ledger: SyncWriteLedger
+    _request_timeout_seconds: float
+
+    def _escalate_accepted(self, authorization: AuthorizationSnapshot, reason: str) -> str: ...
+
+
+def not_an_embeddings_model_error(alias: str) -> OpenAIProtocolError:
+    """Build the public 400 for an alias none of whose rungs serve embeddings.
+
+    Args:
+        alias: The public model alias the caller named.
+
+    Returns:
+        A field-specific ``unsupported_capability`` error on ``model``.
+    """
+    return OpenAIProtocolError(
+        status_code=400,
+        code="unsupported_capability",
+        message=(
+            f"The model {alias!r} does not serve embeddings. Choose an embeddings model "
+            "from GET /v1/models and resend the request to /v1/embeddings."
+        ),
+        param="model",
+    )
+
+
+def _embeddings_rung(profile_url: str | None, supports_embeddings: bool | None) -> bool:
+    """Whether one resolved rung may serve an embeddings request.
+
+    Both facts fail closed: the catalog must positively declare embeddings
+    support (an unknown tri-state is not a claim), and the connection must
+    expose an OpenAI-wire ``/embeddings`` endpoint.
+    """
+    return profile_url is not None and supports_embeddings is True
+
+
+class NativeEmbeddingsMixin:
+    """The ``admit_embeddings`` boundary method for the native control plane."""
+
+    def admit_embeddings(self: _EmbeddingsPlane, argument: str) -> str:
+        """Decode, authorize, route, and durably accept one embeddings request.
+
+        Mirrors :meth:`NativeControlPlane.admit` for the message-less surface:
+        the raw body decodes through the shared embeddings decoder, the
+        authority and ledger seams accept it as ``api_surface = embeddings``,
+        the direct route narrows past rungs dead at admission and rungs that
+        do not serve embeddings, and every remaining rung gets one fully
+        built ``/embeddings`` payload. No attempt row is written here; each
+        physical dispatch is reserved by ``start_attempt`` with the input-only
+        reservation ceiling.
+
+        Args:
+            argument: JSON object with ``raw_key`` and ``body`` (raw request
+                body text). Any caller ``Idempotency-Key`` is ignored by the
+                data plane and never reaches this method.
+
+        Returns:
+            JSON wire configuration carrying the ordered ``route`` (one
+            OpenAI-wire entry per deployment), ``input_count``, and the
+            frozen retry-policy facts, or an ``{"escalate": reason}``
+            disposition for an accepted request no rung can serve.
+
+        Raises:
+            NativeBridgeError: Decoding, authorization, or routing failed, or
+                no rung of the alias serves embeddings.
+        """
+        assert_not_internal_classification()
+        self._accounting.sweep_expired()
+        data = json.loads(argument)
+        try:
+            decoded = decode_native_embeddings_body(str(data["body"]))
+        except NativeDecodeError as exc:
+            raise NativeBridgeError(exc.error) from exc
+        request = decoded.request
+        deadline = time.monotonic() + self._request_timeout_seconds
+        try:
+            authorization = self._components.store.authorize_request(
+                raw_key=str(data["raw_key"]),
+                alias=decoded.alias,
+                request=request,
+                deadline_monotonic=deadline,
+            )
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise authority_error(exc) from exc
+        try:
+            self._write_ledger.accept_request(authorization=authorization)
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise authority_error(exc) from exc
+        return _admit_accepted(self, authorization, request, deadline)
+
+
+def _admit_accepted(
+    plane: _EmbeddingsPlane,
+    authorization: AuthorizationSnapshot,
+    request: EmbeddingsRequest,
+    deadline: float,
+) -> str:
+    """Route and package one durably accepted embeddings request.
+
+    Every failure past acceptance finishes the accepted request content-free
+    before the public error crosses the boundary, so no open request row
+    leaks.
+    """
+    if not isinstance(authorization.target, DirectTarget):
+        # Learned selection embeds the chat prompt to pick a route; there is
+        # no prompt here, so project aliases are not embeddings models.
+        _finish_unsupported(plane, authorization)
+        raise NativeBridgeError(not_an_embeddings_model_error(authorization.alias))
+    try:
+        route = plane._components.routes.resolve_direct(authorization)  # noqa: SLF001
+        dispatchable = dispatchable_route_profiles(
+            plane._components.runtime_catalogs,  # noqa: SLF001
+            route,
+        )
+    except NativeDialectUnavailableError as exc:
+        return plane._escalate_accepted(authorization, str(exc))  # noqa: SLF001
+    except GatewayRoutingError as exc:
+        plane._accounting.finish_request_quietly(  # noqa: SLF001
+            authorization, gateway_updating_failure()
+        )
+        raise authority_error(exc) from exc
+    record_dead_admission_rungs(
+        plane._accounting,  # noqa: SLF001
+        authorization,
+        dispatchable.dead,
+        fallback_available=bool(dispatchable.indexes),
+    )
+    if not dispatchable.indexes:
+        return plane._escalate_accepted(  # noqa: SLF001
+            authorization, "every certified deployment was unavailable at admission"
+        )
+    serving: list[int] = []
+    for index, (profile, _client) in zip(
+        dispatchable.indexes, dispatchable.resolved_wires, strict=True
+    ):
+        deployment = route.deployments[index]
+        capabilities = deployment.capabilities
+        supports = None if capabilities is None else capabilities.supports_embeddings
+        if _embeddings_rung(profile.embeddings_url, supports):
+            serving.append(index)
+    if not serving:
+        _finish_unsupported(plane, authorization)
+        raise NativeBridgeError(not_an_embeddings_model_error(authorization.alias))
+    served_wires = [
+        wire
+        for index, wire in zip(dispatchable.indexes, dispatchable.resolved_wires, strict=True)
+        if index in serving
+    ]
+    route = select_route_deployments(route, tuple(serving))
+    wire_route: list[JsonObject] = []
+    try:
+        for deployment, (profile, _client) in zip(route.deployments, served_wires, strict=True):
+            require_gateway_provider(deployment.provider)
+            embeddings_url = profile.embeddings_url
+            if embeddings_url is None:  # pragma: no cover - filtered above.
+                raise GatewayRoutingError("embeddings rung lost its wire endpoint")
+            payload = openai_embedding_request(
+                profile.model_id,
+                request.inputs,
+                dimensions=request.dimensions,
+                encoding_format=request.encoding_format,
+                user=request.user,
+            )
+            wire_route.append(
+                deployment_wire_entry(
+                    route,
+                    deployment,
+                    replace(profile, url=embeddings_url),
+                    payload,
+                )
+            )
+    except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+        error = authority_error(exc)
+        plane._accounting.finish_request_quietly(  # noqa: SLF001
+            authorization,
+            GatewayFailure(
+                failure_class=GatewayFailureClass.INTERNAL,
+                safe_message="gateway admission failed before provider dispatch",
+            ),
+        )
+        raise error from exc
+    depth = len(route.deployments)
+    plane._accounting.register(  # noqa: SLF001
+        InflightRequest(
+            authorization=authorization,
+            route=route,
+            request=request,
+            deadline_monotonic=deadline,
+            signers=(None,) * depth,
+            dispatch_bindings=(None,) * depth,
+            reasoning_carrier_authorities=(None,) * depth,
+        )
+    )
+    response: JsonObject = {
+        "request_id": authorization.request_id,
+        "alias": authorization.alias,
+        "alias_revision_id": authorization.alias_revision_id,
+        "exact_model_id": route.snapshot.exact_model_id,
+        "route_reason": route.route_reason,
+        "route": wire_route,
+        "input_count": len(request.inputs),
+        "maximum_total_attempts": MAXIMUM_TOTAL_ATTEMPTS,
+        "maximum_same_deployment_attempts": MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
+    }
+    return json.dumps(response, separators=(",", ":"))
+
+
+def _finish_unsupported(plane: _EmbeddingsPlane, authorization: AuthorizationSnapshot) -> None:
+    """Finish one accepted request that named a non-embeddings alias."""
+    plane._accounting.finish_request_quietly(  # noqa: SLF001
+        authorization,
+        GatewayFailure(
+            failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
+            safe_message="the model alias does not serve embeddings",
+        ),
+    )

--- a/exp/runtime/gateway/native_embeddings.py
+++ b/exp/runtime/gateway/native_embeddings.py
@@ -215,12 +215,13 @@ def _admit_accepted(
             embeddings_url = profile.embeddings_url
             if embeddings_url is None:  # pragma: no cover - filtered above.
                 raise GatewayRoutingError("embeddings rung lost its wire endpoint")
+            # `user` is METADATA_ONLY in the embeddings manifest: recorded as
+            # the attribution label at accept, never forwarded to the provider.
             payload = openai_embedding_request(
                 profile.model_id,
                 request.inputs,
                 dimensions=request.dimensions,
                 encoding_format=request.encoding_format,
-                user=request.user,
             )
             wire_route.append(
                 deployment_wire_entry(

--- a/exp/runtime/gateway/native_embeddings_test.py
+++ b/exp/runtime/gateway/native_embeddings_test.py
@@ -1,0 +1,143 @@
+"""Tests for the native embeddings admission boundary."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import ModelCapabilities
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.lifecycle import load_gateway_components
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.native_accounting import NativeBridgeError
+from exp.runtime.gateway.native_bridge import NativeControlPlane
+
+
+def _control_plane(root: Path, *, embeddings: bool) -> tuple[NativeControlPlane, str]:
+    """Seed the ``coding`` alias as an embeddings or chat model and load the plane."""
+    capabilities = ModelCapabilities(supports_embeddings=True) if embeddings else None
+    _manager, raw_key = _configured_gateway(root, capabilities=capabilities)
+    components = load_gateway_components(
+        root, environment={"TEST_PROVIDER_KEY": "provider-secret-canary"}
+    )
+    return NativeControlPlane(components), raw_key
+
+
+def _admit(control: NativeControlPlane, raw_key: str, body: JsonObject) -> JsonObject:
+    """Run one embeddings admission and decode its JSON answer."""
+    argument = json.dumps({"raw_key": raw_key, "body": json.dumps(body)})
+    return json.loads(control.admit_embeddings(argument))
+
+
+def _public_error(exc: NativeBridgeError) -> JsonObject:
+    """Decode the OpenAI-shaped public error carried across the boundary."""
+    return json.loads(exc.public_error_json)
+
+
+def _request_row(control: NativeControlPlane, request_id: str) -> tuple[str, str | None]:
+    """Read the durable surface and terminal state of one request row."""
+    ledger = cast("SQLiteAttemptLedger", control._components.ledger)  # noqa: SLF001
+    with sqlite3.connect(ledger.database_path) as connection:
+        row = connection.execute(
+            "select api_surface, terminal_state from gateway_requests where request_id = ?",
+            (request_id,),
+        ).fetchone()
+    assert row is not None
+    return (str(row[0]), None if row[1] is None else str(row[1]))
+
+
+def test_admit_builds_the_openai_embeddings_wire_and_settles_input_only(tmp_path: Path) -> None:
+    """Admission returns one ``/embeddings`` payload per rung; settlement bills input tokens."""
+    control, raw_key = _control_plane(tmp_path, embeddings=True)
+    admission = _admit(
+        control,
+        raw_key,
+        {
+            "model": "coding",
+            "input": ["alpha beta", "gamma"],
+            "dimensions": 3,
+            "encoding_format": "float",
+            "user": "tenant-7",
+        },
+    )
+    assert admission["input_count"] == 2
+    assert admission["maximum_total_attempts"] == 8
+    assert "stream" not in admission
+    route = admission["route"]
+    assert isinstance(route, list) and len(route) == 1
+    wire = route[0]
+    assert wire["dialect"] == "openai_compatible"
+    assert wire["url"] == "http://127.0.0.1:9/v1/embeddings"
+    assert wire["headers"]["Authorization"] == "Bearer provider-secret-canary"
+    assert wire["upstream_payload"] == {
+        "model": "provider-model-exact",
+        "input": ["alpha beta", "gamma"],
+        "dimensions": 3,
+        "encoding_format": "float",
+        "user": "tenant-7",
+    }
+    assert wire["upstream_body"] is None
+    request_id = str(admission["request_id"])
+    assert _request_row(control, request_id) == ("embeddings", None)
+
+    started = json.loads(
+        control.start_attempt(
+            json.dumps({"request_id": admission["request_id"], "attempt_ordinal": 0})
+        )
+    )
+    assert started["route_depth"] == 0
+    settled = control.settle(
+        json.dumps(
+            {
+                "request_id": admission["request_id"],
+                "attempt_id": started["attempt_id"],
+                "outcome": "completed",
+                "usage": {"input_tokens": 3, "output_tokens": 0},
+                "tool_names": [],
+                "failure": None,
+            }
+        )
+    )
+    assert settled == "{}"
+    assert _request_row(control, request_id) == ("embeddings", "completed")
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 1
+    assert report["totals"]["input_tokens"] == 3
+    assert report["totals"]["output_tokens"] == 0
+
+
+def test_admit_rejects_a_chat_alias_with_a_model_field_error_and_finishes_the_request(
+    tmp_path: Path,
+) -> None:
+    """An alias whose rungs never claim embeddings fails closed on ``model``, accounted."""
+    control, raw_key = _control_plane(tmp_path, embeddings=False)
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, {"model": "coding", "input": "hello"})
+    error = _public_error(raised.value)
+    assert error["status_code"] == 400
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == "model"
+    assert "does not serve embeddings" in str(error["message"])
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 1
+    assert report["totals"]["input_tokens"] == 0
+
+
+def test_admit_rejects_protocol_failures_before_any_ledger_write(tmp_path: Path) -> None:
+    """A body the shared decoder rejects never accepts a request."""
+    control, raw_key = _control_plane(tmp_path, embeddings=True)
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, {"model": "coding"})
+    error = _public_error(raised.value)
+    assert error["status_code"] == 400
+    assert error["param"] == "input"
+    with pytest.raises(NativeBridgeError) as unknown:
+        _admit(control, "not-a-key", {"model": "coding", "input": "hello"})
+    assert _public_error(unknown.value)["status_code"] == 401
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 0

--- a/exp/runtime/gateway/native_embeddings_test.py
+++ b/exp/runtime/gateway/native_embeddings_test.py
@@ -74,12 +74,12 @@ def test_admit_builds_the_openai_embeddings_wire_and_settles_input_only(tmp_path
     assert wire["dialect"] == "openai_compatible"
     assert wire["url"] == "http://127.0.0.1:9/v1/embeddings"
     assert wire["headers"]["Authorization"] == "Bearer provider-secret-canary"
+    # `user` is metadata-only: the attribution label at accept, never on the wire.
     assert wire["upstream_payload"] == {
         "model": "provider-model-exact",
         "input": ["alpha beta", "gamma"],
         "dimensions": 3,
         "encoding_format": "float",
-        "user": "tenant-7",
     }
     assert wire["upstream_body"] is None
     request_id = str(admission["request_id"])

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -24,6 +24,7 @@ from exp.runtime.gateway.contracts import (
     GatewayFailureClass,
     GatewayRequest,
 )
+from exp.runtime.gateway.embeddings_contracts import ServingRequest
 from exp.runtime.gateway.execution_resolution import (
     GatewayWireContractError,
     _require_deployment_identity,
@@ -95,7 +96,7 @@ class InflightRequest:
 
     authorization: AuthorizationSnapshot
     route: GatewayRoute
-    request: GatewayRequest
+    request: ServingRequest
     deadline_monotonic: float
     attempt_counts: list[int] = field(default_factory=list)
     total_attempts: int = 0

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import assert_never
+
 from exp.common.core.artifacts import JsonObject, Sha256, sha256_json
 from exp.runtime.gateway.contracts import EncryptedReasoningBlock, GatewayRequest
+from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest, ServingRequest
 
 
 def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
@@ -132,7 +135,7 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
     return envelope
 
 
-def canonical_request_sha256(request: GatewayRequest) -> Sha256:
+def canonical_request_sha256(request: ServingRequest) -> Sha256:
     """Digest one canonical request including excluded provider replay authority.
 
     A caller operation key reused with different replayed reasoning must be
@@ -140,13 +143,22 @@ def canonical_request_sha256(request: GatewayRequest) -> Sha256:
     request with no carrier digests exactly as its plain serialization, so
     every request decoded before the carriers existed keeps its identity.
 
+    The embeddings surface has no messages, tools, or provider carriers, so it
+    digests exactly as its plain serialization with no replay envelope.
+
     Args:
-        request: Canonical gateway request as decoded from the public wire.
+        request: Canonical serving request as decoded from the public wire.
 
     Returns:
         The stable canonical request digest.
     """
-    envelope = provider_replay_authority(request)
-    if envelope is None:
-        return sha256_json(request)
-    return sha256_json({"request_sha256": sha256_json(request), **envelope})
+    match request:
+        case EmbeddingsRequest():
+            return sha256_json(request)
+        case GatewayRequest():
+            envelope = provider_replay_authority(request)
+            if envelope is None:
+                return sha256_json(request)
+            return sha256_json({"request_sha256": sha256_json(request), **envelope})
+        case _:  # pragma: no cover - exhaustive over the ServingRequest union.
+            assert_never(request)

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 
 class GatewaySchemaError(RuntimeError):
@@ -620,6 +620,27 @@ _MIGRATION_13 = (
     "ALTER TABLE gateway_attempts ADD COLUMN long_context_reasoning_rate INTEGER",
 )
 
+# The v14 gateway_requests definition: the v10 table with the api_surface
+# CHECK widened once more to admit the embeddings surface. Migrations 11-13
+# touched other tables, so this is otherwise the live definition verbatim.
+_GATEWAY_REQUESTS_V14_SQL = _GATEWAY_REQUESTS_V10_SQL.replace(
+    "api_surface IN ('chat_completions', 'responses', 'messages')",
+    "api_surface IN ('chat_completions', 'responses', 'messages', 'embeddings')",
+)
+
+_MIGRATION_14 = (
+    # Same CHECK-only in-place rewrite as migration 10 (see its comment).
+    "PRAGMA writable_schema = ON",
+    (
+        "UPDATE sqlite_master SET sql = '"
+        + _GATEWAY_REQUESTS_V14_SQL.replace("'", "''")
+        + "' WHERE type = 'table' AND name = 'gateway_requests'"
+    ),
+    "PRAGMA writable_schema = RESET",
+    "CREATE TABLE gateway_schema_refresh_v14 (noop INTEGER) STRICT",
+    "DROP TABLE gateway_schema_refresh_v14",
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -634,6 +655,7 @@ _MIGRATIONS = {
     11: _MIGRATION_11,
     12: _MIGRATION_12,
     13: _MIGRATION_13,
+    14: _MIGRATION_14,
 }
 
 

--- a/exp/runtime/gateway/sqlite/migrations_test.py
+++ b/exp/runtime/gateway/sqlite/migrations_test.py
@@ -987,3 +987,95 @@ def test_v12_adds_bedrock_auth_locators_and_preserves_ambient_authority(
         assert migrated.execute("PRAGMA foreign_key_check").fetchall() == []
     finally:
         migrated.close()
+
+
+def test_v14_migration_widens_api_surface_to_embeddings_and_preserves_rows(
+    tmp_path: Path,
+) -> None:
+    """The v14 rewrite admits the embeddings surface without touching v13 data.
+
+    A v13 database with one full request-and-attempt chain migrates in place:
+    the existing rows and the child foreign key survive, an ``embeddings``
+    request becomes insertable, and any other surface value stays rejected.
+    """
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for version in range(1, 14):
+            for statement in migrations._MIGRATIONS[version]:
+                connection.execute(statement)
+        connection.execute("PRAGMA user_version = 13")
+        seed_statements = """
+            INSERT INTO organizations VALUES ('org', 'org', 'Org', 1, 't', 't');
+            INSERT INTO identities VALUES ('id', 'org', 'Identity', NULL, 1, 't', 't');
+            INSERT INTO virtual_keys (
+                key_id, organization_id, identity_id, prefix,
+                fingerprint_version, fingerprint_sha256, created_at
+            ) VALUES ('key', 'org', 'id', 'pfx', 1, '{fingerprint}', 't');
+            INSERT INTO catalog_snapshot_refs VALUES ('snap', 'org', '{digest}', 't');
+            INSERT INTO gateway_aliases (
+                alias_id, organization_id, alias_name, active_revision_id,
+                created_at, updated_at
+            ) VALUES ('alias', 'org', 'alias', NULL, 't', 't');
+            INSERT INTO alias_revisions (
+                revision_id, organization_id, alias_id, revision_number,
+                target_kind, pool_id, catalog_sha256, snapshot_ref, created_at
+            ) VALUES ('rev', 'org', 'alias', 1, 'direct', 'pool', '{digest}', 'snap', 't');
+            INSERT INTO gateway_requests (
+                request_id, organization_id, identity_id, key_id, alias_id,
+                alias_revision_id, api_surface, canonical_request_sha256,
+                accepted_at, deadline_at
+            ) VALUES (
+                'req-1', 'org', 'id', 'key', 'alias', 'rev', 'messages',
+                '{digest}', 't', 't'
+            );
+            INSERT INTO gateway_attempts (
+                attempt_id, request_id, organization_id, attempt_ordinal,
+                route_depth, deployment_id, provider, exact_model_id, pool_id,
+                catalog_sha256, state, started_at, budget_period_start
+            ) VALUES (
+                'att-1', 'req-1', 'org', 0, 0, 'deploy', 'provider', 'exact',
+                'pool', '{digest}', 'completed', 't', '2026-08-01T00:00:00+00:00'
+            );
+            """.format(fingerprint="a" * 64, digest="b" * 64)
+        for statement in seed_statements.split(";"):
+            if statement.strip():
+                connection.execute(statement)
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None and backup.exists()
+    migrated = connect_database(path)
+    try:
+        assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        assert migrated.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert migrated.execute("PRAGMA foreign_key_check").fetchall() == []
+        surviving = migrated.execute(
+            "SELECT api_surface FROM gateway_requests WHERE request_id = 'req-1'"
+        ).fetchone()
+        assert surviving[0] == "messages"
+        request_columns = (
+            "request_id, organization_id, identity_id, key_id, alias_id, "
+            "alias_revision_id, api_surface, canonical_request_sha256, accepted_at, deadline_at"
+        )
+        migrated.execute(
+            f"INSERT INTO gateway_requests ({request_columns}) "
+            "VALUES ('req-2', 'org', 'id', 'key', 'alias', 'rev', 'embeddings', ?, 't', 't')",
+            ("c" * 64,),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            migrated.execute(
+                f"INSERT INTO gateway_requests ({request_columns}) "
+                "VALUES ('req-3', 'org', 'id', 'key', 'alias', 'rev', 'bogus', ?, 't', 't')",
+                ("d" * 64,),
+            )
+        migrated.execute("DELETE FROM gateway_attempts WHERE attempt_id = 'att-1'")
+        migrated.execute("DELETE FROM gateway_requests WHERE request_id = 'req-1'")
+    finally:
+        migrated.close()

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -11,6 +11,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import assert_never
 
 from exp.common.core.artifacts import Sha256, sha256_json
 from exp.runtime.gateway.auth import (
@@ -29,6 +30,7 @@ from exp.runtime.gateway.contracts import (
     GatewayTarget,
     ProjectTarget,
 )
+from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest, ServingRequest
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.replay_identity import canonical_request_sha256
 from exp.runtime.gateway.sqlite import key_delivery
@@ -643,7 +645,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
         *,
         raw_key: str,
         alias: str,
-        request: GatewayRequest,
+        request: ServingRequest,
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,
@@ -700,7 +702,15 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 activation_ref=str(row["activation_ref"]),
                 catalog_sha256=str(row["catalog_sha256"]),
             )
-        caller_operation = _caller_operation_sha256(request)
+        match request:
+            case EmbeddingsRequest():
+                # Keyed replay is deferred for the embeddings surface: it carries
+                # no idempotency key and never claims a caller-operation scope.
+                caller_operation = None
+            case GatewayRequest():
+                caller_operation = _caller_operation_sha256(request)
+            case _:  # pragma: no cover - exhaustive over the ServingRequest union.
+                assert_never(request)
         return AuthorizationSnapshot(
             request_id=f"request-{uuid.uuid4().hex}",
             organization_id=organization_id,

--- a/exp/runtime/gateway/tests/native_embeddings_test.py
+++ b/exp/runtime/gateway/tests/native_embeddings_test.py
@@ -277,7 +277,7 @@ def test_official_client_round_trips_base64_vectors_and_settles(engine: _Serving
 def test_raw_float_request_forwards_every_field_and_ignores_idempotency_key(
     engine: _ServingEngine,
 ) -> None:
-    """A string input with dimensions and float encoding crosses verbatim; user stays gateway-side."""
+    """Dimensions and float encoding cross verbatim; ``user`` stays gateway-side."""
     response = _post(
         engine,
         {

--- a/exp/runtime/gateway/tests/native_embeddings_test.py
+++ b/exp/runtime/gateway/tests/native_embeddings_test.py
@@ -1,0 +1,370 @@
+"""End-to-end embeddings tests against the served native engine.
+
+One shared native serving subprocess (the driver from ``native_messages_test``)
+serves a seeded root with two aliases on one OpenAI-compatible loopback
+connection: ``coding`` (a chat model) and ``embedder`` (a catalog-declared
+embeddings model). The tests drive ``POST /v1/embeddings`` through the real
+Rust data plane and shared python control plane with the official OpenAI
+client and raw HTTP, and read the settled accounting back from the live usage
+report.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import signal
+import struct
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import openai
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import (
+    GatewayDeploymentCapabilities,
+    GatewayTokenPrices,
+    ModelCapabilities,
+)
+from exp.runtime.gateway.catalog_authority import upsert_singleton_deployment
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.tests.native_messages_test import (
+    _DRIVER_SOURCE,
+    _HOST,
+    _REQUEST_TIMEOUT_SECONDS,
+    _ServingEngine,
+)
+
+pytest.importorskip("exp_gateway_native")
+
+_VECTOR_WIDTH = 3
+
+
+def _vector(position: int) -> list[float]:
+    """Return the deterministic loopback vector for one input position."""
+    return [float(position + 1), 0.5, -0.25]
+
+
+class _EmbeddingsUpstream(BaseHTTPRequestHandler):
+    """OpenAI-compatible ``/embeddings`` mock whose shape is selected by the first input."""
+
+    payloads: list[JsonObject] = []
+    payloads_lock = threading.Lock()
+
+    def _answer(self, status: int, body: JsonObject) -> None:
+        encoded = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract.
+        """Answer one canned embeddings response selected by the first input."""
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        with self.payloads_lock:
+            self.payloads.append(payload)
+        if not self.path.endswith("/embeddings"):
+            self._answer(404, {"error": {"message": "unknown route", "type": "invalid_request"}})
+            return
+        raw_inputs = payload["input"]
+        inputs = [raw_inputs] if isinstance(raw_inputs, str) else list(raw_inputs)
+        selector = inputs[0]
+        if selector == "reject-param":
+            self._answer(
+                400,
+                {
+                    "error": {
+                        "message": "'$.input' is too long. Maximum length is 2048 items.",
+                        "type": "invalid_request_error",
+                        "param": "input",
+                        "code": "invalid_value",
+                    }
+                },
+            )
+            return
+        if selector == "server-error":
+            self._answer(500, {"error": {"message": "boom", "type": "server_error"}})
+            return
+        encoding = payload.get("encoding_format", "float")
+        data: list[JsonObject] = []
+        # Answer in reverse order so the gateway's index-based reordering is exercised.
+        for position in reversed(range(len(inputs))):
+            vector = _vector(position)
+            embedding: object = (
+                base64.b64encode(struct.pack(f"<{_VECTOR_WIDTH}f", *vector)).decode()
+                if encoding == "base64"
+                else vector
+            )
+            data.append({"object": "embedding", "index": position, "embedding": embedding})
+        if selector == "short-count":
+            data.pop()
+        prompt_tokens = sum(len(text.split()) for text in inputs)
+        body: JsonObject = {"object": "list", "data": data, "model": payload["model"]}
+        if selector != "unbilled":
+            body["usage"] = {"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens}
+        self._answer(200, body)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002 - stdlib name.
+        """Keep the test output quiet."""
+        del format, args
+
+
+@pytest.fixture(scope="module", name="engine")
+def _engine(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_ServingEngine]:
+    """Serve one shared native engine over a root with chat and embeddings aliases.
+
+    Yields:
+        The live serving facts as a :class:`_ServingEngine`.
+    """
+    root = tmp_path_factory.mktemp("native-embeddings-root")
+    with _EmbeddingsUpstream.payloads_lock:
+        _EmbeddingsUpstream.payloads.clear()
+    upstream = ThreadingHTTPServer((_HOST, 0), _EmbeddingsUpstream)
+    upstream_thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    upstream_thread.start()
+    manager, raw_key = _configured_gateway(
+        root, base_url=f"http://{_HOST}:{upstream.server_address[1]}/v1"
+    )
+    normalized, snapshot, _changed = upsert_singleton_deployment(
+        root,
+        deployment_alias="embedder",
+        connection_name="provider-main",
+        provider_model="embedder-model-exact",
+        exact_model_id="embedder-revision-exact",
+        revision=None,
+        capabilities=ModelCapabilities(supports_embeddings=True),
+        gateway_capabilities=GatewayDeploymentCapabilities(),
+        prices=GatewayTokenPrices(input_micro_usd_per_million_tokens=20_000),
+        pricing_source=None,
+        replace=False,
+    )
+    manager.activate_direct_alias(
+        alias_id="embedder",
+        alias_name="embedder",
+        revision_id="revision-embedder",
+        pool_id="embedder",
+        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+        catalog_sha256=normalized.identity_sha256(),
+    )
+    manager.add_grant(identity_id="default", alias_id="embedder")
+    driver = root / "native_embeddings_driver.py"
+    driver.write_text(_DRIVER_SOURCE + "\n")
+    config = json.dumps({"root": str(root), "request_timeout_seconds": _REQUEST_TIMEOUT_SECONDS})
+    stderr_log = root / "driver-stderr.log"
+    environment = dict(os.environ)
+    environment["TEST_PROVIDER_KEY"] = "provider-secret-canary"
+    stderr_sink = stderr_log.open("wb")
+    process = subprocess.Popen(  # noqa: S603 - the interpreter runs our generated driver.
+        [sys.executable, str(driver), config],
+        stdout=subprocess.PIPE,
+        stderr=stderr_sink,
+        env=environment,
+        text=True,
+    )
+    try:
+        announced_ports: list[int] = []
+
+        def _collect_announcements() -> None:
+            """Record every port announcement the driver prints on stdout."""
+            assert process.stdout is not None
+            for line in process.stdout:
+                announced_ports.append(int(json.loads(line)["port"]))
+
+        reader = threading.Thread(target=_collect_announcements, daemon=True)
+        reader.start()
+        live_deadline = time.monotonic() + 30
+        port = 0
+        while True:
+            if announced_ports:
+                port = announced_ports[-1]
+                try:
+                    models = httpx.get(
+                        f"http://{_HOST}:{port}/v1/models",
+                        headers={"authorization": f"Bearer {raw_key}"},
+                        timeout=2.0,
+                    )
+                    if models.status_code == 200 and sorted(
+                        item["id"] for item in models.json()["data"]
+                    ) == ["coding", "embedder"]:
+                        break
+                except (httpx.HTTPError, ValueError, KeyError, TypeError):
+                    pass
+            assert process.poll() is None, f"driver died: {stderr_log.read_text()}"
+            assert time.monotonic() < live_deadline, "native engine never became live"
+            time.sleep(0.05)
+        yield _ServingEngine(port=port, raw_key=raw_key, root=root)
+    finally:
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+        exit_code = process.wait(timeout=20)
+        stderr_sink.close()
+        upstream.shutdown()
+        upstream.server_close()
+        upstream_thread.join(timeout=5)
+        assert exit_code == 0, f"driver exited {exit_code}: {stderr_log.read_text()}"
+
+
+def _terminal_attempts(base: str, state: str) -> int:
+    """Read one terminal-state attempt total from the live usage report."""
+    report = httpx.get(f"{base}/usage.json", timeout=5.0).json()
+    for count in report["totals"]["terminal_counts"]:
+        if count["state"] == state:
+            return int(count["attempts"])
+    return 0
+
+
+def _total(base: str, key: str) -> int:
+    """Read one integer total (``requests``, ``input_tokens``, ...) from the live usage report."""
+    return int(httpx.get(f"{base}/usage.json", timeout=5.0).json()["totals"][key])
+
+
+def _last_upstream_payload() -> JsonObject:
+    """Return the most recent payload the loopback provider received."""
+    with _EmbeddingsUpstream.payloads_lock:
+        return _EmbeddingsUpstream.payloads[-1]
+
+
+def _post(engine: _ServingEngine, body: JsonObject, **headers: str) -> httpx.Response:
+    """POST one raw embeddings body with the seeded key."""
+    return httpx.post(
+        f"{engine.base}/v1/embeddings",
+        headers={"authorization": f"Bearer {engine.raw_key}", **headers},
+        json=body,
+        timeout=30.0,
+    )
+
+
+def test_official_client_round_trips_base64_vectors_and_settles(engine: _ServingEngine) -> None:
+    """The OpenAI SDK's default base64 request decodes to the provider's exact floats."""
+    completed_before = _terminal_attempts(engine.base, "completed")
+    requests_before = _total(engine.base, "requests")
+    input_before = _total(engine.base, "input_tokens")
+    output_before = _total(engine.base, "output_tokens")
+    client = openai.OpenAI(base_url=f"{engine.base}/v1", api_key=engine.raw_key)
+    raw = client.embeddings.with_raw_response.create(
+        model="embedder", input=["alpha beta", "gamma"]
+    )
+    response = raw.parse()
+    assert raw.headers["x-gateway-alias"] == "embedder"
+    assert raw.headers["x-gateway-provider"] == "openai-compatible"
+    assert raw.headers["x-gateway-deployment"]
+    assert raw.headers["x-gateway-route-depth"] == "0"
+    assert raw.headers["x-request-id"]
+    assert response.model == "embedder"
+    assert response.usage.prompt_tokens == 3
+    assert response.usage.total_tokens == 3
+    assert [item.index for item in response.data] == [0, 1]
+    assert [item.embedding for item in response.data] == [_vector(0), _vector(1)]
+    upstream = _last_upstream_payload()
+    assert upstream["model"] == "embedder-model-exact"
+    assert upstream["input"] == ["alpha beta", "gamma"]
+    assert upstream["encoding_format"] == "base64"
+    assert _terminal_attempts(engine.base, "completed") == completed_before + 1
+    assert _total(engine.base, "requests") == requests_before + 1
+    assert _total(engine.base, "input_tokens") == input_before + 3
+    assert _total(engine.base, "output_tokens") == output_before
+
+
+def test_raw_float_request_forwards_every_field_and_ignores_idempotency_key(
+    engine: _ServingEngine,
+) -> None:
+    """A string input with dimensions, user, and float encoding crosses verbatim."""
+    response = _post(
+        engine,
+        {
+            "model": "embedder",
+            "input": "one two three",
+            "dimensions": 3,
+            "encoding_format": "float",
+            "user": "tenant-7",
+        },
+        **{"Idempotency-Key": "ignored-on-embeddings", "x-client-request-id": "corr-1"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.headers["x-client-request-id"] == "corr-1"
+    assert response.json() == {
+        "object": "list",
+        "data": [{"object": "embedding", "index": 0, "embedding": _vector(0)}],
+        "model": "embedder",
+        "usage": {"prompt_tokens": 3, "total_tokens": 3},
+    }
+    assert _last_upstream_payload() == {
+        "model": "embedder-model-exact",
+        "input": ["one two three"],
+        "dimensions": 3,
+        "encoding_format": "float",
+        "user": "tenant-7",
+    }
+
+
+def test_chat_alias_is_refused_on_the_model_field_and_accounted(engine: _ServingEngine) -> None:
+    """An alias with no embeddings rung fails closed before any provider dispatch."""
+    payloads_before = len(_EmbeddingsUpstream.payloads)
+    requests_before = _total(engine.base, "requests")
+    response = _post(engine, {"model": "coding", "input": "hello"})
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == "model"
+    assert "'coding' does not serve embeddings" in error["message"]
+    assert len(_EmbeddingsUpstream.payloads) == payloads_before
+    assert _total(engine.base, "requests") == requests_before + 1
+
+
+def test_protocol_and_key_failures_are_openai_shaped(engine: _ServingEngine) -> None:
+    """Decode failures name the field; an unknown key is a uniform 401."""
+    missing_input = _post(engine, {"model": "embedder"})
+    assert missing_input.status_code == 400
+    assert missing_input.json()["error"]["param"] == "input"
+    empty_item = _post(engine, {"model": "embedder", "input": ["ok", ""]})
+    assert empty_item.status_code == 400
+    unknown = httpx.post(
+        f"{engine.base}/v1/embeddings",
+        headers={"authorization": "Bearer not-a-key"},
+        json={"model": "embedder", "input": "hello"},
+        timeout=10.0,
+    )
+    assert unknown.status_code == 401
+    assert unknown.json()["error"]["code"] == "invalid_key"
+
+
+def test_provider_client_error_relays_the_parameter_and_detail(engine: _ServingEngine) -> None:
+    """A provider 400 reaches the caller as a 400 naming the rejected field."""
+    failed_before = _terminal_attempts(engine.base, "failed")
+    response = _post(engine, {"model": "embedder", "input": ["reject-param"]})
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request"
+    assert error["param"] == "input"
+    assert "Maximum length is 2048 items" in error["message"]
+    assert _terminal_attempts(engine.base, "failed") == failed_before + 1
+
+
+@pytest.mark.parametrize(
+    ("selector", "expected_fragment"),
+    (
+        ("short-count", "malformed response"),
+        ("unbilled", "malformed response"),
+        ("server-error", "provider service failed"),
+    ),
+)
+def test_unbillable_or_failing_provider_answers_fail_closed(
+    engine: _ServingEngine, selector: str, expected_fragment: str
+) -> None:
+    """A vector-count mismatch, a missing prompt_tokens, or a 5xx never reaches the caller."""
+    failed_before = _terminal_attempts(engine.base, "failed")
+    response = _post(engine, {"model": "embedder", "input": [selector, "second"]})
+    assert response.status_code == 502, response.text
+    error = response.json()["error"]
+    assert error["code"] == "all_routes_failed"
+    assert expected_fragment in error["message"]
+    assert _terminal_attempts(engine.base, "failed") == failed_before + 1

--- a/exp/runtime/gateway/tests/native_embeddings_test.py
+++ b/exp/runtime/gateway/tests/native_embeddings_test.py
@@ -277,7 +277,7 @@ def test_official_client_round_trips_base64_vectors_and_settles(engine: _Serving
 def test_raw_float_request_forwards_every_field_and_ignores_idempotency_key(
     engine: _ServingEngine,
 ) -> None:
-    """A string input with dimensions, user, and float encoding crosses verbatim."""
+    """A string input with dimensions and float encoding crosses verbatim; user stays gateway-side."""
     response = _post(
         engine,
         {
@@ -297,12 +297,12 @@ def test_raw_float_request_forwards_every_field_and_ignores_idempotency_key(
         "model": "embedder",
         "usage": {"prompt_tokens": 3, "total_tokens": 3},
     }
+    # `user` stays gateway-side (attribution label), never on the provider wire.
     assert _last_upstream_payload() == {
         "model": "embedder-model-exact",
         "input": ["one two three"],
         "dimensions": 3,
         "encoding_format": "float",
-        "user": "tenant-7",
     }
 
 

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -179,6 +179,11 @@ class GatewayWireProfile:
     pre-serialized body the data plane must send verbatim, and the resolved
     client exposes ``sign_gateway_dispatch``."""
 
+    embeddings_url: str | None = None
+    """Full OpenAI-wire ``/embeddings`` endpoint for this connection, sharing
+    ``headers``; ``None`` when the connection speaks no embeddings wire, so the
+    embeddings surface excludes the rung instead of dispatching a chat URL."""
+
     def __post_init__(self) -> None:
         """Reject malformed operator wire contracts before admission."""
         if self.dialect not in {

--- a/exp/runtime/models/providers/openai.py
+++ b/exp/runtime/models/providers/openai.py
@@ -276,6 +276,7 @@ class OpenAIClient(OpenAIEmbeddingMixin):
         return GatewayWireProfile(
             dialect="openai_responses",
             url=f"{self._base_url}/{self._request_path(self._completion_path())}",
+            embeddings_url=f"{self._base_url}/{self._request_path('embeddings')}",
             headers=self._headers(),
             model_id=self._model.model_id,
             timeout_seconds=self._timeout_seconds,

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -162,6 +162,7 @@ def openai_embedding_request(
     *,
     dimensions: int | None = None,
     encoding_format: Literal["float", "base64"] | None = None,
+    user: str | None = None,
 ) -> JsonObject:
     """Convert ordered text into one OpenAI-compatible embedding request.
 
@@ -172,6 +173,8 @@ def openai_embedding_request(
             from the wire when absent so the provider's native width applies.
         encoding_format: Optional caller vector encoding. Omitted when absent so
             the provider default (``float``) applies.
+        user: Optional end-user attribution forwarded verbatim; omitted when
+            absent.
 
     Returns:
         The OpenAI-compatible ``/embeddings`` request body.
@@ -181,6 +184,8 @@ def openai_embedding_request(
         request["dimensions"] = dimensions
     if encoding_format is not None:
         request["encoding_format"] = encoding_format
+    if user is not None:
+        request["user"] = user
     return request
 
 
@@ -433,6 +438,7 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         return GatewayWireProfile(
             dialect="openai_compatible",
             url=f"{self._base_url}/{self._request_path(self._completion_path())}",
+            embeddings_url=f"{self._base_url}/{self._request_path('embeddings')}",
             headers=self._headers(),
             model_id=self._model.model_id,
             timeout_seconds=self._timeout_seconds,

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -162,7 +162,6 @@ def openai_embedding_request(
     *,
     dimensions: int | None = None,
     encoding_format: Literal["float", "base64"] | None = None,
-    user: str | None = None,
 ) -> JsonObject:
     """Convert ordered text into one OpenAI-compatible embedding request.
 
@@ -173,8 +172,6 @@ def openai_embedding_request(
             from the wire when absent so the provider's native width applies.
         encoding_format: Optional caller vector encoding. Omitted when absent so
             the provider default (``float``) applies.
-        user: Optional end-user attribution forwarded verbatim; omitted when
-            absent.
 
     Returns:
         The OpenAI-compatible ``/embeddings`` request body.
@@ -184,8 +181,6 @@ def openai_embedding_request(
         request["dimensions"] = dimensions
     if encoding_format is not None:
         request["encoding_format"] = encoding_format
-    if user is not None:
-        request["user"] = user
     return request
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.25"
+version = "0.7.26"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.20,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.21,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.20"
+version = "0.3.21"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.25"
+version = "0.7.26"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What

The native data plane serves the OpenAI Embeddings API. This is PR3 of the embeddings surface (after #718 raw sibling primitives and #720 contract/decode/manifest).

- **Admission** (`native_embeddings.py`, `admit_embeddings` bridge method): reuses the chat surface's authority, ledger, deployment-health, and reservation seams over the `ServingRequest = GatewayRequest | EmbeddingsRequest` union (exhaustive `match`/`assert_never` on every reader: budgets, replay identity, store, bridge seal guard). The direct route is narrowed past rungs dead at admission and past rungs that do not serve embeddings — a rung serves only when the catalog positively declares `supports_embeddings` **and** the connection exposes an OpenAI-wire `/embeddings` endpoint (`GatewayWireProfile.embeddings_url`, set by the OpenAI and OpenAI-compatible clients; Azure inherits and keeps its `api-version`). No rung → `400 unsupported_capability` on `model`, accounted as a failed request. Project targets are refused (learned selection embeds the chat prompt; there is none).
- **Dispatch** (`route_embeddings.rs`): buffered POST per attempt on the same `start_attempt` → dispatch → settle ladder as chat (same-deployment redial / failover per the control plane's health + budget authority), one vector per input validated and reordered by index, `prompt_tokens` required (unbilled answers are `MalformedResponse`, failover-eligible), public alias relabeled, gateway identity headers emitted, input-only usage settled. An inbound `Idempotency-Key` is ignored (no replay protocol on this surface; keying it would share the chat namespace).
- **Reservation**: input leg only via canonical byte length (never undercounts) — `embeddings_input_ceiling_micro_usd`.
- **Ledger**: `api_surface = 'embeddings'`; sqlite migration 14 widens the CHECK (same in-place rewrite as v10).
- `openai_embedding_request` forwards `user`; `_resolve_route` moved to `native_admission.resolve_admission_route` (line budget), delegate kept for the guardrail ordering tests.
- Version 0.7.26 / native 0.3.21 (0.7.25 / 0.3.20 are claimed by #734).

Deliberately absent on day one (documented in the module docstring): keyed replay, input guardrails, project targets, body-signing (Bedrock) dialects, non-OpenAI wires (Gemini `embedContent`, Bedrock Titan/Cohere).

## Evidence

- `uv run ruff check .` / `ruff format --check` / `ty check`: clean. `cargo fmt --check`, `cargo clippy --no-default-features -- -D warnings`, `cargo test --no-default-features`: clean (133 tests incl. 2 new).
- Full `uv run pytest -q -n 4`: 3317 passed, 6 skipped, 1 failure in `exp/runtime/environments/local_test.py::…child_crash…` that passes in isolation (untouched module; sandbox flake).
- New e2e `exp/runtime/gateway/tests/native_embeddings_test.py` (real Rust server + python control plane + loopback JSON provider, official `openai` client): base64 default round trip decodes to the provider's exact floats; float+dimensions+user forwarded verbatim; `Idempotency-Key` ignored; chat alias → 400 on `model`; decode failures name `input`; unknown key → 401; provider 400 relays `param` + detail; count mismatch / missing usage / 5xx → 502 `all_routes_failed`; usage report increments requests + input tokens with zero output.
- **Live, house OpenAI key, through the served native engine**: `text-embedding-3-small` (2×1536, prompt_tokens=6), `text-embedding-3-large` (2×3072), `text-embedding-ada-002` (2×1536) all served with the public alias relabeled and `x-gateway-provider: openai`; `dimensions=8` honored on 3-small; `dimensions` on ada-002 relays OpenAI's own "This model does not support specifying dimensions." as a 400.

Platform PR (edge relay, `models.output_modalities += 'embedding'` classification, Postgres `api_surface` widening, compose acceptance) follows once this is released and pinned.