### PR TITLE
gateway: a tool call cut off by the output budget is Incomplete, not a malformed stream (crate 0.3.27)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.26"
+version = "0.3.27"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.26"
+version = "0.3.27"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -17,7 +17,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde_json::{Map, Value};
 
 use crate::errors::{Failure, FailureClass};
-use crate::events::{simplified_event, Event, ProviderOutputItemKind, ToolAccumulator, Usage};
+use crate::events::{
+    require_json_object_text, simplified_event, Event, ProviderOutputItemKind, ToolAccumulator,
+    Usage,
+};
 use crate::eventstream::EventStreamDecoder;
 use crate::sse::{SseDecoder, SseEvent};
 
@@ -166,6 +169,34 @@ fn finish_open_tools(tools: &mut BTreeMap<u32, ToolAccumulator>) -> Result<Vec<E
     for (index, tool) in tools.iter_mut() {
         if !tool.completed {
             complete_streamed_tool(*index, tool, &mut events)?;
+        }
+    }
+    Ok(events)
+}
+
+/// Finish open tools on a stream the provider cut off at its output budget.
+///
+/// A call whose accumulated arguments still parse as a JSON object completes
+/// normally; one left mid-fragment by the truncation is DROPPED (marked
+/// completed without a `ToolCallCompleted`), because the provider never
+/// finished it and the caller's remedy is a larger budget, not a retry of a
+/// "malformed" provider. Only the `finish_reason == "length"` terminal may use
+/// this; every other terminal keeps the strict object contract.
+fn finish_open_tools_truncated(
+    tools: &mut BTreeMap<u32, ToolAccumulator>,
+) -> Result<Vec<Event>, Failure> {
+    let mut events = Vec::new();
+    for (index, tool) in tools.iter_mut() {
+        if tool.completed {
+            continue;
+        }
+        let parses = tool.custom
+            || tool.raw_arguments.is_empty()
+            || require_json_object_text(&tool.raw_arguments).is_ok();
+        if parses {
+            complete_streamed_tool(*index, tool, &mut events)?;
+        } else {
+            tool.completed = true;
         }
     }
     Ok(events)

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -4,8 +4,8 @@
 use serde_json::Value;
 
 use super::{
-    complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
-    provider_stream_failed, refusal_failure, Normalizer,
+    complete_streamed_tool, finish_open_tools, finish_open_tools_truncated, malformed,
+    optional_text, parse_object, provider_stream_failed, refusal_failure, Normalizer,
 };
 use crate::errors::{Failure, FailureClass};
 use crate::events::{
@@ -727,11 +727,23 @@ impl Normalizer {
         frame: &crate::sse::SseEvent,
     ) -> Result<Vec<Event>, Failure> {
         if frame.data == "[DONE]" {
-            let mut events = finish_open_tools(&mut self.tools)?;
+            let finish = self.finish_reason.as_deref();
+            // A tool call cut off by the output budget (finish_reason=length,
+            // arguments still an open JSON fragment) is the provider's honest
+            // truncation, not a malformed stream: it surfaces as Incomplete
+            // with the truncated call dropped, exactly what the caller must
+            // act on (raise max_tokens), never as a 502. Live shape: Tencent
+            // TokenHub glm-5.3 at max_tokens=32 streamed `{"` + `city` then
+            // finished with length (staging, 2026-09-03). Any other finish
+            // keeps the strict contract: unparsable arguments are malformed.
+            let mut events = if finish == Some("length") {
+                finish_open_tools_truncated(&mut self.tools)?
+            } else {
+                finish_open_tools(&mut self.tools)?
+            };
             if let Some(usage) = self.usage.take() {
                 events.push(Event::Usage(usage));
             }
-            let finish = self.finish_reason.as_deref();
             if self.refusal_seen || matches!(finish, Some("content_filter" | "safety")) {
                 events.push(Event::Failed(refusal_failure()));
             } else if finish == Some("length") {

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -541,9 +541,13 @@ fn a_tool_call_cut_off_by_the_output_budget_is_incomplete_not_malformed() {
             None,
         ))
         .expect("tool start must normalize");
+    // The empty first `arguments` rides as an empty delta, as on every wire.
     assert!(matches!(
         started.as_slice(),
-        [Event::ToolCallStarted { .. }]
+        [
+            Event::ToolCallStarted { .. },
+            Event::ToolArgumentsDelta { .. }
+        ]
     ));
     for fragment in ["{\"", "city"] {
         normalizer

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -523,3 +523,96 @@ fn compatible_stream_folds_additive_reasoning_into_the_terminal_usage() {
         other => panic!("unexpected events: {other:?}"),
     }
 }
+
+#[test]
+fn a_tool_call_cut_off_by_the_output_budget_is_incomplete_not_malformed() {
+    // Live shape (Tencent TokenHub glm-5.3, max_tokens=32, staging
+    // 2026-09-03): the call starts, two argument fragments arrive, then the
+    // provider finishes with `length`. The truncated call is dropped and the
+    // stream ends Incomplete — the caller's remedy is a larger budget, so a
+    // 502 "malformed response" was the wrong verdict.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    let started = normalizer
+        .feed(&compatible_chunk(
+            serde_json::json!({"tool_calls": [{
+                "index": 0, "id": "call_73e9f9cfb9004dc1aaa71615", "type": "function",
+                "function": {"name": "get_weather", "arguments": ""},
+            }]}),
+            None,
+        ))
+        .expect("tool start must normalize");
+    assert!(matches!(
+        started.as_slice(),
+        [Event::ToolCallStarted { .. }]
+    ));
+    for fragment in ["{\"", "city"] {
+        normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"tool_calls": [{"index": 0, "function": {"arguments": fragment}}]}),
+                None,
+            ))
+            .expect("argument fragments must normalize");
+    }
+    assert!(normalizer
+        .feed(&compatible_chunk(serde_json::json!({}), Some("length")))
+        .expect("length finish must normalize")
+        .is_empty());
+    let events = normalizer
+        .feed(&SseEvent {
+            event: None,
+            data: "[DONE]".to_string(),
+        })
+        .expect("a length-truncated tool call must not be malformed");
+    assert!(matches!(events.as_slice(), [Event::Incomplete]));
+}
+
+#[test]
+fn a_complete_tool_call_still_completes_when_the_budget_ends_the_stream() {
+    // finish_reason=length AFTER the arguments closed: the call is intact and
+    // must still be delivered; only the terminal reads Incomplete.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    normalizer
+        .feed(&compatible_chunk(
+            serde_json::json!({"tool_calls": [{
+                "index": 0, "id": "call_1", "type": "function",
+                "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"},
+            }]}),
+            Some("length"),
+        ))
+        .expect("tool chunk must normalize");
+    let events = normalizer
+        .feed(&SseEvent {
+            event: None,
+            data: "[DONE]".to_string(),
+        })
+        .expect("stream must finish");
+    assert!(matches!(
+        events.as_slice(),
+        [Event::ToolCallCompleted { call, .. }, Event::Incomplete]
+            if call.raw_arguments == "{\"city\": \"Paris\"}"
+    ));
+}
+
+#[test]
+fn unparsable_tool_arguments_stay_malformed_on_a_normal_finish() {
+    // The strict contract holds whenever the provider claims it finished the
+    // call: a `tool_calls`/`stop` terminal with a dangling fragment is still a
+    // malformed stream, never silently dropped.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    normalizer
+        .feed(&compatible_chunk(
+            serde_json::json!({"tool_calls": [{
+                "index": 0, "id": "call_1", "type": "function",
+                "function": {"name": "get_weather", "arguments": "{\"city"},
+            }]}),
+            Some("tool_calls"),
+        ))
+        .expect("tool chunk must normalize");
+    let failure = normalizer
+        .feed(&SseEvent {
+            event: None,
+            data: "[DONE]".to_string(),
+        })
+        .expect_err("a dangling fragment on a normal finish is malformed");
+    assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.26,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.27,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.26"
+version = "0.3.27"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Problem

On the OpenAI-compatible wire, `feed_openai_compatible`'s `[DONE]` branch called `finish_open_tools` before looking at `finish_reason`, so a tool call the provider truncated at the output budget (`finish_reason: "length"`, arguments still an open JSON fragment) failed `require_json_object_text` and the whole request died **502 `malformed_response`** ("provider returned a malformed response; retry the request") — hiding the caller's actual remedy (a larger `max_tokens`) behind a retry hint that can never succeed.

Live shape (platform staging 2026-09-03, `malformed_response_boundary reason="streamed tool arguments are not valid JSON"`): Tencent TokenHub `glm-5.3` at `max_tokens: 32` streamed `ToolCallStarted(get_weather)`, argument fragments `{"` and `city`, then finished with `length` (the same lane's non-stream run spent the whole budget on reasoning, `finish_reason: "length"`, no tool call). The same class hits every OpenAI-compatible rung whenever a tool call outgrows the budget.

## Change

Only the `length` terminal changes (`finish_open_tools_truncated`): an open call whose accumulated arguments still parse as a JSON object completes normally; one left mid-fragment is dropped (marked completed, no `ToolCallCompleted`); the stream ends `Incomplete`, which the encoders already render as `finish_reason: "length"`. Every other terminal keeps the strict contract: a dangling fragment on `tool_calls`/`stop` is still `MalformedResponse`. Anthropic Messages (`input_json_delta` cut by `max_tokens`) is the analogous case on its wire and is left as is here.

## Tests

- `a_tool_call_cut_off_by_the_output_budget_is_incomplete_not_malformed` — the TokenHub shape end to end → `[Incomplete]`, no error.
- `a_complete_tool_call_still_completes_when_the_budget_ends_the_stream` — intact arguments + `length` → `ToolCallCompleted` then `Incomplete`.
- `unparsable_tool_arguments_stay_malformed_on_a_normal_finish` — `tool_calls` terminal with a fragment → `MalformedResponse` (negative).

`cargo test --no-default-features`: 160 passed; `cargo clippy -D warnings`: clean. Crate `0.3.26 → 0.3.27`, pin floor, Cargo.lock, uv.lock. No release (rides the deferred bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
