### PR TITLE
gateway: srn sampling — drop+disclose+serve instead of rejecting (Task A)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -305,8 +305,9 @@ idempotency header, so this surface never joins the keyed replay stores.
 Route admission preserves caller capabilities in three verbatim-preference layers before any
 coercion: operationally dead rungs are skipped (`dispatchable_route_profiles`), generation
 controls narrow the waterfall to the rungs that preserve every exact value
-(`compatible_generation_parameter_profile_indexes`), and each remaining deployment passes the
-capability preflight plus payload build. Only when zero rungs survive does the
+(`compatible_generation_parameter_profile_indexes`), falling back to the rungs that can serve the
+request only through a disclosed drop when no rung preserves it, and each remaining deployment
+passes the capability preflight plus payload build. Only when zero rungs survive does the
 capability-preservation policy (`exp/runtime/models/providers/capability_policy.py`) attempt one
 minimal COERCE-WITH-DISCLOSURE: a reasoning effort snaps to the nearest level any rung supports
 on the canonical ladder (ties prefer the lower level), ANY effort on a route with no reasoning
@@ -314,7 +315,13 @@ support at all drops (first-party clients pin effort globally, so a named reject
 sessions unusable against non-reasoning models the provider itself serves fine without the
 parameter; the Messages surface's verbatim `output_config.effort` is stripped with it so the
 dropped value reaches the provider through no channel), and `strict: true` tools degrade to
-best-effort schemas. A caller `service_tier` on the OpenAI-family surfaces forwards verbatim
+best-effort schemas. On a reasoning route that accepts sampling only at `reasoning_effort=none`
+(`sampling_requires_reasoning_none`, e.g. gpt-5.6-sol/luna), a `temperature`/`top_p` sent with
+reasoning on is dropped and disclosed as `temperature->dropped(set_reasoning_effort_none)` rather
+than rejected — the model accepts sampling, just not at that effort, so the request serves and the
+caller is told how to keep the value (set `reasoning_effort=none`); a route that never declares the
+control at all (Anthropic constrained `[1,1]` sampling) still hard-rejects it, since there is
+nothing to honor at any effort. A caller `service_tier` on the OpenAI-family surfaces forwards verbatim
 only on rungs dispatching tenant-owned (BYOK) credentials, where the caller pays the provider
 directly; host-funded rungs never emit it (the tier changes provider pricing while the gateway
 bills catalog rates) and a route with no eligible rung drops it with disclosure. Anthropic's own

--- a/exp/runtime/models/providers/generation_route_compat.py
+++ b/exp/runtime/models/providers/generation_route_compat.py
@@ -33,14 +33,36 @@ def compatible_generation_parameter_profile_indexes(
     """
     if not profiles:
         raise ValueError("generation parameter selection requires at least one wire profile")
-    compatible: list[int] = []
+    # Prefer rungs that HONOR the caller's sampling exactly over rungs that can
+    # only serve it by dropping temperature/top_p (a reasoning route at an effort
+    # other than none). Both are servable, but preserving the caller's intent
+    # wins when a rung can — the drop is a last resort, not a peer of an exact
+    # rung. Only if no rung honors it do the serve-with-drop rungs stand in.
+    exact: list[int] = []
+    serviceable: list[int] = []
     for index, profile in enumerate(profiles):
         try:
-            route_generation_parameter_requests((profile,), request)
+            _public, provider = route_generation_parameter_requests((profile,), request)
         except ProviderParameterError:
             continue
-        compatible.append(index)
-    if compatible:
-        return tuple(compatible)
+        serviceable.append(index)
+        if _honors_requested_sampling(request, provider):
+            exact.append(index)
+    if exact:
+        return tuple(exact)
+    if serviceable:
+        return tuple(serviceable)
     route_generation_parameter_requests(profiles, request)
     raise AssertionError("an incompatible route returned without a parameter error")
+
+
+def _honors_requested_sampling(request: GatewayRequest, provider_request: GatewayRequest) -> bool:
+    """Return whether a rung kept every sampling control the caller actually sent.
+
+    A rung that dropped a requested ``temperature``/``top_p`` (the srn drop) did
+    not preserve the caller's intent exactly, so it is only a fallback behind any
+    rung that honors the value.
+    """
+    if request.temperature is not None and provider_request.temperature is None:
+        return False
+    return not (request.top_p is not None and provider_request.top_p is None)

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -295,32 +295,55 @@ def route_generation_parameter_requests(
         """Return the caller effort or this wire's required provider default."""
         return _effective_profile_reasoning_effort(profile, request.reasoning_effort)
 
+    def sampling_declared(profile: GatewayWireProfile, *, top_p: bool = False) -> bool:
+        """Return whether one rung declares this sampling control at all."""
+        return profile.supports_top_p is True if top_p else profile.supports_temperature
+
     def sampling_supported(profile: GatewayWireProfile, *, top_p: bool = False) -> bool:
         """Return whether one rung accepts this request's sampling mode."""
-        declared = profile.supports_top_p is True if top_p else profile.supports_temperature
-        return declared and (
+        return sampling_declared(profile, top_p=top_p) and (
             not profile.sampling_requires_reasoning_none
             or profile_reasoning_effort(profile) == "none"
         )
 
+    def srn_only_block(*, top_p: bool = False) -> bool:
+        """Return whether the ONLY reason the route blocks this control is srn.
+
+        Every rung declares the control, but at least one is a reasoning route
+        that accepts sampling only at ``reasoning_effort=none`` and is not at
+        none here. Such a control is dropped-and-disclosed rather than rejected:
+        the model does accept it, just not at this effort. A rung that does not
+        declare the control at all (Anthropic constrained sampling) is a genuine
+        unsupported case and is NOT covered here, so it still hard-rejects.
+        """
+        return all(sampling_declared(profile, top_p=top_p) for profile in profiles) and not all(
+            sampling_supported(profile, top_p=top_p) for profile in profiles
+        )
+
     if request.temperature is not None:
-        _require_route_numeric_parameter(
-            profiles,
-            param="temperature",
-            value=request.temperature,
-            supported=sampling_supported,
-            minimum=lambda profile: profile.minimum_temperature,
-            maximum=lambda profile: profile.maximum_temperature,
-        )
+        if srn_only_block():
+            ignore("temperature", "temperature->dropped(set_reasoning_effort_none)")
+        else:
+            _require_route_numeric_parameter(
+                profiles,
+                param="temperature",
+                value=request.temperature,
+                supported=sampling_supported,
+                minimum=lambda profile: profile.minimum_temperature,
+                maximum=lambda profile: profile.maximum_temperature,
+            )
     if request.top_p is not None:
-        _require_route_numeric_parameter(
-            profiles,
-            param="top_p",
-            value=request.top_p,
-            supported=lambda profile: sampling_supported(profile, top_p=True),
-            minimum=lambda profile: profile.minimum_top_p,
-            maximum=lambda profile: profile.maximum_top_p,
-        )
+        if srn_only_block(top_p=True):
+            ignore("top_p", "top_p->dropped(set_reasoning_effort_none)")
+        else:
+            _require_route_numeric_parameter(
+                profiles,
+                param="top_p",
+                value=request.top_p,
+                supported=lambda profile: sampling_supported(profile, top_p=True),
+                minimum=lambda profile: profile.minimum_top_p,
+                maximum=lambda profile: profile.maximum_top_p,
+            )
     if request.top_k is not None:
         _require_route_numeric_parameter(
             profiles,

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -739,6 +739,30 @@ def test_generation_parameter_selection_uses_each_default_for_sampling() -> None
     assert compatible_generation_parameter_profile_indexes(profiles, request) == (1,)
 
 
+def test_generation_parameter_selection_serves_with_drop_when_no_rung_honors() -> None:
+    """When every rung is a reasoning route that blocks sampling at this effort, all
+    rungs stay selectable (they serve by dropping+disclosing), not rejected."""
+    profiles = tuple(
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url=f"https://reasoning{position}.test",
+            model_id=f"provider/reasoning-{position}",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning",
+            reasoning_effort="high",
+            supported_reasoning_efforts=("none", "high"),
+            reasoning_effort_required=True,
+            sampling_requires_reasoning_none=True,
+        )
+        for position in range(2)
+    )
+    request = _chat_request().model_copy(update={"temperature": 0.5})
+
+    # No rung honors temperature at effort=high, so both remain serviceable and the
+    # value is dropped+disclosed on whichever serves (rather than a hard rejection).
+    assert compatible_generation_parameter_profile_indexes(profiles, request) == (0, 1)
+
+
 def test_route_accepts_anthropic_max_effort_without_translation() -> None:
     """The provider's documented max level is preserved exactly."""
     request = _chat_request().model_copy(update={"reasoning_effort": "max"})
@@ -916,8 +940,9 @@ def test_route_rejects_out_of_range_provider_controls() -> None:
     assert "between 0.0 and 1.0" in str(raised.value)
 
 
-def test_conditional_sampling_requires_explicit_none_reasoning() -> None:
-    """GPT-5.1 sampling is accepted only when the caller selects exact no-reasoning mode."""
+def test_srn_sampling_drops_and_discloses_instead_of_rejecting() -> None:
+    """On a reasoning route (srn), temperature/top_p sent with reasoning on is dropped
+    and disclosed, not rejected: the model accepts sampling, just not at this effort."""
     profile = GatewayWireProfile(
         dialect="openai_responses",
         url="https://provider.test",
@@ -925,22 +950,65 @@ def test_conditional_sampling_requires_explicit_none_reasoning() -> None:
         supports_reasoning=True,
         reasoning_wire_format="openai_responses",
         reasoning_effort="medium",
+        supports_temperature=True,
         supports_top_p=True,
         sampling_requires_reasoning_none=True,
     )
-    with pytest.raises(ProviderParameterError) as raised:
-        route_generation_parameter_requests((profile,), _chat_request(temperature=0.2))
+    public_request, provider_request = route_generation_parameter_requests(
+        (profile,), _chat_request(temperature=0.2, top_p=0.9)
+    )
 
-    assert raised.value.code == "unsupported_parameter"
-    assert raised.value.param == "temperature"
+    # The caller value survives on the public copy for reflection, is dropped from
+    # the provider payload, and both drops are disclosed with an actionable reason.
+    assert public_request.temperature == 0.2
+    assert public_request.top_p == 0.9
+    assert provider_request.temperature is None
+    assert provider_request.top_p is None
+    assert public_request.ignored_parameters == (
+        "temperature->dropped(set_reasoning_effort_none)",
+        "top_p->dropped(set_reasoning_effort_none)",
+    )
 
+
+def test_srn_sampling_is_honored_at_explicit_none_reasoning() -> None:
+    """The sampling hatch stays open: reasoning_effort=none honors temperature/top_p."""
+    profile = GatewayWireProfile(
+        dialect="openai_responses",
+        url="https://provider.test",
+        model_id="gpt-5.1",
+        supports_reasoning=True,
+        reasoning_wire_format="openai_responses",
+        reasoning_effort="medium",
+        supports_temperature=True,
+        supports_top_p=True,
+        sampling_requires_reasoning_none=True,
+    )
     request = _chat_request(temperature=0.2, top_p=0.9).model_copy(
         update={"reasoning_effort": "none"}
     )
     public_request, provider_request = route_generation_parameter_requests((profile,), request)
 
     assert public_request.temperature == 0.2
+    assert provider_request.temperature == 0.2
+    assert provider_request.top_p == 0.9
     assert provider_request.reasoning_effort == "none"
+    assert public_request.ignored_parameters == ()
+
+
+def test_genuinely_unsupported_sampling_still_hard_rejects() -> None:
+    """A route that never declares temperature (Anthropic constrained [1,1]) still
+    rejects — there is nothing to honor at any effort, so it is not srn-droppable."""
+    profile = GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://provider.test",
+        model_id="claude-constrained",
+        supports_temperature=False,
+    )
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((profile,), _chat_request(temperature=0.2))
+
+    assert raised.value.code == "unsupported_parameter"
+    assert raised.value.param == "temperature"
 
 
 def test_payload_builder_rejects_conditional_sampling_without_admission() -> None:


### PR DESCRIPTION
## What

A route that accepts `temperature`/`top_p` **only** at `reasoning_effort=none` (`sampling_requires_reasoning_none`, e.g. gpt-5.6-sol/luna) used to 400 ("temperature is not supported by this model route") when a caller sent `temperature`/`top_p` with reasoning on. The model **does** accept sampling — just not at that effort — so a hard reject is worse than adapting. Now the request **serves** with the sampling control dropped before dispatch and **disclosed** to the caller. (Design A, as approved.)

## How

- **`route_generation_parameter_requests`** (streaming_requests.py): split the srn-block from the genuinely-unsupported case. When every rung **declares** the control but at least one blocks it *solely* because it's a reasoning route not at `effort=none`, drop it via the existing `ignore()` seam (nulls the provider field + records the disclosure) instead of raising. A rung that never declares the control (Anthropic constrained `[1,1]`) still **hard-rejects** — nothing to honor at any effort. **No Rust/schema change** — the drop rides the existing `x-experiential-ignored-parameters` body key; the redundant payload-build guard (reasoning_compat.py) auto-no-ops once the provider field is nulled.
- **Disclosure token** (owner chose the visible-warning form; no OpenAI-wire warning field exists): self-explanatory `temperature->dropped(set_reasoning_effort_none)` / `top_p->dropped(...)` — field-name prefix (still parseable) + the existing `->` transition convention + the actionable fix.
- **`generation_route_compat.py`**: the per-rung selection probe treated my drop as "compatible," which would lose a rung that could *honor* temperature. Fixed: selection now **prefers rungs that honor the caller's sampling exactly** and only falls back to serve-with-drop rungs when none honor it — preserving intent when any rung can (this is the "adapt to preserve intent" principle applied to selection).
- **docs/reference/gateway-architecture.md** documents the srn drop + the honor-first selection fallback. (`/docs/errors` is a platform web route — that copy is platform-side, flagged to the lead.)

## Tests

- `test_srn_sampling_drops_and_discloses_instead_of_rejecting` — served; `provider_request.temperature/top_p` nulled; `public_request` keeps caller values + both disclosure tokens.
- `test_srn_sampling_is_honored_at_explicit_none_reasoning` — `reasoning_effort=none` honors sampling, no disclosure.
- `test_genuinely_unsupported_sampling_still_hard_rejects` — Anthropic constrained → 400 `unsupported_parameter`.
- `test_generation_parameter_selection_uses_each_default_for_sampling` — heterogeneous route still narrows to the honoring rung.
- `test_generation_parameter_selection_serves_with_drop_when_no_rung_honors` — pure-srn route stays serviceable (drop-serve, not rejected).
- 648 provider+protocol tests + gateway admission green; ruff/ty clean.

## Version

No bump — accumulating into the **held 0.7.28** release (matches #742/#743/#746). Pure Python, no native/schema change → P0-safe to develop; NO deploy until the reconciled release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)