### PR TITLE
gateway/batch: batch support for OpenAI-compatible providers (Doubleword)

### DIFF
--- a/exp/runtime/gateway/batch/providers.py
+++ b/exp/runtime/gateway/batch/providers.py
@@ -702,8 +702,16 @@ class OpenRouterBatchClient:
         )
 
 
+class DoublewordBatchClient(OpenAIBatchClient):
+    """Doubleword Batch API: the OpenAI batch dialect at Doubleword's endpoint."""
+
+    provider = "doubleword"
+    _base = "https://api.doubleword.ai/v1"
+
+
 PROVIDER_CLIENTS: dict[str, ProviderBatchClient] = {
     OpenAIBatchClient.provider: OpenAIBatchClient(),
     AnthropicBatchClient.provider: AnthropicBatchClient(),
     OpenRouterBatchClient.provider: OpenRouterBatchClient(),
+    DoublewordBatchClient.provider: DoublewordBatchClient(),
 }

--- a/exp/runtime/gateway/batch/providers.py
+++ b/exp/runtime/gateway/batch/providers.py
@@ -702,11 +702,36 @@ class OpenRouterBatchClient:
         )
 
 
-class DoublewordBatchClient(OpenAIBatchClient):
+class OpenAICompatibleBatchClient(OpenAIBatchClient):
+    """The OpenAI batch dialect at a configurable base URL and provider name.
+
+    Any provider that serves the OpenAI Batch API verbatim (file upload plus
+    ``/batches`` create, poll, cancel, and file-id results) is reachable by
+    binding its ``base_url`` and provider identity on the instance.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        base_url: str,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        """Bind the provider identity and endpoint for this instance."""
+        super().__init__(transport=transport)
+        self.provider = provider
+        self._base = base_url
+
+
+class DoublewordBatchClient(OpenAICompatibleBatchClient):
     """Doubleword Batch API: the OpenAI batch dialect at Doubleword's endpoint."""
 
     provider = "doubleword"
     _base = "https://api.doubleword.ai/v1"
+
+    def __init__(self, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        """Bind the Doubleword endpoint, with an optional injected transport."""
+        super().__init__(provider=self.provider, base_url=self._base, transport=transport)
 
 
 PROVIDER_CLIENTS: dict[str, ProviderBatchClient] = {

--- a/exp/runtime/gateway/batch/providers_test.py
+++ b/exp/runtime/gateway/batch/providers_test.py
@@ -28,6 +28,7 @@ from exp.runtime.gateway.batch.contracts import (
 from exp.runtime.gateway.batch.providers import (
     ANTHROPIC_HOST,
     AnthropicBatchClient,
+    DoublewordBatchClient,
     OpenAIBatchClient,
     OpenRouterBatchClient,
     provider_error_detail,
@@ -833,3 +834,54 @@ def test_anthropic_success_without_a_message_and_unknown_result_types_name_thems
         "type": "unknown",
         "message": "the provider reported this request as unknown",
     }
+
+
+def test_doubleword_speaks_the_openai_dialect_at_the_doubleword_host() -> None:
+    """The client uploads then creates the batch against api.doubleword.ai."""
+    hosts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hosts.append(request.url.host)
+        if request.url.path == "/v1/files":
+            return httpx.Response(200, json={"id": "file_dw"})
+        assert request.url.path == "/v1/batches"
+        assert json.loads(request.content) == {
+            "input_file_id": "file_dw",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        }
+        return httpx.Response(200, json={"id": "pb_dw"})
+
+    client = DoublewordBatchClient(transport=_transport(handler))
+    provider_id = asyncio.run(client.submit(job=_job("doubleword"), api_key="sk-dw"))
+    assert provider_id == "pb_dw"
+    assert hosts == ["api.doubleword.ai", "api.doubleword.ai"]
+
+
+def test_doubleword_results_download_from_the_doubleword_host() -> None:
+    """Result files are fetched from Doubleword, not the OpenAI host."""
+    hosts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hosts.append(request.url.host)
+        if request.url.path == "/v1/batches/pb_1":
+            return httpx.Response(200, json={"status": "completed", "output_file_id": "fo"})
+        assert request.url.path == "/v1/files/fo/content"
+        return httpx.Response(
+            200,
+            text=json.dumps(
+                {
+                    "custom_id": "line-0",
+                    "response": {
+                        "status_code": 200,
+                        "body": {"usage": {"prompt_tokens": 3, "completion_tokens": 5}},
+                    },
+                    "error": None,
+                }
+            ),
+        )
+
+    client = DoublewordBatchClient(transport=_transport(handler))
+    results = asyncio.run(client.results(job=_job("doubleword"), api_key="sk"))
+    assert results[0].custom_id == "line-0" and results[0].output_tokens == 5
+    assert set(hosts) == {"api.doubleword.ai"}

--- a/exp/runtime/gateway/batch/providers_test.py
+++ b/exp/runtime/gateway/batch/providers_test.py
@@ -30,6 +30,7 @@ from exp.runtime.gateway.batch.providers import (
     AnthropicBatchClient,
     DoublewordBatchClient,
     OpenAIBatchClient,
+    OpenAICompatibleBatchClient,
     OpenRouterBatchClient,
     provider_error_detail,
     require_exact_host,
@@ -885,3 +886,23 @@ def test_doubleword_results_download_from_the_doubleword_host() -> None:
     results = asyncio.run(client.results(job=_job("doubleword"), api_key="sk"))
     assert results[0].custom_id == "line-0" and results[0].output_tokens == 5
     assert set(hosts) == {"api.doubleword.ai"}
+
+
+def test_openai_compatible_client_targets_its_configured_base() -> None:
+    """A configured provider and base URL drive the OpenAI batch dialect there."""
+    hosts: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hosts.append(request.url.host)
+        if request.url.path == "/v1/files":
+            return httpx.Response(200, json={"id": "file_x"})
+        assert request.url.path == "/v1/batches"
+        return httpx.Response(200, json={"id": "pb_x"})
+
+    client = OpenAICompatibleBatchClient(
+        provider="acme", base_url="https://batch.acme.example/v1", transport=_transport(handler)
+    )
+    assert client.provider == "acme"
+    provider_id = asyncio.run(client.submit(job=_job("acme"), api_key="sk-acme"))
+    assert provider_id == "pb_x"
+    assert set(hosts) == {"batch.acme.example"}

--- a/exp/runtime/gateway/batch/tests/live_test.py
+++ b/exp/runtime/gateway/batch/tests/live_test.py
@@ -27,6 +27,7 @@ from exp.runtime.gateway.batch.contracts import (
 )
 from exp.runtime.gateway.batch.providers import (
     AnthropicBatchClient,
+    DoublewordBatchClient,
     OpenAIBatchClient,
     OpenRouterBatchClient,
     ProviderBatchClient,
@@ -145,4 +146,22 @@ def test_live_openrouter_chat_batch() -> None:
             {"messages": [{"role": "user", "content": "Say ok."}], "max_tokens": 8},
         ),
         os.environ["OPENROUTER_API_KEY"],
+    )
+
+
+@pytest.mark.skipif(
+    not (_LIVE and os.environ.get("DOUBLEWORD_API_KEY")),
+    reason="set EXP_LIVE_BATCH=1 and DOUBLEWORD_API_KEY to run the live Doubleword batch",
+)
+def test_live_doubleword_chat_batch() -> None:
+    """One real two-line Kimi K3 chat batch on Doubleword completes and settles."""
+    _run(
+        DoublewordBatchClient(),
+        _job(
+            "doubleword",
+            "/v1/chat/completions",
+            "moonshotai/kimi-k3",
+            {"messages": [{"role": "user", "content": "Say ok."}], "max_tokens": 8},
+        ),
+        os.environ["DOUBLEWORD_API_KEY"],
     )

--- a/exp/runtime/gateway/tests/doubleword_batch_live_test.py
+++ b/exp/runtime/gateway/tests/doubleword_batch_live_test.py
@@ -1,0 +1,156 @@
+"""Gated live certification: a real Doubleword batch through the native routes.
+
+One real native server binds a loopback socket over real gateway components;
+the batch lane runs over in-memory seams but with the real Doubleword provider
+client and a real Doubleword API key, so a tiny two-line batch crosses actual
+HTTP bytes through the Rust routes, the bridge, the plane, and the engine, then
+out to Doubleword's real Batch API and back. Gated the same way as the
+per-provider live tests: it spends real money in the smallest amount and runs
+only when explicitly selected.
+
+    EXP_LIVE_BATCH=1 DOUBLEWORD_API_KEY=... \
+        uv run pytest exp/runtime/gateway/tests/doubleword_batch_live_test.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from exp.runtime.gateway.batch import BatchControlPlane, BatchEngine
+from exp.runtime.gateway.batch.contracts import BatchDeployment
+from exp.runtime.gateway.batch.engine_test import MemoryFiles, MemoryLedger, MemoryStore
+from exp.runtime.gateway.batch.providers import DoublewordBatchClient
+from exp.runtime.gateway.lifecycle import load_gateway_components
+from exp.runtime.gateway.tests.launch_test import _configure_gateway, _unused_port
+from exp.runtime.gateway.tests.native_batches_test import _serve_with
+
+_LIVE = os.environ.get("EXP_LIVE_BATCH") == "1"
+_KEY = os.environ.get("DOUBLEWORD_API_KEY")
+_MODEL_ALIAS = "kimi-k3-batch"
+_PROVIDER_MODEL = "moonshotai/kimi-k3"
+_DEADLINE_SECONDS = 8 * 60.0
+
+
+class _DoublewordCatalog:
+    """BatchCatalog exposing one Doubleword batch model."""
+
+    def batch_deployment(self, *, model: str) -> BatchDeployment | None:
+        """Resolve the single Doubleword batch alias, else None."""
+        if model != _MODEL_ALIAS:
+            return None
+        return BatchDeployment(
+            model=_MODEL_ALIAS,
+            provider="doubleword",
+            provider_model=_PROVIDER_MODEL,
+            credential_reference="secret://doubleword",
+            surfaces=("/v1/chat/completions",),
+            input_micro_usd_per_million_tokens=100_000,
+            output_micro_usd_per_million_tokens=200_000,
+        )
+
+
+class _LiveSecrets:
+    """BatchSecretResolver returning the real Doubleword key for any reference."""
+
+    def resolve(self, reference: str) -> str:
+        """Return the configured live key."""
+        return _KEY or ""
+
+
+def _line(custom_id: str) -> str:
+    """Render one real chat batch line addressed to the Doubleword alias."""
+    return json.dumps(
+        {
+            "custom_id": custom_id,
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": {
+                "model": _MODEL_ALIAS,
+                "messages": [{"role": "user", "content": "Say ok."}],
+                "max_tokens": 8,
+            },
+        }
+    )
+
+
+@pytest.mark.skipif(
+    not (_LIVE and _KEY),
+    reason="set EXP_LIVE_BATCH=1 and DOUBLEWORD_API_KEY to run the live Doubleword batch lane",
+)
+def test_doubleword_batch_lane_over_real_http(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Upload, submit, poll to completion, and download a real Doubleword batch."""
+    monkeypatch.setenv("LOOPBACK_PROVIDER_KEY", "provider-secret")
+    _manager, raw_key = _configure_gateway(tmp_path, base_url="http://127.0.0.1:9/v1")
+    store = MemoryStore()
+    ledger = MemoryLedger()
+    engine = BatchEngine(
+        store=store,
+        files=MemoryFiles(),
+        catalog=_DoublewordCatalog(),
+        ledger=ledger,
+        secrets_resolver=_LiveSecrets(),
+        clients={"doubleword": DoublewordBatchClient()},
+    )
+    port = _unused_port()
+    inner = load_gateway_components(tmp_path)
+    batches = BatchControlPlane(engine=engine, control=inner.store)
+    thread, shutdown, _plane, _ = _serve_with(tmp_path, port, batches, inner)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        auth = {"Authorization": f"Bearer {raw_key}"}
+        with httpx.Client(timeout=30.0) as client:
+            content = "\n".join([_line("live-0"), _line("live-1")]).encode("utf-8")
+            uploaded = client.post(
+                f"{base}/v1/files",
+                headers=auth,
+                data={"purpose": "batch"},
+                files={"file": ("input.jsonl", content, "application/jsonl")},
+            )
+            assert uploaded.status_code == 200, uploaded.text
+            file_id = uploaded.json()["id"]
+
+            created = client.post(
+                f"{base}/v1/batches",
+                headers=auth,
+                json={"input_file_id": file_id, "endpoint": "/v1/chat/completions"},
+            )
+            assert created.status_code == 200, created.text
+            batch_id = created.json()["id"]
+
+            deadline = time.monotonic() + _DEADLINE_SECONDS
+            while True:
+                asyncio.run(engine.poll_once())
+                job = store.jobs.get(batch_id)
+                if job is not None and job.settled:
+                    break
+                assert time.monotonic() < deadline, "live Doubleword batch did not settle in time"
+                time.sleep(3)
+
+            finished = client.get(f"{base}/v1/batches/{batch_id}", headers=auth)
+            assert finished.status_code == 200
+            final = finished.json()
+            assert final["status"] == "completed", final
+            assert final["request_counts"] == {"total": 2, "completed": 2, "failed": 0}
+            output_file_id = final["output_file_id"]
+            assert output_file_id
+
+            downloaded = client.get(f"{base}/v1/files/{output_file_id}/content", headers=auth)
+            assert downloaded.status_code == 200
+            assert downloaded.headers["content-type"].startswith("application/jsonl")
+            assert b'"custom_id": "live-0"' in downloaded.content
+            assert b'"custom_id": "live-1"' in downloaded.content
+            assert len(ledger.settled) == 2
+    finally:
+        shutdown.request_shutdown()
+        thread.join(timeout=10)
+        inner.write_ledger.close()
+    assert not thread.is_alive()


### PR DESCRIPTION
Closes #755

## What

Adds a batch provider client so Doubleword, and any OpenAI-compatible endpoint, can be reached through the `/v1/batches` lane. Doubleword speaks the OpenAI Batch dialect verbatim (file upload, `/batches` create, poll, cancel, file-id results), so the client reuses the OpenAI batch path and only binds the base URL.

## Two shapes, as separate commits

The existing batch clients are one concrete class per vendor, so this offers both approaches and you can pick the one you prefer:

1. Concrete `DoublewordBatchClient`, a small subclass overriding the provider name and base URL. Matches the current per-vendor pattern.
2. Generic `OpenAICompatibleBatchClient`, taking a configurable base URL and provider, with `DoublewordBatchClient` rebased onto it. Reusable for any OpenAI-compatible provider.

Drop the second commit for the concrete-only version, or keep both for the generic seam. Either way the registration and behaviour are identical.

## Scope

Client and registration only. Enabling the lane for a host (the `BatchControlPlane`, the catalog row, and the secret resolver) stays the host's job, as for the existing providers. No engine, plane, route, or contract changes.

## Testing

- Wire-level unit tests over `httpx.MockTransport`: the client drives the OpenAI batch dialect at Doubleword's host, and the generic client targets its configured base.
- Gated live tests (`EXP_LIVE_BATCH=1` plus `DOUBLEWORD_API_KEY`): a real two-line batch through the direct client, and the full served `/v1/batches` lane over real HTTP against Doubleword's batch API. Both pass, and small batches settle in about thirty seconds.
- `ruff` and `ty` clean; batch package suite green.

## Open question

`OpenAICompatibleBatchClient` inherits from the vendor-named `OpenAIBatchClient`. If you would rather not couple the generic client to the OpenAI class, a shared `_OpenAIDialectBatchClient` base for both is an easy alternative. Draft while you weigh the client shape and that inheritance.
