### PR TITLE
azure: keep a dated Azure OpenAI api_version on the deployments surface for inferred Foundry hosts

### DIFF
--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -27,6 +27,13 @@ DEFAULT_AZURE_API_SURFACE: AzureApiSurface = "openai_deployments"
 # The Foundry model-inference surface requires a dated API version, so an endpoint left on the
 # Azure OpenAI ``v1`` spelling still resolves to a version that surface accepts.
 MODEL_INFERENCE_FALLBACK_API_VERSION = "2024-05-01-preview"
+# The ``api-version`` values the model-inference surface (``{resource}/models``) answers. Every
+# other dated version belongs to the Azure OpenAI deployments vocabulary: a Foundry resource
+# answers ``/models/chat/completions?api-version=2024-10-21`` with a bare 404 ``Resource not
+# found`` while serving the same deployment at ``/openai/deployments/{name}`` on that version.
+MODEL_INFERENCE_API_VERSIONS: frozenset[str] = frozenset(
+    {MODEL_INFERENCE_FALLBACK_API_VERSION, "2025-04-01-preview"}
+)
 
 
 def resolve_azure_api_surface(
@@ -40,7 +47,10 @@ def resolve_azure_api_surface(
     An explicitly configured surface always wins. Otherwise the surface follows the endpoint
     host, so a Foundry resource reaches the model-inference surface without an operator having to
     name it. An inferred model-inference surface also upgrades the Azure OpenAI ``v1`` API
-    version, which that surface rejects.
+    version, which that surface rejects, and keeps a dated Azure OpenAI version (``2024-10-21``)
+    on the deployments surface that version belongs to: a Foundry resource serves that surface as
+    well, whereas the model-inference surface 404s every version outside its own vocabulary.
+    Inference never sends a version to a surface that rejects it.
 
     Args:
         endpoint: Azure resource endpoint from the connection.
@@ -55,8 +65,11 @@ def resolve_azure_api_surface(
     inferred = infer_azure_api_surface(endpoint)
     if inferred is None:
         return DEFAULT_AZURE_API_SURFACE, api_version
-    if inferred == "model_inference" and api_version == _V1_API_VERSION:
-        return inferred, MODEL_INFERENCE_FALLBACK_API_VERSION
+    if inferred == "model_inference":
+        if api_version == _V1_API_VERSION:
+            return inferred, MODEL_INFERENCE_FALLBACK_API_VERSION
+        if api_version not in MODEL_INFERENCE_API_VERSIONS:
+            return DEFAULT_AZURE_API_SURFACE, api_version
     return inferred, api_version
 
 

--- a/exp/runtime/models/providers/azure_test.py
+++ b/exp/runtime/models/providers/azure_test.py
@@ -20,6 +20,7 @@ from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.providers.azure import (
     AZURE_OPENAI_API_KEY_ENV,
     AZURE_OPENAI_ENDPOINT_ENV,
+    MODEL_INFERENCE_API_VERSIONS,
     MODEL_INFERENCE_FALLBACK_API_VERSION,
     AzureClient,
     bind_azure_api_key,
@@ -520,11 +521,32 @@ def test_resolution_upgrades_an_unconfigured_foundry_connection() -> None:
         api_version="v1",
         configured_surface=None,
     ) == ("model_inference", MODEL_INFERENCE_FALLBACK_API_VERSION)
+    for version in sorted(MODEL_INFERENCE_API_VERSIONS):
+        assert resolve_azure_api_surface(
+            endpoint="https://resource.services.ai.azure.com",
+            api_version=version,
+            configured_surface=None,
+        ) == ("model_inference", version)
+
+
+def test_resolution_keeps_a_dated_azure_openai_version_on_the_deployments_surface() -> None:
+    """A Foundry host with an Azure OpenAI dated version serves /openai/deployments, not /models.
+
+    Live-tested 2026-09-03 against a Foundry resource: ``/models/chat/completions`` answers
+    ``api-version=2024-10-21`` with a bare 404 ``Resource not found`` while
+    ``/openai/deployments/{name}/chat/completions`` serves the same deployment on that version.
+    """
     assert resolve_azure_api_surface(
         endpoint="https://resource.services.ai.azure.com",
-        api_version="2024-05-01-preview",
+        api_version="2024-10-21",
         configured_surface=None,
-    ) == ("model_inference", "2024-05-01-preview")
+    ) == ("openai_deployments", "2024-10-21")
+    # An operator who declares the surface keeps authority over the version sent with it.
+    assert resolve_azure_api_surface(
+        endpoint="https://resource.services.ai.azure.com",
+        api_version="2024-10-21",
+        configured_surface="model_inference",
+    ) == ("model_inference", "2024-10-21")
 
 
 def test_resolution_leaves_unrecognized_and_azure_openai_hosts_on_deployments() -> None:


### PR DESCRIPTION
## Bug

`resolve_azure_api_surface` infers `model_inference` for `*.services.ai.azure.com` hosts and forwards the connection's dated `api_version` to that surface verbatim. The model-inference surface (`{resource}/models`) only answers its own versions (`2024-05-01-preview`, `2025-04-01-preview`). An Azure OpenAI dated version such as `2024-10-21` — the example `ConnectionConfig`'s own validator message documents — gets a bare 404 `Resource not found` from `/models/chat/completions`, which the gateway classifies as `provider_not_found` ("provider deployment was not found"). Every deployment on the resource looks missing.

Live-reproduced 2026-09-03 against a Foundry resource with 19 deployments (platform's house Azure connection, `api_version: 2024-10-21`):

| request | result |
|---|---|
| `POST /models/chat/completions?api-version=2024-10-21` | 404 `{"error":{"code":"404","message":"Resource not found"}}` |
| `POST /models/chat/completions?api-version=2024-05-01-preview` | 200 |
| `POST /models/chat/completions?api-version=2025-04-01-preview` | 200 |
| `POST /models/chat/completions?api-version=2024-08-01-preview` / `2025-01-01-preview` / `2025-04-01` / `2025-03-01-preview` | 404 |
| `POST /openai/deployments/DeepSeek-V4-Flash/chat/completions?api-version=2024-10-21` | 200 (also 200 on `2024-05-01-preview` and `2025-04-01-preview`; a missing name gets the proper `DeploymentNotFound`) |

Downstream effect: 90+ prod gateway attempts on the house Azure lane over 30 days, 0 successes, all `provider_not_found`; the platform's servability sweep disabled all 20 house Azure lanes as dead.

## Fix

An inferred `model_inference` surface keeps a version outside `MODEL_INFERENCE_API_VERSIONS` on the deployments surface that version belongs to (a Foundry resource serves that surface too). Unchanged: the `v1` → fallback upgrade, model-inference versions pass through, an operator-declared surface stays authoritative over the version sent with it. Inference never sends a version to a surface that rejects it.

Behaviour change is limited to configurations that were 404-dead before, so no working lane can regress. Loss of `top_k` etc. on such connections is not a regression either (they served nothing); an operator wanting model inference declares `azure_api_surface=model_inference` with a version from that vocabulary.

## Tests

- `test_resolution_upgrades_an_unconfigured_foundry_connection` now covers every version in `MODEL_INFERENCE_API_VERSIONS`.
- New `test_resolution_keeps_a_dated_azure_openai_version_on_the_deployments_surface` (inferred → deployments; declared → kept).
- `uv run --extra dev pytest exp/runtime/models/providers/azure_test.py exp/runtime/models/registry_test.py`: 46 passed. `ruff check .`, `ruff format --check .`, `ty check`: clean.

Platform follow-up (experientiallabs/platform): the house connection has been moved to `2024-05-01-preview` as the immediate mitigation (works on both the current and the fixed engine); pin bump once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)