### PR TITLE
gateway: per-alias fail-safe catalog build — one bad row never crashes the worker (v0.7.28)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,15 @@ uv run pytest -q
 - No-subcommand `exp` serves only explicit active gateway aliases. The `--project` form serves one
   frozen router policy. Simulation callers choose an `AgentRuntime` and `EnvironmentRuntime`
   directly, in process.
+- The multi-alias worker's catalog build is per-alias fail-safe: a granted alias that cannot build
+  (bad rung, missing revision, malformed capabilities, or a rung with no native wire dialect) is
+  excluded and marked UNAVAILABLE (surfaced in the startup receipt and the `catalog.aliases_excluded`
+  log; a direct call to it 503s), and the worker binds and serves every other alias. No single
+  catalog row may abort the whole build or crash the worker; only an entirely empty servable set
+  fails startup loud. This is EXCLUSION, never a fallback — the RUST-only serving contract holds, so
+  an unservable alias is dropped, never served through some other path. The single-alias owned
+  project gateway (`--project`) keeps the all-or-nothing `native_serving_blockers` gate, since its
+  one alias has nothing else to serve.
 - Local Pi and process-environment adapters execute external code on the user's machine only when
   a caller explicitly selects them. Preserve bounded processes, the explicit working directory,
   and fail-closed support checks.

--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -227,7 +227,6 @@ def _run_gateway(
     )
     from exp.runtime.gateway.management import GatewayManagement
     from exp.runtime.gateway.native_bridge import NativeControlPlane
-    from exp.runtime.gateway.native_execution import native_serving_blockers
     from exp.runtime.gateway.native_server import (
         NativeGatewayServerError,
         serve_native_gateway,
@@ -267,13 +266,11 @@ def _run_gateway(
                         None if compatibility is None else frozenset({compatibility.alias})
                     ),
                 )
-                blockers = native_serving_blockers(components)
-                if blockers:
-                    details = "; ".join(blockers)
-                    raise typer.BadParameter(
-                        "the native engine cannot serve every granted alias: "
-                        f"{details}. Fix the provider configuration and rerun 'exp'."
-                    )
+                # The catalog build is per-alias fail-safe: a granted alias the
+                # native engine cannot serve is excluded (marked UNAVAILABLE and
+                # surfaced in the receipt below), so the worker binds and serves
+                # every other alias instead of refusing to start on one bad row.
+                # An empty servable set already fails loud in load_gateway_components.
                 # Loaded directly (rather than through native_server's own
                 # import) so this composition can wire the content-free
                 # metrics snapshot into the control plane before the process

--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -225,10 +225,6 @@ def test_project_option_launches_the_native_gateway_on_loopback(
     monkeypatch.setattr("exp.runtime.gateway.lifecycle.load_gateway_components", load_components)
     monkeypatch.setattr("exp.runtime.gateway.lifecycle.gateway_instance_lock", instance_lock)
     monkeypatch.setattr(
-        "exp.runtime.gateway.native_execution.native_serving_blockers",
-        lambda _components: (),
-    )
-    monkeypatch.setattr(
         "exp.runtime.gateway.guardrails.config.load_guardrail_engine",
         lambda _root: None,
     )
@@ -309,10 +305,6 @@ def test_unbindable_port_fails_before_any_ready_receipt(
     monkeypatch.setattr(
         "exp.runtime.gateway.lifecycle.load_gateway_components",
         lambda _root, **_kwargs: components,
-    )
-    monkeypatch.setattr(
-        "exp.runtime.gateway.native_execution.native_serving_blockers",
-        lambda _components: (),
     )
     monkeypatch.setattr(
         "exp.runtime.gateway.guardrails.config.load_guardrail_engine",

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -51,7 +51,6 @@ from exp.runtime.gateway.routing import (
 from exp.runtime.gateway.sqlite.store import SQLiteGatewayStore
 from exp.runtime.models import ModelConnectionError, RuntimeModelCatalog
 from exp.runtime.models.credentials import MissingModelCredentialError, ModelCredentialError
-from exp.runtime.router.errors import RouterApplicationError
 from exp.runtime.router.runtime import DecisionSink, RouterRuntime, RouterRuntimeIntegrityError
 
 _DEFAULT_GRACEFUL_TIMEOUT_SECONDS = 10.0
@@ -593,124 +592,132 @@ def _load_alias_state(
     fallback_revisions: dict[tuple[str, str], _ServedFallback] = {}
 
     for alias in aliases:
+        # Per-alias fail-safe: no single malformed catalog row (bad rung, missing
+        # revision, bad capabilities, natively unservable alias) may abort the build
+        # — each marks just that alias UNAVAILABLE and serves the rest; this outer
+        # guard backstops any exception the specific handlers below miss.
         try:
-            revision_id, catalog_sha256 = _required_revision(alias)
-            catalog, normalized = _load_snapshot(manager, alias)
-        except GatewayLifecycleError as exc:
-            # The alias's active revision pins an unservable snapshot (parse
-            # failure or a same-version self-inconsistent digest). Serve the most
-            # recent prior revision that loads instead of 503-ing the alias, and
-            # record the re-key so admission attributes to the revision served.
-            # Imported here to avoid a module import cycle with the fallback
-            # loader, which reuses this module's per-revision helpers.
-            from exp.runtime.gateway.alias_fallback import load_last_good_fallback
-
-            fallback = load_last_good_fallback(
-                manager,
-                alias,
-                environment=environment,
-                project_repository=project_repository,
-                decision_sink=decision_sink,
-                exact_models=exact_models,
-            )
-            if fallback is None:
-                unavailable_aliases.append((alias.alias_name, str(exc)))
-                continue
-            normalized_catalogs[fallback.key] = fallback.normalized
-            runtime_catalogs[fallback.key] = fallback.runtime_catalog
-            if fallback.activation is not None:
-                activations[fallback.activation[0]] = fallback.activation[1]
-            readiness.append(fallback.proof)
-            served = fallback.proof.authorization
-            if alias.revision_id is not None:
-                fallback_revisions[(alias.alias_name, alias.revision_id)] = _ServedFallback(
-                    alias_revision_id=served.alias_revision_id,
-                    catalog_sha256=served.catalog_sha256,
-                    target=served.target,
-                )
-            _logger.warning(
-                "gateway alias %r active revision pins an unservable snapshot (%s); "
-                "serving last-good prior revision %r",
-                alias.alias_name,
-                exc,
-                served.alias_revision_id,
-            )
-            continue
-        key = (revision_id, catalog_sha256)
-        runtime_catalog = RuntimeModelCatalog(catalog, environment=environment)
-        if alias.target_kind == "direct":
             try:
-                proof = _direct_readiness(manager, alias, normalized, runtime_catalog)
-            except (GatewayLifecycleError, ModelConnectionError, ModelCredentialError) as exc:
+                revision_id, catalog_sha256 = _required_revision(alias)
+                catalog, normalized = _load_snapshot(manager, alias)
+            except GatewayLifecycleError as exc:
+                # The alias's active revision pins an unservable snapshot (parse
+                # failure or a same-version self-inconsistent digest). Serve the
+                # most recent prior revision that loads instead of 503-ing the
+                # alias, and record the re-key so admission attributes to the
+                # revision served. Imported here to avoid a module import cycle
+                # with the fallback loader, which reuses this module's helpers.
+                from exp.runtime.gateway.alias_fallback import load_last_good_fallback
+
+                fallback = load_last_good_fallback(
+                    manager,
+                    alias,
+                    environment=environment,
+                    project_repository=project_repository,
+                    decision_sink=decision_sink,
+                    exact_models=exact_models,
+                )
+                if fallback is None:
+                    unavailable_aliases.append((alias.alias_name, str(exc)))
+                    continue
+                normalized_catalogs[fallback.key] = fallback.normalized
+                runtime_catalogs[fallback.key] = fallback.runtime_catalog
+                if fallback.activation is not None:
+                    activations[fallback.activation[0]] = fallback.activation[1]
+                readiness.append(fallback.proof)
+                served = fallback.proof.authorization
+                if alias.revision_id is not None:
+                    fallback_revisions[(alias.alias_name, alias.revision_id)] = _ServedFallback(
+                        alias_revision_id=served.alias_revision_id,
+                        catalog_sha256=served.catalog_sha256,
+                        target=served.target,
+                    )
+                _logger.warning(
+                    "gateway alias %r active revision pins an unservable snapshot (%s); "
+                    "serving last-good prior revision %r",
+                    alias.alias_name,
+                    exc,
+                    served.alias_revision_id,
+                )
+                continue
+            key = (revision_id, catalog_sha256)
+            runtime_catalog = RuntimeModelCatalog(catalog, environment=environment)
+            if alias.target_kind == "direct":
+                try:
+                    proof = _direct_readiness(manager, alias, normalized, runtime_catalog)
+                except (GatewayLifecycleError, ModelConnectionError, ModelCredentialError) as exc:
+                    if isinstance(exc, MissingModelCredentialError):
+                        unavailable_aliases.append((alias.alias_name, exc.detail))
+                        missing_credential_variables.add(exc.environment_variable)
+                    else:
+                        unavailable_aliases.append((alias.alias_name, str(exc)))
+                    continue
+                normalized_catalogs[key] = normalized
+                runtime_catalogs[key] = runtime_catalog
+                readiness.append(proof)
+                continue
+            if alias.target_kind != "project":
+                unavailable_aliases.append((alias.alias_name, "unknown target kind"))
+                continue
+            if project_repository is None:
+                unavailable_aliases.append(
+                    (alias.alias_name, "project alias requires a project activation repository")
+                )
+                continue
+            try:
+                project_ref = _required(alias.project_ref, "project reference", alias)
+                activation_ref = _required(alias.activation_ref, "activation reference", alias)
+                activation = project_repository.load(
+                    project_ref,
+                    activation_ref,
+                    runtime_catalog=runtime_catalog,
+                )
+                try:
+                    require_project_activation_authority(
+                        activation,
+                        project_ref=project_ref,
+                        activation_ref=activation_ref,
+                    )
+                except ProjectActivationError as exc:
+                    raise GatewayLifecycleError(str(exc)) from exc
+                runtime = RouterRuntime.from_activation(
+                    activation,
+                    runtime_catalog,
+                    decision_sink=decision_sink,
+                )
+                proof = _project_readiness(
+                    manager,
+                    alias,
+                    normalized,
+                    runtime,
+                    runtime_catalog,
+                    exact_models=exact_models,
+                )
+            except (
+                GatewayLifecycleError,
+                ModelConnectionError,
+                ModelCredentialError,
+                ProjectActivationError,
+                RouterRuntimeIntegrityError,
+            ) as exc:
                 if isinstance(exc, MissingModelCredentialError):
                     unavailable_aliases.append((alias.alias_name, exc.detail))
                     missing_credential_variables.add(exc.environment_variable)
                 else:
                     unavailable_aliases.append((alias.alias_name, str(exc)))
                 continue
+            activations[(project_ref, activation_ref, catalog_sha256)] = runtime
             normalized_catalogs[key] = normalized
             runtime_catalogs[key] = runtime_catalog
             readiness.append(proof)
-            continue
-        if alias.target_kind != "project":
-            unavailable_aliases.append((alias.alias_name, "unknown target kind"))
-            continue
-        if project_repository is None:
-            unavailable_aliases.append(
-                (alias.alias_name, "project alias requires a project activation repository")
+        except Exception as exc:  # noqa: BLE001 - exclude one bad alias; never abort the build.
+            _logger.warning(
+                "gateway alias %r failed to build and was excluded (UNAVAILABLE): %s",
+                alias.alias_name,
+                exc,
             )
-            continue
-        try:
-            project_ref = _required(alias.project_ref, "project reference", alias)
-            activation_ref = _required(alias.activation_ref, "activation reference", alias)
-            activation = project_repository.load(
-                project_ref,
-                activation_ref,
-                runtime_catalog=runtime_catalog,
-            )
-            try:
-                require_project_activation_authority(
-                    activation,
-                    project_ref=project_ref,
-                    activation_ref=activation_ref,
-                )
-            except ProjectActivationError as exc:
-                raise GatewayLifecycleError(str(exc)) from exc
-            runtime = RouterRuntime.from_activation(
-                activation,
-                runtime_catalog,
-                decision_sink=decision_sink,
-            )
-            proof = _project_readiness(
-                manager,
-                alias,
-                normalized,
-                runtime,
-                runtime_catalog,
-                exact_models=exact_models,
-            )
-        except RouterApplicationError as exc:
-            if not _caused_by_connection_error(exc):
-                raise
             unavailable_aliases.append((alias.alias_name, str(exc)))
             continue
-        except (
-            GatewayLifecycleError,
-            ModelConnectionError,
-            ModelCredentialError,
-            ProjectActivationError,
-            RouterRuntimeIntegrityError,
-        ) as exc:
-            if isinstance(exc, MissingModelCredentialError):
-                unavailable_aliases.append((alias.alias_name, exc.detail))
-                missing_credential_variables.add(exc.environment_variable)
-            else:
-                unavailable_aliases.append((alias.alias_name, str(exc)))
-            continue
-        activations[(project_ref, activation_ref, catalog_sha256)] = runtime
-        normalized_catalogs[key] = normalized
-        runtime_catalogs[key] = runtime_catalog
-        readiness.append(proof)
 
     if not readiness:
         unavailable = "; ".join(f"{name} ({why})" for name, why in sorted(unavailable_aliases))
@@ -723,6 +730,16 @@ def _load_alias_state(
         message = f"no granted active alias is locally available{detail}{remediation}"
         raise GatewayLifecycleError(message)
 
+    if unavailable_aliases:
+        # Countable, operator-visible signal (exclusion must never be silent): the
+        # stable "catalog.aliases_excluded" event alerts; the set rides the receipt.
+        excluded = ", ".join(name for name, _why in sorted(unavailable_aliases))
+        _logger.warning(
+            "catalog.aliases_excluded: %d excluded (UNAVAILABLE), serving %d: %s",
+            len(unavailable_aliases),
+            len(readiness),
+            excluded,
+        )
     return _AliasAuthorityState(
         authorities=frozenset(_authority_key(item) for item in readiness),
         normalized_catalogs=normalized_catalogs,
@@ -824,6 +841,26 @@ def _load_snapshot(
     return catalog, normalized
 
 
+def _require_native_servability(
+    alias: GatewayAliasView,
+    catalog: NormalizedGatewayCatalog,
+    runtime_catalog: RuntimeModelCatalog,
+) -> None:
+    """Fail readiness (excluding the alias) when the native engine cannot serve it.
+
+    Such an alias used to pass readiness then abort the whole worker at the fleet
+    startup gate; raising here excludes just it (UNAVAILABLE), never a fallback.
+    """
+    # Imported at call time to avoid a module import cycle.
+    from exp.runtime.gateway.native_execution import alias_native_blockers
+
+    reasons = alias_native_blockers(alias.alias_name, catalog, runtime_catalog)
+    if reasons:
+        raise GatewayLifecycleError(
+            f"alias {alias.alias_name!r} cannot be served natively: {'; '.join(reasons)}"
+        )
+
+
 def _direct_readiness(
     manager: GatewayManagement,
     alias: GatewayAliasView,
@@ -841,6 +878,7 @@ def _direct_readiness(
         if deployment is None:
             raise GatewayLifecycleError(f"alias {alias.alias_name!r} deployment is unavailable")
         runtime_catalog.resolve(deployment.source_alias)
+    _require_native_servability(alias, catalog, runtime_catalog)
     authorization = _readiness_authorization(
         manager,
         alias,
@@ -903,6 +941,7 @@ def _project_readiness(
             first_pool = pools[0]
     if first_pool is None:
         raise GatewayLifecycleError(f"project alias {alias.alias_name!r} has no candidates")
+    _require_native_servability(alias, catalog, runtime_catalog)
     authorization = _readiness_authorization(
         manager,
         alias,
@@ -918,16 +957,6 @@ def _project_readiness(
         pool_id=first_pool.pool_id,
         deployment_ids=first_pool.deployment_ids,
     )
-
-
-def _caused_by_connection_error(exception: BaseException) -> bool:
-    """Return whether a project activation failed only at local client construction."""
-    current: BaseException | None = exception
-    while current is not None:
-        if isinstance(current, (ModelConnectionError, ModelCredentialError)):
-            return True
-        current = current.__cause__
-    return False
 
 
 def _readiness_authorization(

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -53,7 +53,7 @@ from exp.runtime.gateway.lifecycle import (
     gateway_instance_lock,
     load_gateway_components,
 )
-from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.gateway.management import GatewayAliasView, GatewayManagement
 from exp.runtime.gateway.project_activation import ProjectActivation, ProjectActivationError
 from exp.runtime.gateway.routing import GatewayRoutingError
 from exp.runtime.models import RuntimeModelCatalog
@@ -322,6 +322,137 @@ def test_missing_secret_marks_only_its_direct_alias_unavailable(tmp_path: Path) 
     ((alias_name, reason),) = components.unavailable_aliases
     assert alias_name == "broken"
     assert "MISSING_PROVIDER_KEY" in reason
+    with pytest.raises(GatewayRoutingError):
+        _authorize(components, raw_key, "broken")
+
+
+def test_a_natively_unservable_alias_is_excluded_and_the_rest_serve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A half-activated alias whose only rung has no native dialect is excluded.
+
+    This is the incident's muse-glimmer shape: a never-activated model whose lone
+    rung was flipped active resolves to a provider with no native wire dialect. It
+    must not abort the whole worker at the startup gate (which took the fleet down);
+    the build marks it UNAVAILABLE and serves every other alias, and calling it
+    directly is a per-request failure, not a crash.
+    """
+    from exp.runtime.models.providers.errors import ProviderCapabilityError
+    from exp.runtime.models.providers.gemini import GeminiClient
+
+    def _no_native_dialect(self: GeminiClient) -> object:
+        del self
+        raise ProviderCapabilityError(capability="native_data_plane")
+
+    monkeypatch.setattr(GeminiClient, "gateway_wire_profile", _no_native_dialect)
+
+    manager, raw_key = _configured_gateway(tmp_path)
+    upsert_connection(
+        tmp_path,
+        name="gemini-main",
+        connection=ConnectionConfig(provider="gemini", api_key_env="TEST_GEMINI_KEY"),
+        replace=False,
+    )
+    normalized, snapshot, _changed = upsert_singleton_deployment(
+        tmp_path,
+        deployment_alias="muse-glimmer",
+        connection_name="gemini-main",
+        provider_model="muse-glimmer-exact",
+        exact_model_id="muse-glimmer-revision",
+        revision=None,
+        capabilities=ModelCapabilities(),
+        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+        prices=GatewayTokenPrices(),
+        pricing_source=None,
+        replace=False,
+    )
+    manager.activate_direct_alias(
+        alias_id="muse-glimmer",
+        alias_name="muse-glimmer",
+        revision_id="revision-muse",
+        pool_id="muse-glimmer",
+        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+        catalog_sha256=normalized.identity_sha256(),
+    )
+    manager.add_grant(identity_id="default", alias_id="muse-glimmer")
+
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "available", "TEST_GEMINI_KEY": "gemini-key"},
+    )
+
+    # The worker binds and serves the good alias; only the bad one is UNAVAILABLE.
+    assert _granted_authorities(components, raw_key) == {"coding": "revision-one"}
+    ((alias_name, reason),) = components.unavailable_aliases
+    assert alias_name == "muse-glimmer"
+    assert "cannot be served natively" in reason
+    assert "native dialect" in reason
+    with pytest.raises(GatewayRoutingError):
+        _authorize(components, raw_key, "muse-glimmer")
+
+
+def test_an_unexpected_error_building_one_alias_excludes_only_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unanticipated exception building one alias excludes just that alias.
+
+    No single malformed catalog row may abort the whole build (the startup-time
+    all-or-nothing build was the fleet-wide catalog outage's root cause), so even
+    an exception type the specific handlers do not anticipate is caught by the
+    per-alias backstop and marked UNAVAILABLE while the rest serve.
+    """
+    import exp.runtime.gateway.lifecycle as lifecycle_module
+
+    original_load_snapshot = lifecycle_module._load_snapshot
+
+    def _boom(manager: GatewayManagement, alias: GatewayAliasView) -> object:
+        if alias.alias_name == "broken":
+            raise RuntimeError("unexpected catalog build failure")
+        return original_load_snapshot(manager, alias)
+
+    monkeypatch.setattr(lifecycle_module, "_load_snapshot", _boom)
+
+    manager, raw_key = _configured_gateway(tmp_path)
+    upsert_connection(
+        tmp_path,
+        name="gemini-main",
+        connection=ConnectionConfig(provider="gemini", api_key_env="TEST_GEMINI_KEY"),
+        replace=False,
+    )
+    normalized, snapshot, _changed = upsert_singleton_deployment(
+        tmp_path,
+        deployment_alias="broken",
+        connection_name="gemini-main",
+        provider_model="broken-exact",
+        exact_model_id="broken-revision",
+        revision=None,
+        capabilities=ModelCapabilities(),
+        gateway_capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+        prices=GatewayTokenPrices(),
+        pricing_source=None,
+        replace=False,
+    )
+    manager.activate_direct_alias(
+        alias_id="broken",
+        alias_name="broken",
+        revision_id="revision-broken",
+        pool_id="broken",
+        snapshot_ref=f"catalog-snapshots/{snapshot.name}",
+        catalog_sha256=normalized.identity_sha256(),
+    )
+    manager.add_grant(identity_id="default", alias_id="broken")
+
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "available", "TEST_GEMINI_KEY": "gemini-key"},
+    )
+
+    assert _granted_authorities(components, raw_key) == {"coding": "revision-one"}
+    ((alias_name, reason),) = components.unavailable_aliases
+    assert alias_name == "broken"
+    assert "unexpected catalog build failure" in reason
     with pytest.raises(GatewayRoutingError):
         _authorize(components, raw_key, "broken")
 

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -17,7 +17,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from exp.common.core.artifacts import JsonObject
-from exp.common.models.gateway_catalog import ExactModelDeployment, FailoverMode
+from exp.common.models.gateway_catalog import (
+    ExactModelDeployment,
+    FailoverMode,
+    NormalizedGatewayCatalog,
+)
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     GatewayFailure,
@@ -577,14 +581,61 @@ def deployment_wire_entry(
     }
 
 
-def native_serving_blockers(components: LocalGatewayComponents) -> tuple[str, ...]:
-    """Name every granted alias the native engine cannot serve, with reasons.
+def alias_native_blockers(
+    alias: str,
+    normalized: NormalizedGatewayCatalog,
+    runtime_catalog: RuntimeModelCatalog,
+) -> tuple[str, ...]:
+    """Name why the native engine cannot serve one alias, or ``()`` if it can.
 
-    The launch runs this before binding the public socket: every
-    deployment reachable from a granted alias revision (direct pools and
-    project candidates alike live in the alias's catalog snapshot) must
-    resolve to a provider client with a native wire dialect, since no other
-    engine exists to serve the request.
+    Every deployment reachable from the alias's catalog snapshot (direct pools
+    and project candidates alike) must resolve to a provider client with a
+    native wire dialect and a valid wire contract, since no other engine exists
+    to serve the request. This is the per-alias servability check the catalog
+    build runs so a structurally unservable alias is excluded (marked
+    UNAVAILABLE) rather than aborting the whole build; the same check names the
+    fleet-level startup blockers.
+
+    Args:
+        alias: Public alias name, used only for the returned reason text.
+        normalized: The alias's normalized catalog snapshot.
+        runtime_catalog: The frozen runtime catalog for the alias's revision.
+
+    Returns:
+        Display-safe reasons the alias cannot be served natively, deduplicated,
+        or an empty tuple when every deployment resolves to a native wire.
+    """
+    reasons: list[str] = []
+    for deployment in normalized.deployments:
+        try:
+            resolved = runtime_catalog.resolve(deployment.source_alias)
+        except Exception:  # noqa: BLE001 - name the deployment, not the internals.
+            reasons.append(f"deployment {deployment.deployment_id!r} does not resolve")
+            continue
+        client = resolved.client
+        if not isinstance(client, NativeWireClient):
+            reasons.append(f"provider {deployment.provider!r} has no native wire profile")
+            continue
+        try:
+            _resolved_wire_profile(deployment, resolved)
+        except ProviderCapabilityError as exc:
+            if exc.capability != "native_data_plane":
+                raise
+            reasons.append(f"provider {deployment.provider!r} has no native dialect implementation")
+        except GatewayWireContractError:
+            reasons.append(
+                f"deployment {deployment.deployment_id!r} has an invalid reasoning wire contract"
+            )
+    return tuple(dict.fromkeys(reasons))
+
+
+def native_serving_blockers(components: LocalGatewayComponents) -> tuple[str, ...]:
+    """Name every loaded alias the native engine cannot serve, with reasons.
+
+    Diagnostic over the ready generation: the catalog build already excludes an
+    unservable alias, so this returns empty on a healthy worker. It stays as the
+    all-or-nothing gate for the single-alias owned project gateway, whose one
+    alias has nothing else to fall back to.
 
     Args:
         components: Loaded local gateway components.
@@ -600,31 +651,7 @@ def native_serving_blockers(components: LocalGatewayComponents) -> tuple[str, ..
         if runtime_catalog is None or normalized is None:
             blockers.append(f"{alias}: the authorized catalog snapshot is not loaded")
             continue
-        reasons: list[str] = []
-        for deployment in normalized.deployments:
-            try:
-                resolved = runtime_catalog.resolve(deployment.source_alias)
-            except Exception:  # noqa: BLE001 - name the deployment, not the internals.
-                reasons.append(f"deployment {deployment.deployment_id!r} does not resolve")
-                continue
-            client = resolved.client
-            if not isinstance(client, NativeWireClient):
-                reasons.append(f"provider {deployment.provider!r} has no native wire profile")
-                continue
-            try:
-                _resolved_wire_profile(deployment, resolved)
-            except ProviderCapabilityError as exc:
-                if exc.capability != "native_data_plane":
-                    raise
-                reasons.append(
-                    f"provider {deployment.provider!r} has no native dialect implementation"
-                )
-            except GatewayWireContractError:
-                reasons.append(
-                    f"deployment {deployment.deployment_id!r} has an invalid "
-                    "reasoning wire contract"
-                )
+        reasons = alias_native_blockers(alias, normalized, runtime_catalog)
         if reasons:
-            unique = ", ".join(dict.fromkeys(reasons))
-            blockers.append(f"{alias}: {unique}")
+            blockers.append(f"{alias}: {', '.join(reasons)}")
     return tuple(blockers)

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -356,17 +356,18 @@ def test_maximize_cache_still_fails_over_on_operational_deadness() -> None:
     assert candidate == 1
 
 
-def test_native_serving_blockers_name_dialectless_providers(
+def test_dialectless_provider_alias_is_excluded_not_a_startup_blocker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rust-only startup validation names every alias the engine cannot serve.
+    """A dialectless alias is excluded (UNAVAILABLE); the worker serves the rest.
 
     Every currently supported provider implements a native dialect, so the
     "no native dialect implementation" branch is exercised by patching a real
-    client's ``gateway_wire_profile`` back to the unimplemented base
-    behavior, rather than by a provider connection string this registry can
-    still resolve.
+    client's ``gateway_wire_profile`` back to the unimplemented base behavior.
+    Under the per-alias fail-safe build such an alias no longer aborts worker
+    startup: it is marked UNAVAILABLE and the build serves every other alias, so
+    the fleet-level ``native_serving_blockers`` diagnostic comes back clean.
     """
     from exp.common.models import (
         GatewayDeploymentCapabilities,
@@ -426,18 +427,28 @@ def test_native_serving_blockers_name_dialectless_providers(
             "TEST_GEMINI_KEY": "gemini-secret-canary",
         },
     )
-    blockers = native_serving_blockers(components)
-    assert len(blockers) == 1
-    assert blockers[0].startswith("escalated: ")
-    assert "gemini" in blockers[0]
-    assert "native dialect" in blockers[0]
+    # The dialectless alias is excluded at build, so the served generation has no
+    # blockers and the worker binds.
+    assert native_serving_blockers(components) == ()
+    unavailable = dict(components.unavailable_aliases)
+    assert "escalated" in unavailable
+    assert "gemini" in unavailable["escalated"]
+    assert "native dialect" in unavailable["escalated"]
+    # The other granted alias still loads and serves.
+    served = {alias for alias, _revision, _digest in components.reloader.state.authorities}
+    assert "coding" in served
+    assert "escalated" not in served
 
 
-def test_native_serving_blockers_name_reasoning_wire_contract_conflicts(
+def test_reasoning_wire_contract_conflict_excludes_the_alias(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rust startup rejects catalog reasoning metadata the provider profile cannot carry."""
+    """An alias whose reasoning metadata the provider profile cannot carry is excluded.
+
+    The build rejects the invalid reasoning wire contract per-alias (UNAVAILABLE)
+    instead of aborting the worker, so a servable alias still serves.
+    """
     from dataclasses import replace
 
     from exp.common.models import (
@@ -504,14 +515,20 @@ def test_native_serving_blockers_name_reasoning_wire_contract_conflicts(
     manager.add_grant(identity_id="default", alias_id="reasoning")
     components = load_gateway_components(
         tmp_path,
-        environment={"TEST_GEMINI_KEY": "gemini-secret-canary"},
+        environment={
+            "TEST_PROVIDER_KEY": "provider-secret-canary",
+            "TEST_GEMINI_KEY": "gemini-secret-canary",
+        },
     )
 
-    blockers = native_serving_blockers(components)
-
-    assert len(blockers) == 1
-    assert blockers[0].startswith("reasoning: ")
-    assert "invalid reasoning wire contract" in blockers[0]
+    # Excluded at build (UNAVAILABLE), not a fleet-wide startup blocker.
+    assert native_serving_blockers(components) == ()
+    unavailable = dict(components.unavailable_aliases)
+    assert "reasoning" in unavailable
+    assert "invalid reasoning wire contract" in unavailable["reasoning"]
+    served = {alias for alias, _revision, _digest in components.reloader.state.authorities}
+    assert "coding" in served
+    assert "reasoning" not in served
 
 
 def test_route_reorder_permutes_dispatch_order_and_rejects_non_permutations() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.27"
+version = "0.7.28"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.27"
+version = "0.7.28"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Incident

A burst of catalog rung-enable admin drafts crashed the **entire gateway worker fleet**: `catalog_sha256` went null, `/v1` returned 502 for *every* model until the drafts were reverted. This is guardrail #1 of five before retrying the fireworks enablement.

## Root cause (STEP 1)

The crash is an **all-or-nothing WORKER STARTUP build** — not a rebuild storm. The running-worker hot-reload path is already safe (`_AliasAuthorityReloader.refresh_if_drifted` keeps the previous generation on any failure), so the outage only surfaced once workers restarted and couldn't come back → fleet-wide crash-loop.

Two startup gaps:
- **Gap A** — `native_serving_blockers` (native_execution.py) was a hard startup gate: serve.py refused to bind the socket if *any* loaded alias was unservable, across *all* authorities. `_direct_readiness` never checked native dialect, so a half-activated alias (muse-glimmer's lone rung with no native dialect) passed readiness then tripped the gate → every model down.
- **Gap B** — `_load_alias_state`'s per-alias `except` caught only a narrow type set; `RuntimeModelCatalog(...)` was unguarded; the project path re-raised a non-connection `RouterApplicationError`. An unexpected exception building one alias aborted the whole build.

Existing #714/#722 roll-safety (schema-skew / dead-pin) does not cover a half-activated/malformed alias at build time — genuine gap.

## Fix (STEP 2) — per-alias fail-safe build

- **Gap A:** extracted `alias_native_blockers` from `native_serving_blockers`; the per-alias servability check now runs inside `_direct_readiness`/`_project_readiness` and raises `GatewayLifecycleError`, routing an unservable alias through the existing per-alias **exclusion** path. serve.py's worker startup gate is removed (the build self-excludes). The single-alias owned project gateway (`--project`, router/application.py) keeps the all-or-nothing gate — its one alias has nothing else to serve.
- **Gap B:** the per-alias loop body is wrapped in a catch-all backstop — any exception building one alias excludes just it (UNAVAILABLE) and the build serves the rest. Removed the now-unused `_caused_by_connection_error` re-raise.

## Guardrails (as approved)

1. **Visibility (never silent):** an excluded alias is absent from the served set (unlisted; a direct call 503s via `GatewayRoutingError`), rides the startup receipt's `unavailable_aliases`, and emits the countable `catalog.aliases_excluded` WARNING (there is no Python metrics counter in the gateway; the stable log line is the alertable signal — a monitor can also read the receipt).
2. **Backstop:** an entirely empty servable set still fails startup loud (`no granted active alias is locally available`).
3. **Rust-only preserved:** this is EXCLUSION, never a fallback — no alias is served through any non-native path.
4. **Startup-scoped:** the already-safe running-worker reload path is untouched.

## Tests (STEP 3)

- `test_a_natively_unservable_alias_is_excluded_and_the_rest_serve` — the **muse-glimmer shape** (active rung, never-activated, no native dialect): worker binds, serves `coding`, marks muse-glimmer UNAVAILABLE with the reason, and a direct call 503s.
- `test_an_unexpected_error_building_one_alias_excludes_only_it` — Gap B: an unanticipated `RuntimeError` building one alias excludes only it; the rest serve.
- The two `native_serving_blockers` tests move to the exclusion contract (build succeeds, alias excluded, `native_serving_blockers` returns clean).

`cargo` n/a (pure Python). `ruff format`/`ruff check`/`ty` clean; lifecycle.py at the 999-line limit (repo_layout_test green). 65 tests across lifecycle/native_execution/serve/router/layout pass.

## ⚠️ Contract flip to confirm on your pass

This deliberately flips the documented invariant "the worker fails startup if any granted alias resolves to a deployment without a native wire dialect" → "an unservable alias is excluded (UNAVAILABLE); the worker serves the rest." The engine repo's AGENTS.md is updated here. **The platform repo's AGENTS.md/CLAUDE.md also carry this invariant (referencing `explabs/gateway/native_host.py::native_serving_blockers`) — that wording needs a matching update in the platform repo when the 0.7.28 pin lands; I can't edit it from this engine PR.**

## Version

Engine 0.7.27 → 0.7.28. Pure Python — native unchanged (floor stays `>=0.3.22`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)