### PR TITLE
gateway: log the real exception behind an INTERNAL admission failure

### DIFF
--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -25,6 +25,7 @@ metrics and fails the request closed with the shared internal error.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from collections.abc import Callable
 
@@ -135,6 +136,8 @@ from exp.runtime.openai_protocol.state import (
     ProtocolNamespace,
     replay_key,
 )
+
+_logger = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT_SECONDS = 120.0
 
@@ -577,6 +580,22 @@ class NativeControlPlane(
             failure = GatewayFailure(
                 failure_class=GatewayFailureClass.INTERNAL,
                 safe_message="gateway admission failed before provider dispatch",
+            )
+            # The public error and the ledger row carry only the sanitized
+            # text, so this record is the ONLY place the real exception
+            # survives: an unlogged INTERNAL here left a granted alias failing
+            # 500 for hours with nothing to diagnose (platform staging,
+            # 2026-09-03). The message names the request and alias; the
+            # traceback rides exc_info. Nothing here carries a credential.
+            _logger.exception(
+                "gateway admission failed before provider dispatch",
+                extra={
+                    "operation": "native_admit",
+                    "request_id": authorization.request_id,
+                    "alias": authorization.alias,
+                    "alias_revision_id": authorization.alias_revision_id,
+                    "exception_type": type(exc).__name__,
+                },
             )
             self._accounting.finish_request_quietly(authorization, failure)
             raise error from exc

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import sqlite3
 import threading
 import time
@@ -13,6 +14,7 @@ from unittest import mock
 
 import pytest
 
+import exp.runtime.gateway.native_bridge as native_bridge_module
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import (
     GatewayDeploymentCapabilities,
@@ -4703,3 +4705,49 @@ def test_rust_messages_paused_turn_keeps_its_stop_reason() -> None:
     assert '"stop_reason":"pause_turn"' in frames
     body = json.loads(native.completed_messages_fixture("request-abc", "coding", fixture))
     assert body["stop_reason"] == "pause_turn"
+
+
+def test_internal_admission_failures_log_the_real_exception(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sanitized 500 hides the cause everywhere else, so the bridge logs it once.
+
+    A granted alias whose admission blew up with an unexpected exception used
+    to fail 500 with the traceback recorded nowhere (public error, ledger row,
+    and worker log all carry only the sanitized text). The record names the
+    request and alias and carries the exception on ``exc_info``.
+    """
+    control, raw_key = _pool_control_plane(tmp_path)
+
+    def explode(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        message = "hydrated snapshot names a deployment this worker never registered"
+        raise KeyError(message)
+
+    monkeypatch.setattr(native_bridge_module, "resolve_admission_route", explode)
+    body = json.dumps({"model": "coding", "messages": [{"role": "user", "content": "hi"}]})
+
+    with (
+        caplog.at_level(logging.ERROR, logger="exp.runtime.gateway.native_bridge"),
+        pytest.raises(NativeBridgeError) as raised,
+    ):
+        _admit(control, raw_key, body)
+
+    error = json.loads(raised.value.public_error_json)
+    assert error["status_code"] == 500
+    assert error["code"] == "internal_error"
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "gateway admission failed before provider dispatch"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.exc_info is not None
+    assert record.exc_info[0] is KeyError
+    # ``extra`` fields land on the record's namespace, not on the typed class.
+    fields = record.__dict__
+    assert fields["alias"] == "coding"
+    assert str(fields["request_id"]).startswith("request-")
+    assert fields["exception_type"] == "KeyError"
+    assert fields["operation"] == "native_admit"


### PR DESCRIPTION
## Problem

`NativeControlPlane.admit`'s last-resort `except Exception` (native_bridge.py) maps any unexpected admission exception to the sanitized 500 `internal_error` and finishes the request quietly — and never logs it. The public error, the ledger row (`failure_class=internal`, `error_message="gateway admission failed before provider dispatch"`), and the worker log therefore all carry only the sanitized text. Observed on the platform's staging 2026-09-03: `qwen3.8-27b` (and `glm-5`, `nova-2-lite-v1`) failed 500 on every request for hours after a catalog catch-up/hydration, with no traceback anywhere to say which exception fired.

## Change

The branch logs one ERROR record through the module logger (`_logger.exception`) with `exc_info` and `extra` naming the request id, alias, alias revision, and exception type. Nothing in the record carries a credential (the exception chain here holds env NAMES only, like the catalog paths). Python-only; no crate change, no version bump.

## Test

`test_internal_admission_failures_log_the_real_exception`: monkeypatches `resolve_admission_route` to raise `KeyError`, asserts the public 500 `internal_error` is unchanged and exactly one record with the sanitized message, `exc_info[0] is KeyError`, and the request/alias/exception_type/operation extras.

`ruff`, `ty`, and `exp/runtime/gateway/native_bridge_test.py` (121 passed) green on Python 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
