### PR TITLE
gateway: declare additive-reasoning Chat Completions wires per deployment (reasoning_tokens_additive)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -215,10 +215,11 @@ of `output_tokens` and `cached_input_tokens` a subset of `input_tokens`, and set
 subset at its own rate and the remainder at the base rate. Wires that report reasoning outside
 their output total are folded by the native usage mappers before the counts leave the data plane:
 Gemini `thoughtsTokenCount` is additive by Google's definition and always folds into
-`output_tokens`; on Chat Completions a `reasoning_tokens` count above `completion_tokens` is
-impossible under subset semantics, so it identifies an additive provider (xAI, natively or relayed
-by Azure Foundry) and folds, while OpenAI, OpenRouter, Fireworks, and DeepSeek pass through
-untouched. Anthropic and Bedrock bill thinking inside their output total and publish no separate
+`output_tokens`; on Chat Completions a deployment whose catalog declares
+`reasoning_tokens_additive` (xAI, natively or relayed by Azure Foundry) folds every reported
+reasoning count, and an undeclared deployment folds when `reasoning_tokens` exceeds
+`completion_tokens`, which is impossible under subset semantics and so identifies an additive
+provider on its own; OpenAI, OpenRouter, Fireworks, and DeepSeek pass through untouched. Anthropic and Bedrock bill thinking inside their output total and publish no separate
 count, so their reasoning subset stays unknown. The customer-visible `completion_tokens` and
 `total_tokens` therefore match what is billed on every lane.
 

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -210,6 +210,18 @@ while keyed replay creates no new reservation. A period is the immutable UTC buc
 month. Management and remaining-allocation reports are CLI surfaces only. There is no budgets
 dashboard.
 
+Normalized usage follows OpenAI subset semantics on every wire: `reasoning_tokens` counts a subset
+of `output_tokens` and `cached_input_tokens` a subset of `input_tokens`, and settlement prices the
+subset at its own rate and the remainder at the base rate. Wires that report reasoning outside
+their output total are folded by the native usage mappers before the counts leave the data plane:
+Gemini `thoughtsTokenCount` is additive by Google's definition and always folds into
+`output_tokens`; on Chat Completions a `reasoning_tokens` count above `completion_tokens` is
+impossible under subset semantics, so it identifies an additive provider (xAI, natively or relayed
+by Azure Foundry) and folds, while OpenAI, OpenRouter, Fireworks, and DeepSeek pass through
+untouched. Anthropic and Bedrock bill thinking inside their output total and publish no separate
+count, so their reasoning subset stays unknown. The customer-visible `completion_tokens` and
+`total_tokens` therefore match what is billed on every lane.
+
 Each physical attempt records its own provider, model, usage, latency, terminal state, estimated
 cost attribution, and frozen credential-ownership billing source. Later catalog activation and
 process restart never rewrite that source. Schema-v1/v2 attempt rows migrate explicitly as

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -459,6 +459,17 @@ class GatewayDeploymentCapabilities(ContractModel):
     reports_refusals: bool = False
     reports_cached_input_tokens: bool = False
     reports_reasoning_tokens: bool = False
+    reasoning_tokens_additive: bool = False
+    """Whether this Chat Completions wire reports reasoning OUTSIDE ``completion_tokens``.
+
+    OpenAI and the providers that mirror it count ``completion_tokens_details.reasoning_tokens``
+    inside ``completion_tokens``; xAI (natively and relayed by Azure Foundry) reports it in
+    addition. The gateway settles reasoning as a subset of output, so a declared deployment has
+    its reasoning count folded into ``output_tokens`` by the data plane before settlement, and
+    its customer-visible ``completion_tokens`` then includes reasoning like OpenAI's. Only the
+    Chat Completions dialect reads this: Gemini thoughts are always additive and always folded,
+    and the other wires publish no separate reasoning count.
+    """
     time_to_first_byte_base_seconds: float | None = Field(default=None, gt=0)
     """Deployment override for the lane's flat time-to-first-byte allowance.
 

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -199,19 +199,29 @@ pub struct Normalizer {
     // provider supplies no tool index; assignment order mirrors the python
     // mapper's local counter.
     gemini_tool_index: u32,
-    // Fireworks-only route identity authorizing reasoning_content capture.
-    reasoning_content_route_sha256: Option<String>,
+    // Per-deployment facts that shape normalization beyond the dialect.
+    options: NormalizerOptions,
+}
+
+/// Deployment-declared facts that shape normalization beyond the wire dialect.
+#[derive(Debug, Clone, Default)]
+pub struct NormalizerOptions {
+    /// Fireworks-only route identity authorizing `reasoning_content` capture.
+    pub reasoning_content_route_sha256: Option<String>,
+    /// The deployment declares that its Chat Completions usage reports
+    /// `reasoning_tokens` OUTSIDE `completion_tokens` (xAI semantics), so the
+    /// count is folded into `output_tokens` even when it is no larger than the
+    /// visible answer. Without the declaration only the self-evident case
+    /// (reasoning above completion) folds.
+    pub reasoning_tokens_additive: bool,
 }
 
 impl Normalizer {
     pub fn new(dialect: Dialect) -> Self {
-        Self::new_with_reasoning_content_route(dialect, None)
+        Self::with_options(dialect, NormalizerOptions::default())
     }
 
-    pub fn new_with_reasoning_content_route(
-        dialect: Dialect,
-        reasoning_content_route_sha256: Option<String>,
-    ) -> Self {
+    pub fn with_options(dialect: Dialect, options: NormalizerOptions) -> Self {
         Self {
             dialect,
             tools: BTreeMap::new(),
@@ -231,7 +241,7 @@ impl Normalizer {
             usage: None,
             finish_reason: None,
             gemini_tool_index: 0,
-            reasoning_content_route_sha256,
+            options,
         }
     }
 

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -376,6 +376,46 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn thinking_usage_forwards_output_tokens_with_no_reasoning_subset() {
+        // Anthropic bills extended thinking inside output_tokens and publishes
+        // no separate thinking count, so the normalized usage forwards the
+        // provider total as reported and leaves the reasoning subset unknown
+        // rather than inventing one; the subset contract holds trivially.
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let start_message = frame(serde_json::json!({
+            "type": "message_start",
+            "message": {"usage": {"input_tokens": 41, "output_tokens": 3}},
+        }));
+        assert!(normalizer.feed(&start_message).expect("start").is_empty());
+        let thinking = frame(serde_json::json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": "", "signature": ""},
+        }));
+        assert!(normalizer
+            .feed(&thinking)
+            .expect("thinking start")
+            .is_empty());
+        let message_delta = frame(serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": null},
+            "usage": {"input_tokens": 41, "output_tokens": 412},
+        }));
+        assert!(normalizer.feed(&message_delta).expect("delta").is_empty());
+        let events = normalizer
+            .feed(&frame(serde_json::json!({"type": "message_stop"})))
+            .expect("message stop");
+        match events.as_slice() {
+            [Event::Usage(usage), Event::Completed] => {
+                assert_eq!(usage.input_tokens, Some(41));
+                assert_eq!(usage.output_tokens, Some(412));
+                assert_eq!(usage.reasoning_tokens, None);
+            }
+            other => panic!("unexpected events: {other:?}"),
+        }
+    }
+
     /// Frame shapes captured live from one web_search stream (2026-08-31):
     /// server tool use with a leading empty input fragment, the whole result
     /// in its start frame, a cited answer, terminal usage that supersedes the

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -211,16 +211,107 @@ mod gemini_tests {
                     "name": "lookup",
                     "raw_arguments": raw_arguments,
                 }),
+                // thoughtsTokenCount is additive on the Gemini wire, so the
+                // output total carries the folded 5 + 3 and reasoning names
+                // the subset.
                 json!({
                     "kind": "usage",
                     "input_tokens": 11,
-                    "output_tokens": 5,
+                    "output_tokens": 8,
                     "cached_input_tokens": 2,
                     "reasoning_tokens": 3,
                 }),
                 json!({"kind": "completed"}),
             ]
         );
+    }
+
+    #[test]
+    fn gemini_thinking_stream_folds_thoughts_into_the_terminal_usage() {
+        // Verbatim frames from gemini-3.7-flash streamGenerateContent?alt=sse
+        // (2026-09-03): every chunk carries the full usageMetadata, the final
+        // chunk adds the thoughtSignature part and STOP. Google's
+        // totalTokenCount (11 + 7 + 654 = 672) shows thoughts are additive, so
+        // the normalized output total is 661 with 654 as the reasoning subset.
+        let usage_metadata = json!({
+            "promptTokenCount": 11,
+            "candidatesTokenCount": 7,
+            "totalTokenCount": 672,
+            "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+            "thoughtsTokenCount": 654,
+            "serviceTier": "standard",
+        });
+        let chunks = [
+            sse(&json!({
+                "candidates": [{"content": {"parts": [{"text": "Sunlight scatters off air "}], "role": "model"}, "index": 0}],
+                "usageMetadata": usage_metadata,
+                "modelVersion": "gemini-3.7-flash",
+                "responseId": "resp-1",
+            })),
+            sse(&json!({
+                "candidates": [{
+                    "content": {"parts": [{"text": "molecules.", "thoughtSignature": "CikB"}], "role": "model"},
+                    "finishReason": "STOP",
+                    "index": 0,
+                }],
+                "usageMetadata": usage_metadata,
+                "modelVersion": "gemini-3.7-flash",
+                "responseId": "resp-1",
+            })),
+        ];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(failure.is_none());
+        assert_eq!(
+            events,
+            vec![
+                json!({"kind": "text_delta", "text": "Sunlight scatters off air "}),
+                json!({"kind": "text_delta", "text": "molecules."}),
+                json!({
+                    "kind": "usage",
+                    "input_tokens": 11,
+                    "output_tokens": 661,
+                    "cached_input_tokens": 0,
+                    "reasoning_tokens": 654,
+                }),
+                json!({"kind": "completed"}),
+            ]
+        );
+    }
+
+    #[test]
+    fn gemini_stream_without_thinking_keeps_the_reasoning_subset_unknown() {
+        // Verbatim usageMetadata from gemini-2.5-flash with thinkingBudget 0:
+        // no thoughtsTokenCount is published, so nothing folds and the subset
+        // stays unknown rather than being invented as zero.
+        let chunks = [sse(&json!({
+            "candidates": [{
+                "content": {"parts": [{"text": "Air scatters blue light most."}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 11,
+                "candidatesTokenCount": 9,
+                "totalTokenCount": 20,
+                "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+                "serviceTier": "standard",
+            },
+        }))];
+        let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
+        let (events, failure) = run_stream(Dialect::GeminiGenerateContent, &refs);
+        assert!(failure.is_none());
+        assert_eq!(
+            events[1],
+            json!({
+                "kind": "usage",
+                "input_tokens": 11,
+                "output_tokens": 9,
+                "cached_input_tokens": 0,
+                "reasoning_tokens": null,
+            })
+        );
+        assert_eq!(events[2], json!({"kind": "completed"}));
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -749,7 +749,8 @@ impl Normalizer {
         if let Some(raw_usage) = payload.get("usage") {
             if !raw_usage.is_null() {
                 self.usage = Some(
-                    openai_compatible_usage(raw_usage).map_err(|message| malformed(&message))?,
+                    openai_compatible_usage(raw_usage, self.options.reasoning_tokens_additive)
+                        .map_err(|message| malformed(&message))?,
                 );
             }
         }
@@ -781,7 +782,7 @@ impl Normalizer {
             self.refusal_seen = true;
             events.push(Event::RefusalDelta(refusal.clone()));
         }
-        if let Some(route_sha256) = self.reasoning_content_route_sha256.clone() {
+        if let Some(route_sha256) = self.options.reasoning_content_route_sha256.clone() {
             if let Some(value) = delta.get("reasoning_content") {
                 let reasoning = match value {
                     Value::Null => None,

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -329,3 +329,79 @@ fn completed_reasoning_items_pass_encrypted_content_through() {
         ] if item_id.as_deref() == Some("rs_2")
     ));
 }
+
+#[test]
+fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
+    // Verbatim final frames from Azure Foundry grok-4.3 (silen-resource,
+    // 2026-09-03, stream_options.include_usage): xAI reports 655 reasoning
+    // tokens OUTSIDE completion_tokens=8 (its total_tokens 677 = 14 + 8 + 655),
+    // so the normalized usage carries the folded output total with the
+    // reasoning subset intact, and the cached prompt leg passes through.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    let text = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "8ca8705f-1504-4bec-a739-38e3726ff3d4",
+            "object": "chat.completion.chunk",
+            "created": 1788425522,
+            "model": "grok-4.3",
+            "choices": [{"index": 0, "delta": {"content": "Because"}, "finish_reason": null}],
+            "system_fingerprint": "fp_39c5j0a3e9",
+        })
+        .to_string(),
+    };
+    assert!(matches!(
+        normalizer.feed(&text).expect("text").as_slice(),
+        [Event::TextDelta(delta)] if delta == "Because"
+    ));
+    let finish = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "8ca8705f-1504-4bec-a739-38e3726ff3d4",
+            "object": "chat.completion.chunk",
+            "created": 1788425522,
+            "model": "grok-4.3",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "system_fingerprint": "fp_39c5j0a3e9",
+        })
+        .to_string(),
+    };
+    assert!(normalizer.feed(&finish).expect("finish").is_empty());
+    let usage = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "8ca8705f-1504-4bec-a739-38e3726ff3d4",
+            "object": "chat.completion.chunk",
+            "created": 1788425522,
+            "model": "grok-4.3",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 14,
+                "completion_tokens": 8,
+                "total_tokens": 677,
+                "prompt_tokens_details": {"text_tokens": 14, "audio_tokens": 0, "image_tokens": 0, "cached_tokens": 4},
+                "completion_tokens_details": {"reasoning_tokens": 655, "audio_tokens": 0, "accepted_prediction_tokens": 0, "rejected_prediction_tokens": 0},
+                "num_sources_used": 0,
+                "cost_in_usd_ticks": 0,
+            },
+            "system_fingerprint": "fp_39c5j0a3e9",
+            "service_tier": "default",
+        })
+        .to_string(),
+    };
+    assert!(normalizer.feed(&usage).expect("usage").is_empty());
+    let done = SseEvent {
+        event: None,
+        data: "[DONE]".to_string(),
+    };
+    let events = normalizer.feed(&done).expect("terminal");
+    match events.as_slice() {
+        [Event::Usage(usage), Event::Completed] => {
+            assert_eq!(usage.input_tokens, Some(14));
+            assert_eq!(usage.output_tokens, Some(663));
+            assert_eq!(usage.cached_input_tokens, Some(4));
+            assert_eq!(usage.reasoning_tokens, Some(655));
+        }
+        other => panic!("unexpected events: {other:?}"),
+    }
+}

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -2,7 +2,9 @@
 //! module line budget).
 
 use super::*;
-use crate::dialects::{Dialect, MAXIMUM_RETAINED_PROVIDER_ENTRIES, OUTPUT_OVERFLOW_MESSAGE};
+use crate::dialects::{
+    Dialect, NormalizerOptions, MAXIMUM_RETAINED_PROVIDER_ENTRIES, OUTPUT_OVERFLOW_MESSAGE,
+};
 use crate::sse::SseEvent;
 fn reasoning_delta(output_index: u32, summary_index: u32, delta: &str) -> SseEvent {
     SseEvent {
@@ -127,9 +129,12 @@ fn compatible_reasoning_content_requires_fireworks_route_authority() {
         .to_string(),
     };
     let route_sha256 = "a".repeat(64);
-    let mut authorized = Normalizer::new_with_reasoning_content_route(
+    let mut authorized = Normalizer::with_options(
         Dialect::OpenAiCompatible,
-        Some(route_sha256.clone()),
+        NormalizerOptions {
+            reasoning_content_route_sha256: Some(route_sha256.clone()),
+            ..NormalizerOptions::default()
+        },
     );
     let events = authorized
         .feed(&frame)
@@ -162,9 +167,12 @@ fn fireworks_reasoning_content_rejects_non_text_values() {
         })
         .to_string(),
     };
-    let mut normalizer = Normalizer::new_with_reasoning_content_route(
+    let mut normalizer = Normalizer::with_options(
         Dialect::OpenAiCompatible,
-        Some("a".repeat(64)),
+        NormalizerOptions {
+            reasoning_content_route_sha256: Some("a".repeat(64)),
+            ..NormalizerOptions::default()
+        },
     );
 
     assert!(normalizer.feed(&frame).is_err());
@@ -401,6 +409,58 @@ fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
             assert_eq!(usage.output_tokens, Some(663));
             assert_eq!(usage.cached_input_tokens, Some(4));
             assert_eq!(usage.reasoning_tokens, Some(655));
+        }
+        other => panic!("unexpected events: {other:?}"),
+    }
+}
+
+#[test]
+fn declared_additive_deployment_folds_reasoning_even_below_the_visible_answer() {
+    // A deployment whose catalog declares reasoning_tokens_additive reports xAI
+    // semantics: reasoning is outside completion_tokens whatever its size. The
+    // heuristic alone would miss this long-answer, short-reasoning turn (5 <= 40);
+    // the declaration folds it, and the undeclared normalizer forwards it raw.
+    let usage_frame = || SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "chatcmpl-additive",
+            "object": "chat.completion.chunk",
+            "model": "grok-4.3",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 30,
+                "completion_tokens": 40,
+                "total_tokens": 75,
+                "completion_tokens_details": {"reasoning_tokens": 5},
+            },
+        })
+        .to_string(),
+    };
+    let done = || SseEvent {
+        event: None,
+        data: "[DONE]".to_string(),
+    };
+    let mut declared = Normalizer::with_options(
+        Dialect::OpenAiCompatible,
+        NormalizerOptions {
+            reasoning_tokens_additive: true,
+            ..NormalizerOptions::default()
+        },
+    );
+    assert!(declared.feed(&usage_frame()).expect("usage").is_empty());
+    match declared.feed(&done()).expect("terminal").as_slice() {
+        [Event::Usage(usage), Event::Completed] => {
+            assert_eq!(usage.output_tokens, Some(45));
+            assert_eq!(usage.reasoning_tokens, Some(5));
+        }
+        other => panic!("unexpected events: {other:?}"),
+    }
+    let mut undeclared = Normalizer::new(Dialect::OpenAiCompatible);
+    assert!(undeclared.feed(&usage_frame()).expect("usage").is_empty());
+    match undeclared.feed(&done()).expect("terminal").as_slice() {
+        [Event::Usage(usage), Event::Completed] => {
+            assert_eq!(usage.output_tokens, Some(40));
+            assert_eq!(usage.reasoning_tokens, Some(5));
         }
         other => panic!("unexpected events: {other:?}"),
     }

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -15,9 +15,10 @@
 //! - Chat Completions (`openai_compatible_usage`): OpenAI, OpenRouter, DeepSeek,
 //!   Fireworks, and Azure-relayed Fireworks fold reasoning into
 //!   `completion_tokens`; xAI (native and relayed by Azure Foundry) reports it
-//!   outside. A reasoning count above `completion_tokens` is impossible under
-//!   subset semantics, so it is taken as proof of an additive provider and
-//!   folded; a folded provider is never touched.
+//!   outside. A deployment declaring `reasoning_tokens_additive` folds every
+//!   reported count; without the declaration a reasoning count above
+//!   `completion_tokens`, impossible under subset semantics, is taken as proof
+//!   of an additive provider and folded. A folded provider is never touched.
 //! - Gemini (`gemini_usage`): `thoughtsTokenCount` is additive by Google's
 //!   definition (`totalTokenCount` = prompt + candidates + thoughts), so it is
 //!   folded into `output_tokens` unconditionally.
@@ -700,13 +701,16 @@ fn fold_additive_reasoning(
 ///
 /// `completion_tokens_details.reasoning_tokens` is a subset of
 /// `completion_tokens` on OpenAI and every provider that mirrors it, and is
-/// forwarded as reported. A reasoning count ABOVE `completion_tokens` cannot
-/// occur under subset semantics; it identifies a provider that reports
-/// reasoning additively (xAI, natively or relayed by Azure Foundry), so the
-/// count is folded into `output_tokens` and `reasoning_tokens` keeps naming
-/// the subset. The fold misses an additive provider only when its reasoning
-/// happens to be no larger than its visible answer.
-pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
+/// forwarded as reported. A provider that reports reasoning additively (xAI,
+/// natively or relayed by Azure Foundry) has its count folded into
+/// `output_tokens` while `reasoning_tokens` keeps naming the subset. The fold
+/// applies when the deployment declares `declared_additive`
+/// (`GatewayDeploymentCapabilities.reasoning_tokens_additive`) or when the
+/// reported reasoning count is ABOVE `completion_tokens`, which cannot occur
+/// under subset semantics and so identifies an additive provider on its own.
+/// An undeclared additive provider is missed only when its reasoning happens
+/// to be no larger than its visible answer.
+pub fn openai_compatible_usage(value: &Value, declared_additive: bool) -> Result<Usage, String> {
     let object = value
         .as_object()
         .ok_or_else(|| "OpenAI-compatible usage must be an object".to_string())?;
@@ -718,7 +722,7 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
         "reasoning_tokens",
     )?;
     let output_tokens = match reasoning_tokens {
-        Some(reasoning) if reasoning > completion_tokens => {
+        Some(reasoning) if declared_additive || reasoning > completion_tokens => {
             fold_additive_reasoning(completion_tokens, reasoning, "OpenAI-compatible")?
         }
         _ => completion_tokens,

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -1,4 +1,32 @@
 //! Provider-neutral stream events, the Rust mirror of `GatewayEvent`.
+//!
+//! # Usage contract
+//!
+//! Every usage mapper in this module emits OpenAI subset semantics:
+//! `reasoning_tokens` (when known) counts a SUBSET of `output_tokens`, and
+//! `cached_input_tokens` a subset of `input_tokens`. Settlement prices the
+//! reasoning subset at the reasoning rate and the remainder of `output_tokens`
+//! at the output rate, so a wire that reports reasoning OUTSIDE its output
+//! total would bill every reasoning token at zero unless the mapper folds it
+//! back in. Per wire:
+//!
+//! - OpenAI Responses (`openai_usage`): `output_tokens_details.reasoning_tokens`
+//!   is a documented subset of `output_tokens`; forwarded as reported.
+//! - Chat Completions (`openai_compatible_usage`): OpenAI, OpenRouter, DeepSeek,
+//!   Fireworks, and Azure-relayed Fireworks fold reasoning into
+//!   `completion_tokens`; xAI (native and relayed by Azure Foundry) reports it
+//!   outside. A reasoning count above `completion_tokens` is impossible under
+//!   subset semantics, so it is taken as proof of an additive provider and
+//!   folded; a folded provider is never touched.
+//! - Gemini (`gemini_usage`): `thoughtsTokenCount` is additive by Google's
+//!   definition (`totalTokenCount` = prompt + candidates + thoughts), so it is
+//!   folded into `output_tokens` unconditionally.
+//! - Anthropic Messages and Bedrock Converse: thinking is billed inside the
+//!   provider's `output_tokens` and no separate count is published, so
+//!   `reasoning_tokens` stays `None` and the total is forwarded as reported.
+//!
+//! A fold whose total leaves the persistable ledger range is a provider
+//! contract violation and fails the stream; totals are never clamped.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -651,20 +679,53 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
     }))
 }
 
-/// Parse a Chat Completions usage object, mirroring
-/// `streaming_usage.openai_compatible_usage`: a malformed object fails the
-/// stream instead of silently dropping token accounting.
+/// Fold a reasoning count the provider reports OUTSIDE its output total back
+/// into that total, so the emitted usage satisfies the reasoning-subset
+/// contract (see the module documentation). A folded total beyond the
+/// persistable ledger range is a provider contract violation, never a clamped
+/// or wrapped total.
+fn fold_additive_reasoning(
+    output_tokens: u64,
+    reasoning_tokens: u64,
+    label: &str,
+) -> Result<u64, String> {
+    output_tokens
+        .checked_add(reasoning_tokens)
+        .filter(|total| *total <= MAXIMUM_LEDGER_COUNT)
+        .ok_or_else(|| format!("{label} output token total overflows a persistable count"))
+}
+
+/// Parse a Chat Completions usage object: a malformed object fails the stream
+/// instead of silently dropping token accounting.
+///
+/// `completion_tokens_details.reasoning_tokens` is a subset of
+/// `completion_tokens` on OpenAI and every provider that mirrors it, and is
+/// forwarded as reported. A reasoning count ABOVE `completion_tokens` cannot
+/// occur under subset semantics; it identifies a provider that reports
+/// reasoning additively (xAI, natively or relayed by Azure Foundry), so the
+/// count is folded into `output_tokens` and `reasoning_tokens` keeps naming
+/// the subset. The fold misses an additive provider only when its reasoning
+/// happens to be no larger than its visible answer.
 pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
         .ok_or_else(|| "OpenAI-compatible usage must be an object".to_string())?;
+    let completion_tokens = count_or_zero(object, "completion_tokens", "completion_tokens")?;
+    let reasoning_tokens = optional_usage_detail(
+        object,
+        "completion_tokens_details",
+        "reasoning_tokens",
+        "reasoning_tokens",
+    )?;
+    let output_tokens = match reasoning_tokens {
+        Some(reasoning) if reasoning > completion_tokens => {
+            fold_additive_reasoning(completion_tokens, reasoning, "OpenAI-compatible")?
+        }
+        _ => completion_tokens,
+    };
     Ok(Usage {
         input_tokens: Some(count_or_zero(object, "prompt_tokens", "prompt_tokens")?),
-        output_tokens: Some(count_or_zero(
-            object,
-            "completion_tokens",
-            "completion_tokens",
-        )?),
+        output_tokens: Some(output_tokens),
         cached_input_tokens: optional_usage_detail(
             object,
             "prompt_tokens_details",
@@ -672,18 +733,19 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
             "cached_tokens",
         )?,
         cache_creation_input_tokens: None,
-        reasoning_tokens: optional_usage_detail(
-            object,
-            "completion_tokens_details",
-            "reasoning_tokens",
-            "reasoning_tokens",
-        )?,
+        reasoning_tokens,
     })
 }
 
-/// Parse Gemini `usageMetadata`, mirroring the python `_usage` normalizer:
-/// cached tokens are an input subset, absent counts are zero (`require_integer`
-/// parity), and `thoughtsTokenCount` stays unknown when omitted.
+/// Parse Gemini `usageMetadata`: cached tokens are an input subset, absent
+/// counts are zero (`require_integer` parity), and `thoughtsTokenCount` stays
+/// unknown when omitted.
+///
+/// Google defines thinking tokens as ADDITIVE to `candidatesTokenCount`
+/// (`totalTokenCount` = prompt + candidates + thoughts, and response pricing
+/// is the sum of output and thinking tokens), so a reported
+/// `thoughtsTokenCount` is folded into `output_tokens`; `reasoning_tokens`
+/// names the subset the ledger prices at the reasoning rate.
 pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
@@ -696,17 +758,22 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
             "Gemini thoughtsTokenCount",
         )?),
     };
+    let candidates_tokens = count_or_zero(
+        object,
+        "candidatesTokenCount",
+        "Gemini candidatesTokenCount",
+    )?;
+    let output_tokens = match reasoning_tokens {
+        Some(reasoning) => fold_additive_reasoning(candidates_tokens, reasoning, "Gemini")?,
+        None => candidates_tokens,
+    };
     Ok(Usage {
         input_tokens: Some(count_or_zero(
             object,
             "promptTokenCount",
             "Gemini promptTokenCount",
         )?),
-        output_tokens: Some(count_or_zero(
-            object,
-            "candidatesTokenCount",
-            "Gemini candidatesTokenCount",
-        )?),
+        output_tokens: Some(output_tokens),
         cached_input_tokens: Some(count_or_zero(
             object,
             "cachedContentTokenCount",
@@ -717,12 +784,13 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
     })
 }
 
-/// Parse Bedrock `metadata.usage`, mirroring the python `_usage` normalizer:
-/// cache read and write legs fold into total input, cached input reports the
-/// read leg, and absent counts are zero (`require_integer` parity). Legs and
-/// the folded total beyond the persistable ledger range are provider
-/// contract violations and fail the stream rather than reaching settlement
-/// as a value the ledger could never write.
+/// Parse Bedrock `metadata.usage`: cache read and write legs fold into total
+/// input, cached input reports the read leg, and absent counts are zero
+/// (`require_integer` parity). Legs and the folded total beyond the
+/// persistable ledger range are provider contract violations and fail the
+/// stream rather than reaching settlement as a value the ledger could never
+/// write. Converse bills a reasoning model's thinking inside `outputTokens`
+/// and publishes no separate count, so `reasoning_tokens` stays unknown.
 pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
     let usage = value
         .and_then(Value::as_object)
@@ -798,155 +866,5 @@ pub fn require_u64(object: &Map<String, Value>, key: &str, label: &str) -> Resul
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn output_tokens_lead_a_turn_but_control_frames_do_not() {
-        // Content, reasoning, and tool-call deltas are the first visible output.
-        assert!(Event::TextDelta("hi".to_string()).is_output_token());
-        assert!(Event::RefusalDelta("no".to_string()).is_output_token());
-        assert!(Event::ProviderTextDelta {
-            output_index: 0,
-            item_id: "msg_1".to_string(),
-            delta: "hi".to_string(),
-        }
-        .is_output_token());
-        assert!(Event::ThinkingDelta {
-            index: 0,
-            delta: "hmm".to_string(),
-        }
-        .is_output_token());
-        // A tool-only turn's first token is the tool call itself.
-        assert!(Event::ToolCallStarted {
-            index: 0,
-            call_id: "call_1".to_string(),
-            name: "get".to_string(),
-        }
-        .is_output_token());
-        // Usage, terminals, and opaque reasoning-carrier frames never lead.
-        assert!(!Event::Usage(Usage::default()).is_output_token());
-        assert!(!Event::Completed.is_output_token());
-        assert!(!Event::Incomplete.is_output_token());
-        assert!(!Event::ThinkingSignature {
-            index: 0,
-            signature: "sig".to_string(),
-        }
-        .is_output_token());
-        // A Responses item-start reserves a slot before the first delta; it
-        // must not stamp TTFT early -- the following delta is the real token.
-        assert!(!Event::ProviderOutputItemStarted {
-            output_index: 0,
-            item_id: Some("msg_1".to_string()),
-            kind: ProviderOutputItemKind::Message,
-            status: None,
-            phase: None,
-        }
-        .is_output_token());
-        // An empty delta (role-establishing or empty refusal frame) carries no
-        // visible token, so it must not stamp TTFT.
-        assert!(!Event::TextDelta(String::new()).is_output_token());
-        assert!(!Event::RefusalDelta(String::new()).is_output_token());
-        assert!(!Event::ProviderTextDelta {
-            output_index: 0,
-            item_id: "msg_1".to_string(),
-            delta: String::new(),
-        }
-        .is_output_token());
-    }
-
-    #[test]
-    fn openai_compatible_usage_counts_absent_fields_as_zero() {
-        let usage = openai_compatible_usage(&json!({"prompt_tokens": 7})).expect("valid usage");
-        assert_eq!(usage.input_tokens, Some(7));
-        assert_eq!(usage.output_tokens, Some(0));
-        assert_eq!(usage.cached_input_tokens, None);
-        assert_eq!(usage.reasoning_tokens, None);
-    }
-
-    #[test]
-    fn openai_compatible_usage_rejects_malformed_counts() {
-        assert!(openai_compatible_usage(&json!({"prompt_tokens": "7"})).is_err());
-        assert!(
-            openai_compatible_usage(&json!({"prompt_tokens": MAXIMUM_LEDGER_COUNT + 1})).is_err()
-        );
-        assert!(openai_compatible_usage(&json!([1])).is_err());
-        assert!(openai_compatible_usage(
-            &json!({"prompt_tokens": 1, "completion_tokens": 1, "prompt_tokens_details": 3})
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn parsed_counts_are_bounded_to_the_persistable_ledger_range() {
-        let at_bound = json!({"count": MAXIMUM_LEDGER_COUNT});
-        let over_bound = json!({"count": MAXIMUM_LEDGER_COUNT + 1});
-        let at_object = at_bound.as_object().expect("object");
-        let over_object = over_bound.as_object().expect("object");
-        // Exactly i64::MAX is persistable and accepted; one past it is a
-        // provider contract violation everywhere counts are parsed.
-        assert_eq!(
-            count_or_zero(at_object, "count", "count"),
-            Ok(MAXIMUM_LEDGER_COUNT)
-        );
-        assert!(count_or_zero(over_object, "count", "count").is_err());
-        assert_eq!(
-            require_u64(at_object, "count", "count"),
-            Ok(MAXIMUM_LEDGER_COUNT)
-        );
-        assert!(require_u64(over_object, "count", "count").is_err());
-        assert!(openai_usage(Some(&json!({
-            "input_tokens": 1,
-            "output_tokens": 1,
-            "output_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT + 1},
-        })))
-        .is_err());
-    }
-
-    #[test]
-    fn bedrock_usage_folds_cache_legs_and_rejects_unrepresentable_totals() {
-        let usage = bedrock_usage(Some(&json!({
-            "inputTokens": 9,
-            "outputTokens": 4,
-            "cacheReadInputTokens": 2,
-            "cacheWriteInputTokens": 1,
-        })))
-        .expect("valid usage");
-        assert_eq!(usage.input_tokens, Some(12));
-        assert_eq!(usage.cached_input_tokens, Some(2));
-        // A leg beyond the persistable ledger range fails at the parser.
-        assert!(bedrock_usage(Some(&json!({
-            "inputTokens": MAXIMUM_LEDGER_COUNT + 1,
-            "outputTokens": 1,
-        })))
-        .is_err());
-        // Individually persistable legs whose folded total is not are a
-        // provider contract violation, never a clamped or wrapped total.
-        assert!(bedrock_usage(Some(&json!({
-            "inputTokens": MAXIMUM_LEDGER_COUNT,
-            "outputTokens": 1,
-            "cacheReadInputTokens": 1,
-        })))
-        .is_err());
-        assert!(bedrock_usage(Some(&json!(null))).is_err());
-        assert!(bedrock_usage(None).is_err());
-    }
-
-    #[test]
-    fn openai_usage_treats_absent_and_null_objects_as_unknown() {
-        assert!(openai_usage(None).expect("absent is unknown").is_none());
-        assert!(openai_usage(Some(&serde_json::Value::Null))
-            .expect("null is unknown")
-            .is_none());
-        let usage = openai_usage(Some(&json!({
-            "input_tokens": 2,
-            "output_tokens": 3,
-            "output_tokens_details": {"reasoning_tokens": 1},
-        })))
-        .expect("valid usage")
-        .expect("usage present");
-        assert_eq!(usage.reasoning_tokens, Some(1));
-        assert_eq!(usage.cached_input_tokens, None);
-    }
-}
+#[path = "events/tests.rs"]
+mod tests;

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -60,7 +60,7 @@ fn output_tokens_lead_a_turn_but_control_frames_do_not() {
 
 #[test]
 fn openai_compatible_usage_counts_absent_fields_as_zero() {
-    let usage = openai_compatible_usage(&json!({"prompt_tokens": 7})).expect("valid usage");
+    let usage = openai_compatible_usage(&json!({"prompt_tokens": 7}), false).expect("valid usage");
     assert_eq!(usage.input_tokens, Some(7));
     assert_eq!(usage.output_tokens, Some(0));
     assert_eq!(usage.cached_input_tokens, None);
@@ -69,11 +69,15 @@ fn openai_compatible_usage_counts_absent_fields_as_zero() {
 
 #[test]
 fn openai_compatible_usage_rejects_malformed_counts() {
-    assert!(openai_compatible_usage(&json!({"prompt_tokens": "7"})).is_err());
-    assert!(openai_compatible_usage(&json!({"prompt_tokens": MAXIMUM_LEDGER_COUNT + 1})).is_err());
-    assert!(openai_compatible_usage(&json!([1])).is_err());
+    assert!(openai_compatible_usage(&json!({"prompt_tokens": "7"}), false).is_err());
+    assert!(
+        openai_compatible_usage(&json!({"prompt_tokens": MAXIMUM_LEDGER_COUNT + 1}), false)
+            .is_err()
+    );
+    assert!(openai_compatible_usage(&json!([1]), false).is_err());
     assert!(openai_compatible_usage(
-        &json!({"prompt_tokens": 1, "completion_tokens": 1, "prompt_tokens_details": 3})
+        &json!({"prompt_tokens": 1, "completion_tokens": 1, "prompt_tokens_details": 3}),
+        false
     )
     .is_err());
 }
@@ -178,28 +182,34 @@ fn openai_compatible_usage_leaves_a_folded_provider_untouched() {
     // is forwarded exactly; the equal case is a legal subset, not evidence of
     // an additive provider.
     for (completion, reasoning) in [(700u64, 690u64), (690, 690), (5, 0)] {
-        let usage = openai_compatible_usage(&json!({
-            "prompt_tokens": 36,
-            "completion_tokens": completion,
-            "total_tokens": 36 + completion,
-            "completion_tokens_details": {"reasoning_tokens": reasoning},
-        }))
+        let usage = openai_compatible_usage(
+            &json!({
+                "prompt_tokens": 36,
+                "completion_tokens": completion,
+                "total_tokens": 36 + completion,
+                "completion_tokens_details": {"reasoning_tokens": reasoning},
+            }),
+            false,
+        )
         .expect("valid usage");
         assert_eq!(usage.output_tokens, Some(completion));
         assert_eq!(usage.reasoning_tokens, Some(reasoning));
     }
     // OpenRouter normalizes upstream reasoning into completion_tokens and
     // reports the subset alongside (shape captured from openrouter.ai).
-    let openrouter = openai_compatible_usage(&json!({
-        "prompt_tokens": 14,
-        "completion_tokens": 543,
-        "total_tokens": 557,
-        "cost": 0.0016,
-        "is_byok": false,
-        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
-        "cost_details": {"upstream_inference_cost": null},
-        "completion_tokens_details": {"reasoning_tokens": 480, "image_tokens": 0},
-    }))
+    let openrouter = openai_compatible_usage(
+        &json!({
+            "prompt_tokens": 14,
+            "completion_tokens": 543,
+            "total_tokens": 557,
+            "cost": 0.0016,
+            "is_byok": false,
+            "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+            "cost_details": {"upstream_inference_cost": null},
+            "completion_tokens_details": {"reasoning_tokens": 480, "image_tokens": 0},
+        }),
+        false,
+    )
     .expect("valid usage");
     assert_eq!(openrouter.output_tokens, Some(543));
     assert_eq!(openrouter.reasoning_tokens, Some(480));
@@ -212,25 +222,28 @@ fn openai_compatible_usage_folds_an_additive_provider_into_output_tokens() {
     // its own total_tokens confirms (14 + 7 + 1303 = 1324). A reasoning count
     // above completion_tokens is impossible under subset semantics, so the
     // mapper folds it and the subset stays reported.
-    let usage = openai_compatible_usage(&json!({
-        "prompt_tokens": 14,
-        "completion_tokens": 7,
-        "total_tokens": 1324,
-        "audio_prompt_tokens": 0,
-        "prompt_tokens_details": {
-            "cached_tokens": 0,
-            "audio_tokens": 0,
-            "text_tokens": 14,
-            "image_tokens": 0,
-        },
-        "completion_tokens_details": {
-            "reasoning_tokens": 1303,
-            "audio_tokens": 0,
-            "accepted_prediction_tokens": 0,
-            "rejected_prediction_tokens": 0,
-        },
-        "num_sources_used": 0,
-    }))
+    let usage = openai_compatible_usage(
+        &json!({
+            "prompt_tokens": 14,
+            "completion_tokens": 7,
+            "total_tokens": 1324,
+            "audio_prompt_tokens": 0,
+            "prompt_tokens_details": {
+                "cached_tokens": 0,
+                "audio_tokens": 0,
+                "text_tokens": 14,
+                "image_tokens": 0,
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": 1303,
+                "audio_tokens": 0,
+                "accepted_prediction_tokens": 0,
+                "rejected_prediction_tokens": 0,
+            },
+            "num_sources_used": 0,
+        }),
+        false,
+    )
     .expect("valid usage");
     assert_eq!(usage.input_tokens, Some(14));
     assert_eq!(usage.output_tokens, Some(1310));
@@ -242,11 +255,14 @@ fn openai_compatible_usage_folds_an_additive_provider_into_output_tokens() {
         1324
     );
     // A fold whose total leaves the persistable range is a contract violation.
-    assert!(openai_compatible_usage(&json!({
-        "prompt_tokens": 1,
-        "completion_tokens": 1,
-        "completion_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT},
-    }))
+    assert!(openai_compatible_usage(
+        &json!({
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "completion_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT},
+        }),
+        false
+    )
     .is_err());
 }
 
@@ -313,4 +329,27 @@ fn gemini_usage_folds_thoughts_into_output_tokens() {
         "thoughtsTokenCount": 1,
     }))
     .is_err());
+}
+
+#[test]
+fn openai_compatible_usage_honours_the_deployment_declaration() {
+    // A declared-additive deployment folds even when reasoning is no larger
+    // than the visible answer (the case the heuristic alone cannot see), and
+    // still has nothing to fold when the provider publishes no reasoning count.
+    let usage = openai_compatible_usage(
+        &json!({
+            "prompt_tokens": 30,
+            "completion_tokens": 40,
+            "completion_tokens_details": {"reasoning_tokens": 5},
+        }),
+        true,
+    )
+    .expect("valid usage");
+    assert_eq!(usage.output_tokens, Some(45));
+    assert_eq!(usage.reasoning_tokens, Some(5));
+    let undetailed =
+        openai_compatible_usage(&json!({"prompt_tokens": 30, "completion_tokens": 40}), true)
+            .expect("valid usage");
+    assert_eq!(undetailed.output_tokens, Some(40));
+    assert_eq!(undetailed.reasoning_tokens, None);
 }

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -1,0 +1,316 @@
+//! Usage-mapper and count-parsing regressions for `events.rs` (moved out of
+//! the module for its line budget).
+
+use super::*;
+use serde_json::json;
+
+#[test]
+fn output_tokens_lead_a_turn_but_control_frames_do_not() {
+    // Content, reasoning, and tool-call deltas are the first visible output.
+    assert!(Event::TextDelta("hi".to_string()).is_output_token());
+    assert!(Event::RefusalDelta("no".to_string()).is_output_token());
+    assert!(Event::ProviderTextDelta {
+        output_index: 0,
+        item_id: "msg_1".to_string(),
+        delta: "hi".to_string(),
+    }
+    .is_output_token());
+    assert!(Event::ThinkingDelta {
+        index: 0,
+        delta: "hmm".to_string(),
+    }
+    .is_output_token());
+    // A tool-only turn's first token is the tool call itself.
+    assert!(Event::ToolCallStarted {
+        index: 0,
+        call_id: "call_1".to_string(),
+        name: "get".to_string(),
+    }
+    .is_output_token());
+    // Usage, terminals, and opaque reasoning-carrier frames never lead.
+    assert!(!Event::Usage(Usage::default()).is_output_token());
+    assert!(!Event::Completed.is_output_token());
+    assert!(!Event::Incomplete.is_output_token());
+    assert!(!Event::ThinkingSignature {
+        index: 0,
+        signature: "sig".to_string(),
+    }
+    .is_output_token());
+    // A Responses item-start reserves a slot before the first delta; it
+    // must not stamp TTFT early -- the following delta is the real token.
+    assert!(!Event::ProviderOutputItemStarted {
+        output_index: 0,
+        item_id: Some("msg_1".to_string()),
+        kind: ProviderOutputItemKind::Message,
+        status: None,
+        phase: None,
+    }
+    .is_output_token());
+    // An empty delta (role-establishing or empty refusal frame) carries no
+    // visible token, so it must not stamp TTFT.
+    assert!(!Event::TextDelta(String::new()).is_output_token());
+    assert!(!Event::RefusalDelta(String::new()).is_output_token());
+    assert!(!Event::ProviderTextDelta {
+        output_index: 0,
+        item_id: "msg_1".to_string(),
+        delta: String::new(),
+    }
+    .is_output_token());
+}
+
+#[test]
+fn openai_compatible_usage_counts_absent_fields_as_zero() {
+    let usage = openai_compatible_usage(&json!({"prompt_tokens": 7})).expect("valid usage");
+    assert_eq!(usage.input_tokens, Some(7));
+    assert_eq!(usage.output_tokens, Some(0));
+    assert_eq!(usage.cached_input_tokens, None);
+    assert_eq!(usage.reasoning_tokens, None);
+}
+
+#[test]
+fn openai_compatible_usage_rejects_malformed_counts() {
+    assert!(openai_compatible_usage(&json!({"prompt_tokens": "7"})).is_err());
+    assert!(openai_compatible_usage(&json!({"prompt_tokens": MAXIMUM_LEDGER_COUNT + 1})).is_err());
+    assert!(openai_compatible_usage(&json!([1])).is_err());
+    assert!(openai_compatible_usage(
+        &json!({"prompt_tokens": 1, "completion_tokens": 1, "prompt_tokens_details": 3})
+    )
+    .is_err());
+}
+
+#[test]
+fn parsed_counts_are_bounded_to_the_persistable_ledger_range() {
+    let at_bound = json!({"count": MAXIMUM_LEDGER_COUNT});
+    let over_bound = json!({"count": MAXIMUM_LEDGER_COUNT + 1});
+    let at_object = at_bound.as_object().expect("object");
+    let over_object = over_bound.as_object().expect("object");
+    // Exactly i64::MAX is persistable and accepted; one past it is a
+    // provider contract violation everywhere counts are parsed.
+    assert_eq!(
+        count_or_zero(at_object, "count", "count"),
+        Ok(MAXIMUM_LEDGER_COUNT)
+    );
+    assert!(count_or_zero(over_object, "count", "count").is_err());
+    assert_eq!(
+        require_u64(at_object, "count", "count"),
+        Ok(MAXIMUM_LEDGER_COUNT)
+    );
+    assert!(require_u64(over_object, "count", "count").is_err());
+    assert!(openai_usage(Some(&json!({
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "output_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT + 1},
+    })))
+    .is_err());
+}
+
+#[test]
+fn bedrock_usage_folds_cache_legs_and_rejects_unrepresentable_totals() {
+    let usage = bedrock_usage(Some(&json!({
+        "inputTokens": 9,
+        "outputTokens": 4,
+        "cacheReadInputTokens": 2,
+        "cacheWriteInputTokens": 1,
+    })))
+    .expect("valid usage");
+    assert_eq!(usage.input_tokens, Some(12));
+    assert_eq!(usage.cached_input_tokens, Some(2));
+    // A leg beyond the persistable ledger range fails at the parser.
+    assert!(bedrock_usage(Some(&json!({
+        "inputTokens": MAXIMUM_LEDGER_COUNT + 1,
+        "outputTokens": 1,
+    })))
+    .is_err());
+    // Individually persistable legs whose folded total is not are a
+    // provider contract violation, never a clamped or wrapped total.
+    assert!(bedrock_usage(Some(&json!({
+        "inputTokens": MAXIMUM_LEDGER_COUNT,
+        "outputTokens": 1,
+        "cacheReadInputTokens": 1,
+    })))
+    .is_err());
+    assert!(bedrock_usage(Some(&json!(null))).is_err());
+    assert!(bedrock_usage(None).is_err());
+}
+
+#[test]
+fn openai_usage_treats_absent_and_null_objects_as_unknown() {
+    assert!(openai_usage(None).expect("absent is unknown").is_none());
+    assert!(openai_usage(Some(&serde_json::Value::Null))
+        .expect("null is unknown")
+        .is_none());
+    let usage = openai_usage(Some(&json!({
+        "input_tokens": 2,
+        "output_tokens": 3,
+        "output_tokens_details": {"reasoning_tokens": 1},
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(usage.reasoning_tokens, Some(1));
+    assert_eq!(usage.cached_input_tokens, None);
+}
+
+// Usage-contract pins: every mapper emits reasoning_tokens as a SUBSET of
+// output_tokens (see the module documentation), so settlement never prices a
+// reasoning token at zero because a provider reported it outside its total.
+
+#[test]
+fn openai_responses_usage_forwards_the_documented_reasoning_subset_unchanged() {
+    // OpenAI Responses: output_tokens_details.reasoning_tokens is a subset of
+    // output_tokens by the provider's definition, so the counts pass through.
+    let usage = openai_usage(Some(&json!({
+        "input_tokens": 36,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 700,
+        "output_tokens_details": {"reasoning_tokens": 690},
+        "total_tokens": 736,
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(usage.output_tokens, Some(700));
+    assert_eq!(usage.reasoning_tokens, Some(690));
+    assert!(usage.reasoning_tokens <= usage.output_tokens);
+}
+
+#[test]
+fn openai_compatible_usage_leaves_a_folded_provider_untouched() {
+    // OpenAI-shaped Chat Completions usage (reasoning inside completion_tokens)
+    // is forwarded exactly; the equal case is a legal subset, not evidence of
+    // an additive provider.
+    for (completion, reasoning) in [(700u64, 690u64), (690, 690), (5, 0)] {
+        let usage = openai_compatible_usage(&json!({
+            "prompt_tokens": 36,
+            "completion_tokens": completion,
+            "total_tokens": 36 + completion,
+            "completion_tokens_details": {"reasoning_tokens": reasoning},
+        }))
+        .expect("valid usage");
+        assert_eq!(usage.output_tokens, Some(completion));
+        assert_eq!(usage.reasoning_tokens, Some(reasoning));
+    }
+    // OpenRouter normalizes upstream reasoning into completion_tokens and
+    // reports the subset alongside (shape captured from openrouter.ai).
+    let openrouter = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 543,
+        "total_tokens": 557,
+        "cost": 0.0016,
+        "is_byok": false,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "cost_details": {"upstream_inference_cost": null},
+        "completion_tokens_details": {"reasoning_tokens": 480, "image_tokens": 0},
+    }))
+    .expect("valid usage");
+    assert_eq!(openrouter.output_tokens, Some(543));
+    assert_eq!(openrouter.reasoning_tokens, Some(480));
+}
+
+#[test]
+fn openai_compatible_usage_folds_an_additive_provider_into_output_tokens() {
+    // Verbatim usage from Azure Foundry grok-4.3 (silen-resource, 2026-09-03,
+    // non-streaming): xAI reports reasoning OUTSIDE completion_tokens, which
+    // its own total_tokens confirms (14 + 7 + 1303 = 1324). A reasoning count
+    // above completion_tokens is impossible under subset semantics, so the
+    // mapper folds it and the subset stays reported.
+    let usage = openai_compatible_usage(&json!({
+        "prompt_tokens": 14,
+        "completion_tokens": 7,
+        "total_tokens": 1324,
+        "audio_prompt_tokens": 0,
+        "prompt_tokens_details": {
+            "cached_tokens": 0,
+            "audio_tokens": 0,
+            "text_tokens": 14,
+            "image_tokens": 0,
+        },
+        "completion_tokens_details": {
+            "reasoning_tokens": 1303,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
+        "num_sources_used": 0,
+    }))
+    .expect("valid usage");
+    assert_eq!(usage.input_tokens, Some(14));
+    assert_eq!(usage.output_tokens, Some(1310));
+    assert_eq!(usage.reasoning_tokens, Some(1303));
+    assert_eq!(usage.cached_input_tokens, Some(0));
+    // The folded totals reproduce the provider's own total_tokens.
+    assert_eq!(
+        usage.input_tokens.unwrap() + usage.output_tokens.unwrap(),
+        1324
+    );
+    // A fold whose total leaves the persistable range is a contract violation.
+    assert!(openai_compatible_usage(&json!({
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "completion_tokens_details": {"reasoning_tokens": MAXIMUM_LEDGER_COUNT},
+    }))
+    .is_err());
+}
+
+#[test]
+fn gemini_usage_folds_thoughts_into_output_tokens() {
+    // Verbatim usageMetadata from gemini-3.7-flash (generateContent,
+    // 2026-09-03), thinking on: Google's totalTokenCount is prompt +
+    // candidates + thoughts (11 + 8 + 524 = 543), so thoughts are additive and
+    // fold into output_tokens while reasoning_tokens names the subset.
+    let thinking = gemini_usage(&json!({
+        "promptTokenCount": 11,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 543,
+        "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+        "thoughtsTokenCount": 524,
+        "serviceTier": "standard",
+    }))
+    .expect("valid usage");
+    assert_eq!(thinking.input_tokens, Some(11));
+    assert_eq!(thinking.output_tokens, Some(532));
+    assert_eq!(thinking.reasoning_tokens, Some(524));
+    assert_eq!(thinking.cached_input_tokens, Some(0));
+    assert_eq!(
+        thinking.input_tokens.unwrap() + thinking.output_tokens.unwrap(),
+        543
+    );
+
+    // Verbatim from gemini-2.5-flash with thinkingBudget 0: no
+    // thoughtsTokenCount at all, so the reasoning subset stays unknown and
+    // output_tokens is the candidate count (11 + 9 = 20).
+    let no_thinking = gemini_usage(&json!({
+        "promptTokenCount": 11,
+        "candidatesTokenCount": 9,
+        "totalTokenCount": 20,
+        "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 11}],
+        "serviceTier": "standard",
+    }))
+    .expect("valid usage");
+    assert_eq!(no_thinking.output_tokens, Some(9));
+    assert_eq!(no_thinking.reasoning_tokens, None);
+
+    // Documented cached-content shape (cachedContentTokenCount plus
+    // cacheTokensDetails): the cache leg stays an input subset while thoughts
+    // still fold into output.
+    let cached = gemini_usage(&json!({
+        "promptTokenCount": 3582,
+        "candidatesTokenCount": 7,
+        "totalTokenCount": 3806,
+        "cachedContentTokenCount": 3072,
+        "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 3582}],
+        "cacheTokensDetails": [{"modality": "TEXT", "tokenCount": 3072}],
+        "thoughtsTokenCount": 217,
+    }))
+    .expect("valid usage");
+    assert_eq!(cached.input_tokens, Some(3582));
+    assert_eq!(cached.cached_input_tokens, Some(3072));
+    assert_eq!(cached.output_tokens, Some(224));
+    assert_eq!(cached.reasoning_tokens, Some(217));
+
+    // A fold whose total leaves the persistable range is a contract violation.
+    assert!(gemini_usage(&json!({
+        "promptTokenCount": 1,
+        "candidatesTokenCount": MAXIMUM_LEDGER_COUNT,
+        "thoughtsTokenCount": 1,
+    }))
+    .is_err());
+}

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -11,7 +11,8 @@ use futures_util::stream::BoxStream;
 use futures_util::StreamExt;
 
 use crate::dialects::{
-    Dialect, FrameDecoder, Normalizer, MAXIMUM_RETAINED_OUTPUT_BYTES, OUTPUT_OVERFLOW_MESSAGE,
+    Dialect, FrameDecoder, Normalizer, NormalizerOptions, MAXIMUM_RETAINED_OUTPUT_BYTES,
+    OUTPUT_OVERFLOW_MESSAGE,
 };
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
@@ -150,46 +151,26 @@ impl UpstreamRelay {
         response: reqwest::Response,
         dialect: Dialect,
         first_byte_deadline: Instant,
+        options: NormalizerOptions,
     ) -> Self {
-        Self::new_with_reasoning_content_route(response, dialect, first_byte_deadline, None)
-    }
-
-    pub fn new_with_reasoning_content_route(
-        response: reqwest::Response,
-        dialect: Dialect,
-        first_byte_deadline: Instant,
-        reasoning_content_route_sha256: Option<String>,
-    ) -> Self {
-        Self::from_stream_with_reasoning_content_route(
+        Self::from_stream(
             response.bytes_stream().boxed(),
             dialect,
             first_byte_deadline,
-            reasoning_content_route_sha256,
+            options,
         )
     }
 
-    #[cfg(test)]
     fn from_stream(
         stream: BoxStream<'static, reqwest::Result<Bytes>>,
         dialect: Dialect,
         first_byte_deadline: Instant,
-    ) -> Self {
-        Self::from_stream_with_reasoning_content_route(stream, dialect, first_byte_deadline, None)
-    }
-
-    fn from_stream_with_reasoning_content_route(
-        stream: BoxStream<'static, reqwest::Result<Bytes>>,
-        dialect: Dialect,
-        first_byte_deadline: Instant,
-        reasoning_content_route_sha256: Option<String>,
+        options: NormalizerOptions,
     ) -> Self {
         Self {
             stream,
             decoder: FrameDecoder::new(dialect),
-            normalizer: Normalizer::new_with_reasoning_content_route(
-                dialect,
-                reasoning_content_route_sha256,
-            ),
+            normalizer: Normalizer::with_options(dialect, options),
             pending: VecDeque::new(),
             eof: false,
             first_byte_recorded: false,
@@ -397,7 +378,7 @@ pub async fn collect_committed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dialects::Dialect;
+    use crate::dialects::{Dialect, NormalizerOptions};
     use crate::events::Event;
     use futures_util::stream;
 
@@ -414,6 +395,7 @@ mod tests {
             stream::iter(frames).boxed(),
             Dialect::OpenAiCompatible,
             Instant::now() + Duration::from_secs(5),
+            NormalizerOptions::default(),
         );
         assert!(
             relay.first_token_at().is_none(),
@@ -467,6 +449,7 @@ mod tests {
             stream::iter(frames).boxed(),
             Dialect::GeminiGenerateContent,
             Instant::now() + Duration::from_secs(5),
+            NormalizerOptions::default(),
         );
         let deadline = Instant::now() + Duration::from_secs(30);
         let per_chunk = Duration::from_secs(5);
@@ -512,6 +495,7 @@ mod tests {
             never,
             Dialect::OpenAiCompatible,
             Instant::now() + time_to_first_byte,
+            NormalizerOptions::default(),
         );
         let request_deadline = Instant::now() + Duration::from_secs(120);
         let per_chunk_timeout = Duration::from_secs(35);

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::bridge::Bridge;
-use crate::dialects::Dialect;
+use crate::dialects::{Dialect, NormalizerOptions};
 use crate::encode::compact_json;
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
@@ -68,6 +68,12 @@ pub struct DeploymentWire {
     pub upstream_body: Option<String>,
     #[serde(default)]
     pub fireworks_reasoning_route_sha256: Option<String>,
+    /// The deployment declares that its Chat Completions usage reports
+    /// `reasoning_tokens` outside `completion_tokens`, so the normalizer folds
+    /// the count into `output_tokens` unconditionally (see
+    /// `NormalizerOptions::reasoning_tokens_additive`).
+    #[serde(default)]
+    pub reasoning_tokens_additive: bool,
     pub idempotency_key: String,
     /// Deployment override for the flat first-byte allowance; the serving
     /// configuration's default applies when absent.
@@ -510,15 +516,15 @@ async fn run_attempt(
         }
     };
     guard.mark_opened();
-    let mut relay = match wire.fireworks_reasoning_route_sha256.clone() {
-        Some(route_sha256) => UpstreamRelay::new_with_reasoning_content_route(
-            response,
-            dialect,
-            first_byte_deadline,
-            Some(route_sha256),
-        ),
-        None => UpstreamRelay::new(response, dialect, first_byte_deadline),
-    };
+    let mut relay = UpstreamRelay::new(
+        response,
+        dialect,
+        first_byte_deadline,
+        NormalizerOptions {
+            reasoning_content_route_sha256: wire.fireworks_reasoning_route_sha256.clone(),
+            reasoning_tokens_additive: wire.reasoning_tokens_additive,
+        },
+    );
     let mut usage: Option<Usage> = None;
     let mut tool_names: Vec<String> = Vec::new();
     let mut withheld: Vec<Event> = Vec::new();
@@ -682,6 +688,7 @@ mod tests {
             upstream_payload: Value::Null,
             upstream_body: None,
             fireworks_reasoning_route_sha256: None,
+            reasoning_tokens_additive: false,
             idempotency_key: "op".to_string(),
             time_to_first_byte_base_seconds: base,
             time_to_first_byte_seconds_per_million_input_tokens: slope,

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -567,6 +567,9 @@ def deployment_wire_entry(
         "upstream_payload": None if upstream_body is not None else upstream_payload,
         "upstream_body": upstream_body,
         "fireworks_reasoning_route_sha256": profile.fireworks_reasoning_route_sha256,
+        # A declared additive-reasoning wire folds reasoning_tokens into
+        # output_tokens in the data plane so settlement's subset contract holds.
+        "reasoning_tokens_additive": capabilities.reasoning_tokens_additive,
         "idempotency_key": deployment_operation_key(route, deployment),
         # First-byte allowance overrides; the data plane falls back to its
         # serving defaults when a deployment declares nothing.

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from exp.common.models.catalog import GatewayDeploymentMetadata
+from exp.common.models.catalog import GatewayDeploymentCapabilities, GatewayDeploymentMetadata
 from exp.common.models.gateway_catalog import ExactModelDeployment
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
@@ -20,10 +20,12 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.native_execution import (
     claim_route_from,
+    deployment_wire_entry,
     next_route_candidate,
     select_route_deployments,
 )
 from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.models.providers.base import GatewayWireProfile
 
 _KEYS: tuple[DeploymentHealthKey, ...] = (
     ("catalog" + "0" * 57, "deployment-a", "connection-a"),
@@ -91,6 +93,24 @@ def _failover_only() -> GatewayFailure:
         failure_class=GatewayFailureClass.THROTTLED,
         safe_message="provider throttled the request",
         failover_eligible=True,
+    )
+
+
+def test_wire_entry_carries_the_additive_reasoning_declaration() -> None:
+    """The data plane folds reasoning only for deployments whose catalog declares it."""
+    route = _route()
+    profile = GatewayWireProfile(dialect="openai_compatible", url="https://provider.test/v1")
+    declared = route.deployment.model_copy(
+        update={
+            "gateway": GatewayDeploymentMetadata(
+                capabilities=GatewayDeploymentCapabilities(reasoning_tokens_additive=True)
+            )
+        }
+    )
+    assert deployment_wire_entry(route, declared, profile, {})["reasoning_tokens_additive"] is True
+    assert (
+        deployment_wire_entry(route, route.deployment, profile, {})["reasoning_tokens_additive"]
+        is False
     )
 
 
@@ -453,7 +473,6 @@ def test_native_serving_blockers_name_reasoning_wire_contract_conflicts(
     from exp.runtime.gateway.lifecycle import load_gateway_components
     from exp.runtime.gateway.lifecycle_test import _configured_gateway
     from exp.runtime.gateway.native_execution import native_serving_blockers
-    from exp.runtime.models.providers.base import GatewayWireProfile
     from exp.runtime.models.providers.gemini import GeminiClient
 
     original_wire_profile = GeminiClient.gateway_wire_profile

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -89,9 +89,11 @@ GEMINI_GOLDEN_EVENTS: tuple[JsonObject, ...] = (
         "raw_arguments": _GEMINI_RAW_ARGUMENTS,
     },
     {
+        # Gemini thoughts are additive on the wire, so the engine folds the 3
+        # thought tokens into the output total and reports them as its subset.
         "kind": "usage",
         "input_tokens": 11,
-        "output_tokens": 5,
+        "output_tokens": 8,
         "cached_input_tokens": 2,
         "reasoning_tokens": 3,
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.22,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.23,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.23,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.24,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.22"
+version = "0.3.23"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## HELD: stacked on #741 (base branch `identity-stability`); do not merge before #741 and #743

This PR adds a field to `GatewayDeploymentCapabilities`. On `main`'s identity serializer (`canonical_json_bytes`, `exclude_none=False`, every default emitted) that moves every deployment digest in the catalog, which is exactly the 0.7.22 -> 0.7.25 incident. On #741's exclude-default serialization a default-valued field contributes zero identity bytes, so this lands digest-neutral with no `SNAPSHOT_SCHEMA_VERSION` bump. It is therefore based on `identity-stability`; GitHub retargets it to `main` when #741 merges. It also carries #743's commit (the fold itself) so the diff is coherent; that commit disappears from the diff once #743 is on `main` and this branch is rebased.

## What it does

`experientiallabs/platform#1157` step 1-3: per-deployment declaration that a Chat Completions wire reports reasoning OUTSIDE `completion_tokens`.

- `exp/common/models/catalog.py`: `GatewayDeploymentCapabilities.reasoning_tokens_additive: bool = False` (documented).
- `exp/runtime/gateway/native_execution.py::deployment_wire_entry`: carries the flag to the data plane next to `fireworks_reasoning_route_sha256`.
- Rust: `waterfall.rs::DeploymentWire.reasoning_tokens_additive` (`serde(default)`), threaded through `UpstreamRelay` into the `Normalizer` as a new `NormalizerOptions { reasoning_content_route_sha256, reasoning_tokens_additive }` (replaces the `new_with_reasoning_content_route` constructor variant rather than adding a third one); `openai_compatible_usage(value, declared_additive)` folds when declared OR when reasoning > completion (#743's self-evident case).
- Gemini needs no declaration (always additive, always folded in #743); Anthropic, Bedrock, and Responses publish subset semantics and ignore the flag.

## Identity evidence

On this branch (`SNAPSHOT_SCHEMA_VERSION = 3`, exclude-default identity):

```
default caps under identity serialization:  {}
declared caps under identity serialization: {'reasoning_tokens_additive': True}
```

`test_identity_digest_is_pinned_until_a_deliberate_schema_version_bump` and `test_added_defaulted_fields_and_explicit_defaults_do_not_perturb_identity` pass untouched with the new field, which is #741's stated contract for additive growth. Declaring the flag on a deployment changes that deployment's digest, as a catalog fact should.

On `main` today the same default `GatewayDeploymentCapabilities()` serializes to 770 bytes of identity (`{"maximum_stop_sequences":null,...,"supports_audio_input":false,...}`), so this field cannot land there without a bump; the bump is #741's.

## Heuristic vs declaration (why both)

#743's heuristic (fold when reasoning > completion) closed every observed prod row (platform#1157: 2/2 Grok rows, both live probes, and every additive receipt captured for this work had reasoning 5x to 200x the answer). It misses an additive provider only when reasoning is no larger than the visible answer, which for a reasoning model means a long answer after brief thinking. The declaration closes that case exactly and is what the platform already stamps on both Grok Azure lanes (`update_route` drafts in platform#1157, applied). `declared_additive_deployment_folds_reasoning_even_below_the_visible_answer` pins the difference: 30 in / 40 out / 5 reasoning -> declared 45 output, undeclared 40.

## Validation

- `cargo fmt --check`, `cargo clippy --no-default-features --all-targets -D warnings`, `cargo test --no-default-features`: 153 passed.
- `ruff check`, `ruff format --check`, `ty check`: clean.
- Targeted pytest (gateway_catalog, catalog, native_execution, dialect parity, native bridge, budgets, repo layout): 233 passed.
- Native crate 0.3.23 -> 0.3.24 (on top of #743's 0.3.23).

## Platform follow-ups (after the pin bump that carries this)

- Add `reasoning_tokens_additive` to `PROTOCOL_BOOLEAN_CAPABILITY_KEYS` (engine-pinned test) and to #947's dialect contract registry / the authored `azure_openai` Grok contract.
- The build warning in `explabs/gateway/catalog.py` (host lane declares the flag, pinned engine cannot fold) goes quiet.
- Observation, not changed here: `budgets.py::maximum_attempt_cost_micro_usd` bounds the reservation by the caller's output ceiling; on an additive wire the folded output can exceed `max_tokens` (xAI counts reasoning outside the cap), so the ceiling can under-reserve on declared lanes. Settlement is exact; only the pre-charge bound is affected.

Generated with [Claude Code](https://claude.com/claude-code)
