### PR TITLE
gateway: fold additive reasoning tokens into output_tokens on the Gemini and Chat Completions wires

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -215,12 +215,15 @@ of `output_tokens` and `cached_input_tokens` a subset of `input_tokens`, and set
 subset at its own rate and the remainder at the base rate. Wires that report reasoning outside
 their output total are folded by the native usage mappers before the counts leave the data plane:
 Gemini `thoughtsTokenCount` is additive by Google's definition and always folds into
-`output_tokens`; on Chat Completions a `reasoning_tokens` count above `completion_tokens` is
-impossible under subset semantics, so it identifies an additive provider (xAI, natively or relayed
-by Azure Foundry) and folds, while OpenAI, OpenRouter, Fireworks, and DeepSeek pass through
-untouched. Anthropic and Bedrock bill thinking inside their output total and publish no separate
-count, so their reasoning subset stays unknown. The customer-visible `completion_tokens` and
-`total_tokens` therefore match what is billed on every lane.
+`output_tokens`; on the OpenAI-shaped wires (Chat Completions and Responses) the provider's own
+`total_tokens` decides: `input + output` is the subset shape (OpenAI, OpenRouter, Fireworks,
+DeepSeek) and passes through untouched, `input + output + reasoning` is the additive shape (xAI,
+natively or relayed by Azure Foundry) and folds; without a decisive total, a reasoning count above
+the output total folds. Anthropic and Bedrock bill thinking inside their output total and publish
+no separate count, so their reasoning subset stays unknown. The customer-visible `completion_tokens`
+and `total_tokens` therefore match what is billed. Note that an additive provider's `max_tokens`
+bounds only its visible answer, so a folded output total can exceed the caller's cap that the
+reservation ceiling was computed from; settlement charges the exact folded total.
 
 Each physical attempt records its own provider, model, usage, latency, terminal state, estimated
 cost attribution, and frozen credential-ownership billing source. Later catalog activation and

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -210,6 +210,18 @@ while keyed replay creates no new reservation. A period is the immutable UTC buc
 month. Management and remaining-allocation reports are CLI surfaces only. There is no budgets
 dashboard.
 
+Normalized usage follows OpenAI subset semantics on every wire: `reasoning_tokens` counts a subset
+of `output_tokens` and `cached_input_tokens` a subset of `input_tokens`, and settlement prices the
+subset at its own rate and the remainder at the base rate. Wires that report reasoning outside
+their output total are folded by the native usage mappers before the counts leave the data plane:
+Gemini `thoughtsTokenCount` is additive by Google's definition and always folds into
+`output_tokens`; on Chat Completions a `reasoning_tokens` count above `completion_tokens` is
+impossible under subset semantics, so it identifies an additive provider (xAI, natively or relayed
+by Azure Foundry) and folds, while OpenAI, OpenRouter, Fireworks, and DeepSeek pass through
+untouched. Anthropic and Bedrock bill thinking inside their output total and publish no separate
+count, so their reasoning subset stays unknown. The customer-visible `completion_tokens` and
+`total_tokens` therefore match what is billed on every lane.
+
 Each physical attempt records its own provider, model, usage, latency, terminal state, estimated
 cost attribution, and frozen credential-ownership billing source. Later catalog activation and
 process restart never rewrite that source. Schema-v1/v2 attempt rows migrate explicitly as

--- a/exp/runtime/gateway/budgets.py
+++ b/exp/runtime/gateway/budgets.py
@@ -856,19 +856,15 @@ def _unknown_token_volume(
 ) -> tuple[int, int]:
     """Sum observed token volume across one limit's unresolved unknown-cost attempts.
 
-    Input volume includes cached input tokens and output volume includes reasoning
-    tokens, so operators can gauge the real traffic behind attempts whose price is
-    still unknown.
+    Cached-input and reasoning counts are subsets of the input and output totals
+    (``GatewayUsage``), so the totals alone gauge the real traffic behind attempts
+    whose price is still unknown.
     """
     row = connection.execute(
         """
         SELECT
-            COALESCE(SUM(
-                COALESCE(a.input_tokens, 0) + COALESCE(a.cached_input_tokens, 0)
-            ), 0) AS input_volume,
-            COALESCE(SUM(
-                COALESCE(a.output_tokens, 0) + COALESCE(a.reasoning_tokens, 0)
-            ), 0) AS output_volume
+            COALESCE(SUM(COALESCE(a.input_tokens, 0)), 0) AS input_volume,
+            COALESCE(SUM(COALESCE(a.output_tokens, 0)), 0) AS output_volume
         FROM gateway_attempt_budget_charges AS c
         JOIN gateway_attempts AS a ON a.attempt_id = c.attempt_id
         WHERE c.budget_id = ?

--- a/exp/runtime/gateway/budgets_test.py
+++ b/exp/runtime/gateway/budgets_test.py
@@ -528,7 +528,9 @@ def test_default_limit_admits_unpriced_attempts_and_tracks_token_volume(
     remaining = budgets.remaining(organization_id="org", period="2026-08")[0]
     assert remaining.unknown_cost_attempts == 1
     assert remaining.unknown_cost_input_tokens == 120
-    assert remaining.unknown_cost_output_tokens == 20
+    # Reasoning is a subset of output_tokens, so the volume gauge reports the
+    # output total once rather than adding the subset a second time.
+    assert remaining.unknown_cost_output_tokens == 16
     assert remaining.remaining_micro_usd == 1_000
     assert not remaining.exhausted
 

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -12,8 +12,8 @@ use super::{
 use crate::encode::compact_json;
 use crate::errors::Failure;
 use crate::events::{
-    count_if_present, count_or_zero, require_string, require_u64, Event, ToolAccumulator, Usage,
-    MAXIMUM_LEDGER_COUNT,
+    bounded_ledger_sum, count_if_present, count_or_zero, require_string, require_u64, Event,
+    ToolAccumulator, Usage,
 };
 
 impl Normalizer {
@@ -271,17 +271,11 @@ impl Normalizer {
             }
             "message_stop" => {
                 events.extend(finish_open_tools(&mut self.tools)?);
-                // Individually persistable legs whose folded total is not
-                // are a provider contract violation, exactly like the
-                // Bedrock cache-leg fold.
-                let input_tokens = self
-                    .input_tokens
-                    .checked_add(self.cache_read)
-                    .and_then(|total| total.checked_add(self.cache_write))
-                    .filter(|total| *total <= MAXIMUM_LEDGER_COUNT)
-                    .ok_or_else(|| {
-                        malformed("Anthropic input token total overflows a persistable count")
-                    })?;
+                let input_tokens = bounded_ledger_sum(
+                    &[self.input_tokens, self.cache_read, self.cache_write],
+                    "Anthropic input",
+                )
+                .map_err(|message| malformed(&message))?;
                 events.push(Event::Usage(Usage {
                     input_tokens: Some(input_tokens),
                     output_tokens: Some(self.output_tokens),
@@ -374,46 +368,6 @@ mod tests {
             events.as_slice(),
             [Event::RedactedThinking { index: 1, data }] if data == "opaque=="
         ));
-    }
-
-    #[test]
-    fn thinking_usage_forwards_output_tokens_with_no_reasoning_subset() {
-        // Anthropic bills extended thinking inside output_tokens and publishes
-        // no separate thinking count, so the normalized usage forwards the
-        // provider total as reported and leaves the reasoning subset unknown
-        // rather than inventing one; the subset contract holds trivially.
-        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
-        let start_message = frame(serde_json::json!({
-            "type": "message_start",
-            "message": {"usage": {"input_tokens": 41, "output_tokens": 3}},
-        }));
-        assert!(normalizer.feed(&start_message).expect("start").is_empty());
-        let thinking = frame(serde_json::json!({
-            "type": "content_block_start",
-            "index": 0,
-            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
-        }));
-        assert!(normalizer
-            .feed(&thinking)
-            .expect("thinking start")
-            .is_empty());
-        let message_delta = frame(serde_json::json!({
-            "type": "message_delta",
-            "delta": {"stop_reason": "end_turn", "stop_sequence": null},
-            "usage": {"input_tokens": 41, "output_tokens": 412},
-        }));
-        assert!(normalizer.feed(&message_delta).expect("delta").is_empty());
-        let events = normalizer
-            .feed(&frame(serde_json::json!({"type": "message_stop"})))
-            .expect("message stop");
-        match events.as_slice() {
-            [Event::Usage(usage), Event::Completed] => {
-                assert_eq!(usage.input_tokens, Some(41));
-                assert_eq!(usage.output_tokens, Some(412));
-                assert_eq!(usage.reasoning_tokens, None);
-            }
-            other => panic!("unexpected events: {other:?}"),
-        }
     }
 
     /// Frame shapes captured live from one web_search stream (2026-08-31):
@@ -531,6 +485,9 @@ mod tests {
                 assert_eq!(usage.input_tokens, Some(12294));
                 assert_eq!(usage.output_tokens, Some(103));
                 assert_eq!(usage.cached_input_tokens, Some(4));
+                // Anthropic bills thinking inside output_tokens and publishes
+                // no separate count, so the reasoning subset stays unknown.
+                assert_eq!(usage.reasoning_tokens, None);
             }
             other => panic!("unexpected events: {other:?}"),
         }

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -376,6 +376,46 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn thinking_usage_forwards_output_tokens_with_no_reasoning_subset() {
+        // Anthropic bills extended thinking inside output_tokens and publishes
+        // no separate thinking count, so the normalized usage forwards the
+        // provider total as reported and leaves the reasoning subset unknown
+        // rather than inventing one; the subset contract holds trivially.
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let start_message = frame(serde_json::json!({
+            "type": "message_start",
+            "message": {"usage": {"input_tokens": 41, "output_tokens": 3}},
+        }));
+        assert!(normalizer.feed(&start_message).expect("start").is_empty());
+        let thinking = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+        }));
+        assert!(normalizer
+            .feed(&thinking)
+            .expect("thinking start")
+            .is_empty());
+        let message_delta = frame(serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+            "usage": {"input_tokens": 41, "output_tokens": 412},
+        }));
+        assert!(normalizer.feed(&message_delta).expect("delta").is_empty());
+        let events = normalizer
+            .feed(&frame(serde_json::json!({"type": "message_stop"})))
+            .expect("message stop");
+        match events.as_slice() {
+            [Event::Usage(usage), Event::Completed] => {
+                assert_eq!(usage.input_tokens, Some(41));
+                assert_eq!(usage.output_tokens, Some(412));
+                assert_eq!(usage.reasoning_tokens, None);
+            }
+            other => panic!("unexpected events: {other:?}"),
+        }
+    }
+
     /// Frame shapes captured live from one web_search stream (2026-08-31):
     /// server tool use with a leading empty input fragment, the whole result
     /// in its start frame, a cited answer, terminal usage that supersedes the

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -1,5 +1,4 @@
-//! Gemini `streamGenerateContent` frame mapping, mirroring the python
-//! `_gemini_events` mapper, plus its golden-fixture tests.
+//! Gemini `streamGenerateContent` frame mapping plus its golden-fixture tests.
 
 use serde_json::Value;
 
@@ -8,11 +7,11 @@ use crate::errors::{Failure, FailureClass};
 use crate::events::{gemini_usage, require_string, Event, ToolAccumulator};
 
 impl Normalizer {
-    /// Normalize one Gemini `streamGenerateContent` SSE frame, mirroring the
-    /// `_gemini_events` mapper: reasoning parts are skipped, whole function
-    /// calls expand to start/arguments/completed, and the terminal candidate
-    /// flushes the latest usage before its finish reason maps to the shared
-    /// completion, incomplete, refusal, or provider-internal outcome.
+    /// Normalize one Gemini `streamGenerateContent` SSE frame: reasoning parts
+    /// are skipped, whole function calls expand to start/arguments/completed,
+    /// and the terminal candidate flushes the latest usage before its finish
+    /// reason maps to the shared completion, incomplete, refusal, or
+    /// provider-internal outcome.
     pub(super) fn feed_gemini(
         &mut self,
         frame: &crate::sse::SseEvent,
@@ -228,23 +227,21 @@ mod gemini_tests {
 
     #[test]
     fn gemini_thinking_stream_folds_thoughts_into_the_terminal_usage() {
-        // Verbatim frames from gemini-3.7-flash streamGenerateContent?alt=sse
-        // (2026-09-03): every chunk carries the full usageMetadata, the final
-        // chunk adds the thoughtSignature part and STOP. Google's
-        // totalTokenCount (11 + 7 + 654 = 672) shows thoughts are additive, so
-        // the normalized output total is 661 with 654 as the reasoning subset.
-        let usage_metadata = json!({
-            "promptTokenCount": 11,
-            "candidatesTokenCount": 7,
-            "totalTokenCount": 672,
-            "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
-            "thoughtsTokenCount": 654,
-            "serviceTier": "standard",
-        });
+        // Frame shapes from gemini-3.7-flash streamGenerateContent?alt=sse
+        // (2026-09-03): every chunk carries usageMetadata, the final chunk
+        // adds the thoughtSignature part and STOP. The terminal chunk's counts
+        // win over the earlier partial ones, and Google's totalTokenCount
+        // (11 + 7 + 654 = 672) shows thoughts are additive, so the normalized
+        // output total is 661 with 654 as the reasoning subset.
         let chunks = [
             sse(&json!({
                 "candidates": [{"content": {"parts": [{"text": "Sunlight scatters off air "}], "role": "model"}, "index": 0}],
-                "usageMetadata": usage_metadata,
+                "usageMetadata": {
+                    "promptTokenCount": 11,
+                    "candidatesTokenCount": 3,
+                    "totalTokenCount": 668,
+                    "thoughtsTokenCount": 654,
+                },
                 "modelVersion": "gemini-3.7-flash",
                 "responseId": "resp-1",
             })),
@@ -254,7 +251,14 @@ mod gemini_tests {
                     "finishReason": "STOP",
                     "index": 0,
                 }],
-                "usageMetadata": usage_metadata,
+                "usageMetadata": {
+                    "promptTokenCount": 11,
+                    "candidatesTokenCount": 7,
+                    "totalTokenCount": 672,
+                    "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+                    "thoughtsTokenCount": 654,
+                    "serviceTier": "standard",
+                },
                 "modelVersion": "gemini-3.7-flash",
                 "responseId": "resp-1",
             })),
@@ -277,41 +281,6 @@ mod gemini_tests {
                 json!({"kind": "completed"}),
             ]
         );
-    }
-
-    #[test]
-    fn gemini_stream_without_thinking_keeps_the_reasoning_subset_unknown() {
-        // Verbatim usageMetadata from gemini-2.5-flash with thinkingBudget 0:
-        // no thoughtsTokenCount is published, so nothing folds and the subset
-        // stays unknown rather than being invented as zero.
-        let chunks = [sse(&json!({
-            "candidates": [{
-                "content": {"parts": [{"text": "Air scatters blue light most."}], "role": "model"},
-                "finishReason": "STOP",
-                "index": 0,
-            }],
-            "usageMetadata": {
-                "promptTokenCount": 11,
-                "candidatesTokenCount": 9,
-                "totalTokenCount": 20,
-                "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
-                "serviceTier": "standard",
-            },
-        }))];
-        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
-        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
-        assert!(failure.is_none());
-        assert_eq!(
-            events[1],
-            json!({
-                "kind": "usage",
-                "input_tokens": 11,
-                "output_tokens": 9,
-                "cached_input_tokens": 0,
-                "reasoning_tokens": null,
-            })
-        );
-        assert_eq!(events[2], json!({"kind": "completed"}));
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -211,16 +211,107 @@ mod gemini_tests {
                     "name": "lookup",
                     "raw_arguments": raw_arguments,
                 }),
+                // thoughtsTokenCount is additive on the Gemini wire, so the
+                // output total carries the folded 5 + 3 and reasoning names
+                // the subset.
                 json!({
                     "kind": "usage",
                     "input_tokens": 11,
-                    "output_tokens": 5,
+                    "output_tokens": 8,
                     "cached_input_tokens": 2,
                     "reasoning_tokens": 3,
                 }),
                 json!({"kind": "completed"}),
             ]
         );
+    }
+
+    #[test]
+    fn gemini_thinking_stream_folds_thoughts_into_the_terminal_usage() {
+        // Verbatim frames from gemini-3.7-flash streamGenerateContent?alt=sse
+        // (2026-09-03): every chunk carries the full usageMetadata, the final
+        // chunk adds the thoughtSignature part and STOP. Google's
+        // totalTokenCount (11 + 7 + 654 = 672) shows thoughts are additive, so
+        // the normalized output total is 661 with 654 as the reasoning subset.
+        let usage_metadata = json!({
+            "promptTokenCount": 11,
+            "candidatesTokenCount": 7,
+            "totalTokenCount": 672,
+            "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+            "thoughtsTokenCount": 654,
+            "serviceTier": "standard",
+        });
+        let chunks = [
+            sse(&json!({
+                "candidates": [{"content": {"parts": [{"text": "Sunlight scatters off air "}], "role": "model"}, "index": 0}],
+                "usageMetadata": usage_metadata,
+                "modelVersion": "gemini-3.7-flash",
+                "responseId": "resp-1",
+            })),
+            sse(&json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "molecules.", "thoughtSignature": "CikB"}], "role": "model"},
+                    "finishReason": "STOP",
+                    "index": 0,
+                }],
+                "usageMetadata": usage_metadata,
+                "modelVersion": "gemini-3.7-flash",
+                "responseId": "resp-1",
+            })),
+        ];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(failure.is_none());
+        assert_eq!(
+            events,
+            vec![
+                json!({"kind": "text_delta", "text": "Sunlight scatters off air "}),
+                json!({"kind": "text_delta", "text": "molecules."}),
+                json!({
+                    "kind": "usage",
+                    "input_tokens": 11,
+                    "output_tokens": 661,
+                    "cached_input_tokens": 0,
+                    "reasoning_tokens": 654,
+                }),
+                json!({"kind": "completed"}),
+            ]
+        );
+    }
+
+    #[test]
+    fn gemini_stream_without_thinking_keeps_the_reasoning_subset_unknown() {
+        // Verbatim usageMetadata from gemini-2.5-flash with thinkingBudget 0:
+        // no thoughtsTokenCount is published, so nothing folds and the subset
+        // stays unknown rather than being invented as zero.
+        let chunks = [sse(&json!({
+            "candidates": [{
+                "content": {"parts": [{"text": "Air scatters blue light most."}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 11,
+                "candidatesTokenCount": 9,
+                "totalTokenCount": 20,
+                "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+                "serviceTier": "standard",
+            },
+        }))];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(failure.is_none());
+        assert_eq!(
+            events[1],
+            json!({
+                "kind": "usage",
+                "input_tokens": 11,
+                "output_tokens": 9,
+                "cached_input_tokens": 0,
+                "reasoning_tokens": null,
+            })
+        );
+        assert_eq!(events[2], json!({"kind": "completed"}));
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -403,9 +403,10 @@ fn dashscope_argument_deltas_restate_an_empty_tool_call_id() {
 fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
     // Verbatim final frames from Azure Foundry grok-4.3 (silen-resource,
     // 2026-09-03, stream_options.include_usage): xAI reports 655 reasoning
-    // tokens OUTSIDE completion_tokens=8 (its total_tokens 677 = 14 + 8 + 655),
-    // so the normalized usage carries the folded output total with the
-    // reasoning subset intact, and the cached prompt leg passes through.
+    // tokens OUTSIDE completion_tokens=8, which its total_tokens identifies
+    // (677 = 14 + 8 + 655), so the normalized usage carries the folded output
+    // total with the reasoning subset intact, and the cached prompt leg passes
+    // through.
     let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
     let text = SseEvent {
         event: None,

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -398,6 +398,67 @@ fn dashscope_argument_deltas_restate_an_empty_tool_call_id() {
         .feed(&compatible_chunk(serde_json::json!({}), Some("tool_calls")))
         .expect("finish chunk must normalize")
         .is_empty());
+
+#[test]
+fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
+    // Verbatim final frames from Azure Foundry grok-4.3 (silen-resource,
+    // 2026-09-03, stream_options.include_usage): xAI reports 655 reasoning
+    // tokens OUTSIDE completion_tokens=8 (its total_tokens 677 = 14 + 8 + 655),
+    // so the normalized usage carries the folded output total with the
+    // reasoning subset intact, and the cached prompt leg passes through.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    let text = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "8ca8705f-1504-4bec-a739-38e3726ff3d4",
+            "object": "chat.completion.chunk",
+            "created": 1788425522,
+            "model": "grok-4.3",
+            "choices": [{"index": 0, "delta": {"content": "Because"}, "finish_reason": null}],
+            "system_fingerprint": "fp_39c5j0a3e9",
+        })
+        .to_string(),
+    };
+    assert!(matches!(
+        normalizer.feed(&text).expect("text").as_slice(),
+        [Event::TextDelta(delta)] if delta == "Because"
+    ));
+    let finish = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "8ca8705f-1504-4bec-a739-38e3726ff3d4",
+            "object": "chat.completion.chunk",
+            "created": 1788425522,
+            "model": "grok-4.3",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "system_fingerprint": "fp_39c5j0a3e9",
+        })
+        .to_string(),
+    };
+    assert!(normalizer.feed(&finish).expect("finish").is_empty());
+    let usage = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "8ca8705f-1504-4bec-a739-38e3726ff3d4",
+            "object": "chat.completion.chunk",
+            "created": 1788425522,
+            "model": "grok-4.3",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 14,
+                "completion_tokens": 8,
+                "total_tokens": 677,
+                "prompt_tokens_details": {"text_tokens": 14, "audio_tokens": 0, "image_tokens": 0, "cached_tokens": 4},
+                "completion_tokens_details": {"reasoning_tokens": 655, "audio_tokens": 0, "accepted_prediction_tokens": 0, "rejected_prediction_tokens": 0},
+                "num_sources_used": 0,
+                "cost_in_usd_ticks": 0,
+            },
+            "system_fingerprint": "fp_39c5j0a3e9",
+            "service_tier": "default",
+        })
+        .to_string(),
+    };
+    assert!(normalizer.feed(&usage).expect("usage").is_empty());
     let done = SseEvent {
         event: None,
         data: "[DONE]".to_string(),
@@ -444,5 +505,15 @@ fn compatible_stream_still_rejects_a_changed_non_empty_tool_call_identity() {
             ))
             .expect_err("a changed non-empty identity must stay malformed");
         assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+
+    let events = normalizer.feed(&done).expect("terminal");
+    match events.as_slice() {
+        [Event::Usage(usage), Event::Completed] => {
+            assert_eq!(usage.input_tokens, Some(14));
+            assert_eq!(usage.output_tokens, Some(663));
+            assert_eq!(usage.cached_input_tokens, Some(4));
+            assert_eq!(usage.reasoning_tokens, Some(655));
+        }
+        other => panic!("unexpected events: {other:?}"),
     }
 }

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -398,6 +398,54 @@ fn dashscope_argument_deltas_restate_an_empty_tool_call_id() {
         .feed(&compatible_chunk(serde_json::json!({}), Some("tool_calls")))
         .expect("finish chunk must normalize")
         .is_empty());
+    let done = SseEvent {
+        event: None,
+        data: "[DONE]".to_string(),
+    };
+    let events = normalizer.feed(&done).expect("stream must complete");
+    assert!(matches!(
+        events.as_slice(),
+        [Event::ToolCallCompleted { call, .. }, Event::Completed]
+            if call.call_id == "call_8f08d2b0fc0c4d8fab7123"
+                && call.name == "get_current_weather"
+                && call.raw_arguments == "{\"location\": \"Hangzhou\"}"
+    ));
+}
+
+#[test]
+fn compatible_stream_still_rejects_a_changed_non_empty_tool_call_identity() {
+    // The identity guard keeps its teeth: a later delta naming a DIFFERENT
+    // non-empty id or name is still a malformed stream.
+    for (id, name) in [
+        ("call_other", "get_current_weather"),
+        ("call_1", "other_tool"),
+    ] {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+        normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"tool_calls": [{
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_current_weather", "arguments": ""},
+                }]}),
+                None,
+            ))
+            .expect("first tool delta must normalize");
+        let failure = normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"tool_calls": [{
+                    "index": 0,
+                    "id": id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": "{}"},
+                }]}),
+                None,
+            ))
+            .expect_err("a changed non-empty identity must stay malformed");
+        assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+    }
+}
 
 #[test]
 fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
@@ -464,49 +512,6 @@ fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
         event: None,
         data: "[DONE]".to_string(),
     };
-    let events = normalizer.feed(&done).expect("stream must complete");
-    assert!(matches!(
-        events.as_slice(),
-        [Event::ToolCallCompleted { call, .. }, Event::Completed]
-            if call.call_id == "call_8f08d2b0fc0c4d8fab7123"
-                && call.name == "get_current_weather"
-                && call.raw_arguments == "{\"location\": \"Hangzhou\"}"
-    ));
-}
-
-#[test]
-fn compatible_stream_still_rejects_a_changed_non_empty_tool_call_identity() {
-    // The identity guard keeps its teeth: a later delta naming a DIFFERENT
-    // non-empty id or name is still a malformed stream.
-    for (id, name) in [
-        ("call_other", "get_current_weather"),
-        ("call_1", "other_tool"),
-    ] {
-        let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
-        normalizer
-            .feed(&compatible_chunk(
-                serde_json::json!({"tool_calls": [{
-                    "index": 0,
-                    "id": "call_1",
-                    "type": "function",
-                    "function": {"name": "get_current_weather", "arguments": ""},
-                }]}),
-                None,
-            ))
-            .expect("first tool delta must normalize");
-        let failure = normalizer
-            .feed(&compatible_chunk(
-                serde_json::json!({"tool_calls": [{
-                    "index": 0,
-                    "id": id,
-                    "type": "function",
-                    "function": {"name": name, "arguments": "{}"},
-                }]}),
-                None,
-            ))
-            .expect_err("a changed non-empty identity must stay malformed");
-        assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
-
     let events = normalizer.feed(&done).expect("terminal");
     match events.as_slice() {
         [Event::Usage(usage), Event::Completed] => {

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -10,14 +10,15 @@
 //! total would bill every reasoning token at zero unless the mapper folds it
 //! back in. Per wire:
 //!
-//! - OpenAI Responses (`openai_usage`): `output_tokens_details.reasoning_tokens`
-//!   is a documented subset of `output_tokens`; forwarded as reported.
-//! - Chat Completions (`openai_compatible_usage`): OpenAI, OpenRouter, DeepSeek,
-//!   Fireworks, and Azure-relayed Fireworks fold reasoning into
-//!   `completion_tokens`; xAI (native and relayed by Azure Foundry) reports it
-//!   outside. A reasoning count above `completion_tokens` is impossible under
-//!   subset semantics, so it is taken as proof of an additive provider and
-//!   folded; a folded provider is never touched.
+//! - OpenAI-shaped wires (Responses via `openai_usage`, Chat Completions via
+//!   `openai_compatible_usage`): OpenAI, OpenRouter, DeepSeek, and Fireworks
+//!   report reasoning inside the output total; xAI (native and relayed by
+//!   Azure Foundry) reports it outside on both wires. The provider's own
+//!   `total_tokens` decides: `input + output` is the subset shape and is
+//!   forwarded as reported, `input + output + reasoning` is the additive shape
+//!   and folds (`fold_openai_shaped_reasoning`). Without a decisive total, a
+//!   reasoning count above the output total is impossible under subset
+//!   semantics and folds.
 //! - Gemini (`gemini_usage`): `thoughtsTokenCount` is additive by Google's
 //!   definition (`totalTokenCount` = prompt + candidates + thoughts), so it is
 //!   folded into `output_tokens` unconditionally.
@@ -641,9 +642,53 @@ fn optional_usage_detail(
     }
 }
 
-/// Parse an OpenAI-shaped usage object from a terminal Responses payload,
-/// mirroring `streaming_usage.openai_usage`: an omitted object is unknown
-/// usage, while a malformed one fails the stream.
+/// Sum persistable legs into one ledger count. Individually persistable legs
+/// whose total is not are a provider contract violation, never a clamped or
+/// wrapped total.
+pub fn bounded_ledger_sum(legs: &[u64], label: &str) -> Result<u64, String> {
+    legs.iter()
+        .try_fold(0u64, |total, leg| total.checked_add(*leg))
+        .filter(|total| *total <= MAXIMUM_LEDGER_COUNT)
+        .ok_or_else(|| format!("{label} token total overflows a persistable count"))
+}
+
+/// Resolve the output total of an OpenAI-shaped usage object so that
+/// `reasoning_tokens` names a subset of it (see the module documentation).
+///
+/// The provider's own `total_tokens` is authoritative when it matches either
+/// accounting: `input + output` is the documented subset shape and the output
+/// total is forwarded as reported; `input + output + reasoning` is the
+/// additive shape (xAI, natively or relayed by Azure Foundry) and reasoning is
+/// folded in. Without a decisive total, a reasoning count above the output
+/// total cannot occur under subset semantics and is folded.
+fn fold_openai_shaped_reasoning(
+    input_tokens: u64,
+    output_tokens: u64,
+    reasoning_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+    label: &str,
+) -> Result<u64, String> {
+    let Some(reasoning) = reasoning_tokens.filter(|reasoning| *reasoning > 0) else {
+        return Ok(output_tokens);
+    };
+    let subset_total = input_tokens.checked_add(output_tokens);
+    let additive_total = subset_total.and_then(|total| total.checked_add(reasoning));
+    let additive = match total_tokens {
+        Some(total) if Some(total) == subset_total => false,
+        Some(total) if Some(total) == additive_total => true,
+        _ => reasoning > output_tokens,
+    };
+    if additive {
+        bounded_ledger_sum(&[output_tokens, reasoning], label)
+    } else {
+        Ok(output_tokens)
+    }
+}
+
+/// Parse an OpenAI-shaped usage object from a terminal Responses payload: an
+/// omitted object is unknown usage, while a malformed one fails the stream.
+/// `output_tokens_details.reasoning_tokens` folds into `output_tokens` when
+/// the provider's `total_tokens` shows it was reported additively.
 pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
     let value = match value {
         None | Some(Value::Null) => return Ok(None),
@@ -652,17 +697,25 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
     let object = value
         .as_object()
         .ok_or_else(|| "OpenAI usage must be an object".to_string())?;
+    let input_tokens = count_or_zero(object, "input_tokens", "OpenAI input_tokens")?;
+    let reported_output = count_or_zero(object, "output_tokens", "OpenAI output_tokens")?;
+    let reasoning_tokens = optional_usage_detail(
+        object,
+        "output_tokens_details",
+        "reasoning_tokens",
+        "OpenAI reasoning_tokens",
+    )?;
+    let total_tokens = count_if_present(object, "total_tokens", "OpenAI usage")?;
+    let output_tokens = fold_openai_shaped_reasoning(
+        input_tokens,
+        reported_output,
+        reasoning_tokens,
+        total_tokens,
+        "OpenAI output",
+    )?;
     Ok(Some(Usage {
-        input_tokens: Some(count_or_zero(
-            object,
-            "input_tokens",
-            "OpenAI input_tokens",
-        )?),
-        output_tokens: Some(count_or_zero(
-            object,
-            "output_tokens",
-            "OpenAI output_tokens",
-        )?),
+        input_tokens: Some(input_tokens),
+        output_tokens: Some(output_tokens),
         cached_input_tokens: optional_usage_detail(
             object,
             "input_tokens_details",
@@ -670,46 +723,19 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
             "OpenAI cached_tokens",
         )?,
         cache_creation_input_tokens: None,
-        reasoning_tokens: optional_usage_detail(
-            object,
-            "output_tokens_details",
-            "reasoning_tokens",
-            "OpenAI reasoning_tokens",
-        )?,
+        reasoning_tokens,
     }))
-}
-
-/// Fold a reasoning count the provider reports OUTSIDE its output total back
-/// into that total, so the emitted usage satisfies the reasoning-subset
-/// contract (see the module documentation). A folded total beyond the
-/// persistable ledger range is a provider contract violation, never a clamped
-/// or wrapped total.
-fn fold_additive_reasoning(
-    output_tokens: u64,
-    reasoning_tokens: u64,
-    label: &str,
-) -> Result<u64, String> {
-    output_tokens
-        .checked_add(reasoning_tokens)
-        .filter(|total| *total <= MAXIMUM_LEDGER_COUNT)
-        .ok_or_else(|| format!("{label} output token total overflows a persistable count"))
 }
 
 /// Parse a Chat Completions usage object: a malformed object fails the stream
 /// instead of silently dropping token accounting.
-///
-/// `completion_tokens_details.reasoning_tokens` is a subset of
-/// `completion_tokens` on OpenAI and every provider that mirrors it, and is
-/// forwarded as reported. A reasoning count ABOVE `completion_tokens` cannot
-/// occur under subset semantics; it identifies a provider that reports
-/// reasoning additively (xAI, natively or relayed by Azure Foundry), so the
-/// count is folded into `output_tokens` and `reasoning_tokens` keeps naming
-/// the subset. The fold misses an additive provider only when its reasoning
-/// happens to be no larger than its visible answer.
+/// `completion_tokens_details.reasoning_tokens` folds into `output_tokens`
+/// when the provider's `total_tokens` shows it was reported additively.
 pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
         .ok_or_else(|| "OpenAI-compatible usage must be an object".to_string())?;
+    let input_tokens = count_or_zero(object, "prompt_tokens", "prompt_tokens")?;
     let completion_tokens = count_or_zero(object, "completion_tokens", "completion_tokens")?;
     let reasoning_tokens = optional_usage_detail(
         object,
@@ -717,14 +743,16 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
         "reasoning_tokens",
         "reasoning_tokens",
     )?;
-    let output_tokens = match reasoning_tokens {
-        Some(reasoning) if reasoning > completion_tokens => {
-            fold_additive_reasoning(completion_tokens, reasoning, "OpenAI-compatible")?
-        }
-        _ => completion_tokens,
-    };
+    let total_tokens = count_if_present(object, "total_tokens", "OpenAI-compatible usage")?;
+    let output_tokens = fold_openai_shaped_reasoning(
+        input_tokens,
+        completion_tokens,
+        reasoning_tokens,
+        total_tokens,
+        "OpenAI-compatible output",
+    )?;
     Ok(Usage {
-        input_tokens: Some(count_or_zero(object, "prompt_tokens", "prompt_tokens")?),
+        input_tokens: Some(input_tokens),
         output_tokens: Some(output_tokens),
         cached_input_tokens: optional_usage_detail(
             object,
@@ -764,7 +792,7 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
         "Gemini candidatesTokenCount",
     )?;
     let output_tokens = match reasoning_tokens {
-        Some(reasoning) => fold_additive_reasoning(candidates_tokens, reasoning, "Gemini")?,
+        Some(reasoning) => bounded_ledger_sum(&[candidates_tokens, reasoning], "Gemini output")?,
         None => candidates_tokens,
     };
     Ok(Usage {
@@ -806,11 +834,7 @@ pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
         "cacheWriteInputTokens",
         "Bedrock cacheWriteInputTokens",
     )?;
-    let input_tokens = fresh
-        .checked_add(cache_read)
-        .and_then(|total| total.checked_add(cache_write))
-        .filter(|total| *total <= MAXIMUM_LEDGER_COUNT)
-        .ok_or_else(|| "Bedrock input token total overflows a persistable count".to_string())?;
+    let input_tokens = bounded_ledger_sum(&[fresh, cache_read, cache_write], "Bedrock input")?;
     Ok(Usage {
         input_tokens: Some(input_tokens),
         output_tokens: Some(count_or_zero(
@@ -866,5 +890,4 @@ pub fn require_u64(object: &Map<String, Value>, key: &str, label: &str) -> Resul
 }
 
 #[cfg(test)]
-#[path = "events/tests.rs"]
 mod tests;

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -1,4 +1,32 @@
 //! Provider-neutral stream events, the Rust mirror of `GatewayEvent`.
+//!
+//! # Usage contract
+//!
+//! Every usage mapper in this module emits OpenAI subset semantics:
+//! `reasoning_tokens` (when known) counts a SUBSET of `output_tokens`, and
+//! `cached_input_tokens` a subset of `input_tokens`. Settlement prices the
+//! reasoning subset at the reasoning rate and the remainder of `output_tokens`
+//! at the output rate, so a wire that reports reasoning OUTSIDE its output
+//! total would bill every reasoning token at zero unless the mapper folds it
+//! back in. Per wire:
+//!
+//! - OpenAI Responses (`openai_usage`): `output_tokens_details.reasoning_tokens`
+//!   is a documented subset of `output_tokens`; forwarded as reported.
+//! - Chat Completions (`openai_compatible_usage`): OpenAI, OpenRouter, DeepSeek,
+//!   Fireworks, and Azure-relayed Fireworks fold reasoning into
+//!   `completion_tokens`; xAI (native and relayed by Azure Foundry) reports it
+//!   outside. A reasoning count above `completion_tokens` is impossible under
+//!   subset semantics, so it is taken as proof of an additive provider and
+//!   folded; a folded provider is never touched.
+//! - Gemini (`gemini_usage`): `thoughtsTokenCount` is additive by Google's
+//!   definition (`totalTokenCount` = prompt + candidates + thoughts), so it is
+//!   folded into `output_tokens` unconditionally.
+//! - Anthropic Messages and Bedrock Converse: thinking is billed inside the
+//!   provider's `output_tokens` and no separate count is published, so
+//!   `reasoning_tokens` stays `None` and the total is forwarded as reported.
+//!
+//! A fold whose total leaves the persistable ledger range is a provider
+//! contract violation and fails the stream; totals are never clamped.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -651,20 +679,53 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
     }))
 }
 
-/// Parse a Chat Completions usage object, mirroring
-/// `streaming_usage.openai_compatible_usage`: a malformed object fails the
-/// stream instead of silently dropping token accounting.
+/// Fold a reasoning count the provider reports OUTSIDE its output total back
+/// into that total, so the emitted usage satisfies the reasoning-subset
+/// contract (see the module documentation). A folded total beyond the
+/// persistable ledger range is a provider contract violation, never a clamped
+/// or wrapped total.
+fn fold_additive_reasoning(
+    output_tokens: u64,
+    reasoning_tokens: u64,
+    label: &str,
+) -> Result<u64, String> {
+    output_tokens
+        .checked_add(reasoning_tokens)
+        .filter(|total| *total <= MAXIMUM_LEDGER_COUNT)
+        .ok_or_else(|| format!("{label} output token total overflows a persistable count"))
+}
+
+/// Parse a Chat Completions usage object: a malformed object fails the stream
+/// instead of silently dropping token accounting.
+///
+/// `completion_tokens_details.reasoning_tokens` is a subset of
+/// `completion_tokens` on OpenAI and every provider that mirrors it, and is
+/// forwarded as reported. A reasoning count ABOVE `completion_tokens` cannot
+/// occur under subset semantics; it identifies a provider that reports
+/// reasoning additively (xAI, natively or relayed by Azure Foundry), so the
+/// count is folded into `output_tokens` and `reasoning_tokens` keeps naming
+/// the subset. The fold misses an additive provider only when its reasoning
+/// happens to be no larger than its visible answer.
 pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
         .ok_or_else(|| "OpenAI-compatible usage must be an object".to_string())?;
+    let completion_tokens = count_or_zero(object, "completion_tokens", "completion_tokens")?;
+    let reasoning_tokens = optional_usage_detail(
+        object,
+        "completion_tokens_details",
+        "reasoning_tokens",
+        "reasoning_tokens",
+    )?;
+    let output_tokens = match reasoning_tokens {
+        Some(reasoning) if reasoning > completion_tokens => {
+            fold_additive_reasoning(completion_tokens, reasoning, "OpenAI-compatible")?
+        }
+        _ => completion_tokens,
+    };
     Ok(Usage {
         input_tokens: Some(count_or_zero(object, "prompt_tokens", "prompt_tokens")?),
-        output_tokens: Some(count_or_zero(
-            object,
-            "completion_tokens",
-            "completion_tokens",
-        )?),
+        output_tokens: Some(output_tokens),
         cached_input_tokens: optional_usage_detail(
             object,
             "prompt_tokens_details",
@@ -672,18 +733,19 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
             "cached_tokens",
         )?,
         cache_creation_input_tokens: None,
-        reasoning_tokens: optional_usage_detail(
-            object,
-            "completion_tokens_details",
-            "reasoning_tokens",
-            "reasoning_tokens",
-        )?,
+        reasoning_tokens,
     })
 }
 
-/// Parse Gemini `usageMetadata`, mirroring the python `_usage` normalizer:
-/// cached tokens are an input subset, absent counts are zero (`require_integer`
-/// parity), and `thoughtsTokenCount` stays unknown when omitted.
+/// Parse Gemini `usageMetadata`: cached tokens are an input subset, absent
+/// counts are zero (`require_integer` parity), and `thoughtsTokenCount` stays
+/// unknown when omitted.
+///
+/// Google defines thinking tokens as ADDITIVE to `candidatesTokenCount`
+/// (`totalTokenCount` = prompt + candidates + thoughts, and response pricing
+/// is the sum of output and thinking tokens), so a reported
+/// `thoughtsTokenCount` is folded into `output_tokens`; `reasoning_tokens`
+/// names the subset the ledger prices at the reasoning rate.
 pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
@@ -696,17 +758,22 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
             "Gemini thoughtsTokenCount",
         )?),
     };
+    let candidates_tokens = count_or_zero(
+        object,
+        "candidatesTokenCount",
+        "Gemini candidatesTokenCount",
+    )?;
+    let output_tokens = match reasoning_tokens {
+        Some(reasoning) => fold_additive_reasoning(candidates_tokens, reasoning, "Gemini")?,
+        None => candidates_tokens,
+    };
     Ok(Usage {
         input_tokens: Some(count_or_zero(
             object,
             "promptTokenCount",
             "Gemini promptTokenCount",
         )?),
-        output_tokens: Some(count_or_zero(
-            object,
-            "candidatesTokenCount",
-            "Gemini candidatesTokenCount",
-        )?),
+        output_tokens: Some(output_tokens),
         cached_input_tokens: Some(count_or_zero(
             object,
             "cachedContentTokenCount",
@@ -717,12 +784,13 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
     })
 }
 
-/// Parse Bedrock `metadata.usage`, mirroring the python `_usage` normalizer:
-/// cache read and write legs fold into total input, cached input reports the
-/// read leg, and absent counts are zero (`require_integer` parity). Legs and
-/// the folded total beyond the persistable ledger range are provider
-/// contract violations and fail the stream rather than reaching settlement
-/// as a value the ledger could never write.
+/// Parse Bedrock `metadata.usage`: cache read and write legs fold into total
+/// input, cached input reports the read leg, and absent counts are zero
+/// (`require_integer` parity). Legs and the folded total beyond the
+/// persistable ledger range are provider contract violations and fail the
+/// stream rather than reaching settlement as a value the ledger could never
+/// write. Converse bills a reasoning model's thinking inside `outputTokens`
+/// and publishes no separate count, so `reasoning_tokens` stays unknown.
 pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
     let usage = value
         .and_then(Value::as_object)
@@ -798,155 +866,5 @@ pub fn require_u64(object: &Map<String, Value>, key: &str, label: &str) -> Resul
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn output_tokens_lead_a_turn_but_control_frames_do_not() {
-        // Content, reasoning, and tool-call deltas are the first visible output.
-        assert!(Event::TextDelta("hi".to_string()).is_output_token());
-        assert!(Event::RefusalDelta("no".to_string()).is_output_token());
-        assert!(Event::ProviderTextDelta {
-            output_index: 0,
-            item_id: "msg_1".to_string(),
-            delta: "hi".to_string(),
-        }
-        .is_output_token());
-        assert!(Event::ThinkingDelta {
-            index: 0,
-            delta: "hmm".to_string(),
-        }
-        .is_output_token());
-        // A tool-only turn's first token is the tool call itself.
-        assert!(Event::ToolCallStarted {
-            index: 0,
-            call_id: "call_1".to_string(),
-            name: "get".to_string(),
-        }
-        .is_output_token());
-        // Usage, terminals, and opaque reasoning-carrier frames never lead.
-        assert!(!Event::Usage(Usage::default()).is_output_token());
-        assert!(!Event::Completed.is_output_token());
-        assert!(!Event::Incomplete.is_output_token());
-        assert!(!Event::ThinkingSignature {
-            index: 0,
-            signature: "sig".to_string(),
-        }
-        .is_output_token());
-        // A Responses item-start reserves a slot before the first delta; it
-        // must not stamp TTFT early -- the following delta is the real token.
-        assert!(!Event::ProviderOutputItemStarted {
-            output_index: 0,
-            item_id: Some("msg_1".to_string()),
-            kind: ProviderOutputItemKind::Message,
-            status: None,
-            phase: None,
-        }
-        .is_output_token());
-        // An empty delta (role-establishing or empty refusal frame) carries no
-        // visible token, so it must not stamp TTFT.
-        assert!(!Event::TextDelta(String::new()).is_output_token());
-        assert!(!Event::RefusalDelta(String::new()).is_output_token());
-        assert!(!Event::ProviderTextDelta {
-            output_index: 0,
-            item_id: "msg_1".to_string(),
-            delta: String::new(),
-        }
-        .is_output_token());
-    }
-
-    #[test]
-    fn openai_compatible_usage_counts_absent_fields_as_zero() {
-        let usage = openai_compatible_usage(&json!({"prompt_tokens": 7})).expect("valid usage");
-        assert_eq!(usage.input_tokens, Some(7));
-        assert_eq!(usage.output_tokens, Some(0));
-        assert_eq!(usage.cached_input_tokens, None);
-        assert_eq!(usage.reasoning_tokens, None);
-    }
-
-    #[test]
-    fn openai_compatible_usage_rejects_malformed_counts() {
-        assert!(openai_compatible_usage(&json!({"prompt_tokens": "7"})).is_err());
-        assert!(
-            openai_compatible_usage(&json!({"prompt_tokens": MAXIMUM_LEDGER_COUNT + 1})).is_err()
-        );
-        assert!(openai_compatible_usage(&json!([1])).is_err());
-        assert!(openai_compatible_usage(
-            &json!({"prompt_tokens": 1, "completion_tokens": 1, "prompt_tokens_details": 3})
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn parsed_counts_are_bounded_to_the_persistable_ledger_range() {
-        let at_bound = json!({"count": MAXIMUM_LEDGER_COUNT});
-        let over_bound = json!({"count": MAXIMUM_LEDGER_COUNT + 1});
-        let at_object = at_bound.as_object().expect("object");
-        let over_object = over_bound.as_object().expect("object");
-        // Exactly i64::MAX is persistable and accepted; one past it is a
-        // provider contract violation everywhere counts are parsed.
-        assert_eq!(
-            count_or_zero(at_object, "count", "count"),
-            Ok(MAXIMUM_LEDGER_COUNT)
-        );
-        assert!(count_or_zero(over_object, "count", "count").is_err());
-        assert_eq!(
-            require_u64(at_object, "count", "count"),
-            Ok(MAXIMUM_LEDGER_COUNT)
-        );
-        assert!(require_u64(over_object, "count", "count").is_err());
-        assert!(openai_usage(Some(&json!({
-            "input_tokens": 1,
-            "output_tokens": 1,
-            "output_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT + 1},
-        })))
-        .is_err());
-    }
-
-    #[test]
-    fn bedrock_usage_folds_cache_legs_and_rejects_unrepresentable_totals() {
-        let usage = bedrock_usage(Some(&json!({
-            "inputTokens": 9,
-            "outputTokens": 4,
-            "cacheReadInputTokens": 2,
-            "cacheWriteInputTokens": 1,
-        })))
-        .expect("valid usage");
-        assert_eq!(usage.input_tokens, Some(12));
-        assert_eq!(usage.cached_input_tokens, Some(2));
-        // A leg beyond the persistable ledger range fails at the parser.
-        assert!(bedrock_usage(Some(&json!({
-            "inputTokens": MAXIMUM_LEDGER_COUNT + 1,
-            "outputTokens": 1,
-        })))
-        .is_err());
-        // Individually persistable legs whose folded total is not are a
-        // provider contract violation, never a clamped or wrapped total.
-        assert!(bedrock_usage(Some(&json!({
-            "inputTokens": MAXIMUM_LEDGER_COUNT,
-            "outputTokens": 1,
-            "cacheReadInputTokens": 1,
-        })))
-        .is_err());
-        assert!(bedrock_usage(Some(&json!(null))).is_err());
-        assert!(bedrock_usage(None).is_err());
-    }
-
-    #[test]
-    fn openai_usage_treats_absent_and_null_objects_as_unknown() {
-        assert!(openai_usage(None).expect("absent is unknown").is_none());
-        assert!(openai_usage(Some(&serde_json::Value::Null))
-            .expect("null is unknown")
-            .is_none());
-        let usage = openai_usage(Some(&json!({
-            "input_tokens": 2,
-            "output_tokens": 3,
-            "output_tokens_details": {"reasoning_tokens": 1},
-        })))
-        .expect("valid usage")
-        .expect("usage present");
-        assert_eq!(usage.reasoning_tokens, Some(1));
-        assert_eq!(usage.cached_input_tokens, None);
-    }
-}
+#[path = "events/tests.rs"]
+mod tests;

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -1,0 +1,316 @@
+//! Usage-mapper and count-parsing regressions for `events.rs` (moved out of
+//! the module for its line budget).
+
+use super::*;
+use serde_json::json;
+
+#[test]
+fn output_tokens_lead_a_turn_but_control_frames_do_not() {
+    // Content, reasoning, and tool-call deltas are the first visible output.
+    assert!(Event::TextDelta("hi".to_string()).is_output_token());
+    assert!(Event::RefusalDelta("no".to_string()).is_output_token());
+    assert!(Event::ProviderTextDelta {
+        output_index: 0,
+        item_id: "msg_1".to_string(),
+        delta: "hi".to_string(),
+    }
+    .is_output_token());
+    assert!(Event::ThinkingDelta {
+        index: 0,
+        delta: "hmm".to_string(),
+    }
+    .is_output_token());
+    // A tool-only turn's first token is the tool call itself.
+    assert!(Event::ToolCallStarted {
+        index: 0,
+        call_id: "call_1".to_string(),
+        name: "get".to_string(),
+    }
+    .is_output_token());
+    // Usage, terminals, and opaque reasoning-carrier frames never lead.
+    assert!(!Event::Usage(Usage::default()).is_output_token());
+    assert!(!Event::Completed.is_output_token());
+    assert!(!Event::Incomplete.is_output_token());
+    assert!(!Event::ThinkingSignature {
+        index: 0,
+        signature: "sig".to_string(),
+    }
+    .is_output_token());
+    // A Responses item-start reserves a slot before the first delta; it
+    // must not stamp TTFT early -- the following delta is the real token.
+    assert!(!Event::ProviderOutputItemStarted {
+        output_index: 0,
+        item_id: Some("msg_1".to_string()),
+        kind: ProviderOutputItemKind::Message,
+        status: None,
+        phase: None,
+    }
+    .is_output_token());
+    // An empty delta (role-establishing or empty refusal frame) carries no
+    // visible token, so it must not stamp TTFT.
+    assert!(!Event::TextDelta(String::new()).is_output_token());
+    assert!(!Event::RefusalDelta(String::new()).is_output_token());
+    assert!(!Event::ProviderTextDelta {
+        output_index: 0,
+        item_id: "msg_1".to_string(),
+        delta: String::new(),
+    }
+    .is_output_token());
+}
+
+#[test]
+fn openai_compatible_usage_counts_absent_fields_as_zero() {
+    let usage = openai_compatible_usage(&json!({"prompt_tokens": 7})).expect("valid usage");
+    assert_eq!(usage.input_tokens, Some(7));
+    assert_eq!(usage.output_tokens, Some(0));
+    assert_eq!(usage.cached_input_tokens, None);
+    assert_eq!(usage.reasoning_tokens, None);
+}
+
+#[test]
+fn openai_compatible_usage_rejects_malformed_counts() {
+    assert!(openai_compatible_usage(&json!({"prompt_tokens": "7"})).is_err());
+    assert!(openai_compatible_usage(&json!({"prompt_tokens": MAXIMUM_LEDGER_COUNT + 1})).is_err());
+    assert!(openai_compatible_usage(&json!([1])).is_err());
+    assert!(openai_compatible_usage(
+        &json!({"prompt_tokens": 1, "completion_tokens": 1, "prompt_tokens_details": 3})
+    )
+    .is_err());
+}
+
+#[test]
+fn parsed_counts_are_bounded_to_the_persistable_ledger_range() {
+    let at_bound = json!({"count": MAXIMUM_LEDGER_COUNT});
+    let over_bound = json!({"count": MAXIMUM_LEDGER_COUNT + 1});
+    let at_object = at_bound.as_object().expect("object");
+    let over_object = over_bound.as_object().expect("object");
+    // Exactly i64::MAX is persistable and accepted; one past it is a
+    // provider contract violation everywhere counts are parsed.
+    assert_eq!(
+        count_or_zero(at_object, "count", "count"),
+        Ok(MAXIMUM_LEDGER_COUNT)
+    );
+    assert!(count_or_zero(over_object, "count", "count").is_err());
+    assert_eq!(
+        require_u64(at_object, "count", "count"),
+        Ok(MAXIMUM_LEDGER_COUNT)
+    );
+    assert!(require_u64(over_object, "count", "count").is_err());
+    assert!(openai_usage(Some(&json!({
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "output_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT + 1},
+    })))
+    .is_err());
+}
+
+#[test]
+fn bedrock_usage_folds_cache_legs_and_rejects_unrepresentable_totals() {
+    let usage = bedrock_usage(Some(&json!({
+        "inputTokens": 9,
+        "outputTokens": 4,
+        "cacheReadInputTokens": 2,
+        "cacheWriteInputTokens": 1,
+    })))
+    .expect("valid usage");
+    assert_eq!(usage.input_tokens, Some(12));
+    assert_eq!(usage.cached_input_tokens, Some(2));
+    // A leg beyond the persistable ledger range fails at the parser.
+    assert!(bedrock_usage(Some(&json!({
+        "inputTokens": MAXIMUM_LEDGER_COUNT + 1,
+        "outputTokens": 1,
+    })))
+    .is_err());
+    // Individually persistable legs whose folded total is not are a
+    // provider contract violation, never a clamped or wrapped total.
+    assert!(bedrock_usage(Some(&json!({
+        "inputTokens": MAXIMUM_LEDGER_COUNT,
+        "outputTokens": 1,
+        "cacheReadInputTokens": 1,
+    })))
+    .is_err());
+    assert!(bedrock_usage(Some(&json!(null))).is_err());
+    assert!(bedrock_usage(None).is_err());
+}
+
+#[test]
+fn openai_usage_treats_absent_and_null_objects_as_unknown() {
+    assert!(openai_usage(None).expect("absent is unknown").is_none());
+    assert!(openai_usage(Some(&serde_json::Value::Null))
+        .expect("null is unknown")
+        .is_none());
+    let usage = openai_usage(Some(&json!({
+        "input_tokens": 2,
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 1},
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(usage.reasoning_tokens, Some(1));
+    assert_eq!(usage.cached_input_tokens, None);
+}
+
+// Usage-contract pins: every mapper emits reasoning_tokens as a SUBSET of
+// output_tokens (see the module documentation), so settlement never prices a
+// reasoning token at zero because a provider reported it outside its total.
+
+#[test]
+fn openai_responses_usage_forwards_the_documented_reasoning_subset_unchanged() {
+    // OpenAI Responses: output_tokens_details.reasoning_tokens is a subset of
+    // output_tokens by the provider's definition, so the counts pass through.
+    let usage = openai_usage(Some(&json!({
+        "input_tokens": 36,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 700,
+        "output_tokens_details": {"reasoning_tokens": 690},
+        "total_tokens": 736,
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(usage.output_tokens, Some(700));
+    assert_eq!(usage.reasoning_tokens, Some(690));
+    assert!(usage.reasoning_tokens <= usage.output_tokens);
+}
+
+#[test]
+fn openai_compatible_usage_leaves_a_folded_provider_untouched() {
+    // OpenAI-shaped Chat Completions usage (reasoning inside completion_tokens)
+    // is forwarded exactly; the equal case is a legal subset, not evidence of
+    // an additive provider.
+    for (completion, reasoning) in [(700u64, 690u64), (690, 690), (5, 0)] {
+        let usage = openai_compatible_usage(&json!({
+            "prompt_tokens": 36,
+            "completion_tokens": completion,
+            "total_tokens": 36 + completion,
+            "completion_tokens_details": {"reasoning_tokens": reasoning},
+        }))
+        .expect("valid usage");
+        assert_eq!(usage.output_tokens, Some(completion));
+        assert_eq!(usage.reasoning_tokens, Some(reasoning));
+    }
+    // OpenRouter normalizes upstream reasoning into completion_tokens and
+    // reports the subset alongside (shape captured from openrouter.ai).
+    let openrouter = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 543,
+        "total_tokens": 557,
+        "cost": 0.0016,
+        "is_byok": false,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "cost_details": {"upstream_inference_cost": null},
+        "completion_tokens_details": {"reasoning_tokens": 480, "image_tokens": 0},
+    }))
+    .expect("valid usage");
+    assert_eq!(openrouter.output_tokens, Some(543));
+    assert_eq!(openrouter.reasoning_tokens, Some(480));
+}
+
+#[test]
+fn openai_compatible_usage_folds_an_additive_provider_into_output_tokens() {
+    // Verbatim usage from Azure Foundry grok-4.3 (silen-resource, 2026-09-03,
+    // non-streaming): xAI reports reasoning OUTSIDE completion_tokens, which
+    // its own total_tokens confirms (14 + 7 + 1303 = 1324). A reasoning count
+    // above completion_tokens is impossible under subset semantics, so the
+    // mapper folds it and the subset stays reported.
+    let usage = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 7,
+        "total_tokens": 1324,
+        "audio_prompt_tokens": 0,
+        "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0,
+            "text_tokens": 14,
+            "image_tokens": 0,
+        },
+        "completion_tokens_details": {
+            "reasoning_tokens": 1303,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
+        "num_sources_used": 0,
+    }))
+    .expect("valid usage");
+    assert_eq!(usage.input_tokens, Some(14));
+    assert_eq!(usage.output_tokens, Some(1310));
+    assert_eq!(usage.reasoning_tokens, Some(1303));
+    assert_eq!(usage.cached_input_tokens, Some(0));
+    // The folded totals reproduce the provider's own total_tokens.
+    assert_eq!(
+        usage.input_tokens.unwrap() + usage.output_tokens.unwrap(),
+        1324
+    );
+    // A fold whose total leaves the persistable range is a contract violation.
+    assert!(openai_compatible_usage(&json!({
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "completion_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT},
+    }))
+    .is_err());
+}
+
+#[test]
+fn gemini_usage_folds_thoughts_into_output_tokens() {
+    // Verbatim usageMetadata from gemini-3.7-flash (generateContent,
+    // 2026-09-03), thinking on: Google's totalTokenCount is prompt +
+    // candidates + thoughts (11 + 8 + 524 = 543), so thoughts are additive and
+    // fold into output_tokens while reasoning_tokens names the subset.
+    let thinking = gemini_usage(&json!({
+        "promptTokenCount": 11,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 543,
+        "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+        "thoughtsTokenCount": 524,
+        "serviceTier": "standard",
+    }))
+    .expect("valid usage");
+    assert_eq!(thinking.input_tokens, Some(11));
+    assert_eq!(thinking.output_tokens, Some(532));
+    assert_eq!(thinking.reasoning_tokens, Some(524));
+    assert_eq!(thinking.cached_input_tokens, Some(0));
+    assert_eq!(
+        thinking.input_tokens.unwrap() + thinking.output_tokens.unwrap(),
+        543
+    );
+
+    // Verbatim from gemini-2.5-flash with thinkingBudget 0: no
+    // thoughtsTokenCount at all, so the reasoning subset stays unknown and
+    // output_tokens is the candidate count (11 + 9 = 20).
+    let no_thinking = gemini_usage(&json!({
+        "promptTokenCount": 11,
+        "candidatesTokenCount": 9,
+        "totalTokenCount": 20,
+        "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+        "serviceTier": "standard",
+    }))
+    .expect("valid usage");
+    assert_eq!(no_thinking.output_tokens, Some(9));
+    assert_eq!(no_thinking.reasoning_tokens, None);
+
+    // Documented cached-content shape (cachedContentTokenCount plus
+    // cacheTokensDetails): the cache leg stays an input subset while thoughts
+    // still fold into output.
+    let cached = gemini_usage(&json!({
+        "promptTokenCount": 3582,
+        "candidatesTokenCount": 7,
+        "totalTokenCount": 3806,
+        "cachedContentTokenCount": 3072,
+        "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 3582}],
+        "cacheTokensDetails": [{"modality": "TEXT", "tokenCount": 3072}],
+        "thoughtsTokenCount": 217,
+    }))
+    .expect("valid usage");
+    assert_eq!(cached.input_tokens, Some(3582));
+    assert_eq!(cached.cached_input_tokens, Some(3072));
+    assert_eq!(cached.output_tokens, Some(224));
+    assert_eq!(cached.reasoning_tokens, Some(217));
+
+    // A fold whose total leaves the persistable range is a contract violation.
+    assert!(gemini_usage(&json!({
+        "promptTokenCount": 1,
+        "candidatesTokenCount": MAXIMUM_LEDGER_COUNT,
+        "thoughtsTokenCount": 1,
+    }))
+    .is_err());
+}

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -1,5 +1,4 @@
-//! Usage-mapper and count-parsing regressions for `events.rs` (moved out of
-//! the module for its line budget).
+//! Usage-mapper and count-parsing regressions for `events.rs`.
 
 use super::*;
 use serde_json::json;
@@ -155,10 +154,10 @@ fn openai_usage_treats_absent_and_null_objects_as_unknown() {
 // reasoning token at zero because a provider reported it outside its total.
 
 #[test]
-fn openai_responses_usage_forwards_the_documented_reasoning_subset_unchanged() {
+fn openai_responses_usage_folds_reasoning_only_when_the_total_shows_it_additive() {
     // OpenAI Responses: output_tokens_details.reasoning_tokens is a subset of
-    // output_tokens by the provider's definition, so the counts pass through.
-    let usage = openai_usage(Some(&json!({
+    // output_tokens (total_tokens = input + output), so the counts pass through.
+    let subset = openai_usage(Some(&json!({
         "input_tokens": 36,
         "input_tokens_details": {"cached_tokens": 0},
         "output_tokens": 700,
@@ -167,9 +166,20 @@ fn openai_responses_usage_forwards_the_documented_reasoning_subset_unchanged() {
     })))
     .expect("valid usage")
     .expect("usage present");
-    assert_eq!(usage.output_tokens, Some(700));
-    assert_eq!(usage.reasoning_tokens, Some(690));
-    assert!(usage.reasoning_tokens <= usage.output_tokens);
+    assert_eq!(subset.output_tokens, Some(700));
+    assert_eq!(subset.reasoning_tokens, Some(690));
+    // xAI's documented Responses usage (docs.x.ai) reports reasoning outside
+    // output_tokens, and its total_tokens (32 + 9 + 110 = 151) says so.
+    let additive = openai_usage(Some(&json!({
+        "input_tokens": 32,
+        "output_tokens": 9,
+        "output_tokens_details": {"reasoning_tokens": 110},
+        "total_tokens": 151,
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(additive.output_tokens, Some(119));
+    assert_eq!(additive.reasoning_tokens, Some(110));
 }
 
 #[test]
@@ -188,6 +198,18 @@ fn openai_compatible_usage_leaves_a_folded_provider_untouched() {
         assert_eq!(usage.output_tokens, Some(completion));
         assert_eq!(usage.reasoning_tokens, Some(reasoning));
     }
+    // A total_tokens that names the subset shape is authoritative even when
+    // the reasoning count exceeds the output total; settlement clamps that
+    // provider inconsistency instead of the mapper inventing output.
+    let subset_total = openai_compatible_usage(&json!({
+        "prompt_tokens": 36,
+        "completion_tokens": 5,
+        "total_tokens": 41,
+        "completion_tokens_details": {"reasoning_tokens": 9},
+    }))
+    .expect("valid usage");
+    assert_eq!(subset_total.output_tokens, Some(5));
+    assert_eq!(subset_total.reasoning_tokens, Some(9));
     // OpenRouter normalizes upstream reasoning into completion_tokens and
     // reports the subset alongside (shape captured from openrouter.ai).
     let openrouter = openai_compatible_usage(&json!({
@@ -208,10 +230,9 @@ fn openai_compatible_usage_leaves_a_folded_provider_untouched() {
 #[test]
 fn openai_compatible_usage_folds_an_additive_provider_into_output_tokens() {
     // Verbatim usage from Azure Foundry grok-4.3 (silen-resource, 2026-09-03,
-    // non-streaming): xAI reports reasoning OUTSIDE completion_tokens, which
-    // its own total_tokens confirms (14 + 7 + 1303 = 1324). A reasoning count
-    // above completion_tokens is impossible under subset semantics, so the
-    // mapper folds it and the subset stays reported.
+    // non-streaming): xAI reports reasoning OUTSIDE completion_tokens, and its
+    // own total_tokens identifies the additive shape (14 + 7 + 1303 = 1324),
+    // so the mapper folds it and the subset stays reported.
     let usage = openai_compatible_usage(&json!({
         "prompt_tokens": 14,
         "completion_tokens": 7,
@@ -241,6 +262,35 @@ fn openai_compatible_usage_folds_an_additive_provider_into_output_tokens() {
         usage.input_tokens.unwrap() + usage.output_tokens.unwrap(),
         1324
     );
+    // The total decides regardless of magnitude: a long answer after a short
+    // think (reasoning below completion_tokens) still folds when total_tokens
+    // names the additive shape (14 + 900 + 300 = 1214).
+    let short_think = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 900,
+        "total_tokens": 1214,
+        "completion_tokens_details": {"reasoning_tokens": 300},
+    }))
+    .expect("valid usage");
+    assert_eq!(short_think.output_tokens, Some(1200));
+    assert_eq!(short_think.reasoning_tokens, Some(300));
+    // Without a decisive total, only a reasoning count above completion_tokens
+    // proves the additive shape; a smaller one is indistinguishable from a
+    // subset and passes through.
+    let no_total_above = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 8,
+        "completion_tokens_details": {"reasoning_tokens": 655},
+    }))
+    .expect("valid usage");
+    assert_eq!(no_total_above.output_tokens, Some(663));
+    let no_total_below = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 900,
+        "completion_tokens_details": {"reasoning_tokens": 300},
+    }))
+    .expect("valid usage");
+    assert_eq!(no_total_below.output_tokens, Some(900));
     // A fold whose total leaves the persistable range is a contract violation.
     assert!(openai_compatible_usage(&json!({
         "prompt_tokens": 1,

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -89,9 +89,11 @@ GEMINI_GOLDEN_EVENTS: tuple[JsonObject, ...] = (
         "raw_arguments": _GEMINI_RAW_ARGUMENTS,
     },
     {
+        # Gemini thoughts are additive on the wire, so the engine folds the 3
+        # thought tokens into the output total and reports them as its subset.
         "kind": "usage",
         "input_tokens": 11,
-        "output_tokens": 5,
+        "output_tokens": 8,
         "cached_input_tokens": 2,
         "reasoning_tokens": 3,
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.23,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.24,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Bug

Settlement (the engine's SQLite ledger, `ledger.py::_estimated_cost_micro_usd`, and the platform's `gateway_attempt_cost_micro_usd`) applies OpenAI subset semantics: `reasoning_tokens` is a subset of `output_tokens`, priced at the reasoning rate, with the remainder at the output rate. Two wires forwarded raw provider counts where reasoning is reported OUTSIDE the output total, so every reasoning token on those lanes billed at zero and the customer-visible `completion_tokens` / `total_tokens` disagreed with what the provider charges us:

| wire | mapper | provider semantics | before |
|---|---|---|---|
| Gemini `generateContent` | `events.rs::gemini_usage` | `thoughtsTokenCount` is additive by Google's definition (`totalTokenCount` = prompt + candidates + thoughts) | forwarded raw |
| Chat Completions | `events.rs::openai_compatible_usage` | OpenAI / OpenRouter / Fireworks / DeepSeek fold reasoning into `completion_tokens`; xAI (native and via Azure Foundry) reports it outside | forwarded raw |

Platform finding with prod receipts: experientiallabs/platform#1157 (grok-4.3: 36 in / 10 out / 690 reasoning charged 70 uUSD instead of 1,795; gemini-3.7-flash 38 / 11 / 217 charged 35 instead of 442).

## Fix

- `gemini_usage` folds `thoughtsTokenCount` into `output_tokens` unconditionally; `reasoning_tokens` keeps naming the subset.
- OpenAI-shaped wires (`openai_compatible_usage` for Chat Completions, `openai_usage` for Responses) let the provider's own `total_tokens` decide (`fold_openai_shaped_reasoning`): `input + output` is the documented subset shape and passes through untouched (OpenAI, OpenRouter, Fireworks, DeepSeek); `input + output + reasoning` is the additive shape (xAI natively and via Azure Foundry, on both wires) and folds. Without a decisive total, a reasoning count above the output total, impossible under subset semantics, folds. This closes every observed prod row and the additive-but-smaller regime (long answer after a short think) whenever the provider publishes a total, which xAI does.
- Every fold fails the stream on a total outside the persistable ledger range instead of clamping (`bounded_ledger_sum`, now shared by the Gemini fold, the Bedrock input fold, and the Anthropic `message_stop` input fold).
- `budgets.py::_unknown_token_volume` reports the output total once instead of adding the reasoning subset it already contains (it was correct only by accident on additive lanes).
- The usage contract ("engine-normalized usage always satisfies reasoning subset of output") is documented on the `events` module and in `docs/reference/gateway-architecture.md`.

## Audit of every dialect's usage mapper

| dialect | reasoning semantics | action | pin |
|---|---|---|---|
| `openai_responses` (`openai_usage`) | OpenAI: subset (documented); xAI Responses: ADDITIVE | `total_tokens` decides | `openai_responses_usage_folds_reasoning_only_when_the_total_shows_it_additive` (OpenAI shape passes through; xAI documented shape 32 + 9 + 110 = 151 folds) |
| `openai_compatible`: OpenAI, OpenRouter, Fireworks, DeepSeek, Azure-relayed Kimi | folded (subset) | pass through | `openai_compatible_usage_leaves_a_folded_provider_untouched` (OpenAI shape, equal-count boundary, verbatim OpenRouter shape) |
| `openai_compatible`: xAI native / Azure Foundry Grok | ADDITIVE | `total_tokens` decides (fallback: reasoning > completion) | `openai_compatible_usage_folds_an_additive_provider_into_output_tokens` + `compatible_stream_folds_additive_reasoning_into_the_terminal_usage` (verbatim grok-4.3 non-stream and stream frames, 2026-09-03; short-think 14 + 900 + 300 = 1214 folds; no-total fallback both ways) |
| `gemini_generate_content` (also Vertex) | ADDITIVE | fold always | `gemini_usage_folds_thoughts_into_output_tokens`, `gemini_thinking_stream_folds_thoughts_into_the_terminal_usage`, `gemini_stream_without_thinking_keeps_the_reasoning_subset_unknown` (verbatim gemini-3.7-flash thinking on, gemini-2.5-flash `thinkingBudget: 0`, documented cached shape, overflow) |
| `anthropic_messages` | thinking inside `output_tokens`, no separate count | none (`reasoning_tokens` = None) | `thinking_usage_forwards_output_tokens_with_no_reasoning_subset` |
| `bedrock_converse_stream` | thinking inside `outputTokens`, no separate count | none (`reasoning_tokens` = None) | existing `bedrock_reasoning_blocks_stream_without_failing_the_answer`; doc note on `bedrock_usage` |

Azure `model_inference` / Foundry rides the `openai_compatible` dialect (`AzureClient(OpenAICompatibleClient)`), so it inherits the Chat Completions row; Foundry relays each vendor's own semantics (Grok additive, Kimi folded: live 18 in / 600 out, no reasoning breakdown).

## Empirical verification (locally built engines, official `openai` client, real providers)

Same script, same prompt, a fresh gateway root per engine (Azure Foundry `grok-4.3` via `openai-compatible`, Google `gemini-3.7-flash` via `gemini`; rates in/out 1.25/2.50 and 0.50/1.50 USD per MTok, reasoning rate = output rate as the platform's `coalesce` does):

| engine | lane | reported `prompt / completion / reasoning` | `total_tokens` | ledger `output_tokens` | ledger `reasoning_tokens` | subset holds | `estimated_cost_micro_usd` |
|---|---|---|---|---|---|---|---|
| origin/main (native 0.3.22) | grok-4.3 | 14 / 8 / 1001 | 22 | 8 | 1001 | no | 38 |
| origin/main | gemini-3.7-flash | 11 / 8 / 620 | 19 | 8 | 620 | no | 18 |
| this PR (native 0.3.24) | grok-4.3 | 14 / 1474 / 1467 | 1488 | 1474 | 1467 | yes | 3,703 |
| this PR | gemini-3.7-flash | 11 / 451 / 443 | 462 | 451 | 443 | yes | 682 |

Re-run on the reviewed engine (total-authoritative fold), same script plus a long-answer Grok turn:

| lane | reported `prompt / completion / reasoning` | `total_tokens` | ledger `output / reasoning` | `estimated_cost_micro_usd` |
|---|---|---|---|---|
| grok-4.3 | 14 / 1182 / 1175 | 1196 | 1182 / 1175 | 2,973 |
| grok-4.3 stream | 14 / 1603 / 1595 | 1617 | 1603 / 1595 | 4,025 |
| grok-4.3 long answer | 23 / 1307 / 874 | 1330 | 1307 / 874 | 3,296 |
| gemini-3.7-flash | 11 / 584 / 576 | 595 | 584 / 576 | 882 |
| gemini-3.7-flash stream | 11 / 581 / 573 | 592 | 581 / 573 | 877 |

Every row: `total_tokens == prompt + completion` on our wire, `reasoning <= output` in the ledger, and the folded total reproduces xAI's own `total_tokens` by construction (its total is `prompt + completion + reasoning`, which is what selects the fold). The long-answer turn is the regime where the earlier magnitude heuristic was weakest (visible answer 433 tokens against 874 reasoning); I could not steer grok-4.3 into reasoning strictly below its visible answer live, so that case is pinned by the unit test (`14 + 900 + 300 = 1214`).

Streaming (`stream_options.include_usage`) receipts match: old 14 / 6 / 1466 -> 33 uUSD, new 14 / 1443 / 1435 -> 3,625 uUSD. Cost arithmetic checks: 14 x 1.25 + 1474 x 2.50 = 3,702.5 -> 3,703.

## Validation

- `cargo fmt --check`, `cargo clippy --no-default-features --all-targets -D warnings`, `cargo test --no-default-features`: clean, 149 passed.
- `ruff check`, `ruff format --check`, `ty check`: clean.
- Targeted: `budgets_test.py`, `native_dialect_parity_test.py`, `native_bridge_test.py`, `repo_layout_test.py`: 159 passed. Full `pytest -q`: 3377 passed, 6 skipped on both the first and the reviewed revision; the rebased tree's run is posted below.
- Native crate -> 0.3.24 (Cargo.toml, crate pyproject, Cargo.lock, parent floor, uv.lock), rebased onto main after #742 landed 0.3.23 underneath. #746 / #747 also target 0.3.24: whichever lands second must move above. No `experiential` version bump; the owner is not cutting releases right now.
- `events.rs` tests moved to `events/tests.rs` to stay under the 999-line budget.

## Follow-ups (must ride the platform pin bump)

- **Platform consumers that sum `output_tokens + reasoning_tokens` will double count Gemini and xAI once the pin carries this engine**, because the reasoning subset is now inside `output_tokens` on those lanes too: `supabase/migrations/20260930000000_gateway_rate_limit_tiers.sql`, `explabs/gateway/rate_limit_notice.py`, `supabase/migrations/20261210000000_promo_daily_token_allowance.sql`, and the `+Nr` rendering in `apps/web/.../requests-table.tsx`. Each must read the output total alone (or `output - reasoning` plus `reasoning`) in the pin-bump PR.
- The platform's `reasoning_tokens above output_tokens` settle log (platform#1157) goes quiet on Gemini and Grok lanes; `PROTOCOL_BOOLEAN_CAPABILITY_KEYS` is unaffected by this PR (no capability change here; see #744).
- Customer-visible `completion_tokens` / `total_tokens` on Gemini and Grok lanes grow to OpenAI semantics (they now include reasoning), matching the bill.
- **Not changed here, owner call:** the runtime Python clients used by the optimizer lane (`exp/runtime/models/providers/gemini.py::_gemini_usage`, `openai_compatible.py::_usage`, `openai.py::_usage`) still report the provider's unfolded output total. That is a different subsystem with its own consumers; flagging rather than folding it in a gateway PR.
- **Reservation ceiling caveat (documented in the architecture doc):** an additive provider's `max_tokens` bounds only its visible answer, so the folded output total can exceed the caller's cap the reservation ceiling was computed from, by the whole reasoning leg. Settlement charges the exact folded total; only the pre-charge bound under-reserves (known gap, same class as the platform's byte-estimator ceiling).

Generated with [Claude Code](https://claude.com/claude-code)
