### PR TITLE
gateway: serve POST /v1/images/generations natively (OpenAI-wire, token-billed)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -23,6 +23,11 @@ It serves:
   connection, billed on the provider's reported `prompt_tokens` with no output leg, and
   returned with the provider's exact vectors in `float` or `base64` form; an inbound
   `Idempotency-Key` is ignored because the surface has no replay protocol)
+- `POST /v1/images/generations` (the OpenAI Images API, generations only: prompt in, images
+  out, never streamed; served only by aliases whose catalog capabilities declare
+  `supports_image_generation` on an OpenAI-wire connection, billed on the provider's reported
+  prompt and image tokens, so a model that answers without token usage is refused as
+  unbillable rather than served for free)
 - `GET /health/live` and `GET /health/ready`
 - `GET /usage` and `GET /usage.json`
 

--- a/exp/common/models/gateway_catalog.py
+++ b/exp/common/models/gateway_catalog.py
@@ -24,7 +24,7 @@ ExactModelPoolId = ArtifactId
 GATEWAY_EXCLUDED_PROVIDERS = frozenset({"tinker"})
 """Runtime-resolvable providers whose records never become gateway deployments."""
 
-SNAPSHOT_SCHEMA_VERSION = 1
+SNAPSHOT_SCHEMA_VERSION = 2
 """Normalized-catalog schema version this engine build reads and writes.
 
 Every change to the normalized catalog schema or its normalization output MUST

--- a/exp/common/models/gateway_catalog_test.py
+++ b/exp/common/models/gateway_catalog_test.py
@@ -149,7 +149,7 @@ def test_normalized_schema_change_requires_a_schema_version_bump() -> None:
         "pool": sorted(ExactModelPool.model_fields),
     }
     assert fingerprint == {
-        "schema_version": 1,
+        "schema_version": 2,
         "normalized": ["deployments", "pools", "schema_version"],
         "deployment": [
             "billing_source",

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -416,6 +416,9 @@ class ModelCapabilities(ContractModel):
 
     supports_tools: bool | None = None
     supports_embeddings: bool | None = None
+    # Image generation is served only on a positive claim, like embeddings:
+    # ``None`` is unknown and never dispatches to the images surface.
+    supports_image_generation: bool | None = None
     supports_structured_output: bool = False
     supports_completions: bool | None = None
     supports_temperature: bool = True

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -520,6 +520,11 @@ class ModelCapabilities(ContractModel):
             "cache_write_cost_per_million_tokens_usd",
         }
         excluded.add("supports_completions")
+        # Image generation is admitted fail-closed on its own surface, so the
+        # claim never changes what a chat or embeddings dispatch may do; keep
+        # it out of the identity like supports_completions so existing traces
+        # and frozen catalogs keep their digests.
+        excluded.add("supports_image_generation")
         return sha256_json(self.model_dump(mode="json", exclude=excluded))
 
 

--- a/exp/common/models/model_test.py
+++ b/exp/common/models/model_test.py
@@ -105,6 +105,7 @@ def test_model_request_keeps_tool_contract_and_capabilities_deterministic() -> N
     assert ModelCapabilities(supports_tools=True).model_dump(mode="json") == {
         "supports_tools": True,
         "supports_embeddings": None,
+        "supports_image_generation": None,
         "supports_structured_output": False,
         "supports_completions": None,
         "supports_temperature": True,

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -26,6 +26,7 @@ from exp.runtime.gateway.embeddings_contracts import (
     ServingRequest,
     embeddings_input_ceiling_micro_usd,
 )
+from exp.runtime.gateway.images_contracts import ImagesRequest, images_ceiling_micro_usd
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.replay_identity import provider_replay_authority
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
@@ -550,6 +551,13 @@ def maximum_attempt_cost_micro_usd(
             return embeddings_input_ceiling_micro_usd(
                 request,
                 input_rate=deployment.gateway.prices.input_micro_usd_per_million_tokens,
+                maximum=MAXIMUM_MICRO_USD,
+            )
+        case ImagesRequest():
+            return images_ceiling_micro_usd(
+                request,
+                input_rate=deployment.gateway.prices.input_micro_usd_per_million_tokens,
+                output_rate=deployment.gateway.prices.output_micro_usd_per_million_tokens,
                 maximum=MAXIMUM_MICRO_USD,
             )
         case GatewayRequest():

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -541,11 +541,7 @@ def maximum_attempt_cost_micro_usd(
     request: ServingRequest,
     deployment: ExactModelDeployment,
 ) -> int | None:
-    """Return a conservative integer micro-USD ceiling for one physical call.
-
-    Chat/responses/messages price an input and an output leg; embeddings price an
-    input leg only. Both bound input by canonical byte length (never undercounts).
-    """
+    """Return a conservative micro-USD ceiling for one physical call (per surface)."""
     match request:
         case EmbeddingsRequest():
             return embeddings_input_ceiling_micro_usd(
@@ -570,18 +566,12 @@ def _completion_attempt_cost_micro_usd(
     request: GatewayRequest,
     deployment: ExactModelDeployment,
 ) -> int | None:
-    """Return a conservative integer micro-USD ceiling for one chat/responses call.
+    """Return a conservative micro-USD ceiling for one chat/responses call.
 
-    Canonical UTF-8 bytes conservatively upper-bound input tokens. The caller's output ceiling
-    wins when present, then the frozen deployment limit, then a reservation-only default bounded
-    by the model's context window, so a missing output ceiling never makes a priced route
-    unpriceable. Cached-input and
-    reasoning counts are subsets of the total input and output counts, so the worst case uses
-    the highest applicable rate in each direction rather than adding subset rates to the same
-    token ceiling. A long-context tier joins the worst case exactly when the byte bound reaches
-    its threshold (bytes never undercount tokens, so a smaller request cannot be repriced), and
-    a reachable tier missing a required rate unprices the route. Unknown required prices still
-    produce ``None`` so an applicable hard limit fails closed.
+    Canonical UTF-8 bytes upper-bound input tokens; the output ceiling is the
+    caller's, else the frozen deployment limit, else a reservation-only default
+    bounded by the context window. Cached and reasoning tokens are subsets of the
+    totals, so the worst case charges the higher rate for the whole leg.
     """
     input_tokens = len(canonical_json_bytes(request))
     # Excluded provider carriers (replayed reasoning, native items, verbatim

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -61,6 +61,7 @@ class GatewayApiSurface(StrEnum):
     RESPONSES = "responses"
     MESSAGES = "messages"
     EMBEDDINGS = "embeddings"
+    IMAGES = "images"
 
 
 class GatewayToolDefinition(ContractModel):

--- a/exp/runtime/gateway/embeddings_contracts.py
+++ b/exp/runtime/gateway/embeddings_contracts.py
@@ -8,6 +8,7 @@ from pydantic import Field, field_validator
 
 from exp.common.core.artifacts import ContractModel, canonical_json_bytes
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayRequest
+from exp.runtime.gateway.images_contracts import ImagesRequest
 
 
 class EmbeddingsRequest(ContractModel):
@@ -61,13 +62,14 @@ class EmbeddingsRequest(ContractModel):
         return value
 
 
-ServingRequest = GatewayRequest | EmbeddingsRequest
+ServingRequest = GatewayRequest | EmbeddingsRequest | ImagesRequest
 """One admitted serving request across every public surface.
 
 The money, auth, and accounting seams widen from ``GatewayRequest`` to this
 union so a chat-assuming reader cannot duck-type onto an embeddings request and
 touch an absent leg (messages, output tokens): ``ty`` enumerates every reader
-that must now handle the embeddings arm, and each branches exhaustively.
+that must now handle the embeddings and images arms, and each branches
+exhaustively.
 """
 
 

--- a/exp/runtime/gateway/images_contracts.py
+++ b/exp/runtime/gateway/images_contracts.py
@@ -1,0 +1,78 @@
+"""Canonical image-generation request contract, parallel to the chat ``GatewayRequest``."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from exp.common.core.artifacts import ContractModel, canonical_json_bytes
+from exp.runtime.gateway.contracts import GatewayApiSurface
+
+ImageSize = Literal[
+    "auto",
+    "256x256",
+    "512x512",
+    "1024x1024",
+    "1536x1024",
+    "1024x1536",
+    "1792x1024",
+    "1024x1792",
+]
+ImageQuality = Literal["standard", "hd", "low", "medium", "high", "auto"]
+
+# The largest output-token count one generated image can bill on the OpenAI
+# GPT image models (high quality, 1024x1536 or 1536x1024). The reservation
+# ceiling multiplies it by ``n``; settlement charges the provider's count.
+MAXIMUM_IMAGE_OUTPUT_TOKENS = 6_240
+
+
+class ImagesRequest(ContractModel):
+    """Canonical, provider-neutral image-generation request.
+
+    Parallel to :class:`~exp.runtime.gateway.contracts.GatewayRequest` like the
+    embeddings contract: prompt-in, images-out, never streamed. Only the
+    OpenAI Images API's generation parameters are carried; ``user`` is the
+    end-user attribution label and never a credential.
+    """
+
+    surface: Literal[GatewayApiSurface.IMAGES] = GatewayApiSurface.IMAGES
+    prompt: str = Field(min_length=1, max_length=32_000)
+    n: int = Field(default=1, ge=1, le=10)
+    size: ImageSize | None = None
+    quality: ImageQuality | None = None
+    background: Literal["transparent", "opaque", "auto"] | None = None
+    output_format: Literal["png", "jpeg", "webp"] | None = None
+    output_compression: int | None = Field(default=None, ge=0, le=100)
+    moderation: Literal["low", "auto"] | None = None
+    response_format: Literal["url", "b64_json"] | None = None
+    style: Literal["vivid", "natural"] | None = None
+    user: str | None = Field(default=None, max_length=1024)
+
+    @property
+    def attribution_label(self) -> str | None:
+        """The end-user attribution label (the ``user`` field), per the OpenAI spec."""
+        return self.user
+
+
+def images_ceiling_micro_usd(
+    request: ImagesRequest,
+    *,
+    input_rate: int | None,
+    output_rate: int | None,
+    maximum: int,
+) -> int | None:
+    """Return the conservative reservation ceiling for one token-priced image call.
+
+    GPT image models bill prompt tokens at the input rate and generated image
+    tokens at the output rate; the prompt's canonical byte length upper-bounds
+    the input tokens and ``n`` times the largest per-image token count bounds the
+    output. A lane without both rates is unpriced for images (``None``): the
+    per-image priced models (dall-e) wait for the typed billed-units ledger.
+    """
+    if input_rate is None or output_rate is None:
+        return None
+    input_ceiling = len(canonical_json_bytes(request)) * input_rate
+    output_ceiling = request.n * MAXIMUM_IMAGE_OUTPUT_TOKENS * output_rate
+    ceiling = (input_ceiling + output_ceiling + 999_999) // 1_000_000
+    return ceiling if ceiling <= maximum else None

--- a/exp/runtime/gateway/images_contracts_test.py
+++ b/exp/runtime/gateway/images_contracts_test.py
@@ -1,0 +1,52 @@
+"""Tests for the canonical image-generation contract and its reservation ceiling."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from exp.runtime.gateway.contracts import GatewayApiSurface
+from exp.runtime.gateway.images_contracts import (
+    MAXIMUM_IMAGE_OUTPUT_TOKENS,
+    ImagesRequest,
+    images_ceiling_micro_usd,
+)
+
+
+def test_images_request_defaults_to_one_image_and_records_the_surface() -> None:
+    """A bare prompt is one image on the images surface with every control unset."""
+    request = ImagesRequest(prompt="a cat")
+    assert request.surface is GatewayApiSurface.IMAGES
+    assert request.n == 1
+    assert request.size is None
+    assert request.attribution_label is None
+    assert ImagesRequest(prompt="a cat", user="tenant-7").attribution_label == "tenant-7"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"n": 0}, {"n": 11}, {"prompt": ""}, {"output_compression": 101}, {"size": "9x9"}],
+)
+def test_images_request_rejects_out_of_contract_controls(overrides: dict[str, object]) -> None:
+    """The contract keeps the OpenAI bounds: n in 1..10, known sizes, 0..100 compression."""
+    values: dict[str, object] = {"prompt": "a cat", **overrides}
+    with pytest.raises(ValidationError):
+        ImagesRequest.model_validate(values)
+
+
+def test_reservation_ceiling_prices_prompt_bytes_and_maximum_image_tokens() -> None:
+    """The ceiling bounds prompt bytes at the input rate and n images at the output rate."""
+    request = ImagesRequest(prompt="a cat", n=2)
+    ceiling = images_ceiling_micro_usd(
+        request, input_rate=5_000_000, output_rate=40_000_000, maximum=10**12
+    )
+    assert ceiling is not None
+    output_only = (2 * MAXIMUM_IMAGE_OUTPUT_TOKENS * 40_000_000) // 1_000_000
+    assert ceiling >= output_only
+    assert ceiling < output_only + 5_000_000
+    # A lane without an output rate (per-image priced) is unpriced for images.
+    assert (
+        images_ceiling_micro_usd(request, input_rate=5_000_000, output_rate=None, maximum=10**12)
+        is None
+    )
+    assert images_ceiling_micro_usd(request, input_rate=1, output_rate=1, maximum=0) is None

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.21"
+version = "0.3.22"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -25,6 +25,7 @@ mod responses_retention;
 mod route_batches;
 mod route_chat;
 mod route_embeddings;
+mod route_images;
 mod route_messages;
 mod route_responses;
 mod route_responses_ws;

--- a/exp/runtime/gateway/native/src/route_images.rs
+++ b/exp/runtime/gateway/native/src/route_images.rs
@@ -1,0 +1,507 @@
+//! The native image-generation surface: the `POST /v1/images/generations`
+//! handler.
+//!
+//! Prompt in, images out, never streamed: admission returns one fully built
+//! OpenAI-wire `/images/generations` payload per certified deployment and the
+//! ladder below reserves each attempt through `start_attempt`, POSTs the
+//! payload, buffers the JSON answer under the retained-output cap, validates
+//! it against the request (one image per requested `n`, a reported token
+//! usage), and settles the winning attempt with the provider's prompt and
+//! image token counts. A provider that answers without usage (the per-image
+//! priced dall-e models) is refused as an unbillable answer until the typed
+//! billed-units ledger lands, so no image is ever handed out unaccounted.
+
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Response;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+
+use crate::admission::{acquire_permit, new_guard, wire_drift_response};
+use crate::dialects::{Dialect, MAXIMUM_RETAINED_OUTPUT_BYTES, OUTPUT_OVERFLOW_MESSAGE};
+use crate::encode::compact_json;
+use crate::errors::{Failure, FailureClass, PublicError};
+use crate::events::Usage;
+use crate::metrics::{classify_escalation, METRICS};
+use crate::relay::{collection_public_error, remaining};
+use crate::respond::{
+    bearer_key, error_response, escalation_error, json_response, latin1_header, read_body,
+};
+use crate::server::AppState;
+use crate::settlement::AttemptGuard;
+use crate::upstream::open_stream;
+use crate::waterfall::{successor_possible, DeploymentWire, RoutePolicy, StartResponse};
+
+/// The wire configuration returned by one successful images admission.
+#[derive(Debug, Clone, Deserialize)]
+struct ImagesAdmission {
+    request_id: String,
+    alias: String,
+    alias_revision_id: String,
+    exact_model_id: String,
+    route_reason: String,
+    route: Vec<DeploymentWire>,
+    /// The requested `n`; the provider must answer with exactly this many images.
+    image_count: usize,
+    maximum_total_attempts: u32,
+    maximum_same_deployment_attempts: u32,
+}
+
+impl ImagesAdmission {
+    fn policy(&self) -> RoutePolicy {
+        RoutePolicy {
+            maximum_total_attempts: self.maximum_total_attempts.max(1),
+            maximum_same_deployment_attempts: self.maximum_same_deployment_attempts.max(1),
+            refusal_failover: false,
+        }
+    }
+}
+
+struct Served {
+    depth: usize,
+    body: Value,
+    usage: Usage,
+}
+
+pub(crate) async fn images(
+    State(state): State<AppState>,
+    request: axum::extract::Request,
+) -> Response {
+    state.handled_requests.fetch_add(1, Ordering::Relaxed);
+    let started = Instant::now();
+    let deadline = started + state.request_timeout;
+    let (parts, raw_body) = request.into_parts();
+    let headers = parts.headers;
+    let body = match read_body(raw_body).await {
+        Ok(body) => body,
+        Err(error) => return error_response(&error),
+    };
+    let raw_key = match bearer_key(&headers) {
+        Ok(key) => key,
+        Err(error) => return error_response(&error),
+    };
+    let authenticate = compact_json(&json!({"raw_key": raw_key}));
+    if let Err(error) = state.bridge.call("authenticate", authenticate).await {
+        return error_response(&error);
+    }
+    let body_text = match String::from_utf8(body.to_vec()) {
+        Ok(text) => text,
+        Err(_) => return error_response(&PublicError::invalid_json()),
+    };
+    let client_request_id = latin1_header(&headers, "x-client-request-id");
+
+    let admit_argument = compact_json(&json!({"raw_key": raw_key, "body": body_text}));
+    let admission_text = match state.bridge.call("admit_images", admit_argument).await {
+        Ok(text) => text,
+        Err(error) => return error_response(&error),
+    };
+    let admission_value: Value = match serde_json::from_str(&admission_text) {
+        Ok(value) => value,
+        Err(_) => return error_response(&PublicError::internal()),
+    };
+    if let Some(reason) = admission_value.get("escalate") {
+        METRICS.record_escalation(classify_escalation(reason.as_str().unwrap_or_default()));
+        return error_response(&escalation_error());
+    }
+    let admission: ImagesAdmission = match serde_json::from_value(admission_value.clone()) {
+        Ok(admission) => admission,
+        Err(_) => return wire_drift_response(&state, &admission_value, started).await,
+    };
+    let mut guard = new_guard(&state, admission.request_id.clone(), started);
+    let permit = match acquire_permit(&state, &mut guard, deadline).await {
+        Ok(permit) => permit,
+        Err(response) => return *response,
+    };
+    let _permit = permit;
+
+    match run_ladder(&state, &admission, &raw_key, &mut guard, deadline).await {
+        Err(error) => error_response(&error),
+        Ok(served) => {
+            if !guard
+                .settle("completed", Some(&served.usage), &[], None, true)
+                .await
+            {
+                // Never hand out images the ledger did not record.
+                return error_response(&PublicError::internal());
+            }
+            let response_headers = served_headers(&admission, served.depth, client_request_id);
+            json_response(StatusCode::OK, &served.body, &response_headers)
+        }
+    }
+}
+
+/// Walk the certified ladder to one validated provider answer or the public
+/// error of the exhausting failure (same contract as the embeddings ladder).
+async fn run_ladder(
+    state: &AppState,
+    admission: &ImagesAdmission,
+    raw_key: &str,
+    guard: &mut AttemptGuard,
+    deadline: Instant,
+) -> Result<Served, PublicError> {
+    let policy = admission.policy();
+    let mut total_attempts: u32 = 0;
+    let mut counts: Vec<u32> = vec![0; admission.route.len()];
+    let mut current_depth: Option<usize> = None;
+    let mut last_failure: Option<Failure> = None;
+    loop {
+        let argument = compact_json(&json!({
+            "request_id": admission.request_id,
+            "raw_key": raw_key,
+            "attempt_ordinal": total_attempts,
+            "current_depth": current_depth,
+            "failure": last_failure.as_ref().map(|failure| json!({
+                "failure_class": failure.failure_class.as_str(),
+                "safe_message": failure.safe_message,
+                "retryable_same_deployment": failure.retryable_same_deployment,
+                "failover_eligible": failure.failover_eligible,
+                "rejected_parameter": failure.rejected_parameter,
+                "provider_detail": failure.provider_detail,
+            })),
+        }));
+        let started_text = match state.bridge.call("start_attempt", argument).await {
+            Ok(text) => text,
+            Err(error) => {
+                guard.disarm_finalized("failed");
+                return Err(error);
+            }
+        };
+        let started: StartResponse = match serde_json::from_str(&started_text) {
+            Ok(started) => started,
+            Err(_) => {
+                guard
+                    .abandon(&Failure::new(
+                        FailureClass::Internal,
+                        "gateway attempt wire contract failed",
+                    ))
+                    .await;
+                return Err(PublicError::internal());
+            }
+        };
+        if started.exhausted {
+            guard.disarm_finalized("failed");
+            let failure = started.failure.or(last_failure).unwrap_or_else(|| {
+                Failure::new(
+                    FailureClass::ProviderInternal,
+                    "all exact-model deployments are unavailable",
+                )
+            });
+            return Err(collection_public_error(&failure.boundary()));
+        }
+        let (Some(attempt_id), Some(depth)) = (started.attempt_id, started.route_depth) else {
+            guard
+                .abandon(&Failure::new(
+                    FailureClass::Internal,
+                    "gateway attempt wire contract failed",
+                ))
+                .await;
+            return Err(PublicError::internal());
+        };
+        let Some(wire) = admission.route.get(depth) else {
+            guard.rebind(attempt_id);
+            let failure = Failure::new(
+                FailureClass::Internal,
+                "gateway attempt wire contract failed",
+            );
+            guard
+                .settle("failed", None, &[], Some(&failure), true)
+                .await;
+            return Err(PublicError::internal());
+        };
+        if current_depth == Some(depth) {
+            METRICS.record_open_retry();
+        }
+        guard.rebind(attempt_id);
+        total_attempts += 1;
+        counts[depth] += 1;
+        match dispatch(&state.http, wire, deadline, admission).await {
+            Ok((body, usage)) => return Ok(Served { depth, body, usage }),
+            Err((failure, opened)) => {
+                if opened {
+                    guard.mark_opened();
+                }
+                let boundary = failure.clone().boundary();
+                let possible = successor_possible(
+                    policy,
+                    admission.route.len(),
+                    deadline,
+                    total_attempts,
+                    counts[depth],
+                    depth,
+                    &failure,
+                    false,
+                );
+                if !guard
+                    .settle("failed", None, &[], Some(&boundary), !possible)
+                    .await
+                {
+                    return Err(PublicError::internal());
+                }
+                if possible {
+                    current_depth = Some(depth);
+                    last_failure = Some(failure);
+                    continue;
+                }
+                return Err(collection_public_error(&boundary));
+            }
+        }
+    }
+}
+
+/// POST one admitted payload and validate the buffered answer; the error
+/// carries whether the provider dispatch opened.
+async fn dispatch(
+    http: &reqwest::Client,
+    wire: &DeploymentWire,
+    deadline: Instant,
+    admission: &ImagesAdmission,
+) -> Result<(Value, Usage), (Failure, bool)> {
+    let phase_timeout = Duration::from_secs_f64(wire.timeout_seconds.max(0.001));
+    let bound = remaining(deadline).min(phase_timeout);
+    let response = open_stream(
+        http,
+        &wire.url,
+        &wire.headers,
+        &wire.idempotency_key,
+        &wire.upstream_payload,
+        None,
+        bound,
+        Dialect::OpenAiCompatible,
+    )
+    .await
+    .map_err(|failure| (failure, false))?;
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAXIMUM_RETAINED_OUTPUT_BYTES as u64)
+    {
+        return Err((
+            Failure::new(FailureClass::MalformedResponse, OUTPUT_OVERFLOW_MESSAGE),
+            true,
+        ));
+    }
+    let bytes = read_bounded_body(response, deadline, phase_timeout)
+        .await
+        .map_err(|failure| (failure, true))?;
+    let payload: Value = match serde_json::from_slice(&bytes) {
+        Ok(payload) => payload,
+        Err(_) => return Err((malformed("images response is not JSON"), true)),
+    };
+    public_images(payload, admission).map_err(|failure| (failure, true))
+}
+
+/// Read one provider body chunk by chunk under the retained-output cap (a
+/// generated image set is large; the cap still bounds it).
+async fn read_bounded_body(
+    mut response: reqwest::Response,
+    deadline: Instant,
+    phase_timeout: Duration,
+) -> Result<Vec<u8>, Failure> {
+    let mut body: Vec<u8> = Vec::new();
+    loop {
+        let bound = remaining(deadline).min(phase_timeout);
+        let chunk = match tokio::time::timeout(bound, response.chunk()).await {
+            Ok(Ok(Some(chunk))) => chunk,
+            Ok(Ok(None)) => return Ok(body),
+            Ok(Err(_)) => {
+                return Err(Failure::new(
+                    FailureClass::Transport,
+                    "provider connection failed while sending the images response",
+                )
+                .with_retry(true, true))
+            }
+            Err(_) => {
+                return Err(Failure::new(
+                    FailureClass::Timeout,
+                    "provider did not finish the images response in time",
+                )
+                .with_retry(false, true))
+            }
+        };
+        if body.len() + chunk.len() > MAXIMUM_RETAINED_OUTPUT_BYTES {
+            return Err(Failure::new(
+                FailureClass::MalformedResponse,
+                OUTPUT_OVERFLOW_MESSAGE,
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+}
+
+fn malformed(reason: &str) -> Failure {
+    Failure::new(FailureClass::MalformedResponse, reason).with_retry(false, true)
+}
+
+/// Validate one provider `/images/generations` body against the admitted
+/// request and rebuild it as the public answer: exactly `n` images, each a
+/// `b64_json` or `url` string (passed through untouched, with any
+/// `revised_prompt`), and a billable token usage. The public body keeps the
+/// provider's `created`, `usage`, and the echoed rendering facts.
+fn public_images(payload: Value, admission: &ImagesAdmission) -> Result<(Value, Usage), Failure> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| malformed("images response is not an object"))?;
+    let data = object
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| malformed("images response omitted the data array"))?;
+    if data.len() != admission.image_count {
+        return Err(malformed(
+            "images response count does not match the requested n",
+        ));
+    }
+    let mut images: Vec<Value> = Vec::with_capacity(data.len());
+    for item in data {
+        let entry = item
+            .as_object()
+            .ok_or_else(|| malformed("images response item is not an object"))?;
+        let mut public_item = Map::new();
+        let mut carried = false;
+        for key in ["b64_json", "url", "revised_prompt"] {
+            if let Some(value) = entry.get(key).filter(|value| value.is_string()) {
+                carried |= key != "revised_prompt";
+                public_item.insert(key.to_string(), value.clone());
+            }
+        }
+        if !carried {
+            return Err(malformed(
+                "images response item carried neither b64_json nor url",
+            ));
+        }
+        images.push(Value::Object(public_item));
+    }
+    // The surface bills on these counts: an answer without token usage (the
+    // per-image priced models) is unbillable here and is refused, never a zero.
+    let usage = object
+        .get("usage")
+        .and_then(Value::as_object)
+        .ok_or_else(|| malformed("images response omitted its token usage"))?;
+    let input_tokens = usage
+        .get("input_tokens")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| malformed("images response omitted usage.input_tokens"))?;
+    let output_tokens = usage
+        .get("output_tokens")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| malformed("images response omitted usage.output_tokens"))?;
+    let mut public = Map::new();
+    public.insert(
+        "created".to_string(),
+        object.get("created").cloned().unwrap_or(Value::from(0)),
+    );
+    public.insert("data".to_string(), Value::Array(images));
+    for key in ["background", "output_format", "quality", "size"] {
+        if let Some(value) = object.get(key) {
+            public.insert(key.to_string(), value.clone());
+        }
+    }
+    public.insert("usage".to_string(), Value::Object(usage.clone()));
+    let usage = Usage {
+        input_tokens: Some(input_tokens),
+        output_tokens: Some(output_tokens),
+        cached_input_tokens: None,
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    Ok((Value::Object(public), usage))
+}
+
+fn served_headers(
+    admission: &ImagesAdmission,
+    depth: usize,
+    client_request_id: Option<String>,
+) -> Vec<(String, String)> {
+    let (provider, deployment_id) = admission
+        .route
+        .get(depth)
+        .map(|wire| (wire.provider.clone(), wire.deployment_id.clone()))
+        .unwrap_or_default();
+    let mut headers = vec![
+        ("x-request-id".to_string(), admission.request_id.clone()),
+        ("x-gateway-alias".to_string(), admission.alias.clone()),
+        (
+            "x-gateway-alias-revision".to_string(),
+            admission.alias_revision_id.clone(),
+        ),
+        (
+            "x-gateway-canonical-model".to_string(),
+            admission.exact_model_id.clone(),
+        ),
+        ("x-gateway-provider".to_string(), provider),
+        ("x-gateway-deployment".to_string(), deployment_id),
+        ("x-gateway-route-depth".to_string(), depth.to_string()),
+        (
+            "x-gateway-route-reason".to_string(),
+            admission.route_reason.clone(),
+        ),
+    ];
+    if let Some(value) = client_request_id {
+        headers.push(("x-client-request-id".to_string(), value));
+    }
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admission(image_count: usize) -> ImagesAdmission {
+        ImagesAdmission {
+            request_id: "request-1".to_string(),
+            alias: "painter".to_string(),
+            alias_revision_id: "revision-one".to_string(),
+            exact_model_id: "model-exact".to_string(),
+            route_reason: "direct".to_string(),
+            route: Vec::new(),
+            image_count,
+            maximum_total_attempts: 8,
+            maximum_same_deployment_attempts: 2,
+        }
+    }
+
+    #[test]
+    fn provider_answer_keeps_images_and_bills_token_usage() {
+        let payload = json!({
+            "created": 1_700_000_000,
+            "background": "opaque",
+            "output_format": "png",
+            "quality": "low",
+            "size": "1024x1024",
+            "data": [
+                {"b64_json": "aW1hZ2U=", "revised_prompt": "a cat"},
+                {"url": "https://example.invalid/img.png"},
+            ],
+            "usage": {
+                "input_tokens": 11,
+                "output_tokens": 272,
+                "total_tokens": 283,
+                "input_tokens_details": {"text_tokens": 11, "image_tokens": 0},
+            },
+        });
+        let (body, usage) = public_images(payload.clone(), &admission(2)).expect("valid answer");
+        assert_eq!(body["data"], payload["data"]);
+        assert_eq!(body["usage"], payload["usage"]);
+        assert_eq!(body["created"], json!(1_700_000_000));
+        assert_eq!(body["quality"], json!("low"));
+        assert_eq!(usage.input_tokens, Some(11));
+        assert_eq!(usage.output_tokens, Some(272));
+    }
+
+    #[test]
+    fn unbilled_short_or_imageless_answers_are_malformed() {
+        let unbilled = json!({"created": 1, "data": [{"b64_json": "aW1hZ2U="}]});
+        let short =
+            json!({"data": [{"b64_json": "x"}], "usage": {"input_tokens": 1, "output_tokens": 1}});
+        let imageless = json!({
+            "data": [{"revised_prompt": "only text"}, {"b64_json": "x"}],
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        });
+        for payload in [unbilled, short, imageless] {
+            let failure = public_images(payload, &admission(2)).expect_err("malformed");
+            assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+            assert!(failure.failover_eligible);
+        }
+    }
+}

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -31,6 +31,7 @@ use crate::route_batches::{
 };
 use crate::route_chat::chat;
 use crate::route_embeddings::embeddings;
+use crate::route_images::images;
 use crate::route_messages::{messages, messages_count_tokens};
 use crate::route_responses::responses;
 use crate::route_responses_ws::responses_ws;
@@ -158,6 +159,7 @@ pub async fn run(
         .route("/v1/models/{model_id}", get(model_detail))
         .route("/v1/chat/completions", post(chat))
         .route("/v1/embeddings", post(embeddings))
+        .route("/v1/images/generations", post(images))
         .route("/v1/responses", post(responses).get(responses_ws))
         .route("/v1/messages", post(messages))
         .route("/v1/messages/count_tokens", post(messages_count_tokens))

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -86,6 +86,7 @@ from exp.runtime.gateway.native_execution import (
     resolve_route_profiles,
     select_route_deployments,
 )
+from exp.runtime.gateway.native_images import NativeImagesMixin
 from exp.runtime.gateway.native_observability import NativeObservabilityMixin
 from exp.runtime.gateway.native_reasoning import (
     authenticate_reasoning_history,
@@ -138,7 +139,9 @@ from exp.runtime.openai_protocol.state import (
 _REQUEST_TIMEOUT_SECONDS = 120.0
 
 
-class NativeControlPlane(NativeBatchRelayMixin, NativeEmbeddingsMixin, NativeObservabilityMixin):
+class NativeControlPlane(
+    NativeBatchRelayMixin, NativeEmbeddingsMixin, NativeImagesMixin, NativeObservabilityMixin
+):
     """Authority and accounting callbacks for the native data plane.
 
     Rust worker threads share the group-commit writer and the locked in-flight

--- a/exp/runtime/gateway/native_decode.py
+++ b/exp/runtime/gateway/native_decode.py
@@ -10,8 +10,10 @@ from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 from exp.runtime.openai_protocol.requests import (
     DecodedEmbeddingsRequest,
     DecodedGatewayRequest,
+    DecodedImagesRequest,
     decode_chat,
     decode_embeddings,
+    decode_images,
     decode_responses,
 )
 
@@ -118,3 +120,23 @@ def _load_object_body(body: str) -> JsonObject:
             )
         )
     return payload
+
+
+def decode_native_images_body(body: str) -> DecodedImagesRequest:
+    """Decode one raw ``/images/generations`` body with the shared images decoder.
+
+    Args:
+        body: Raw request body text.
+
+    Returns:
+        The public alias and canonical image-generation request.
+
+    Raises:
+        NativeDecodeError: The body is not JSON, not an object, or fails shared
+            protocol validation.
+    """
+    payload = _load_object_body(body)
+    try:
+        return decode_images(payload)
+    except OpenAIProtocolError as exc:
+        raise NativeDecodeError(exc) from exc

--- a/exp/runtime/gateway/native_decode.py
+++ b/exp/runtime/gateway/native_decode.py
@@ -7,13 +7,12 @@ import json
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.anthropic_protocol.requests import decode_messages
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+from exp.runtime.openai_protocol.images_requests import DecodedImagesRequest, decode_images
 from exp.runtime.openai_protocol.requests import (
     DecodedEmbeddingsRequest,
     DecodedGatewayRequest,
-    DecodedImagesRequest,
     decode_chat,
     decode_embeddings,
-    decode_images,
     decode_responses,
 )
 

--- a/exp/runtime/gateway/native_images.py
+++ b/exp/runtime/gateway/native_images.py
@@ -1,0 +1,238 @@
+"""Image-generation admission for the native data plane.
+
+The images surface reuses the chat surface's authority, ledger, route
+resolution, deployment-health, and reservation seams unchanged (the same
+shape as :mod:`exp.runtime.gateway.native_embeddings`) and differs only in
+what it admits: a prompt-in, images-out request that dispatches one buffered
+OpenAI-wire ``/images/generations`` POST per attempt and bills the provider's
+reported prompt and image tokens.
+
+Deliberately absent on day one: image edits and variations (multipart image
+input), streaming partial images, per-image priced models (dall-e answers
+without token usage and is refused as unbilled until the typed billed-units
+ledger lands), keyed replay, and non-OpenAI wires.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import replace
+from typing import Protocol
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    GatewayFailure,
+    GatewayFailureClass,
+)
+from exp.runtime.gateway.guardrails.client import assert_not_internal_classification
+from exp.runtime.gateway.images_contracts import ImagesRequest
+from exp.runtime.gateway.native_accounting import (
+    NativeAttemptAccounting,
+    NativeBridgeError,
+    authority_error,
+    gateway_updating_failure,
+    record_dead_admission_rungs,
+)
+from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
+from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_images_body
+from exp.runtime.gateway.native_execution import (
+    MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
+    MAXIMUM_TOTAL_ATTEMPTS,
+    InflightRequest,
+    NativeDialectUnavailableError,
+    deployment_wire_entry,
+    dispatchable_route_profiles,
+    select_route_deployments,
+)
+from exp.runtime.gateway.routing import GatewayRoutingError
+from exp.runtime.models.providers import require_gateway_provider
+from exp.runtime.models.providers.openai_compatible import openai_images_request
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+
+class _ImagesPlane(Protocol):
+    """The control-plane state the images admission reads and writes."""
+
+    _components: NativeGatewayComponents
+    _accounting: NativeAttemptAccounting
+    _write_ledger: SyncWriteLedger
+    _request_timeout_seconds: float
+
+    def _escalate_accepted(self, authorization: AuthorizationSnapshot, reason: str) -> str: ...
+
+
+def not_an_image_model_error(alias: str) -> OpenAIProtocolError:
+    """Build the public 400 for an alias none of whose rungs generate images."""
+    return OpenAIProtocolError(
+        status_code=400,
+        code="unsupported_capability",
+        message=(
+            f"The model {alias!r} does not generate images. Choose an image model from "
+            "GET /v1/models and resend the request to /v1/images/generations."
+        ),
+        param="model",
+    )
+
+
+def _images_rung(profile_url: str | None, supports_image_generation: bool | None) -> bool:
+    """Whether one resolved rung may serve an image-generation request (fail-closed)."""
+    return profile_url is not None and supports_image_generation is True
+
+
+class NativeImagesMixin:
+    """The ``admit_images`` boundary method for the native control plane."""
+
+    def admit_images(self: _ImagesPlane, argument: str) -> str:
+        """Decode, authorize, route, and durably accept one image-generation request.
+
+        Args:
+            argument: JSON object with ``raw_key`` and ``body`` (raw request body
+                text). Any caller ``Idempotency-Key`` is ignored by the data plane.
+
+        Returns:
+            JSON wire configuration carrying the ordered ``route`` (one OpenAI-wire
+            entry per deployment), ``image_count`` (the requested ``n``), and the
+            frozen retry-policy facts, or an ``{"escalate": reason}`` disposition.
+
+        Raises:
+            NativeBridgeError: Decoding, authorization, or routing failed, or no
+                rung of the alias generates images.
+        """
+        assert_not_internal_classification()
+        self._accounting.sweep_expired()
+        data = json.loads(argument)
+        try:
+            decoded = decode_native_images_body(str(data["body"]))
+        except NativeDecodeError as exc:
+            raise NativeBridgeError(exc.error) from exc
+        request = decoded.request
+        deadline = time.monotonic() + self._request_timeout_seconds
+        try:
+            authorization = self._components.store.authorize_request(
+                raw_key=str(data["raw_key"]),
+                alias=decoded.alias,
+                request=request,
+                deadline_monotonic=deadline,
+            )
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise authority_error(exc) from exc
+        try:
+            self._write_ledger.accept_request(authorization=authorization)
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise authority_error(exc) from exc
+        return _admit_accepted(self, authorization, request, deadline)
+
+
+def _admit_accepted(
+    plane: _ImagesPlane,
+    authorization: AuthorizationSnapshot,
+    request: ImagesRequest,
+    deadline: float,
+) -> str:
+    """Route and package one durably accepted image-generation request."""
+    if not isinstance(authorization.target, DirectTarget):
+        _finish_unsupported(plane, authorization)
+        raise NativeBridgeError(not_an_image_model_error(authorization.alias))
+    try:
+        route = plane._components.routes.resolve_direct(authorization)  # noqa: SLF001
+        dispatchable = dispatchable_route_profiles(
+            plane._components.runtime_catalogs,  # noqa: SLF001
+            route,
+        )
+    except NativeDialectUnavailableError as exc:
+        return plane._escalate_accepted(authorization, str(exc))  # noqa: SLF001
+    except GatewayRoutingError as exc:
+        plane._accounting.finish_request_quietly(  # noqa: SLF001
+            authorization, gateway_updating_failure()
+        )
+        raise authority_error(exc) from exc
+    record_dead_admission_rungs(
+        plane._accounting,  # noqa: SLF001
+        authorization,
+        dispatchable.dead,
+        fallback_available=bool(dispatchable.indexes),
+    )
+    if not dispatchable.indexes:
+        return plane._escalate_accepted(  # noqa: SLF001
+            authorization, "every certified deployment was unavailable at admission"
+        )
+    serving: list[int] = []
+    for index, (profile, _client) in zip(
+        dispatchable.indexes, dispatchable.resolved_wires, strict=True
+    ):
+        capabilities = route.deployments[index].capabilities
+        supports = None if capabilities is None else capabilities.supports_image_generation
+        if _images_rung(profile.images_url, supports):
+            serving.append(index)
+    if not serving:
+        _finish_unsupported(plane, authorization)
+        raise NativeBridgeError(not_an_image_model_error(authorization.alias))
+    served_wires = [
+        wire
+        for index, wire in zip(dispatchable.indexes, dispatchable.resolved_wires, strict=True)
+        if index in serving
+    ]
+    route = select_route_deployments(route, tuple(serving))
+    wire_route: list[JsonObject] = []
+    try:
+        for deployment, (profile, _client) in zip(route.deployments, served_wires, strict=True):
+            require_gateway_provider(deployment.provider)
+            images_url = profile.images_url
+            if images_url is None:  # pragma: no cover - filtered above.
+                raise GatewayRoutingError("images rung lost its wire endpoint")
+            wire_route.append(
+                deployment_wire_entry(
+                    route,
+                    deployment,
+                    replace(profile, url=images_url),
+                    openai_images_request(profile.model_id, request),
+                )
+            )
+    except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+        error = authority_error(exc)
+        plane._accounting.finish_request_quietly(  # noqa: SLF001
+            authorization,
+            GatewayFailure(
+                failure_class=GatewayFailureClass.INTERNAL,
+                safe_message="gateway admission failed before provider dispatch",
+            ),
+        )
+        raise error from exc
+    depth = len(route.deployments)
+    plane._accounting.register(  # noqa: SLF001
+        InflightRequest(
+            authorization=authorization,
+            route=route,
+            request=request,
+            deadline_monotonic=deadline,
+            signers=(None,) * depth,
+            dispatch_bindings=(None,) * depth,
+            reasoning_carrier_authorities=(None,) * depth,
+        )
+    )
+    response: JsonObject = {
+        "request_id": authorization.request_id,
+        "alias": authorization.alias,
+        "alias_revision_id": authorization.alias_revision_id,
+        "exact_model_id": route.snapshot.exact_model_id,
+        "route_reason": route.route_reason,
+        "route": wire_route,
+        "image_count": request.n,
+        "maximum_total_attempts": MAXIMUM_TOTAL_ATTEMPTS,
+        "maximum_same_deployment_attempts": MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
+    }
+    return json.dumps(response, separators=(",", ":"))
+
+
+def _finish_unsupported(plane: _ImagesPlane, authorization: AuthorizationSnapshot) -> None:
+    """Finish one accepted request that named a non-image alias."""
+    plane._accounting.finish_request_quietly(  # noqa: SLF001
+        authorization,
+        GatewayFailure(
+            failure_class=GatewayFailureClass.UNSUPPORTED_CAPABILITY,
+            safe_message="the model alias does not generate images",
+        ),
+    )

--- a/exp/runtime/gateway/native_images_test.py
+++ b/exp/runtime/gateway/native_images_test.py
@@ -1,0 +1,132 @@
+"""Tests for the native image-generation admission boundary."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import ModelCapabilities
+from exp.runtime.gateway.ledger import SQLiteAttemptLedger
+from exp.runtime.gateway.lifecycle import load_gateway_components
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.native_accounting import NativeBridgeError
+from exp.runtime.gateway.native_bridge import NativeControlPlane
+
+
+def _control_plane(root: Path, *, images: bool) -> tuple[NativeControlPlane, str]:
+    """Seed the ``coding`` alias as an image model or a chat model and load the plane."""
+    capabilities = ModelCapabilities(supports_image_generation=True) if images else None
+    _manager, raw_key = _configured_gateway(root, capabilities=capabilities)
+    components = load_gateway_components(
+        root, environment={"TEST_PROVIDER_KEY": "provider-secret-canary"}
+    )
+    return NativeControlPlane(components), raw_key
+
+
+def _admit(control: NativeControlPlane, raw_key: str, body: JsonObject) -> JsonObject:
+    argument = json.dumps({"raw_key": raw_key, "body": json.dumps(body)})
+    return json.loads(control.admit_images(argument))
+
+
+def _public_error(exc: NativeBridgeError) -> JsonObject:
+    return json.loads(exc.public_error_json)
+
+
+def _request_row(control: NativeControlPlane, request_id: str) -> tuple[str, str | None]:
+    ledger = cast("SQLiteAttemptLedger", control._components.ledger)  # noqa: SLF001
+    with sqlite3.connect(ledger.database_path) as connection:
+        row = connection.execute(
+            "select api_surface, terminal_state from gateway_requests where request_id = ?",
+            (request_id,),
+        ).fetchone()
+    assert row is not None
+    return (str(row[0]), None if row[1] is None else str(row[1]))
+
+
+def test_admit_builds_the_openai_images_wire_and_settles_token_usage(tmp_path: Path) -> None:
+    """Admission returns one ``/images/generations`` payload per rung; settle bills both legs."""
+    control, raw_key = _control_plane(tmp_path, images=True)
+    admission = _admit(
+        control,
+        raw_key,
+        {
+            "model": "coding",
+            "prompt": "a cat",
+            "n": 2,
+            "size": "1024x1024",
+            "quality": "low",
+            "user": "tenant-7",
+        },
+    )
+    assert admission["image_count"] == 2
+    route = admission["route"]
+    assert isinstance(route, list) and len(route) == 1
+    wire = route[0]
+    assert wire["url"] == "http://127.0.0.1:9/v1/images/generations"
+    assert wire["headers"]["Authorization"] == "Bearer provider-secret-canary"
+    # `user` is metadata-only: recorded as the attribution label, never on the wire.
+    assert wire["upstream_payload"] == {
+        "model": "provider-model-exact",
+        "prompt": "a cat",
+        "n": 2,
+        "size": "1024x1024",
+        "quality": "low",
+    }
+    request_id = str(admission["request_id"])
+    assert _request_row(control, request_id) == ("images", None)
+    started = json.loads(
+        control.start_attempt(json.dumps({"request_id": request_id, "attempt_ordinal": 0}))
+    )
+    assert (
+        control.settle(
+            json.dumps(
+                {
+                    "request_id": request_id,
+                    "attempt_id": started["attempt_id"],
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 11, "output_tokens": 544},
+                    "tool_names": [],
+                    "failure": None,
+                }
+            )
+        )
+        == "{}"
+    )
+    assert _request_row(control, request_id) == ("images", "completed")
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 1
+    assert report["totals"]["input_tokens"] == 11
+    assert report["totals"]["output_tokens"] == 544
+
+
+def test_admit_rejects_a_chat_alias_on_the_model_field(tmp_path: Path) -> None:
+    """An alias whose rungs never claim image generation fails closed, accounted."""
+    control, raw_key = _control_plane(tmp_path, images=False)
+    with pytest.raises(NativeBridgeError) as raised:
+        _admit(control, raw_key, {"model": "coding", "prompt": "a cat"})
+    error = _public_error(raised.value)
+    assert error["status_code"] == 400
+    assert error["code"] == "unsupported_capability"
+    assert error["param"] == "model"
+    assert "does not generate images" in str(error["message"])
+    assert json.loads(control.usage_json("{}"))["totals"]["requests"] == 1
+
+
+def test_admit_rejects_protocol_failures_before_any_ledger_write(tmp_path: Path) -> None:
+    """A missing prompt, a streaming request, and an unknown key never accept a request."""
+    control, raw_key = _control_plane(tmp_path, images=True)
+    with pytest.raises(NativeBridgeError) as missing:
+        _admit(control, raw_key, {"model": "coding"})
+    assert _public_error(missing.value)["status_code"] == 400
+    with pytest.raises(NativeBridgeError) as streaming:
+        _admit(control, raw_key, {"model": "coding", "prompt": "a cat", "stream": True})
+    assert _public_error(streaming.value)["status_code"] == 400
+    with pytest.raises(NativeBridgeError) as unknown:
+        _admit(control, "not-a-key", {"model": "coding", "prompt": "a cat"})
+    assert _public_error(unknown.value)["status_code"] == 401
+    assert json.loads(control.usage_json("{}"))["totals"]["requests"] == 0

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -7,6 +7,7 @@ from typing import assert_never
 from exp.common.core.artifacts import JsonObject, Sha256, sha256_json
 from exp.runtime.gateway.contracts import EncryptedReasoningBlock, GatewayRequest
 from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest, ServingRequest
+from exp.runtime.gateway.images_contracts import ImagesRequest
 
 
 def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
@@ -143,8 +144,8 @@ def canonical_request_sha256(request: ServingRequest) -> Sha256:
     request with no carrier digests exactly as its plain serialization, so
     every request decoded before the carriers existed keeps its identity.
 
-    The embeddings surface has no messages, tools, or provider carriers, so it
-    digests exactly as its plain serialization with no replay envelope.
+    The embeddings and images surfaces have no messages, tools, or provider
+    carriers, so they digest exactly as their plain serialization.
 
     Args:
         request: Canonical serving request as decoded from the public wire.
@@ -153,7 +154,7 @@ def canonical_request_sha256(request: ServingRequest) -> Sha256:
         The stable canonical request digest.
     """
     match request:
-        case EmbeddingsRequest():
+        case EmbeddingsRequest() | ImagesRequest():
             return sha256_json(request)
         case GatewayRequest():
             envelope = provider_replay_authority(request)

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 
 class GatewaySchemaError(RuntimeError):
@@ -641,6 +641,24 @@ _MIGRATION_14 = (
     "DROP TABLE gateway_schema_refresh_v14",
 )
 
+# v15: the api_surface CHECK admits the images surface (same in-place rewrite).
+_GATEWAY_REQUESTS_V15_SQL = _GATEWAY_REQUESTS_V14_SQL.replace(
+    "api_surface IN ('chat_completions', 'responses', 'messages', 'embeddings')",
+    "api_surface IN ('chat_completions', 'responses', 'messages', 'embeddings', 'images')",
+)
+
+_MIGRATION_15 = (
+    "PRAGMA writable_schema = ON",
+    (
+        "UPDATE sqlite_master SET sql = '"
+        + _GATEWAY_REQUESTS_V15_SQL.replace("'", "''")
+        + "' WHERE type = 'table' AND name = 'gateway_requests'"
+    ),
+    "PRAGMA writable_schema = RESET",
+    "CREATE TABLE gateway_schema_refresh_v15 (noop INTEGER) STRICT",
+    "DROP TABLE gateway_schema_refresh_v15",
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -656,6 +674,7 @@ _MIGRATIONS = {
     12: _MIGRATION_12,
     13: _MIGRATION_13,
     14: _MIGRATION_14,
+    15: _MIGRATION_15,
 }
 
 

--- a/exp/runtime/gateway/sqlite/migrations_test.py
+++ b/exp/runtime/gateway/sqlite/migrations_test.py
@@ -1079,3 +1079,95 @@ def test_v14_migration_widens_api_surface_to_embeddings_and_preserves_rows(
         migrated.execute("DELETE FROM gateway_requests WHERE request_id = 'req-1'")
     finally:
         migrated.close()
+
+
+def test_v15_migration_widens_api_surface_to_images_and_preserves_rows(
+    tmp_path: Path,
+) -> None:
+    """The v15 rewrite admits the images surface without touching v14 data.
+
+    A v14 database with one full request-and-attempt chain migrates in place:
+    the existing rows and the child foreign key survive, an ``images``
+    request becomes insertable, and any other surface value stays rejected.
+    """
+    path = tmp_path / "gateway.db"
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    connection = connect_database(path)
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for version in range(1, 15):
+            for statement in migrations._MIGRATIONS[version]:
+                connection.execute(statement)
+        connection.execute("PRAGMA user_version = 14")
+        seed_statements = """
+            INSERT INTO organizations VALUES ('org', 'org', 'Org', 1, 't', 't');
+            INSERT INTO identities VALUES ('id', 'org', 'Identity', NULL, 1, 't', 't');
+            INSERT INTO virtual_keys (
+                key_id, organization_id, identity_id, prefix,
+                fingerprint_version, fingerprint_sha256, created_at
+            ) VALUES ('key', 'org', 'id', 'pfx', 1, '{fingerprint}', 't');
+            INSERT INTO catalog_snapshot_refs VALUES ('snap', 'org', '{digest}', 't');
+            INSERT INTO gateway_aliases (
+                alias_id, organization_id, alias_name, active_revision_id,
+                created_at, updated_at
+            ) VALUES ('alias', 'org', 'alias', NULL, 't', 't');
+            INSERT INTO alias_revisions (
+                revision_id, organization_id, alias_id, revision_number,
+                target_kind, pool_id, catalog_sha256, snapshot_ref, created_at
+            ) VALUES ('rev', 'org', 'alias', 1, 'direct', 'pool', '{digest}', 'snap', 't');
+            INSERT INTO gateway_requests (
+                request_id, organization_id, identity_id, key_id, alias_id,
+                alias_revision_id, api_surface, canonical_request_sha256,
+                accepted_at, deadline_at
+            ) VALUES (
+                'req-1', 'org', 'id', 'key', 'alias', 'rev', 'embeddings',
+                '{digest}', 't', 't'
+            );
+            INSERT INTO gateway_attempts (
+                attempt_id, request_id, organization_id, attempt_ordinal,
+                route_depth, deployment_id, provider, exact_model_id, pool_id,
+                catalog_sha256, state, started_at, budget_period_start
+            ) VALUES (
+                'att-1', 'req-1', 'org', 0, 0, 'deploy', 'provider', 'exact',
+                'pool', '{digest}', 'completed', 't', '2026-08-01T00:00:00+00:00'
+            );
+            """.format(fingerprint="a" * 64, digest="b" * 64)
+        for statement in seed_statements.split(";"):
+            if statement.strip():
+                connection.execute(statement)
+        connection.execute("COMMIT")
+    finally:
+        connection.close()
+
+    backup = initialize_database(path)
+
+    assert backup is not None and backup.exists()
+    migrated = connect_database(path)
+    try:
+        assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        assert migrated.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert migrated.execute("PRAGMA foreign_key_check").fetchall() == []
+        surviving = migrated.execute(
+            "SELECT api_surface FROM gateway_requests WHERE request_id = 'req-1'"
+        ).fetchone()
+        assert surviving[0] == "embeddings"
+        request_columns = (
+            "request_id, organization_id, identity_id, key_id, alias_id, "
+            "alias_revision_id, api_surface, canonical_request_sha256, accepted_at, deadline_at"
+        )
+        migrated.execute(
+            f"INSERT INTO gateway_requests ({request_columns}) "
+            "VALUES ('req-2', 'org', 'id', 'key', 'alias', 'rev', 'images', ?, 't', 't')",
+            ("c" * 64,),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            migrated.execute(
+                f"INSERT INTO gateway_requests ({request_columns}) "
+                "VALUES ('req-3', 'org', 'id', 'key', 'alias', 'rev', 'bogus', ?, 't', 't')",
+                ("d" * 64,),
+            )
+        migrated.execute("DELETE FROM gateway_attempts WHERE attempt_id = 'att-1'")
+        migrated.execute("DELETE FROM gateway_requests WHERE request_id = 'req-1'")
+    finally:
+        migrated.close()

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -31,6 +31,7 @@ from exp.runtime.gateway.contracts import (
     ProjectTarget,
 )
 from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest, ServingRequest
+from exp.runtime.gateway.images_contracts import ImagesRequest
 from exp.runtime.gateway.interfaces import GatewayClock
 from exp.runtime.gateway.replay_identity import canonical_request_sha256
 from exp.runtime.gateway.sqlite import key_delivery
@@ -703,9 +704,10 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
                 catalog_sha256=str(row["catalog_sha256"]),
             )
         match request:
-            case EmbeddingsRequest():
-                # Keyed replay is deferred for the embeddings surface: it carries
-                # no idempotency key and never claims a caller-operation scope.
+            case EmbeddingsRequest() | ImagesRequest():
+                # Keyed replay is deferred for the embeddings and images
+                # surfaces: they carry no idempotency key and never claim a
+                # caller-operation scope.
                 caller_operation = None
             case GatewayRequest():
                 caller_operation = _caller_operation_sha256(request)

--- a/exp/runtime/gateway/tests/native_images_test.py
+++ b/exp/runtime/gateway/tests/native_images_test.py
@@ -1,0 +1,323 @@
+"""End-to-end image-generation tests against the served native engine.
+
+One shared native serving subprocess (the driver from ``native_messages_test``)
+serves a seeded root with a chat alias (``coding``) and an image alias
+(``painter``) on one OpenAI-compatible loopback connection whose
+``/images/generations`` route answers base64 images with token usage. The
+tests drive ``POST /v1/images/generations`` through the real Rust data plane
+and shared python control plane with the official OpenAI client and raw HTTP.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import openai
+import pytest
+from openai.types import ImagesResponse
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import (
+    GatewayDeploymentCapabilities,
+    GatewayTokenPrices,
+    ModelCapabilities,
+)
+from exp.runtime.gateway.catalog_authority import upsert_singleton_deployment
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.tests.native_messages_test import (
+    _DRIVER_SOURCE,
+    _HOST,
+    _REQUEST_TIMEOUT_SECONDS,
+    _ServingEngine,
+)
+
+pytest.importorskip("exp_gateway_native")
+
+_PIXEL = base64.b64encode(b"\x89PNG\r\n\x1a\nfake-pixels").decode()
+
+
+class _ImagesUpstream(BaseHTTPRequestHandler):
+    """OpenAI-compatible ``/images/generations`` mock; the prompt selects the shape."""
+
+    payloads: list[JsonObject] = []
+    payloads_lock = threading.Lock()
+
+    def _answer(self, status: int, body: JsonObject) -> None:
+        encoded = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract.
+        """Answer one canned images response selected by the prompt."""
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        with self.payloads_lock:
+            self.payloads.append(payload)
+        if not self.path.endswith("/images/generations"):
+            self._answer(404, {"error": {"message": "unknown route", "type": "invalid_request"}})
+            return
+        prompt = str(payload["prompt"])
+        if prompt == "reject-param":
+            self._answer(
+                400,
+                {
+                    "error": {
+                        "message": "Invalid value: 'huge'. Supported values are: '1024x1024'.",
+                        "type": "invalid_request_error",
+                        "param": "size",
+                        "code": "invalid_value",
+                    }
+                },
+            )
+            return
+        if prompt == "server-error":
+            self._answer(500, {"error": {"message": "boom", "type": "server_error"}})
+            return
+        count = int(payload.get("n", 1))
+        if prompt == "short-count":
+            count -= 1
+        data: list[JsonObject] = [
+            {"b64_json": _PIXEL, "revised_prompt": f"{prompt} #{index}"} for index in range(count)
+        ]
+        body: JsonObject = {
+            "created": 1_700_000_000,
+            "data": data,
+            "quality": payload.get("quality", "auto"),
+            "size": payload.get("size", "1024x1024"),
+        }
+        if prompt != "unbilled":
+            body["usage"] = {
+                "input_tokens": len(prompt.split()),
+                "output_tokens": 272 * count,
+                "total_tokens": len(prompt.split()) + 272 * count,
+                "input_tokens_details": {"text_tokens": len(prompt.split()), "image_tokens": 0},
+            }
+        self._answer(200, body)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002 - stdlib name.
+        """Keep the test output quiet."""
+        del format, args
+
+
+@pytest.fixture(scope="module", name="engine")
+def _engine(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_ServingEngine]:
+    """Serve one shared native engine over a root with chat and image aliases."""
+    root = tmp_path_factory.mktemp("native-images-root")
+    with _ImagesUpstream.payloads_lock:
+        _ImagesUpstream.payloads.clear()
+    upstream = ThreadingHTTPServer((_HOST, 0), _ImagesUpstream)
+    upstream_thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    upstream_thread.start()
+    manager, raw_key = _configured_gateway(
+        root, base_url=f"http://{_HOST}:{upstream.server_address[1]}/v1"
+    )
+    normalized, snapshot, _changed = upsert_singleton_deployment(
+        root,
+        deployment_alias="painter",
+        connection_name="provider-main",
+        provider_model="painter-model-exact",
+        exact_model_id="painter-revision-exact",
+        revision=None,
+        capabilities=ModelCapabilities(supports_image_generation=True),
+        gateway_capabilities=GatewayDeploymentCapabilities(),
+        prices=GatewayTokenPrices(
+            input_micro_usd_per_million_tokens=5_000_000,
+            output_micro_usd_per_million_tokens=40_000_000,
+        ),
+        pricing_source=None,
+        replace=False,
+    )
+    manager.activate_direct_alias(
+        alias_id="painter",
+        alias_name="painter",
+        revision_id="revision-painter",
+        pool_id="painter",
+        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+        catalog_sha256=normalized.identity_sha256(),
+    )
+    manager.add_grant(identity_id="default", alias_id="painter")
+    driver = root / "native_images_driver.py"
+    driver.write_text(_DRIVER_SOURCE + "\n")
+    config = json.dumps({"root": str(root), "request_timeout_seconds": _REQUEST_TIMEOUT_SECONDS})
+    stderr_log = root / "driver-stderr.log"
+    environment = dict(os.environ)
+    environment["TEST_PROVIDER_KEY"] = "provider-secret-canary"
+    stderr_sink = stderr_log.open("wb")
+    process = subprocess.Popen(  # noqa: S603 - the interpreter runs our generated driver.
+        [sys.executable, str(driver), config],
+        stdout=subprocess.PIPE,
+        stderr=stderr_sink,
+        env=environment,
+        text=True,
+    )
+    try:
+        announced_ports: list[int] = []
+
+        def _collect_announcements() -> None:
+            assert process.stdout is not None
+            for line in process.stdout:
+                announced_ports.append(int(json.loads(line)["port"]))
+
+        threading.Thread(target=_collect_announcements, daemon=True).start()
+        live_deadline = time.monotonic() + 30
+        port = 0
+        while True:
+            if announced_ports:
+                port = announced_ports[-1]
+                try:
+                    models = httpx.get(
+                        f"http://{_HOST}:{port}/v1/models",
+                        headers={"authorization": f"Bearer {raw_key}"},
+                        timeout=2.0,
+                    )
+                    if models.status_code == 200 and sorted(
+                        item["id"] for item in models.json()["data"]
+                    ) == ["coding", "painter"]:
+                        break
+                except (httpx.HTTPError, ValueError, KeyError, TypeError):
+                    pass
+            assert process.poll() is None, f"driver died: {stderr_log.read_text()}"
+            assert time.monotonic() < live_deadline, "native engine never became live"
+            time.sleep(0.05)
+        yield _ServingEngine(port=port, raw_key=raw_key, root=root)
+    finally:
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+        exit_code = process.wait(timeout=20)
+        stderr_sink.close()
+        upstream.shutdown()
+        upstream.server_close()
+        upstream_thread.join(timeout=5)
+        assert exit_code == 0, f"driver exited {exit_code}: {stderr_log.read_text()}"
+
+
+def _total(base: str, key: str) -> int:
+    return int(httpx.get(f"{base}/usage.json", timeout=5.0).json()["totals"][key])
+
+
+def _terminal_attempts(base: str, state: str) -> int:
+    report = httpx.get(f"{base}/usage.json", timeout=5.0).json()
+    for count in report["totals"]["terminal_counts"]:
+        if count["state"] == state:
+            return int(count["attempts"])
+    return 0
+
+
+def _post(engine: _ServingEngine, body: JsonObject, **headers: str) -> httpx.Response:
+    return httpx.post(
+        f"{engine.base}/v1/images/generations",
+        headers={"authorization": f"Bearer {engine.raw_key}", **headers},
+        json=body,
+        timeout=30.0,
+    )
+
+
+def test_official_client_generates_images_and_settles_both_token_legs(
+    engine: _ServingEngine,
+) -> None:
+    """The OpenAI SDK's generate call returns the provider's images and bills its usage."""
+    completed_before = _terminal_attempts(engine.base, "completed")
+    input_before = _total(engine.base, "input_tokens")
+    output_before = _total(engine.base, "output_tokens")
+    client = openai.OpenAI(base_url=f"{engine.base}/v1", api_key=engine.raw_key)
+    raw = client.images.with_raw_response.generate(
+        model="painter", prompt="a calico cat", n=2, size="1024x1024", quality="low"
+    )
+    response = raw.parse()
+    assert isinstance(response, ImagesResponse)
+    assert raw.headers["x-gateway-alias"] == "painter"
+    assert raw.headers["x-gateway-provider"] == "openai-compatible"
+    assert response.data is not None and len(response.data) == 2
+    assert response.data[0].b64_json == _PIXEL
+    assert response.data[1].revised_prompt == "a calico cat #1"
+    assert response.usage is not None
+    assert (response.usage.input_tokens, response.usage.output_tokens) == (3, 544)
+    with _ImagesUpstream.payloads_lock:
+        upstream = _ImagesUpstream.payloads[-1]
+    assert upstream == {
+        "model": "painter-model-exact",
+        "prompt": "a calico cat",
+        "n": 2,
+        "size": "1024x1024",
+        "quality": "low",
+    }
+    assert _terminal_attempts(engine.base, "completed") == completed_before + 1
+    assert _total(engine.base, "input_tokens") == input_before + 3
+    assert _total(engine.base, "output_tokens") == output_before + 544
+
+
+def test_raw_request_defaults_n_and_ignores_idempotency_key(engine: _ServingEngine) -> None:
+    """A bare prompt is one image; the caller's Idempotency-Key never keys this surface."""
+    response = _post(
+        engine,
+        {"model": "painter", "prompt": "one cat", "user": "tenant-7"},
+        **{"Idempotency-Key": "ignored", "x-client-request-id": "corr-1"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.headers["x-client-request-id"] == "corr-1"
+    body = response.json()
+    assert len(body["data"]) == 1
+    assert body["usage"]["output_tokens"] == 272
+    with _ImagesUpstream.payloads_lock:
+        upstream = _ImagesUpstream.payloads[-1]
+    assert upstream == {"model": "painter-model-exact", "prompt": "one cat", "n": 1}
+
+
+def test_chat_alias_and_streaming_are_refused_with_field_errors(engine: _ServingEngine) -> None:
+    """A chat alias fails on model; a streaming request fails on stream; both are OpenAI-shaped."""
+    chat = _post(engine, {"model": "coding", "prompt": "a cat"})
+    assert chat.status_code == 400
+    assert chat.json()["error"]["param"] == "model"
+    assert "does not generate images" in chat.json()["error"]["message"]
+    streaming = _post(engine, {"model": "painter", "prompt": "a cat", "stream": True})
+    assert streaming.status_code == 400
+    assert streaming.json()["error"]["param"] == "stream"
+    unknown = httpx.post(
+        f"{engine.base}/v1/images/generations",
+        headers={"authorization": "Bearer not-a-key"},
+        json={"model": "painter", "prompt": "a cat"},
+        timeout=10.0,
+    )
+    assert unknown.status_code == 401
+
+
+def test_provider_client_error_relays_the_parameter(engine: _ServingEngine) -> None:
+    """A provider 400 reaches the caller as a 400 naming the rejected field."""
+    response = _post(engine, {"model": "painter", "prompt": "reject-param"})
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["param"] == "size"
+    assert "Supported values are" in error["message"]
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected_fragment"),
+    [
+        ("unbilled", "malformed response"),
+        ("short-count", "malformed response"),
+        ("server-error", "provider service failed"),
+    ],
+)
+def test_unbillable_or_failing_provider_answers_fail_closed(
+    engine: _ServingEngine, prompt: str, expected_fragment: str
+) -> None:
+    """No usage, a missing image, or a 5xx never hands the caller an unaccounted image."""
+    failed_before = _terminal_attempts(engine.base, "failed")
+    response = _post(engine, {"model": "painter", "prompt": prompt, "n": 2})
+    assert response.status_code == 502, response.text
+    assert response.json()["error"]["code"] == "all_routes_failed"
+    assert expected_fragment in response.json()["error"]["message"]
+    assert _terminal_attempts(engine.base, "failed") == failed_before + 1

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -184,6 +184,10 @@ class GatewayWireProfile:
     ``headers``; ``None`` when the connection speaks no embeddings wire, so the
     embeddings surface excludes the rung instead of dispatching a chat URL."""
 
+    images_url: str | None = None
+    """Full OpenAI-wire ``/images/generations`` endpoint for this connection,
+    sharing ``headers``; ``None`` when the connection speaks no images wire."""
+
     def __post_init__(self) -> None:
         """Reject malformed operator wire contracts before admission."""
         if self.dialect not in {

--- a/exp/runtime/models/providers/openai.py
+++ b/exp/runtime/models/providers/openai.py
@@ -277,6 +277,7 @@ class OpenAIClient(OpenAIEmbeddingMixin):
             dialect="openai_responses",
             url=f"{self._base_url}/{self._request_path(self._completion_path())}",
             embeddings_url=f"{self._base_url}/{self._request_path('embeddings')}",
+            images_url=f"{self._base_url}/{self._request_path('images/generations')}",
             headers=self._headers(),
             model_id=self._model.model_id,
             timeout_seconds=self._timeout_seconds,

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -23,6 +23,7 @@ from exp.common.models import (
     ToolCall,
     Usage,
 )
+from exp.runtime.gateway.images_contracts import ImagesRequest
 from exp.runtime.models.providers.async_transport import (
     AsyncJsonHttpTransport,
 )
@@ -182,6 +183,36 @@ def openai_embedding_request(
     if encoding_format is not None:
         request["encoding_format"] = encoding_format
     return request
+
+
+def openai_images_request(model_id: str, request: ImagesRequest) -> JsonObject:
+    """Convert one canonical image-generation request into the OpenAI wire body.
+
+    Every optional control is omitted when absent so the provider default
+    applies; ``user`` is never forwarded (metadata-only in the manifest).
+
+    Args:
+        model_id: Served image model id.
+        request: Canonical image-generation request.
+
+    Returns:
+        The OpenAI-compatible ``/images/generations`` request body.
+    """
+    body: JsonObject = {"model": model_id, "prompt": request.prompt, "n": request.n}
+    for field in (
+        "size",
+        "quality",
+        "background",
+        "output_format",
+        "output_compression",
+        "moderation",
+        "response_format",
+        "style",
+    ):
+        value = getattr(request, field)
+        if value is not None:
+            body[field] = value
+    return body
 
 
 def openai_compatible_response(
@@ -434,6 +465,7 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             dialect="openai_compatible",
             url=f"{self._base_url}/{self._request_path(self._completion_path())}",
             embeddings_url=f"{self._base_url}/{self._request_path('embeddings')}",
+            images_url=f"{self._base_url}/{self._request_path('images/generations')}",
             headers=self._headers(),
             model_id=self._model.model_id,
             timeout_seconds=self._timeout_seconds,

--- a/exp/runtime/openai_protocol/images_requests.py
+++ b/exp/runtime/openai_protocol/images_requests.py
@@ -1,0 +1,69 @@
+"""Decode the OpenAI Images generation body into the canonical images surface.
+
+Lives beside :mod:`exp.runtime.openai_protocol.requests` (which owns the
+line-budgeted chat, Responses, and embeddings decoders) and reuses its
+validation helpers, so every public surface decodes through one manifest,
+one official-SDK shape check, and one closed wire model.
+"""
+
+from __future__ import annotations
+
+from openai.types.image_generate_params import ImageGenerateParamsNonStreaming
+from pydantic import Field, TypeAdapter, ValidationError
+
+from exp.common.core.artifacts import ContractModel, JsonObject
+from exp.runtime.gateway.images_contracts import ImagesRequest
+from exp.runtime.openai_protocol.manifest import IMAGES_MANIFEST
+from exp.runtime.openai_protocol.requests import (
+    _validate_manifest,
+    _validate_official,
+    _validate_wire,
+    _validation_protocol_error,
+)
+from exp.runtime.openai_protocol.wire_models import _ImagesRequest
+
+_IMAGES_OFFICIAL: TypeAdapter[object] = TypeAdapter[object](ImageGenerateParamsNonStreaming)
+
+
+class DecodedImagesRequest(ContractModel):
+    """Public alias plus its canonical image-generation request."""
+
+    alias: str = Field(min_length=1, max_length=256)
+    request: ImagesRequest
+
+
+def decode_images(payload: JsonObject) -> DecodedImagesRequest:
+    """Decode one Images generation body into the canonical images surface.
+
+    The surface is buffered and never streamed, so ``stream`` / ``partial_images``
+    are refused by the manifest rather than silently answered whole.
+
+    Args:
+        payload: Parsed JSON request body.
+
+    Returns:
+        Public alias and canonical image-generation request.
+
+    Raises:
+        OpenAIProtocolError: The body is invalid, unknown, or unsupported.
+    """
+    _validate_manifest(payload, IMAGES_MANIFEST)
+    _validate_official(_IMAGES_OFFICIAL, payload)
+    request = _validate_wire(_ImagesRequest, payload)
+    try:
+        canonical = ImagesRequest(
+            prompt=request.prompt,
+            n=1 if request.n is None else request.n,
+            size=request.size,
+            quality=request.quality,
+            background=request.background,
+            output_format=request.output_format,
+            output_compression=request.output_compression,
+            moderation=request.moderation,
+            response_format=request.response_format,
+            style=request.style,
+            user=request.user,
+        )
+    except ValidationError as exc:
+        raise _validation_protocol_error(exc) from exc
+    return DecodedImagesRequest(alias=request.model, request=canonical)

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -275,6 +275,37 @@ EMBEDDINGS_MANIFEST = CompatibilityManifest(
 )
 
 
+IMAGES_MANIFEST = CompatibilityManifest(
+    schema_version=1,
+    surface=GatewayApiSurface.IMAGES,
+    fields=(
+        *(
+            _field(path, CompatibilityDisposition.SUPPORTED)
+            for path in (
+                "model",
+                "prompt",
+                "n",
+                "size",
+                "quality",
+                "background",
+                "output_format",
+                "output_compression",
+                "moderation",
+                "response_format",
+                "style",
+            )
+        ),
+        # End-user attribution: recorded gateway-side, never forwarded.
+        _field("user", CompatibilityDisposition.METADATA_ONLY),
+        # Streaming partial images is a Responses-style event stream the
+        # buffered images surface does not carry; a request asking for it is
+        # refused explicitly rather than silently answered whole.
+        _field("stream", CompatibilityDisposition.UNSUPPORTED),
+        _field("partial_images", CompatibilityDisposition.UNSUPPORTED),
+    ),
+)
+
+
 def disposition_map(manifest: CompatibilityManifest) -> dict[str, CompatibilityDisposition]:
     """Index one manifest by exact top-level request field.
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -8,7 +8,6 @@ from typing import Literal, cast
 
 from openai.types import EmbeddingCreateParams
 from openai.types.chat.completion_create_params import CompletionCreateParams
-from openai.types.image_generate_params import ImageGenerateParamsNonStreaming
 from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
 from pydantic_core import ErrorDetails
@@ -40,7 +39,6 @@ from exp.runtime.gateway.contracts import (
     StructuredTextFormat,
 )
 from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest
-from exp.runtime.gateway.images_contracts import ImagesRequest
 from exp.runtime.gateway.reasoning_carrier import (
     FIREWORKS_REASONING_CONTENT_PREFIX,
     parse_reasoning_content_carrier,
@@ -52,7 +50,6 @@ from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_fiel
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
     EMBEDDINGS_MANIFEST,
-    IMAGES_MANIFEST,
     RESPONSES_MANIFEST,
     disposition_map,
 )
@@ -80,7 +77,6 @@ from exp.runtime.openai_protocol.wire_models import (
     _CustomToolCallOutput,
     _EmbeddingsRequest,
     _FunctionCall,
-    _ImagesRequest,
     _Message,
     _ResponseFunctionCall,
     _ResponseMessage,
@@ -95,10 +91,8 @@ from exp.runtime.openai_protocol.wire_models import (
 
 _CHAT_OFFICIAL = TypeAdapter(CompletionCreateParams)
 _RESPONSES_OFFICIAL = TypeAdapter(ResponseCreateParams)
-# Parametrized to object so the invariant TypeAdapter matches _validate_official;
-# EmbeddingCreateParams is a single TypedDict, unlike the union-typed chat/responses params.
+# object-parametrized: EmbeddingCreateParams is one TypedDict, unlike the chat/responses unions.
 _EMBEDDINGS_OFFICIAL: TypeAdapter[object] = TypeAdapter[object](EmbeddingCreateParams)
-_IMAGES_OFFICIAL: TypeAdapter[object] = TypeAdapter[object](ImageGenerateParamsNonStreaming)
 _TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 
 
@@ -119,13 +113,6 @@ class DecodedEmbeddingsRequest(ContractModel):
 
     alias: str = Field(min_length=1, max_length=256)
     request: EmbeddingsRequest
-
-
-class DecodedImagesRequest(ContractModel):
-    """Public alias plus its canonical image-generation request."""
-
-    alias: str = Field(min_length=1, max_length=256)
-    request: ImagesRequest
 
 
 def _without_chat_reasoning_content(payload: JsonObject) -> JsonObject:
@@ -261,43 +248,6 @@ def decode_embeddings(payload: JsonObject) -> DecodedEmbeddingsRequest:
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
     return DecodedEmbeddingsRequest(alias=request.model, request=canonical)
-
-
-def decode_images(payload: JsonObject) -> DecodedImagesRequest:
-    """Decode one Images generation body into the canonical images surface.
-
-    The surface is buffered and never streamed, so ``stream`` / ``partial_images``
-    are refused by the manifest rather than silently answered whole.
-
-    Args:
-        payload: Parsed JSON request body.
-
-    Returns:
-        Public alias and canonical image-generation request.
-
-    Raises:
-        OpenAIProtocolError: The body is invalid, unknown, or unsupported.
-    """
-    _validate_manifest(payload, IMAGES_MANIFEST)
-    _validate_official(_IMAGES_OFFICIAL, payload)
-    request = _validate_wire(_ImagesRequest, payload)
-    try:
-        canonical = ImagesRequest(
-            prompt=request.prompt,
-            n=1 if request.n is None else request.n,
-            size=request.size,
-            quality=request.quality,
-            background=request.background,
-            output_format=request.output_format,
-            output_compression=request.output_compression,
-            moderation=request.moderation,
-            response_format=request.response_format,
-            style=request.style,
-            user=request.user,
-        )
-    except ValidationError as exc:
-        raise _validation_protocol_error(exc) from exc
-    return DecodedImagesRequest(alias=request.model, request=canonical)
 
 
 def decode_responses(

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -8,6 +8,7 @@ from typing import Literal, cast
 
 from openai.types import EmbeddingCreateParams
 from openai.types.chat.completion_create_params import CompletionCreateParams
+from openai.types.image_generate_params import ImageGenerateParamsNonStreaming
 from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
 from pydantic_core import ErrorDetails
@@ -39,6 +40,7 @@ from exp.runtime.gateway.contracts import (
     StructuredTextFormat,
 )
 from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest
+from exp.runtime.gateway.images_contracts import ImagesRequest
 from exp.runtime.gateway.reasoning_carrier import (
     FIREWORKS_REASONING_CONTENT_PREFIX,
     parse_reasoning_content_carrier,
@@ -50,6 +52,7 @@ from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_fiel
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
     EMBEDDINGS_MANIFEST,
+    IMAGES_MANIFEST,
     RESPONSES_MANIFEST,
     disposition_map,
 )
@@ -77,6 +80,7 @@ from exp.runtime.openai_protocol.wire_models import (
     _CustomToolCallOutput,
     _EmbeddingsRequest,
     _FunctionCall,
+    _ImagesRequest,
     _Message,
     _ResponseFunctionCall,
     _ResponseMessage,
@@ -94,6 +98,7 @@ _RESPONSES_OFFICIAL = TypeAdapter(ResponseCreateParams)
 # Parametrized to object so the invariant TypeAdapter matches _validate_official;
 # EmbeddingCreateParams is a single TypedDict, unlike the union-typed chat/responses params.
 _EMBEDDINGS_OFFICIAL: TypeAdapter[object] = TypeAdapter[object](EmbeddingCreateParams)
+_IMAGES_OFFICIAL: TypeAdapter[object] = TypeAdapter[object](ImageGenerateParamsNonStreaming)
 _TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 
 
@@ -114,6 +119,13 @@ class DecodedEmbeddingsRequest(ContractModel):
 
     alias: str = Field(min_length=1, max_length=256)
     request: EmbeddingsRequest
+
+
+class DecodedImagesRequest(ContractModel):
+    """Public alias plus its canonical image-generation request."""
+
+    alias: str = Field(min_length=1, max_length=256)
+    request: ImagesRequest
 
 
 def _without_chat_reasoning_content(payload: JsonObject) -> JsonObject:
@@ -249,6 +261,43 @@ def decode_embeddings(payload: JsonObject) -> DecodedEmbeddingsRequest:
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
     return DecodedEmbeddingsRequest(alias=request.model, request=canonical)
+
+
+def decode_images(payload: JsonObject) -> DecodedImagesRequest:
+    """Decode one Images generation body into the canonical images surface.
+
+    The surface is buffered and never streamed, so ``stream`` / ``partial_images``
+    are refused by the manifest rather than silently answered whole.
+
+    Args:
+        payload: Parsed JSON request body.
+
+    Returns:
+        Public alias and canonical image-generation request.
+
+    Raises:
+        OpenAIProtocolError: The body is invalid, unknown, or unsupported.
+    """
+    _validate_manifest(payload, IMAGES_MANIFEST)
+    _validate_official(_IMAGES_OFFICIAL, payload)
+    request = _validate_wire(_ImagesRequest, payload)
+    try:
+        canonical = ImagesRequest(
+            prompt=request.prompt,
+            n=1 if request.n is None else request.n,
+            size=request.size,
+            quality=request.quality,
+            background=request.background,
+            output_format=request.output_format,
+            output_compression=request.output_compression,
+            moderation=request.moderation,
+            response_format=request.response_format,
+            style=request.style,
+            user=request.user,
+        )
+    except ValidationError as exc:
+        raise _validation_protocol_error(exc) from exc
+    return DecodedImagesRequest(alias=request.model, request=canonical)
 
 
 def decode_responses(

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -424,6 +424,35 @@ class _EmbeddingsRequest(_WireModel):
         return value
 
 
+class _ImagesRequest(_WireModel):
+    """Closed gateway image-generation request profile (OpenAI Images API)."""
+
+    model: str = Field(min_length=1, max_length=256)
+    prompt: str = Field(min_length=1, max_length=32_000)
+    n: int | None = Field(default=None, ge=1, le=10)
+    size: (
+        Literal[
+            "auto",
+            "256x256",
+            "512x512",
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
+            "1792x1024",
+            "1024x1792",
+        ]
+        | None
+    ) = None
+    quality: Literal["standard", "hd", "low", "medium", "high", "auto"] | None = None
+    background: Literal["transparent", "opaque", "auto"] | None = None
+    output_format: Literal["png", "jpeg", "webp"] | None = None
+    output_compression: int | None = Field(default=None, ge=0, le=100)
+    moderation: Literal["low", "auto"] | None = None
+    response_format: Literal["url", "b64_json"] | None = None
+    style: Literal["vivid", "natural"] | None = None
+    user: str | None = Field(default=None, max_length=1024)
+
+
 class _ResponseTool(_WireModel):
     """Responses API function tool declaration."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.26"
+version = "0.7.27"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.21,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.22,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.21"
+version = "0.3.22"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.26"
+version = "0.7.27"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What

M2 of the media-APIs series, stacked on #735 (embeddings) — retarget to `main` once #735 merges. The images surface has the same shape as embeddings:

- **Contract + decode**: `ImagesRequest` (prompt, n, size, quality, background, output_format, output_compression, moderation, response_format, style; `user` is the attribution label, metadata-only) decoded through the official `ImageGenerateParamsNonStreaming` plus a closed manifest; `stream` / `partial_images` are refused explicitly (the surface is buffered).
- **Admission** (`native_images.py`, `admit_images`): direct route narrowed to rungs whose catalog declares `supports_image_generation` **and** whose connection exposes an OpenAI-wire `/images/generations` endpoint (`GatewayWireProfile.images_url`; OpenAI + OpenAI-compatible clients, Azure inherits). No rung → `400 unsupported_capability` on `model`.
- **Dispatch** (`route_images.rs`): buffered POST on the shared start_attempt → dispatch → settle ladder, body read chunk by chunk under the retained-output cap, exactly `n` images validated (each `b64_json` or `url`, `revised_prompt` carried), **token usage required** — an answer without `usage` (the per-image priced dall-e models) is refused as unbillable rather than served for free; settles prompt + image tokens.
- **Reservation**: prompt bytes × input rate + n × 6240 (largest per-image token count) × output rate; a lane without both rates is unpriced for images.
- **Ledger**: `api_surface='images'` (sqlite migration 15). `ModelCapabilities.supports_image_generation` (fail-closed like `supports_embeddings`) → `SNAPSHOT_SCHEMA_VERSION` 1 → 2 per the roll-safety contract (every deployment's capability content changes).
- Version 0.7.27 / native 0.3.22.

Deliberately absent: edits/variations (multipart), streaming partial images, per-image priced models (needs the typed billed-units ledger, M2b), non-OpenAI wires.

## Evidence

- ruff / ty / cargo fmt / clippy (`--no-default-features -D warnings`) / cargo test (135) clean; unit suites green; full `pytest -n 4` running at the time of writing (result in a follow-up comment).
- New e2e `tests/native_images_test.py` (real Rust server + python control plane + loopback provider, official `openai` client): generate n=2 returns both images with `revised_prompt` and bills 3 + 544 tokens into the usage report; bare prompt defaults n=1 and ignores `Idempotency-Key`; chat alias → 400 on `model`; `stream:true` → 400 on `stream`; unknown key → 401; provider 400 relays `param: size` + detail; unbilled / short / 5xx → 502 `all_routes_failed`, attempt recorded failed.
- **Live, house OpenAI key, through the served native engine**: `gpt-image-1-mini` `quality=low 1024x1024` served in 20.9 s, one 1.08 MB PNG, usage `input_tokens=16, output_tokens=272` (image tokens), ledger totals 16 / 272, `x-gateway-provider: openai`; an unsupported `size` relays OpenAI's rejection as a 400 naming `size`.