### PR TITLE
gateway: a text-less provider refusal is a 400 `refusal`, not a 502 routing failure (crate 0.3.26)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.25"
+version = "0.3.26"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -50,6 +50,24 @@ fn error_body_folds_param_and_maps_status_first() {
 }
 
 #[test]
+fn a_text_less_refusal_is_an_invalid_request_error_on_the_messages_surface() {
+    // The Messages envelope maps by status first, so the refusal's 400 lands
+    // on Anthropic's own invalid_request_error type instead of the api_error
+    // a 502 routing failure would have produced.
+    let refused = Failure::new(FailureClass::Refusal, "provider refused the request");
+    assert_eq!(
+        anthropic_error_body(&refused.public_error()),
+        json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "provider refused the request",
+            },
+        })
+    );
+}
+
+#[test]
 fn completed_body_orders_text_before_tool_use_blocks() {
     let events = vec![
         Event::TextDelta("hi".to_string()),

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -262,6 +262,13 @@ impl Failure {
             FailureClass::Timeout => (504, "deadline_exceeded", "api_error"),
             FailureClass::Cancelled => (499, "request_cancelled", "api_error"),
             FailureClass::Guardrail => (400, "content_filter", "invalid_request_error"),
+            // A provider refusal with no visible refusal text is the model's
+            // answer to the request content, not a routing failure: OpenAI
+            // rejects such prompts as a 400 `invalid_request_error` ("rejected
+            // as a result of our safety system"), so the closest error-shaped
+            // convention is that status with its own code. The provider billed
+            // the processed input, so a 502 would misdescribe a charged call.
+            FailureClass::Refusal => (400, "refusal", "invalid_request_error"),
             FailureClass::Unavailable => (503, "gateway_unavailable", "api_error"),
             _ => (502, "all_routes_failed", "api_error"),
         };
@@ -294,6 +301,24 @@ impl Failure {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_refusal_is_a_request_error_with_its_own_code_never_a_routing_failure() {
+        // The provider processed (and billed) the prompt and answered with a
+        // refusal; `all_routes_failed` would file the model's verdict as an
+        // infrastructure fault. Mirrors `public_failure_error`.
+        let refused = Failure::new(FailureClass::Refusal, "provider refused the request");
+        let error = refused.public_error();
+        assert_eq!(error.status_code, 400);
+        assert_eq!(error.code, "refusal");
+        assert_eq!(error.error_type, "invalid_request_error");
+        assert_eq!(error.message, "provider refused the request");
+        assert_eq!(error.retry_after_seconds, None);
+        // Untyped provider failures keep the routing-failure shape.
+        let internal = Failure::new(FailureClass::ProviderInternal, "provider failed");
+        assert_eq!(internal.public_error().status_code, 502);
+        assert_eq!(internal.public_error().code, "all_routes_failed");
+    }
 
     #[test]
     fn rejected_parameter_reaches_the_public_error_only_for_invalid_requests() {

--- a/exp/runtime/openai_protocol/errors.py
+++ b/exp/runtime/openai_protocol/errors.py
@@ -184,6 +184,12 @@ def public_failure_error(
         GatewayFailureClass.TIMEOUT: (504, "deadline_exceeded", "api_error"),
         GatewayFailureClass.CANCELLED: (499, "request_cancelled", "api_error"),
         GatewayFailureClass.GUARDRAIL: (400, "content_filter", "invalid_request_error"),
+        # A refusal with no visible refusal text is the model's answer to the
+        # request content, not a routing failure. OpenAI rejects such prompts
+        # as a 400 ``invalid_request_error`` ("rejected as a result of our
+        # safety system"); the provider billed the processed input, so a 502
+        # would misdescribe a charged call as an infrastructure fault.
+        GatewayFailureClass.REFUSAL: (400, "refusal", "invalid_request_error"),
         GatewayFailureClass.UNAVAILABLE: (503, "gateway_unavailable", "api_error"),
     }
     status, code, error_type = mappings.get(

--- a/exp/runtime/openai_protocol/errors_test.py
+++ b/exp/runtime/openai_protocol/errors_test.py
@@ -92,6 +92,28 @@ def test_unavailable_failure_is_a_retryable_503() -> None:
     assert error.headers() == {"Retry-After": str(UNAVAILABLE_RETRY_AFTER_SECONDS)}
 
 
+def test_refusal_failure_is_a_request_error_not_a_routing_failure() -> None:
+    """A text-less provider refusal is a 400 with its own code, never a 502.
+
+    The provider processed (and billed) the prompt and answered with a
+    refusal; describing that as ``all_routes_failed`` misfiles the model's
+    verdict as an infrastructure fault. OpenAI's own convention for a prompt
+    its safety system rejects is a 400 ``invalid_request_error``.
+    """
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.REFUSAL,
+            safe_message="provider refused the request",
+        )
+    )
+
+    assert error.status_code == 400
+    assert error.detail.code == "refusal"
+    assert error.detail.type == "invalid_request_error"
+    assert error.detail.message == "provider refused the request"
+    assert error.retry_after_seconds is None
+
+
 def test_guardrail_failure_uses_content_filter_shape() -> None:
     """A guardrail block is a sanitized 400 with no request content."""
     error = public_failure_error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.25,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.26,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.25"
+version = "0.3.26"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

A provider refusal with no visible refusal text has no public mapping of its own: `FailureClass::Refusal` falls through the default arm of `Failure::public_error` (`errors.rs`) and `public_failure_error` (`openai_protocol/errors.py`) to **502 `all_routes_failed` / `api_error`** with the message "provider refused the request". That files the model's verdict on the request content as an infrastructure fault. It also became a billing problem on the platform side: experientiallabs/platform#1161 settles a refusal that arrived with the provider's usage report at the processed-input cost (Anthropic bills a refusal like any message), so the 502 now carries a charge.

## What

`FailureClass::Refusal` / `GatewayFailureClass.REFUSAL` → **400, code `refusal`, type `invalid_request_error`**, message unchanged ("provider refused the request"). The Messages surface inherits it through `anthropic_error_body`'s status-first mapping (400 + `invalid_request_error` → Anthropic's `invalid_request_error`). Visible refusals are untouched: a refusal that streamed refusal text still completes publicly as a 200 (`complete_visible_refusal` on chat/responses/messages) while the ledger records the refusal.

**Convention mirrored.** Neither first-party API returns an *error* for a model refusal — Anthropic returns `stop_reason: "refusal"` "as a normal HTTP 200 response, not an error" (platform.claude.com/docs/en/api/handling-stop-reasons), and OpenAI-compatible wires return `finish_reason: "content_filter"` on a 200 — so the only error-shaped precedent for "the request content itself was refused" is the prompt-side content filter: "Prompts that are classified at a filtered category and severity level return an HTTP 400 error" with `code: "content_filter"`, `status: 400` (learn.microsoft.com, Content filtering for Microsoft Foundry Models, Scenario 3). This crate already maps its own guardrail block the same way (`Guardrail => (400, "content_filter", "invalid_request_error")`); the refusal gets the same status and type with its own code so callers can tell the model's refusal from a gateway guardrail.

## Tests

- `errors.rs`: `a_refusal_is_a_request_error_with_its_own_code_never_a_routing_failure` (chat/responses shape; `ProviderInternal` keeps 502).
- `encode_messages/tests.rs`: `a_text_less_refusal_is_an_invalid_request_error_on_the_messages_surface` (Anthropic envelope).
- `openai_protocol/errors_test.py`: `test_refusal_failure_is_a_request_error_not_a_routing_failure`.
- `native_bridge_test.py::test_rust_failure_taxonomy_matches_public_failure_error` (existing, iterates every class) proves Rust and Python agree after both tables changed.

Local: `cargo test --no-default-features` (crate) and `cargo clippy --no-default-features --all-targets -D warnings` green; wheel rebuilt (`uv sync --extra dev --reinstall-package exp-gateway-native`) and `pytest exp/runtime/openai_protocol exp/runtime/gateway/boundary_test.py exp/runtime/gateway/native_bridge_test.py` green; `ruff check`, `ruff format --check`, `ty check` clean.

## Version

The crate gate compares `Cargo.toml` against the base ref on any change under `exp/runtime/gateway/native/`, so this carries the mandatory crate bump 0.3.25 → 0.3.26 (0.3.24 went to #743, 0.3.25 to #746) (Cargo.toml, crate pyproject, Cargo.lock, parent pin floor, uv.lock). No release is cut here; the platform picks it up at its next pin bump. Until then the platform's text-less refusals keep the 502 shape (noted in platform#1161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
