### PR TITLE
gateway: accept DashScope's empty restated tool-call id on argument deltas (crate 0.3.23)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -816,15 +816,20 @@ impl Normalizer {
                                 malformed("OpenAI-compatible tool function must be an object")
                             })?;
                     if let Some(tool) = self.tools.get(&index) {
+                        // An identity is only restated when it is non-empty:
+                        // DashScope (Qwen) argument deltas carry `"id": ""`
+                        // (documented shape, live 2026-09-03), and an empty
+                        // placeholder names nothing, so only a different
+                        // NON-EMPTY id or name is a stream that changed identity.
                         if let Some(Value::String(repeated_id)) = item.get("id") {
-                            if repeated_id != &tool.call_id {
+                            if !repeated_id.is_empty() && repeated_id != &tool.call_id {
                                 return Err(malformed(
                                     "OpenAI-compatible stream changed a tool-call ID",
                                 ));
                             }
                         }
                         if let Some(Value::String(repeated_name)) = function.get("name") {
-                            if repeated_name != &tool.name {
+                            if !repeated_name.is_empty() && repeated_name != &tool.name {
                                 return Err(malformed(
                                     "OpenAI-compatible stream changed a tool-call name",
                                 ));

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -329,3 +329,117 @@ fn completed_reasoning_items_pass_encrypted_content_through() {
         ] if item_id.as_deref() == Some("rs_2")
     ));
 }
+
+fn compatible_chunk(delta: serde_json::Value, finish_reason: Option<&str>) -> SseEvent {
+    SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "chatcmpl-dashscope",
+            "object": "chat.completion.chunk",
+            "created": 1_788_425_855,
+            "model": "qwen3.8-flash",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        })
+        .to_string(),
+    }
+}
+
+#[test]
+fn dashscope_argument_deltas_restate_an_empty_tool_call_id() {
+    // DashScope's documented (and live, 2026-09-03) OpenAI-compatible tool
+    // stream: the first delta names the call, every later argument delta
+    // restates `"id": ""` with a null name. An empty placeholder is not a
+    // changed identity, so the call must accumulate and complete normally
+    // (this exact shape 502'd every qwen tool call as malformed_response).
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    assert!(normalizer
+        .feed(&compatible_chunk(
+            serde_json::json!({"role": "assistant", "content": ""}),
+            None,
+        ))
+        .expect("role delta must normalize")
+        .is_empty());
+    let started = normalizer
+        .feed(&compatible_chunk(
+            serde_json::json!({"tool_calls": [{
+                "index": 0,
+                "id": "call_8f08d2b0fc0c4d8fab7123",
+                "type": "function",
+                "function": {"name": "get_current_weather", "arguments": "{\"location\":"},
+            }]}),
+            None,
+        ))
+        .expect("first tool delta must normalize");
+    assert!(matches!(
+        started.as_slice(),
+        [
+            Event::ToolCallStarted { call_id, name, .. },
+            Event::ToolArgumentsDelta { delta, .. },
+        ] if call_id == "call_8f08d2b0fc0c4d8fab7123"
+            && name == "get_current_weather"
+            && delta == "{\"location\":"
+    ));
+    let continued = normalizer
+        .feed(&compatible_chunk(
+            serde_json::json!({"tool_calls": [{
+                "index": 0,
+                "id": "",
+                "type": "function",
+                "function": {"arguments": " \"Hangzhou\"}", "name": null},
+            }]}),
+            None,
+        ))
+        .expect("an empty restated id is a placeholder, not a changed identity");
+    assert!(matches!(
+        continued.as_slice(),
+        [Event::ToolArgumentsDelta { delta, .. }] if delta == " \"Hangzhou\"}"
+    ));
+    assert!(normalizer
+        .feed(&compatible_chunk(serde_json::json!({}), Some("tool_calls")))
+        .expect("finish chunk must normalize")
+        .is_empty());
+    let done = SseEvent {
+        event: None,
+        data: "[DONE]".to_string(),
+    };
+    let events = normalizer.feed(&done).expect("stream must complete");
+    assert!(matches!(
+        events.as_slice(),
+        [Event::ToolCallCompleted { call, .. }, Event::Completed]
+            if call.call_id == "call_8f08d2b0fc0c4d8fab7123"
+                && call.name == "get_current_weather"
+                && call.raw_arguments == "{\"location\": \"Hangzhou\"}"
+    ));
+}
+
+#[test]
+fn compatible_stream_still_rejects_a_changed_non_empty_tool_call_identity() {
+    // The identity guard keeps its teeth: a later delta naming a DIFFERENT
+    // non-empty id or name is still a malformed stream.
+    for (id, name) in [("call_other", "get_current_weather"), ("call_1", "other_tool")] {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+        normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"tool_calls": [{
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_current_weather", "arguments": ""},
+                }]}),
+                None,
+            ))
+            .expect("first tool delta must normalize");
+        let failure = normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"tool_calls": [{
+                    "index": 0,
+                    "id": id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": "{}"},
+                }]}),
+                None,
+            ))
+            .expect_err("a changed non-empty identity must stay malformed");
+        assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+    }
+}

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -416,7 +416,10 @@ fn dashscope_argument_deltas_restate_an_empty_tool_call_id() {
 fn compatible_stream_still_rejects_a_changed_non_empty_tool_call_identity() {
     // The identity guard keeps its teeth: a later delta naming a DIFFERENT
     // non-empty id or name is still a malformed stream.
-    for (id, name) in [("call_other", "get_current_weather"), ("call_1", "other_tool")] {
+    for (id, name) in [
+        ("call_other", "get_current_weather"),
+        ("call_1", "other_tool"),
+    ] {
         let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
         normalizer
             .feed(&compatible_chunk(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.22,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.23,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Problem

Every tool-carrying request to a DashScope-served model (platform `qwen` house lane, e.g. `qwen3.8-flash`) fails 502 `all_routes_failed` / `malformed_response` — on the streaming AND the buffered surface (upstream is always streamed). Reproduced live on prod 2026-09-03: the gateway emits `ToolCallStarted` + one argument delta, then the stream dies with "provider returned a malformed response".

## Root cause

`exp/runtime/gateway/native/src/dialects/openai.rs` (`feed_openai_compatible`, tool_calls branch): the identity guard rejects any restated `id`/`name` that differs from the accumulator. DashScope's documented stream shape carries the id and name only on the FIRST delta and restates `"id": ""` (with `name: null`) on every later argument delta ([Model Studio function-calling docs](https://www.alibabacloud.com/help/en/model-studio/qwen-function-calling), streaming example: `ChoiceDeltaToolCall(index=0, id='', function=ChoiceDeltaToolCallFunction(arguments=' "Hangzhou"}', name=None), type='function')`). `"" != "call_…"` → `malformed("OpenAI-compatible stream changed a tool-call ID")`.

## Fix

An empty placeholder names nothing: only a different **non-empty** id or name is a changed identity. Two-line predicate change; the guard keeps its teeth for real identity changes.

## Tests

- `dashscope_argument_deltas_restate_an_empty_tool_call_id` — the documented DashScope shape end to end: start → empty-id argument delta → `finish_reason: tool_calls` → `[DONE]` completes with the accumulated arguments `{"location": "Hangzhou"}`.
- `compatible_stream_still_rejects_a_changed_non_empty_tool_call_identity` — a differing non-empty id, and a differing non-empty name, still fail `MalformedResponse`.

`cargo test --no-default-features`: 145 passed. `cargo clippy --no-default-features --all-targets -D warnings`: clean.

## Release mechanics

Crate `0.3.22 → 0.3.23` (Cargo.toml + crate pyproject), `Cargo.lock` via `cargo update -p exp-gateway-native --offline`, root pin floor `exp-gateway-native>=0.3.23`, `uv lock` relocked. Python-side untouched.

## Platform follow-up

Platform pins `exp-gateway-native==0.3.19` (`experiential==0.7.24`); picking this up needs the next engine release + a platform pin bump, then a live `qwen3.8-flash` + tools probe through `/v1/chat/completions` (currently 502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
