### PR TITLE
gateway: class provider 402 as provider_quota deadness, never invalid_request

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -917,6 +917,10 @@ class GatewayFailureClass(StrEnum):
     TIMEOUT = "timeout"
     PROVIDER_AUTHENTICATION = "provider_authentication"
     PROVIDER_NOT_FOUND = "provider_not_found"
+    # The provider ACCOUNT cannot pay for the request (trial quota exhausted,
+    # billing not enabled): operator-actionable deadness that fails over in
+    # every mode. Distinct from QUOTA_EXCEEDED, the CALLER's gateway credit.
+    PROVIDER_QUOTA = "provider_quota"
     REFUSAL = "refusal"
     MALFORMED_RESPONSE = "malformed_response"
     PROVIDER_INTERNAL = "provider_internal"

--- a/exp/runtime/gateway/health.py
+++ b/exp/runtime/gateway/health.py
@@ -14,6 +14,11 @@ DeploymentHealthKey = tuple[str, str, str]
 _HARD_FAILURES = {
     GatewayFailureClass.PROVIDER_AUTHENTICATION,
     GatewayFailureClass.PROVIDER_NOT_FOUND,
+    # An unfunded provider account (402) is the same sticky operator-actionable
+    # deadness as a bad credential: open the circuit immediately so the dead
+    # rung stops being attempted first, and let the half-open probe rediscover
+    # it once the operator funds or enables the account.
+    GatewayFailureClass.PROVIDER_QUOTA,
 }
 _OPERATIONAL_FAILURES = {
     GatewayFailureClass.TRANSPORT,

--- a/exp/runtime/gateway/health_test.py
+++ b/exp/runtime/gateway/health_test.py
@@ -68,6 +68,21 @@ def test_operational_failures_still_open_the_circuit() -> None:
         assert not registry.claim(_KEY)
 
 
+def test_provider_quota_opens_the_circuit_immediately_like_other_hard_deadness() -> None:
+    """An unfunded provider account (402) suppresses the rung after ONE failure.
+
+    Without this, the billing-dead deployment stays first-in-line and burns one
+    wasted attempt per request before every failover; with it, the circuit opens
+    at once and the half-open probe rediscovers the rung when the operator
+    funds or enables the account.
+    """
+    registry = DeploymentHealthRegistry(failure_threshold=2, clock=lambda: 100.0)
+
+    registry.failed(_KEY, _failure(GatewayFailureClass.PROVIDER_QUOTA))
+
+    assert not registry.claim(_KEY)
+
+
 def test_throttle_storms_still_suppress_the_deployment() -> None:
     """Provider throttling keeps its authoritative suppression window."""
     registry = DeploymentHealthRegistry(throttle_seconds=30.0, clock=lambda: 100.0)

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,13 +212,12 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "axum",
  "base64",
  "bytes",
  "futures-util",
- "h2",
  "http",
  "http-body-util",
  "pyo3",

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-util",
+ "h2",
  "http",
  "http-body-util",
  "pyo3",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -35,3 +35,9 @@ thiserror = "2"
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+[dev-dependencies]
+# Frame-level HTTP/2 server control for the reset/goaway regression tests:
+# the production wire to fronting proxies negotiates h2, so mid-stream aborts
+# arrive as RST_STREAM/GOAWAY, a different reqwest path than h1 truncation.
+h2 = "0.4"

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"
@@ -31,12 +31,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.10"
 thiserror = "2"
-
-[dev-dependencies]
-# Frame-level HTTP/2 server control for the reset/goaway regression tests:
-# the production wire to fronting proxies negotiates h2, so mid-stream aborts
-# arrive as RST_STREAM/GOAWAY, a different reqwest path than h1 truncation.
-h2 = "0.4"
 
 [profile.release]
 lto = "thin"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -123,6 +123,10 @@ pub enum FailureClass {
     Timeout,
     ProviderAuthentication,
     ProviderNotFound,
+    /// The provider ACCOUNT cannot pay for the request (quota exhausted,
+    /// billing not enabled): operator-actionable deadness, distinct from
+    /// `QuotaExceeded`, which is the CALLER's gateway credit.
+    ProviderQuota,
     Refusal,
     MalformedResponse,
     ProviderInternal,
@@ -145,6 +149,7 @@ impl FailureClass {
             FailureClass::Timeout => "timeout",
             FailureClass::ProviderAuthentication => "provider_authentication",
             FailureClass::ProviderNotFound => "provider_not_found",
+            FailureClass::ProviderQuota => "provider_quota",
             FailureClass::Refusal => "refusal",
             FailureClass::MalformedResponse => "malformed_response",
             FailureClass::ProviderInternal => "provider_internal",

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -52,6 +52,17 @@ pub fn transport_failure(status: Option<u16>) -> Failure {
             false,
             true,
         ),
+        // 402 is the provider ACCOUNT's billing state (trial quota exhausted,
+        // postpaid billing disabled), never the caller's request fields: it is
+        // operator-actionable deadness, so it fails over in every failover mode
+        // instead of surfacing a corrective 400 to the caller.
+        Some(402) => (
+            FailureClass::ProviderQuota,
+            "provider account quota or billing is exhausted; ask the gateway operator \
+             to fund or enable the provider account",
+            false,
+            true,
+        ),
         Some(408) => (
             FailureClass::Timeout,
             "provider request timed out; retry the request",
@@ -221,6 +232,7 @@ mod tests {
             (Some(403), false, true),
             (Some(404), false, true),
             (Some(429), false, true),
+            (Some(402), false, true),
             (Some(408), true, true),
             (Some(500), true, true),
             (Some(503), true, true),
@@ -242,6 +254,60 @@ mod tests {
                 "failover for {status:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn a_402_with_the_literal_tokenhub_body_classes_provider_quota() {
+        // TokenHub (the Tencent relay) answers HTTP 402 with provider code
+        // 401008 on EVERY request shape once the account's free trial is
+        // exhausted and postpaid billing is off. Classing that invalid_request
+        // blamed 652 callers' request fields for the provider's billing state
+        // (2026-09 incident): the class must be the provider-side quota family,
+        // the rung must fail over, and the body must never be relayed.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buffer = [0u8; 8192];
+            let _ = socket.read(&mut buffer).await;
+            let body = "{\"error\":{\"code\":401008,\"message\":\"free trial quota exhausted \
+                        and postpaid billing is not enabled - enable in Console > Online \
+                        Inference Service\",\"type\":\"payment_required\"}}";
+            let response = format!(
+                "HTTP/1.1 402 Payment Required\r\ncontent-type: application/json\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            socket.write_all(response.as_bytes()).await.expect("write");
+        });
+        let client = build_client(Duration::from_secs(2)).expect("client");
+        let failure = open_stream(
+            &client,
+            &format!("http://{addr}/v1/chat/completions"),
+            &HashMap::new(),
+            "idem-402",
+            &serde_json::json!({"model": "m", "messages": []}),
+            None,
+            Duration::from_secs(5),
+            Dialect::OpenAiCompatible,
+        )
+        .await
+        .expect_err("a 402 must classify as a failure");
+        assert_eq!(failure.failure_class, FailureClass::ProviderQuota);
+        assert!(failure.failover_eligible, "an unfunded rung must fail over");
+        assert!(!failure.retryable_same_deployment);
+        assert!(
+            failure.provider_detail.is_none() && failure.rejected_parameter.is_none(),
+            "a billing failure must stay content-free"
+        );
+        assert!(
+            !failure.safe_message.contains("request fields"),
+            "the caller must never be told to fix their fields for a provider billing state"
+        );
     }
 
     #[test]

--- a/exp/runtime/gateway/testdata/parity_goldens.json
+++ b/exp/runtime/gateway/testdata/parity_goldens.json
@@ -118,6 +118,13 @@
     "type": "invalid_request_error"
    },
    "type": "error"
+  },
+  "provider_quota": {
+   "type": "error",
+   "error": {
+    "type": "api_error",
+    "message": "parity probe message"
+   }
   }
  },
  "anthropic_error_inputs": {
@@ -256,6 +263,14 @@
    "param": null,
    "retry_after_seconds": null,
    "status_code": 400
+  },
+  "provider_quota": {
+   "code": "all_routes_failed",
+   "error_type": "api_error",
+   "message": "parity probe message",
+   "param": null,
+   "retry_after_seconds": null,
+   "status_code": 502
   }
  },
  "anthropic_error_with_param": {

--- a/exp/runtime/models/providers/errors.py
+++ b/exp/runtime/models/providers/errors.py
@@ -219,6 +219,20 @@ def _transport_failure(status_code: int | None) -> GatewayFailure:
             failover_eligible=True,
             safe_details=details,
         )
+    if status_code == 402:
+        # The provider ACCOUNT's billing state (trial quota exhausted, postpaid
+        # billing disabled), never the caller's request fields: operator-
+        # actionable deadness that fails over in every failover mode instead of
+        # surfacing a corrective 400 to the caller.
+        return GatewayFailure(
+            failure_class=GatewayFailureClass.PROVIDER_QUOTA,
+            safe_message=(
+                "provider account quota or billing is exhausted; ask the gateway "
+                "operator to fund or enable the provider account"
+            ),
+            failover_eligible=True,
+            safe_details=details,
+        )
     if status_code == 408:
         return GatewayFailure(
             failure_class=GatewayFailureClass.TIMEOUT,

--- a/exp/runtime/models/providers/errors_test.py
+++ b/exp/runtime/models/providers/errors_test.py
@@ -34,6 +34,18 @@ from exp.runtime.models.providers.transport import ProviderTransportError
             False,
             True,
         ),
+        # The literal TokenHub shape (Tencent relay): HTTP 402, provider code
+        # 401008, "free trial quota exhausted and postpaid billing is not
+        # enabled", on EVERY request shape. The provider account's billing
+        # state must class as provider-side deadness that fails over, never as
+        # the caller's request fields (the 2026-09 misclass sent 652 callers
+        # chasing their own payloads).
+        (
+            ProviderTransportError("raw billing canary", status_code=402),
+            GatewayFailureClass.PROVIDER_QUOTA,
+            False,
+            True,
+        ),
         (
             ProviderTransportError("raw server canary", status_code=503),
             GatewayFailureClass.PROVIDER_INTERNAL,
@@ -158,6 +170,11 @@ def test_parameter_failure_preserves_only_public_code_and_path() -> None:
         (
             ProviderTransportError("raw throttle canary", status_code=429),
             "provider throttled the request; retry after the delay in the Retry-After header",
+        ),
+        (
+            ProviderTransportError("raw billing canary", status_code=402),
+            "provider account quota or billing is exhausted; ask the gateway "
+            "operator to fund or enable the provider account",
         ),
         (
             ProviderTransportError("raw slow canary", status_code=408),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.23,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.24,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.23"
+version = "0.3.24"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Incident

TokenHub (the Tencent relay) answered HTTP 402 with provider code 401008 — "free trial quota exhausted and postpaid billing is not enabled — enable in Console > Online Inference Service" — on **every** request shape. The gateway classed all of it `invalid_request` with the caller-facing text "provider rejected the request; verify the request fields against the model alias capabilities". 652 customer-visible errors blamed the caller's fields for the provider account's billing state, the rung never failed over (`invalid_request` is failover-ineligible), and diagnosis chased the capability/over-claim path for hours because `invalid_request` reads as a request-shape problem by contract.

## Change

**New failure class `provider_quota`** (`GatewayFailureClass.PROVIDER_QUOTA` / `FailureClass::ProviderQuota`): the provider ACCOUNT cannot pay (trial quota exhausted, billing disabled). Deliberately distinct from:

- `quota_exceeded` — that is the CALLER's gateway credit; reusing it would tell customers *they* are out of quota (`429 insufficient_quota`), misattributing in the opposite direction;
- `throttled` — a 402 is sticky operator-actionable deadness, and `throttled` is in the `maximize_cache` no-failover set, which would trap cache-mode pools on the unfunded rung surfacing 429s forever.

Behavior: `failover_eligible=True`, not same-deployment-retryable, fails over in **every** failover mode (deadness family), feeds the health circuit, and publicly renders through the provider-side fall-through (`502 all_routes_failed`, `api_error`) with the message "provider account quota or billing is exhausted; ask the gateway operator to fund or enable the provider account" — never a verify-your-fields 400.

HTTP 402 maps to it in **both mirrored seams**: the native data plane (`upstream.rs::transport_failure`) and the python taxonomy (`providers/errors.py::_transport_failure`). The mapping is dialect-agnostic (status-only), so anthropic/gemini/bedrock lanes get the same treatment.

## Regression fixtures

- Rust: a loopback-HTTP test drives `open_stream` against a canned 402 carrying the **literal TokenHub body** (code 401008) and asserts `ProviderQuota`, failover eligibility, content-free failure (the error body is never read for non-`InvalidRequest` classes), and that the message never says "request fields". The status parity table gains the 402 row.
- Python: both parametrized tables (class/flags and exact message) gain the 402 rows with the incident context inline.
- The Anthropic error-translation parity goldens gain the `provider_quota` entry (generated through the real renderer + native translator; additive-only diff).

## Chores

Native crate 0.3.22 → **0.3.24** (0.3.23 is reserved by in-flight #740) with pin/lock/wheel chores. `SNAPSHOT_SCHEMA_VERSION` untouched — failure classes are not catalog identity.

## Platform pin-time requirements (for the 0.7.28 coordinated-train pin PR)

This is the checklist for whoever authors the platform pin bump that ships this train (#736 + #739 + #740 + #741 + #745). Verified against the platform repo on 2026-09-03:

**From #745 (this PR):**
- `gateway_attempts` / `gateway_usage` `failure_class` columns are free text (`pg_catalog.text`; the only constraint anywhere is a 1..128 length check on `gateway_error_alert_rules.failure_class`) — **no migration needed**; the new `provider_quota` string just starts appearing in rows.
- Platform Python has **no exhaustive `GatewayFailureClass` matches** (only specific-member comparisons with fallthrough: `ledger.py` QUOTA_EXCEEDED/CANCELLED checks), and the enum member itself arrives via the engine pin — **no platform code change needed**.
- Optional operator step: add a `gateway_error_alert_rules` row pinning `failure_class = 'provider_quota'` so a future billing-dead house lane pages the operator while requests spill over silently (that alert is the whole point of the class).

**From #741 (identity stability, schema v3):**
- Hard precondition: platform #1156 (skew-tolerant `read_published_catalog_snapshot` + `authored_sha256`) must be **live in production before this train's pin deploys** (team-lead holds the signal).
- Expect a one-time catalog republication after the pin rolls: every digest re-derives under the exclude-default identity, so convergence republishes each alias under a new `catalog_sha256`. New usage/attempt rows key to the new digests; old rows keep the old ones (attribution is append-only, nothing to migrate).
- No platform code touches `SNAPSHOT_SCHEMA_VERSION` and no test pins a literal catalog digest (the one identity assertion in `catalog_test.py` recomputes both sides through the engine) — **no platform code change needed**.

## Validation

- Full `uv run pytest -q`: 3379 passed, 6 skipped
- `cargo test --no-default-features` (PYO3_PYTHON pinned): 144 passed incl. the new 402 tests; clippy/fmt clean
- `ruff format` / `ruff check` / `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
