### PR TITLE
gateway: make catalog identity additive-stable (exclude-default serialization, schema v3)

### DIFF
--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -719,10 +719,32 @@ class ModelRoles(ContractModel):
         return self
 
 
+SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION = 10_000
+"""Upper bound on an authored catalog version this parser accepts as real.
+
+Mirrors the normalized snapshot's sane-range posture: no product will ever ship
+this many authored-catalog schema revisions, so a value beyond it is corruption
+and fails closed rather than being read as a future contract.
+"""
+
+
 class ModelCatalog(ContractModel):
     """The local model aliases, connection metadata, and project role assignments."""
 
-    schema_version: Literal[2] = 2
+    schema_version: int = Field(default=2, ge=2, le=SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION)
+    """Authored catalog contract revision. Deliberately NOT a ``Literal``.
+
+    Every cross-version hydration parses the authored document first, and a
+    changed ``Literal`` value on a known field raises ``literal_error``, which
+    the forward-compatible read path cannot drop — so a literal here makes any
+    future authored revision warm-fatal on every older pod (the same outage
+    class as the 09-02 catalog incident). A newer stamp within the sane range
+    parses under this build's semantics instead. That makes additive revisions
+    safe by construction; a revision that REINTERPRETS existing fields must not
+    reuse this channel — it needs a new field name or a fleet-first tolerance
+    release. Version 1 stays rejected here: it is only readable through
+    ``_migrate_legacy_model_catalog`` on the TOML load path.
+    """
     connections: dict[str, ConnectionConfig]
     models: dict[str, ModelRecord]
     gateway_pools: dict[str, GatewayPoolRecord] = Field(default_factory=dict)

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -25,7 +25,10 @@ from exp.common.models import (
     load_model_catalog,
     write_model_catalog,
 )
-from exp.common.models.catalog import infer_azure_api_surface
+from exp.common.models.catalog import (
+    SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION,
+    infer_azure_api_surface,
+)
 
 
 def _catalog() -> ModelCatalog:
@@ -169,6 +172,34 @@ def test_legacy_catalog_rejects_noninteger_schema_one_lookalikes(
 
     with pytest.raises(ModelCatalogError, match="schema_version must be an integer"):
         load_model_catalog(path)
+
+
+def test_authored_schema_version_window_and_shape_are_pinned() -> None:
+    """Change-detector for the authored catalog contract every hydration parses first.
+
+    The version is a sane-ranged int, never a ``Literal``: a changed literal on
+    a known field raises ``literal_error``, which the forward-compatible read
+    path cannot drop, so a literal bump would warm-fail every older pod (the
+    09-02 incident class on the authored side). If this test fails you changed
+    the authored contract: an additive field is fine (old read-tolerant parsers
+    drop it) — update the fingerprint; narrowing the version window back to a
+    literal, or a revision that reinterprets existing fields, needs a new field
+    name or a fleet-first tolerance release instead.
+    """
+    authored = _catalog().model_dump(mode="json")
+    for accepted in (2, 3, SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION):
+        parsed = ModelCatalog.model_validate({**authored, "schema_version": accepted})
+        assert parsed.schema_version == accepted
+    for rejected in (0, 1, SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION + 1):
+        with pytest.raises(ValidationError):
+            ModelCatalog.model_validate({**authored, "schema_version": rejected})
+    assert sorted(ModelCatalog.model_fields) == [
+        "connections",
+        "gateway_pools",
+        "models",
+        "roles",
+        "schema_version",
+    ]
 
 
 def test_legacy_catalog_recursively_migrates_sft_base_model_billing(tmp_path: Path) -> None:

--- a/exp/common/models/gateway_catalog.py
+++ b/exp/common/models/gateway_catalog.py
@@ -24,11 +24,15 @@ ExactModelPoolId = ArtifactId
 GATEWAY_EXCLUDED_PROVIDERS = frozenset({"tinker"})
 """Runtime-resolvable providers whose records never become gateway deployments."""
 
-SNAPSHOT_SCHEMA_VERSION = 2
+SNAPSHOT_SCHEMA_VERSION = 3
 """Normalized-catalog schema version this engine build reads and writes.
 
-Every change to the normalized catalog schema or its normalization output MUST
-bump this in the same PR (the roll-safety CI guard enforces it). A rolling
+Every change that alters the IDENTITY serialization of the normalized catalog
+MUST bump this in the same PR (the pinned-digest change-detector test enforces
+it). Since version 3 the identity serialization excludes every field that holds
+its declared default, so ADDING a defaulted field to any model in the catalog
+graph does not alter identity and needs no bump; changing a default, renaming
+or removing a field, or changing normalization output still does. A rolling
 deploy runs two builds at once; a stored snapshot whose ``schema_version``
 differs from this constant is a cross-version skew that the reader serves
 through the tolerant path (its own leniently parsed view keyed by the pinned
@@ -145,8 +149,20 @@ class NormalizedGatewayCatalog(ContractModel):
         return self
 
     def identity_sha256(self) -> Sha256:
-        """Return the deterministic digest pinned by a later gateway activation."""
-        return sha256_json(self)
+        """Return the deterministic digest pinned by a later gateway activation.
+
+        The digest covers only fields that differ from their declared defaults,
+        recursively, so an engine release that ADDS a defaulted field anywhere
+        in the catalog graph reproduces every existing digest unchanged (three
+        consecutive releases perturbing every published digest through additive
+        capability flags is the incident this exclusion ends). A field set
+        explicitly to its default is identical to leaving it unset, which is
+        the contract-equivalence identity wants. ``schema_version`` itself is
+        default-excluded too: cross-build reproducibility of the digest is the
+        point, while roll skew stays detectable from the STORED serialization,
+        which remains a full dump.
+        """
+        return sha256_json(self.model_dump(mode="json", by_alias=True, exclude_defaults=True))
 
 
 def normalize_gateway_catalog(catalog: ModelCatalog) -> NormalizedGatewayCatalog:
@@ -382,7 +398,12 @@ def _pop_location(root: object, location: tuple[str | int, ...]) -> bool:
 
 
 def _capability_declaration_sha256(capabilities: ModelCapabilities | None) -> Sha256:
-    """Hash the full catalog declaration without changing frozen capability identity.
+    """Hash the authored catalog declaration without changing frozen capability identity.
+
+    Default-holding fields are excluded so an engine release that adds a
+    defaulted capability flag reproduces every existing declaration digest
+    (and therefore every singleton ``exact_model_id``) unchanged. ``None``
+    stays distinct from an all-default declaration.
 
     Args:
         capabilities: Existing authored capabilities, or ``None`` when undeclared.
@@ -391,7 +412,9 @@ def _capability_declaration_sha256(capabilities: ModelCapabilities | None) -> Sh
         Digest used only by singleton gateway migration identity.
     """
     return sha256_json(
-        None if capabilities is None else capabilities.model_dump(mode="json", exclude_none=False)
+        None
+        if capabilities is None
+        else capabilities.model_dump(mode="json", by_alias=True, exclude_defaults=True)
     )
 
 

--- a/exp/common/models/gateway_catalog_test.py
+++ b/exp/common/models/gateway_catalog_test.py
@@ -15,7 +15,9 @@ from exp.common.models.catalog import (
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
     GatewayEquivalenceCertification,
+    GatewayLongContextTier,
     GatewayPoolRecord,
+    GatewayTokenPrices,
     ModelCatalog,
     ModelRecord,
     SFTModelProvenance,
@@ -132,15 +134,133 @@ def test_read_pinned_snapshot_serves_a_cross_version_snapshot_without_the_digest
     assert served.pools[0].pool_id == "dep-1"
 
 
+def _identity_fixture_catalog() -> ModelCatalog:
+    """One frozen authored catalog exercising every identity-bearing surface.
+
+    Mixes default and non-default values on purpose: nested gateway capability
+    flags, integer prices with a long-context tier, an authored capability
+    declaration, both billing sources, a certified non-default-failover pool,
+    and a bare all-default record. Never edit this fixture to make a test
+    pass; it is the pinned input of the identity change-detector.
+    """
+    certification = GatewayEquivalenceCertification(
+        certification_id="certification-pinned",
+        provenance="operator comparison run 2026-09-01",
+        evidence_sha256=_DIGEST,
+        certified_at=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+    return ModelCatalog(
+        connections={
+            "openai": ConnectionConfig(provider="openai"),
+            "local": ConnectionConfig(
+                provider="openai-compatible", base_url="https://local.example.test/v1"
+            ),
+        },
+        models={
+            "rich": ModelRecord(
+                connection="local",
+                model="provider-rich",
+                revision="2026-09-01",
+                billing_source=BillingSource.HOST_MANAGED,
+                capabilities=ModelCapabilities(supports_reasoning=True, reasoning_effort="low"),
+                gateway=GatewayDeploymentMetadata(
+                    exact_model_id="exact-certified",
+                    capabilities=GatewayDeploymentCapabilities(
+                        supports_streaming=True, supports_image_input=True
+                    ),
+                    prices=GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=150,
+                        output_micro_usd_per_million_tokens=600,
+                        long_context=GatewayLongContextTier(
+                            input_threshold_tokens=200_000,
+                            input_micro_usd_per_million_tokens=300,
+                        ),
+                    ),
+                ),
+            ),
+            "twin": ModelRecord(
+                connection="openai",
+                model="provider-twin",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+                gateway=GatewayDeploymentMetadata(exact_model_id="exact-certified"),
+            ),
+            "bare": ModelRecord(
+                connection="openai",
+                model="provider-bare",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+            ),
+        },
+        gateway_pools={
+            "certified-pool": GatewayPoolRecord(
+                exact_model_id="exact-certified",
+                deployment_aliases=("rich", "twin"),
+                equivalence=certification,
+                failover_mode="maximize_cache",
+            )
+        },
+    )
+
+
+def test_identity_digest_is_pinned_until_a_deliberate_schema_version_bump() -> None:
+    """The identity serialization of a frozen fixture cannot drift silently.
+
+    Three consecutive releases (0.7.22, 0.7.23, 0.7.25) each added defaulted
+    capability flags that serialized into every published digest without a
+    ``SNAPSHOT_SCHEMA_VERSION`` bump, so every catalog read in a mixed-version
+    fleet failed its own digest check. If this test fails you changed the
+    identity serialization; there are exactly two lawful outs:
+
+    - You ADDED a field: give it a default. Identity excludes default-holding
+      fields, so a properly defaulted addition never trips this test at all.
+    - You deliberately changed identity output (default change, rename,
+      removal, normalization change): bump ``SNAPSHOT_SCHEMA_VERSION`` and
+      repin BOTH values below in the same change.
+    """
+    normalized = normalize_gateway_catalog(_identity_fixture_catalog())
+    assert (SNAPSHOT_SCHEMA_VERSION, normalized.identity_sha256()) == (
+        3,
+        "f9e74a42f5b47ec0a0739836ef15bbfa36df4eaa7c34efee10c421d46962529f",
+    )
+
+
+def test_added_defaulted_fields_and_explicit_defaults_do_not_perturb_identity() -> None:
+    """Identity is stable across additive schema growth and default spelling.
+
+    A default-constructed nested declaration must contribute zero identity
+    bytes (that is what makes a new defaulted field identity-invisible), and a
+    field spelled explicitly at its default must hash identically to leaving
+    it unset.
+    """
+    for model in (
+        GatewayDeploymentCapabilities(),
+        GatewayTokenPrices(),
+        GatewayDeploymentMetadata(),
+        ModelCapabilities(),
+        NormalizedGatewayCatalog(),
+    ):
+        assert model.model_dump(mode="json", by_alias=True, exclude_defaults=True) == {}
+
+    explicit = _identity_fixture_catalog().model_copy(deep=True)
+    spelled = explicit.models["bare"].model_copy(
+        update={"gateway": GatewayDeploymentMetadata(capabilities=GatewayDeploymentCapabilities())}
+    )
+    respelled = explicit.model_copy(update={"models": {**explicit.models, "bare": spelled}})
+    assert (
+        normalize_gateway_catalog(respelled).identity_sha256()
+        == normalize_gateway_catalog(_identity_fixture_catalog()).identity_sha256()
+    )
+
+
 def test_normalized_schema_change_requires_a_schema_version_bump() -> None:
     """Anti-regression change-detector for the roll-safety contract.
 
     A rolling deploy detects a cross-version snapshot only by ``schema_version``,
-    so every change to the normalized-catalog schema (or its normalization
-    output) MUST bump ``SNAPSHOT_SCHEMA_VERSION`` in the same change. If this
-    fails, you changed the schema: bump ``SNAPSHOT_SCHEMA_VERSION`` and update
-    the pinned fingerprint below together, so the reader keeps serving old and
-    new pods through a roll instead of hard-failing.
+    so every change to the normalized-catalog TOP-LEVEL shape MUST bump
+    ``SNAPSHOT_SCHEMA_VERSION`` in the same change (nested additive growth is
+    covered by the pinned identity digest test above, which defaulted fields
+    pass automatically). If this fails, bump ``SNAPSHOT_SCHEMA_VERSION`` and
+    update the pinned fingerprint below together, so the reader keeps serving
+    old and new pods through a roll instead of hard-failing.
     """
     fingerprint = {
         "schema_version": SNAPSHOT_SCHEMA_VERSION,
@@ -149,7 +269,7 @@ def test_normalized_schema_change_requires_a_schema_version_bump() -> None:
         "pool": sorted(ExactModelPool.model_fields),
     }
     assert fingerprint == {
-        "schema_version": 2,
+        "schema_version": 3,
         "normalized": ["deployments", "pools", "schema_version"],
         "deployment": [
             "billing_source",

--- a/exp/runtime/gateway/catalog_authority.py
+++ b/exp/runtime/gateway/catalog_authority.py
@@ -582,9 +582,9 @@ def _write_catalog_snapshot(
         # Content-addressed, but never trust a pre-existing file blindly: a
         # stale or partially written `<sha>.json` (a crash between the atomic
         # temp write and its rename, a restored backup) whose bytes no longer
-        # hash to its own name would otherwise be pinned as a self-inconsistent
-        # snapshot and 503 every alias on it. Rewrite whenever the on-disk bytes
-        # differ, exactly as the authored companion above already does.
+        # serialize the catalog its name pins would otherwise be pinned as a
+        # self-inconsistent snapshot and 503 every alias on it. Rewrite whenever
+        # the on-disk bytes differ, exactly as the authored companion above.
         write_bytes_atomic(snapshot, normalized_bytes, follow_symlinks=False)
         os.chmod(snapshot, 0o600)
     return snapshot

--- a/exp/runtime/gateway/catalog_authority_test.py
+++ b/exp/runtime/gateway/catalog_authority_test.py
@@ -22,6 +22,7 @@ from exp.common.models import (
     ModelRecord,
     ModelRoles,
     normalize_gateway_catalog,
+    read_pinned_normalized_snapshot,
     write_model_catalog,
 )
 from exp.runtime.gateway.catalog_authority import (
@@ -94,10 +95,10 @@ def test_rejected_singleton_deployment_leaves_the_authored_catalog_unchanged(
 
 
 def test_write_catalog_snapshot_repairs_a_stale_content_addressed_file(tmp_path: Path) -> None:
-    """C1 root-cause fix: a normalized snapshot whose on-disk bytes no longer hash
-    to their own content-addressed name (a stale or partially written file) is
-    rewritten instead of blindly trusted, so a self-inconsistent snapshot can
-    never be pinned by this write path."""
+    """C1 root-cause fix: a normalized snapshot whose on-disk bytes no longer
+    serialize the catalog its content-addressed name pins (a stale or partially
+    written file) is rewritten instead of blindly trusted, so a self-inconsistent
+    snapshot can never be pinned by this write path."""
     catalog = ModelCatalog(
         connections={"openai": ConnectionConfig(provider="openai")},
         models={
@@ -111,15 +112,25 @@ def test_write_catalog_snapshot_repairs_a_stale_content_addressed_file(tmp_path:
     normalized = normalize_gateway_catalog(catalog)
 
     snapshot = _write_catalog_snapshot(tmp_path, catalog, normalized)
-    assert sha256(snapshot.read_bytes()).hexdigest() == normalized.identity_sha256()
+    # The name pins the identity digest; the stored bytes are the FULL dump
+    # (schema_version kept for roll-skew detection), so the pinned-reader
+    # round-trip, not a raw byte hash, is what proves content addressing.
+    assert snapshot.name == f"{normalized.identity_sha256()}.json"
+    assert (
+        read_pinned_normalized_snapshot(snapshot.read_bytes(), normalized.identity_sha256())
+        == normalized
+    )
 
     # A stale/corrupt file already sitting at the content-addressed path.
     snapshot.write_bytes(b'{"stale": true}')
     repaired = _write_catalog_snapshot(tmp_path, catalog, normalized)
 
     assert repaired == snapshot
-    # The bytes on disk once again hash to their own content-addressed name.
-    assert sha256(snapshot.read_bytes()).hexdigest() == normalized.identity_sha256()
+    # The bytes on disk once again serialize the catalog the name pins.
+    assert (
+        read_pinned_normalized_snapshot(snapshot.read_bytes(), normalized.identity_sha256())
+        == normalized
+    )
 
 
 def test_valid_singleton_deployment_still_persists_after_validation(tmp_path: Path) -> None:


### PR DESCRIPTION
## DO NOT MERGE until the platform's skew-tolerant published-snapshot reader is confirmed live in production

This change deliberately moves every catalog digest one final time (schema v3). It must roll only into a fleet whose platform reader tolerates a pinned digest it cannot re-derive; team-lead confirms when that hotfix is deployed.

## Incident this ends

The published catalog snapshot failed digest verification on every worker read from 09-02 07:22Z. Root cause (catalog-heal's byte-level repro + this audit): `NormalizedGatewayCatalog`'s identity serialization changed in three consecutive releases without a `SNAPSHOT_SCHEMA_VERSION` bump, so mixed-pin fleets failed the same-version strict digest check on every read:

| Release | Identity change | Bump? |
|---|---|---|
| 0.7.22 | `GatewayDeploymentCapabilities` + `supports_image_input`, `supports_image_url_input` | no (stayed 1) |
| 0.7.23 | + `supports_video_input`, `supports_video_url_input`, `supports_pdf_input`, `supports_pdf_url_input` | no |
| 0.7.24 | none | — |
| 0.7.25 | + `supports_audio_input` (audited: this is the whole identity delta, the third distinct digest) | no |

Each new `bool = False` serialized (`exclude_none=False`) into all ~3k deployments — thousands of leaf diffs, new digest, unchanged version. The existing change-detector (`test_normalized_schema_change_requires_a_schema_version_bump`) fingerprints only the TOP-LEVEL field names of the three normalized models, so nested growth never tripped it.

## The fix: additive fields can no longer change identity

`identity_sha256()` and `_capability_declaration_sha256()` now serialize with `exclude_defaults=True` (recursive, `default_factory`-aware). A field holding its declared default contributes zero identity bytes, so:

- adding a defaulted field anywhere in the catalog graph reproduces every existing digest and every singleton `exact_model_id` unchanged — no bump needed, ever, for additive growth;
- an explicitly spelled default hashes identically to leaving the field unset (contract equivalence);
- `schema_version` itself is default-excluded from identity, so future bumps also stop moving digests; roll-skew detection is unaffected because stored snapshot files keep the FULL dump with `schema_version` persisted (`is_foreign_snapshot` reads the stored value).

Consequence: snapshot files are no longer byte-addressed by name (name = identity digest, bytes = full dump). Nothing in the codebase relied on that byte equality except one test assertion, now replaced with the pinned-reader round-trip; `read_pinned_normalized_snapshot`, `budgets`, `sqlite.platform`, `routing`, and `lifecycle` all verify identity from the parsed model already.

`SNAPSHOT_SCHEMA_VERSION` 2 -> 3: this PR is itself an identity change and follows its own rule (2 is unreleased, but previews may have run main).

## The detector that makes silent violation impossible

`test_identity_digest_is_pinned_until_a_deliberate_schema_version_bump`: a frozen fixture catalog (nested non-default capability flags, integer prices + long-context tier, authored capabilities, both billing sources, certified `maximize_cache` pool, bare all-default record) must produce exactly the pinned `(SNAPSHOT_SCHEMA_VERSION, identity_sha256)` pair. Two lawful outs, stated in the failure text: default the new field (identity ignores it — the test passes untouched), or bump and repin together. A companion test pins the additive-stability property itself (every default-constructed nested declaration dumps to `{}` under identity serialization, and an explicitly spelled default catalog hashes equal). The top-level shape fingerprint test remains for structural changes.

## Validation

- Full `uv run pytest -q` on the committed tree: 3377 passed, 6 skipped
- `ruff format` / `ruff check` / `ty check`: clean
- No `native/` changes; no crate bump needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Finding 6 (routed from platform #1156's review): the authored literal was the same timebomb

`ModelCatalog.schema_version` was `Literal[2]` — and the authored document is what every cross-version hydration parses FIRST. A future literal bump raises `literal_error` on older pods, which `load_forward_compatible` cannot drop (it only removes unknown extras), so the platform tolerance never gets a parsed document to serve: warm-fatal on old pods plus the heal-pass mass-deactivation hazard return, relocated one document over.

Fixed here by de-literaling: `schema_version` is now a sane-ranged int (`ge=2, le=10_000`, mirroring `is_foreign_snapshot`'s posture), so additive authored revisions are roll-safe by construction; the field docstring pins the rule that a revision reinterpreting EXISTING fields must use a new field name or a fleet-first tolerance release. Version 1 stays rejected at validation (migration-path only) and the bool/float lookalike validator stays. A dedicated change-detector pins the acceptance window and the authored top-level field fingerprint. No identity movement — the pinned normalized fixture digest is untouched.
