### PR TITLE
gateway: disclose ignored parameters on the Anthropic Messages envelope (crate 0.3.24)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -324,7 +324,9 @@ group, so a shim rung can no longer silently bill every turn's full context unca
 native rung stands ready; routes narrowing to only marker-dropping wires keep disclosing the
 dropped markers. Every coercion is disclosed in `path->effective` form
 through `ignored_parameters`, logged, and counted in the `admission_parameter_coercions`
-metric; nothing coercible keeps the first rung's own field-scoped rejection.
+metric; every serving surface carries that list to the caller as a body-level
+`x-experiential-ignored-parameters` key (Chat chunk and completion, Responses envelope, and the
+Anthropic message on both `message_start` and the aggregated body), so a drop is never silent; nothing coercible keeps the first rung's own field-scoped rejection.
 The per-deployment `capability_parity` export joins catalog declarations with the engine's
 provider-family ground truth so a catalog can pre-warn on gaps and route around them before a
 caller hits that 400.

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.24"
+version = "0.3.25"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -188,13 +188,25 @@ pub struct MessagesSseEncoder {
     saw_tool_use: bool,
     refusal_seen: bool,
     usage: Option<Usage>,
+    ignored_parameters: Vec<String>,
 }
 
 impl MessagesSseEncoder {
     pub fn new(request_id: &str, model: &str) -> Self {
+        Self::new_with_ignored(request_id, model, Vec::new())
+    }
+
+    /// Build an encoder that discloses controls omitted by route shaping,
+    /// mirroring `ChatSseEncoder::new_with_ignored`.
+    pub fn new_with_ignored(
+        request_id: &str,
+        model: &str,
+        ignored_parameters: Vec<String>,
+    ) -> Self {
         Self {
             message_id: stable_public_id("msg", request_id),
             model: model.to_string(),
+            ignored_parameters,
             started: false,
             terminal: false,
             draining: false,
@@ -223,7 +235,7 @@ impl MessagesSseEncoder {
             ));
         }
         self.started = true;
-        let message = json!({
+        let mut message = json!({
             "id": self.message_id,
             "type": "message",
             "role": "assistant",
@@ -233,6 +245,11 @@ impl MessagesSseEncoder {
             "stop_sequence": Value::Null,
             "usage": {"input_tokens": 0, "output_tokens": 0},
         });
+        // Same body-level disclosure as the Chat and Responses encoders: the
+        // Anthropic envelope has no field for it, and the official SDK
+        // tolerates extra keys, so a dropped control (an empty-ladder
+        // `output_config.effort`, a dropped beta token) is never silent.
+        disclose_ignored_parameters(&mut message, &self.ignored_parameters);
         Ok(vec![
             event_frame(
                 "message_start",
@@ -811,7 +828,22 @@ impl MessagesSseEncoder {
 
 mod aggregate;
 
-pub use aggregate::completed_messages_body;
+pub use aggregate::{completed_messages_body, completed_messages_body_with_ignored};
+
+/// Attach the `x-experiential-ignored-parameters` disclosure to one message
+/// object when any control was dropped; an empty list adds nothing.
+pub(super) fn disclose_ignored_parameters(message: &mut Value, ignored_parameters: &[String]) {
+    if ignored_parameters.is_empty() {
+        return;
+    }
+    message
+        .as_object_mut()
+        .expect("Anthropic message is an object")
+        .insert(
+            "x-experiential-ignored-parameters".to_string(),
+            json!(ignored_parameters),
+        );
+}
 
 #[cfg(test)]
 mod tests;

--- a/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
@@ -29,6 +29,17 @@ pub fn completed_messages_body(
     model: &str,
     events: &[Event],
 ) -> Result<AggregatedMessage, PublicError> {
+    completed_messages_body_with_ignored(request_id, model, events, &[])
+}
+
+/// Build one non-streaming Anthropic message with ignored-control disclosure,
+/// mirroring `completed_chat_body_with_ignored`.
+pub fn completed_messages_body_with_ignored(
+    request_id: &str,
+    model: &str,
+    events: &[Event],
+    ignored_parameters: &[String],
+) -> Result<AggregatedMessage, PublicError> {
     let terminal = events.iter().rev().find(|event| event.is_terminal());
     let terminal = match terminal {
         Some(event) => event,
@@ -219,7 +230,7 @@ pub fn completed_messages_body(
         }
     }
     let content: Vec<Value> = slots.into_iter().flatten().collect();
-    let body = json!({
+    let mut body = json!({
         "id": stable_public_id("msg", request_id),
         "type": "message",
         "role": "assistant",
@@ -229,6 +240,7 @@ pub fn completed_messages_body(
         "stop_sequence": Value::Null,
         "usage": messages_usage(usage.as_ref()),
     });
+    super::disclose_ignored_parameters(&mut body, ignored_parameters);
     Ok(AggregatedMessage {
         body,
         failure: None,

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -612,3 +612,46 @@ fn usage_reports_both_cache_legs_out_of_the_folded_input_total() {
         })
     );
 }
+
+#[test]
+fn ignored_generation_controls_are_disclosed_by_both_messages_encoders() {
+    // A dropped `output_config.effort` on an empty-ladder Claude (or a
+    // dropped beta token) must reach the caller on the Messages surface the
+    // same way Chat and Responses disclose it: a body-level key on the
+    // message object, both on `message_start` and on the aggregated body.
+    let ignored = vec![
+        "reasoning_effort".to_string(),
+        "anthropic-beta.claude-code-20250219".to_string(),
+    ];
+    let mut stream = MessagesSseEncoder::new_with_ignored("request-abc", "coding", ignored.clone());
+    let frames = stream.start().expect("stream start must encode");
+    let message_start = frames
+        .iter()
+        .find(|frame| frame.starts_with("event: message_start"))
+        .expect("message_start frame");
+    assert!(message_start.contains(
+        "\"x-experiential-ignored-parameters\":[\"reasoning_effort\",\"anthropic-beta.claude-code-20250219\"]"
+    ));
+
+    let events = vec![Event::TextDelta("hi".to_string()), Event::Completed];
+    let aggregated =
+        completed_messages_body_with_ignored("request-abc", "coding", &events, &ignored)
+            .expect("aggregates");
+    assert_eq!(
+        aggregated.body["x-experiential-ignored-parameters"],
+        json!(["reasoning_effort", "anthropic-beta.claude-code-20250219"])
+    );
+
+    // Nothing dropped, nothing disclosed: the plain envelope stays byte-identical.
+    let mut plain = MessagesSseEncoder::new("request-abc", "coding");
+    assert!(!plain
+        .start()
+        .expect("plain start must encode")
+        .concat()
+        .contains("x-experiential-ignored-parameters"));
+    let plain_body = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
+    assert!(plain_body
+        .body
+        .get("x-experiential-ignored-parameters")
+        .is_none());
+}

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -21,7 +21,9 @@ use crate::admission::{
     Admission,
 };
 use crate::encode::compact_json;
-use crate::encode_messages::{anthropic_error_body, completed_messages_body, MessagesSseEncoder};
+use crate::encode_messages::{
+    anthropic_error_body, completed_messages_body_with_ignored, MessagesSseEncoder,
+};
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 use crate::metrics::{classify_escalation, METRICS};
@@ -247,8 +249,12 @@ async fn settled_messages_response(admission: &Admission, settled: SettledAttemp
         };
         return sse_body_response(&headers, body);
     }
-    let aggregated = match completed_messages_body(&admission.request_id, &admission.alias, &events)
-    {
+    let aggregated = match completed_messages_body_with_ignored(
+        &admission.request_id,
+        &admission.alias,
+        &events,
+        &admission.ignored_parameters,
+    ) {
         Ok(aggregated) => aggregated,
         Err(error) => return messages_error_response(&error),
     };
@@ -271,8 +277,12 @@ async fn respond_from_messages_events(
     stream_body: bool,
 ) -> Response {
     let refusal_completed = complete_visible_refusal(&mut events);
-    let aggregated = match completed_messages_body(&admission.request_id, &admission.alias, &events)
-    {
+    let aggregated = match completed_messages_body_with_ignored(
+        &admission.request_id,
+        &admission.alias,
+        &events,
+        &admission.ignored_parameters,
+    ) {
         Ok(aggregated) => aggregated,
         Err(error) => {
             guard
@@ -352,7 +362,11 @@ async fn respond_from_messages_events(
 }
 
 fn encode_messages_sse(admission: &Admission, events: &[Event]) -> Result<Vec<u8>, PublicError> {
-    let mut encoder = MessagesSseEncoder::new(&admission.request_id, &admission.alias);
+    let mut encoder = MessagesSseEncoder::new_with_ignored(
+        &admission.request_id,
+        &admission.alias,
+        admission.ignored_parameters.clone(),
+    );
     let mut body = Vec::new();
     for frame in encoder.start()? {
         body.extend_from_slice(frame.as_bytes());
@@ -480,6 +494,7 @@ async fn stream_messages(
     };
     let request_id = admission.request_id.clone();
     let alias = admission.alias.clone();
+    let ignored_parameters = admission.ignored_parameters.clone();
     let phase_timeout = admission.phase_timeout(committed.depth);
     let task_hold = guard.hold_task();
     tokio::spawn(async move {
@@ -487,7 +502,8 @@ async fn stream_messages(
         let _permit = permit;
         let mut guard = guard;
         let mut committed = committed;
-        let mut encoder = MessagesSseEncoder::new(&request_id, &alias);
+        let mut encoder =
+            MessagesSseEncoder::new_with_ignored(&request_id, &alias, ignored_parameters);
         let mut usage: Option<Usage> = committed.usage.take();
         let mut tool_names: Vec<String> = std::mem::take(&mut committed.tool_names);
         let mut visible_refusal = committed.visible_refusal;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.24,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.25,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.24"
+version = "0.3.25"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Problem

Chat and Responses responses carry every admission drop back to the caller as a body-level `x-experiential-ignored-parameters` list (`encode.rs` chunk + completion, `encode_responses/output.rs`). The Anthropic Messages surface never did: when engine #717 drops an `output_config.effort` on an empty-ladder Claude, or admission drops a non-allowlisted `anthropic-beta` token, the caller sees a plain 200 with no trace of the drop. Verified live on prod 2026-09-03: `/v1/messages` `claude-haiku-4.5` + `output_config:{effort:"low"}` → 200 with no disclosure anywhere, while the identical drop on `/v1/chat/completions` discloses `["reasoning_effort"]`.

## Change

- `MessagesSseEncoder::new_with_ignored(request_id, model, ignored)` and `completed_messages_body_with_ignored(request_id, model, events, ignored)`, mirroring `ChatSseEncoder::new_with_ignored` / `completed_chat_body_with_ignored`; the plain constructors delegate with an empty list (the PyO3 fixture entrypoints keep using them).
- `route_messages.rs` threads `admission.ignored_parameters` through the two aggregation sites and both streaming encoders (settled/guarded and the live-stream spawn).
- The list lands as `x-experiential-ignored-parameters` on the `message_start` message object and on the aggregated non-streaming body — the same body-level carrier the other two surfaces use (the Anthropic envelope has no field for it; the official SDK models tolerate extra keys, and Claude Code ignores unknown top-level keys). An empty list adds nothing, so the plain envelope is byte-identical to before.
- `docs/reference/gateway-architecture.md`: the disclosure paragraph now names all three surfaces' carriers.

## Tests

- `ignored_generation_controls_are_disclosed_by_both_messages_encoders`: the key appears on `message_start` and on the aggregated body with the exact list, and the plain constructors emit no such key.
- `cargo test --no-default-features`: 146 passed; `cargo clippy --no-default-features --all-targets -D warnings`: clean; Python parity suites (`exp/runtime/gateway`, `exp/runtime/anthropic_protocol`, `-k "messages or anthropic"`) 171 passed against the rebuilt wheel.

## Release mechanics

Crate `0.3.23 → 0.3.24` (the gate requires a crate bump for any change under `native/`), Cargo.lock via `cargo update -p exp-gateway-native --offline`, root pin floor `>=0.3.24`, `uv lock`. No release cut; merge on green per the platform lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
