### PR TITLE
gateway: pin the upstream-abort hardening invariant (truncation matrix + h2 abort tests)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,12 +212,13 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "axum",
  "base64",
  "bytes",
  "futures-util",
+ "h2",
  "http",
  "http-body-util",
  "pyo3",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"
@@ -31,6 +31,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.10"
 thiserror = "2"
+
+[dev-dependencies]
+# Frame-level HTTP/2 server control for the reset/goaway regression tests:
+# the production wire to fronting proxies negotiates h2, so mid-stream aborts
+# arrive as RST_STREAM/GOAWAY, a different reqwest path than h1 truncation.
+h2 = "0.4"
 
 [profile.release]
 lto = "thin"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -534,3 +534,111 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod h2_abort_tests {
+    use super::*;
+    use crate::dialects::Dialect;
+    use crate::events::Event;
+
+    fn sse_chunk(text: &str) -> Bytes {
+        Bytes::from(format!(
+            "data: {{\"choices\":[{{\"delta\":{{\"content\":\"{text}\"}}}}]}}\n\n"
+        ))
+    }
+
+    /// Serve one h2c response that streams two deltas, then abort it the
+    /// given way after a pacing delay so the client is mid-body when the
+    /// abort lands (mirroring a proxy whose upstream dies mid-response).
+    async fn relay_over_h2(reset_stream: bool) -> (Vec<Event>, Failure) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let address = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let (socket, _peer) = listener.accept().await.expect("accept");
+            let mut connection = h2::server::handshake(socket).await.expect("handshake");
+            let accepted = connection.accept().await;
+            // The connection must keep being polled for handshake frames and
+            // window updates to reach the peer.
+            let driver = tokio::spawn(async move {
+                let _ = futures_util::future::poll_fn(|cx| connection.poll_closed(cx)).await;
+            });
+            if let Some(Ok((_request, mut respond))) = accepted {
+                let response = http::Response::builder()
+                    .status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(())
+                    .expect("response");
+                let mut stream = respond.send_response(response, false).expect("headers");
+                stream.send_data(sse_chunk("hi"), false).expect("data one");
+                stream
+                    .send_data(sse_chunk("there"), false)
+                    .expect("data two");
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                if reset_stream {
+                    // The exact shape a fronting proxy (Caddy) produces when
+                    // its own upstream aborts: the h2 stream resets.
+                    stream.send_reset(h2::Reason::INTERNAL_ERROR);
+                    let _ = driver.await;
+                } else {
+                    // Whole-connection abort: every multiplexed stream on the
+                    // connection severs at once.
+                    driver.abort();
+                    drop(stream);
+                }
+            }
+        });
+        let client = reqwest::Client::builder()
+            .http2_prior_knowledge()
+            .build()
+            .expect("client");
+        let response = client
+            .post(format!("http://{address}/v1/chat/completions"))
+            .body("{}")
+            .send()
+            .await
+            .expect("send");
+        let mut relay = UpstreamRelay::new(
+            response,
+            Dialect::OpenAiCompatible,
+            Instant::now() + Duration::from_secs(5),
+        );
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let per_chunk = Duration::from_secs(5);
+        let mut events = Vec::new();
+        loop {
+            match relay.next_event(deadline, per_chunk, Instant::now()).await {
+                Ok(Some(event)) => events.push(event),
+                Ok(None) => panic!("an aborted stream must surface a failure, not clean EOF"),
+                Err(failure) => return (events, failure),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn an_h2_stream_reset_mid_stream_classifies_and_never_panics() {
+        // Production wire fact (verified live 2026-09-03): the house-lane
+        // proxy negotiates ALPN h2, so its "aborting with incomplete
+        // response" reaches this relay as RST_STREAM, never h1 truncation.
+        let (events, failure) = relay_over_h2(true).await;
+        assert!(
+            matches!(events.as_slice(), [Event::TextDelta(a), Event::TextDelta(b)] if a == "hi" && b == "there"),
+            "delivered deltas precede the abort: {events:?}"
+        );
+        assert_eq!(failure.failure_class, FailureClass::Transport);
+        assert!(failure.failover_eligible, "an aborted rung fails over");
+    }
+
+    #[tokio::test]
+    async fn an_h2_connection_drop_mid_stream_classifies_and_never_panics() {
+        let (events, failure) = relay_over_h2(false).await;
+        assert_eq!(
+            events.len(),
+            2,
+            "delivered deltas precede the abort: {events:?}"
+        );
+        assert_eq!(failure.failure_class, FailureClass::Transport);
+        assert!(failure.failover_eligible);
+    }
+}

--- a/exp/runtime/gateway/tests/native_truncation_test.py
+++ b/exp/runtime/gateway/tests/native_truncation_test.py
@@ -1,0 +1,306 @@
+"""Upstream-truncation hardening: every abort classifies, the process never dies.
+
+Production evidence (2026-09-03): a fronting proxy on a house lane aborts
+with incomplete responses mid-stream ~20 times a day. Every such abort must
+end that one request with a classified failure (or serve the partial); the
+serving process must survive every truncation offset class. The native h2
+abort shapes (RST_STREAM, connection drop) are covered at the relay layer in
+``relay.rs``; this matrix drives the h1 chunked wire end to end through a
+real serving subprocess so a regression that kills the process fails loudly
+here first.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+
+pytest.importorskip("exp_gateway_native")
+
+_HOST = "127.0.0.1"
+
+_DRIVER_SOURCE = textwrap.dedent(
+    '''
+    """Serve the native gateway engine over one seeded root until SIGTERM."""
+
+    import json
+    import os
+    import socket
+    import sys
+    from pathlib import Path
+
+    from exp.runtime.gateway.lifecycle import load_gateway_components
+    from exp.runtime.gateway.native_bridge import NativeControlPlane
+
+    import exp_gateway_native
+
+
+    def main() -> None:
+        """Compose the control plane, announce the public port, and serve."""
+        config = json.loads(sys.argv[1])
+        components = load_gateway_components(
+            Path(config["root"]),
+            environment={"TEST_PROVIDER_KEY": os.environ["TEST_PROVIDER_KEY"]},
+        )
+        control_plane = NativeControlPlane(components, request_timeout_seconds=30.0)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+        sys.stdout.write(json.dumps({"port": port}) + "\\n")
+        sys.stdout.flush()
+        exp_gateway_native.serve(
+            control_plane,
+            json.dumps(
+                {
+                    "host": "127.0.0.1",
+                    "port": port,
+                    "max_active_requests": 8,
+                    "request_timeout_seconds": 30.0,
+                    "graceful_timeout_seconds": 2.0,
+                }
+            ),
+        )
+
+
+    main()
+    '''
+)
+
+
+def _sse_response() -> bytes:
+    """One chunked SSE response shaped like real tool-calling chat traffic."""
+    frames: list[bytes] = []
+
+    def chunk(delta: dict[str, object], finish: str | None = None) -> bytes:
+        payload = {
+            "id": "chatcmpl-x",
+            "object": "chat.completion.chunk",
+            "created": 1700000000,
+            "model": "m",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+        }
+        return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n".encode()
+
+    frames.append(chunk({"role": "assistant", "content": ""}))
+    frames.append(chunk({"content": "Let mé check."}))
+    frames.append(
+        chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_a1",
+                        "type": "function",
+                        "function": {"name": "run_command", "arguments": ""},
+                    }
+                ]
+            }
+        )
+    )
+    for piece in ('{"comm', 'and": "ls -la\\u00e9",', ' "cwd": "/tmp"}'):
+        frames.append(chunk({"tool_calls": [{"index": 0, "function": {"arguments": piece}}]}))
+    frames.append(chunk({}, finish="tool_calls"))
+    usage_frame = {
+        "id": "chatcmpl-x",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "m",
+        "choices": [],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 6, "total_tokens": 15},
+    }
+    frames.append(f"data: {json.dumps(usage_frame)}\n\n".encode())
+    frames.append(b"data: [DONE]\n\n")
+    body = b""
+    for frame in frames:
+        body += f"{len(frame):x}\r\n".encode() + frame + b"\r\n"
+    body += b"0\r\n\r\n"
+    head = (
+        b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\n\r\n"
+    )
+    return head + body
+
+
+def _offset_classes(response: bytes) -> dict[str, int]:
+    """One representative byte offset per truncation class."""
+    head_end = response.index(b"\r\n\r\n") + 4
+    first_frame = response.index(b"data: ")
+    mid_utf8 = response.index("é".encode()) + 1  # between the two utf8 bytes
+    mid_args = response.index(b'"cwd') + 2
+    between = response.index(b"\r\n", first_frame + 10) + 2
+    return {
+        "nothing": 0,
+        "mid_status_line": 6,
+        "mid_headers": head_end - 9,
+        "headers_only": head_end,
+        "mid_chunk_length_header": head_end + 1,
+        "mid_first_frame": first_frame + 25,
+        "mid_utf8_codepoint": mid_utf8,
+        "between_frames": between,
+        "mid_tool_arguments": mid_args,
+        "before_final_chunk": len(response) - 5,
+        "complete": len(response),
+    }
+
+
+class _TruncatingUpstream(threading.Thread):
+    """Raw-socket chunked SSE upstream truncating at a controlled offset."""
+
+    def __init__(self) -> None:
+        """Bind the listener and precompute the full response."""
+        super().__init__(daemon=True)
+        self.response = _sse_response()
+        self.offset = len(self.response)
+        self.mode = "fin"
+        self.listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.listener.bind((_HOST, 0))
+        self.listener.listen(16)
+        self.port = self.listener.getsockname()[1]
+
+    def run(self) -> None:
+        """Serve one truncated response per connection until closed."""
+        while True:
+            try:
+                conn, _peer = self.listener.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn: socket.socket) -> None:
+        """Drain the request, send the truncated response, close per mode."""
+        try:
+            conn.settimeout(10)
+            data = b""
+            while b"\r\n\r\n" not in data:
+                data += conn.recv(65536)
+            head, _sep, rest = data.partition(b"\r\n\r\n")
+            length = 0
+            for line in head.split(b"\r\n"):
+                if line.lower().startswith(b"content-length:"):
+                    length = int(line.split(b":")[1])
+            while len(rest) < length:
+                rest += conn.recv(65536)
+            conn.sendall(self.response[: self.offset])
+            if self.mode == "rst":
+                conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+            conn.close()
+        except OSError:
+            conn.close()
+
+
+@pytest.fixture(scope="module", name="setup")
+def _setup(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple]:
+    """One truncating upstream, one live native engine subprocess."""
+    upstream = _TruncatingUpstream()
+    upstream.start()
+    root = tmp_path_factory.mktemp("truncation-root")
+    _manager, raw_key = _configured_gateway(root, base_url=f"http://{_HOST}:{upstream.port}/v1")
+    driver = root / "driver.py"
+    driver.write_text(_DRIVER_SOURCE + "\n")
+    stderr_log = (root / "driver-stderr.log").open("wb")
+    process = subprocess.Popen(  # noqa: S603 - the interpreter runs our generated driver.
+        [sys.executable, str(driver), json.dumps({"root": str(root)})],
+        stdout=subprocess.PIPE,
+        stderr=stderr_log,
+        env={**__import__("os").environ, "TEST_PROVIDER_KEY": "provider-secret-canary"},
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        port = int(json.loads(process.stdout.readline())["port"])
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                live = httpx.get(f"http://{_HOST}:{port}/health/live", timeout=1.0)
+                if live.status_code == 200:
+                    break
+            except httpx.HTTPError:
+                pass
+            assert process.poll() is None, Path(stderr_log.name).read_text()
+            assert time.monotonic() < deadline, "engine never became live"
+            time.sleep(0.05)
+        yield upstream, process, port, raw_key
+    finally:
+        if process.poll() is None:
+            process.send_signal(signal.SIGTERM)
+        process.wait(timeout=20)
+        stderr_log.close()
+        upstream.listener.close()
+
+
+def test_every_truncation_class_classifies_and_the_process_survives(setup: tuple) -> None:
+    """The hardening invariant: aborts classify, the engine never dies.
+
+    Every truncation offset class, over both close modes and both response
+    modes, must end as a classified public failure (or the served partial)
+    while the serving process stays alive and live-probing green. A process
+    death here is the prod pod-crash class regardless of which offset
+    triggered it.
+    """
+    upstream, process, port, raw_key = setup
+    classes = _offset_classes(upstream.response)
+    surfaces: tuple[tuple[str, str, dict[str, object]], ...] = (
+        (
+            "chat-stream",
+            "/v1/chat/completions",
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 64,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            },
+        ),
+        (
+            "chat-nonstream",
+            "/v1/chat/completions",
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 64,
+            },
+        ),
+        (
+            "responses-stream",
+            "/v1/responses",
+            {"model": "coding", "input": "hi", "max_output_tokens": 64, "stream": True},
+        ),
+    )
+    outcomes: dict[str, str] = {}
+    for mode in ("fin", "rst"):
+        for surface, path, body in surfaces:
+            for name, offset in classes.items():
+                upstream.offset = offset
+                upstream.mode = mode
+                try:
+                    reply = httpx.post(
+                        f"http://{_HOST}:{port}{path}",
+                        headers={"authorization": f"Bearer {raw_key}"},
+                        json=body,
+                        timeout=30.0,
+                    )
+                    outcome = str(reply.status_code)
+                    assert reply.status_code in {200, 502}, (name, mode, surface, reply.text)
+                except httpx.HTTPError as error:
+                    outcome = type(error).__name__
+                outcomes[f"{mode}:{surface}:{name}"] = outcome
+                assert process.poll() is None, (
+                    f"the serving process died on truncation class {name!r} "
+                    f"(mode={mode}, surface={surface}); outcomes so far: {outcomes}"
+                )
+    live = httpx.get(f"http://{_HOST}:{port}/health/live", timeout=2.0)
+    assert live.status_code == 200

--- a/exp/runtime/gateway/tests/native_truncation_test.py
+++ b/exp/runtime/gateway/tests/native_truncation_test.py
@@ -286,18 +286,17 @@ def test_every_truncation_class_classifies_and_the_process_survives(setup: tuple
             for name, offset in classes.items():
                 upstream.offset = offset
                 upstream.mode = mode
-                try:
-                    reply = httpx.post(
-                        f"http://{_HOST}:{port}{path}",
-                        headers={"authorization": f"Bearer {raw_key}"},
-                        json=body,
-                        timeout=30.0,
-                    )
-                    outcome = str(reply.status_code)
-                    assert reply.status_code in {200, 502}, (name, mode, surface, reply.text)
-                except httpx.HTTPError as error:
-                    outcome = type(error).__name__
-                outcomes[f"{mode}:{surface}:{name}"] = outcome
+                # No exception tolerance: a client-side transport or protocol
+                # error would mean the WORKER severed or corrupted its own
+                # response, which is exactly the failure the invariant forbids.
+                reply = httpx.post(
+                    f"http://{_HOST}:{port}{path}",
+                    headers={"authorization": f"Bearer {raw_key}"},
+                    json=body,
+                    timeout=30.0,
+                )
+                assert reply.status_code in {200, 502}, (name, mode, surface, reply.text)
+                outcomes[f"{mode}:{surface}:{name}"] = str(reply.status_code)
                 assert process.poll() is None, (
                     f"the serving process died on truncation class {name!r} "
                     f"(mode={mode}, surface={surface}); outcomes so far: {outcomes}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.22,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.23,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Context

Prod gateway-worker pods are dying time-correlated with the deepseek-v4-flash house lane's fronting proxy logging "aborting with incomplete response" mid-stream (4 deaths across 20 aborts in 14h, all on deployment mp-1f2496a4, terminal_state=unknown_after_crash). Team-lead ordered a repro harness at controlled byte offsets through the native data plane, a fix if a killing offset class exists, and a committed hardening matrix regardless.

## What the hunt found

- **h1 truncation is exonerated.** An `.agents/` sweep (not committed) drove ~8,000 scenarios against a real serving subprocess on 0.7.25: every byte offset of a deepseek-shaped tool-call SSE response (872B, then 2,606B with streamed tool arguments and raw UTF-8) x FIN and RST closes x streamed/non-streamed x slow-reading clients x 16-way concurrent abort storms x delayed mid-stream aborts. Zero process deaths, zero health-probe failures; every abort classified (502 `all_routes_failed` or served-partial 200).
- **The production wire is HTTP/2.** Live ALPN probe of the house lane's base URL negotiates `h2` over TLSv1.3, so prod aborts arrive as `RST_STREAM`/`GOAWAY` frames — a different reqwest/hyper path than h1 truncation, and one h2 connection multiplexes many streams (matches the whole-pod blast radius).
- **The relay layer handles both h2 abort shapes correctly** (proven by the new Rust tests below): delivered deltas surface first, then a classified, failover-eligible `Transport` failure. No panic.
- The remaining crash hypotheses (hyper h2-internal path above the relay, OOM, liveness-probe kill) need the pod's previous-termination evidence, which team-lead is pulling. If that surfaces a real vector, the fix rides a follow-up; this PR pins the invariant the incident violates so it can never regress silently.

## What this ships

1. **`exp/runtime/gateway/tests/native_truncation_test.py`** — end-to-end truncation matrix. A raw-socket chunked-SSE upstream truncates at one representative offset per class (nothing / mid-status-line / mid-headers / headers-only / mid-chunk-length-header / mid-first-frame / mid-raw-UTF-8-codepoint / between-frames / mid-tool-call-arguments / before-final-chunk / complete) x FIN and RST x three surfaces (chat-stream, chat-nonstream, responses-stream), 66 scenarios against a real `exp_gateway_native.serve` subprocess. Every request must return 200 or 502, `process.poll()` must stay alive after every single request, and `/health/live` must be green at the end.
2. **`relay.rs` h2 abort regression tests** — an h2c frame-level server (new dev-dependency `h2 = "0.4"`) sends two SSE DATA frames then either `RST_STREAM(INTERNAL_ERROR)` or a whole-connection drop while the client is mid-body. Both must yield the delivered `TextDelta`s followed by a failover-eligible `FailureClass::Transport`, never a panic.
3. Crate 0.3.22 -> 0.3.23 (test-only change: dev-dependency + `#[cfg(test)]` modules; no data-plane behavior change) with the usual pin/lock chores.

## Validation

- `uv run pytest -q` on the committed tree: 3376 passed, 6 skipped
- `cargo test --no-default-features` (PYO3_PYTHON pinned to the worktree venv): 145 passed, incl. the 2 new h2 tests
- `cargo clippy --all-targets --no-default-features`: clean; `cargo fmt --check`: clean
- `ruff format` / `ruff check` / `ty check`: clean

Target: next release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)