### PR TITLE
gateway: hash and index each distinct catalog object once in route resolution

### DIFF
--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -454,17 +454,36 @@ def _index_catalogs(
         ValueError: A same-version catalog does not match its declared digest.
     """
     indexed: dict[tuple[str, str], _CatalogView] = {}
+    # A repoint mints every alias key against ONE immutable catalog object
+    # (hundreds of keys per snapshot in production), and identity_sha256
+    # re-hashes the whole multi-megabyte document, so the digest is computed
+    # once per distinct object and compared per key; the frozen view is built
+    # and shared once per object too. Per-key hashing made one state build
+    # re-hash the same 6.5 MB catalog 732 times (~35 s of a ~51 s build).
+    # Object ids are stable here because ``catalogs`` keeps every catalog
+    # alive for the whole loop.
+    identity_by_object: dict[int, str] = {}
+    view_by_object: dict[int, _CatalogView] = {}
     for key, catalog in catalogs.items():
         revision_id, catalog_sha256 = key
-        if not is_foreign_snapshot(catalog) and catalog.identity_sha256() != catalog_sha256:
-            raise ValueError(f"catalog for alias revision {revision_id!r} has the wrong digest")
-        indexed[key] = _CatalogView(
-            catalog=catalog,
-            pools={pool.pool_id: pool for pool in catalog.pools},
-            deployments={
-                deployment.deployment_id: deployment for deployment in catalog.deployments
-            },
-        )
+        if not is_foreign_snapshot(catalog):
+            identity = identity_by_object.get(id(catalog))
+            if identity is None:
+                identity = catalog.identity_sha256()
+                identity_by_object[id(catalog)] = identity
+            if identity != catalog_sha256:
+                raise ValueError(f"catalog for alias revision {revision_id!r} has the wrong digest")
+        view = view_by_object.get(id(catalog))
+        if view is None:
+            view = _CatalogView(
+                catalog=catalog,
+                pools={pool.pool_id: pool for pool in catalog.pools},
+                deployments={
+                    deployment.deployment_id: deployment for deployment in catalog.deployments
+                },
+            )
+            view_by_object[id(catalog)] = view
+        indexed[key] = view
     return indexed
 
 

--- a/exp/runtime/gateway/routing_test.py
+++ b/exp/runtime/gateway/routing_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import unittest.mock
 from datetime import UTC, datetime
 
 import pytest
@@ -254,6 +255,36 @@ def test_index_rejects_a_same_version_catalog_under_the_wrong_digest() -> None:
     corruption and still fails closed when the resolver indexes it."""
     with pytest.raises(ValueError, match="wrong digest"):
         CatalogRouteResolver({(_REVISION, "b" * 64): _single_pool_catalog()})
+
+
+def test_index_hashes_a_shared_catalog_object_once_and_shares_its_view() -> None:
+    """Keys sharing one immutable catalog verify with ONE identity computation.
+
+    A repoint mints hundreds of alias keys against the same snapshot object, and
+    per-key hashing re-hashed the same multi-megabyte production document 732
+    times (~35 s of a ~51 s catalog state build). The digest check must stay
+    per KEY (a shared object pinned under a second, wrong digest still fails
+    closed), while the expensive hash and the indexed view are per OBJECT.
+    """
+    catalog = _single_pool_catalog()
+    digest = catalog.identity_sha256()
+    calls = 0
+    original = type(catalog).identity_sha256
+
+    def counting(self: NormalizedGatewayCatalog) -> str:
+        nonlocal calls
+        calls += 1
+        return original(self)
+
+    keys = [(f"alias-revision-{index:03d}", digest) for index in range(50)]
+    with unittest.mock.patch.object(type(catalog), "identity_sha256", counting):
+        resolver = CatalogRouteResolver(dict.fromkeys(keys, catalog))
+    assert calls == 1
+    views = resolver._catalogs  # noqa: SLF001 -- pinning the shared-view invariant
+    assert all(views[key] is views[keys[0]] for key in keys)
+
+    with pytest.raises(ValueError, match="wrong digest"):
+        CatalogRouteResolver({keys[0]: catalog, ("alias-revision-bad", "b" * 64): catalog})
 
 
 def test_index_serves_a_cross_version_catalog_under_its_pinned_digest() -> None:


### PR DESCRIPTION
## Problem (routed from the platform's catalog-incident follow-ups, P2)

`CatalogRouteResolver._index_catalogs` verified `catalog.identity_sha256()` per alias KEY, but a repoint mints every key against ONE immutable `NormalizedGatewayCatalog` object. Measured on the real production document: one state build re-hashed the same 6.5 MB catalog 732 times — 35.4 s at 48 ms/call, the dominant term of the 51 s `build_catalog_state` cost and of the 11-minute pod warms seen during the 09-03 deploy rollbacks. Each key also rebuilt its own `_CatalogView` (two dicts of ~2,400 entries at production scale): another ~0.3–1 s and 732 duplicate dict pairs held in memory.

## Change (strictly resolver-internal)

The digest is computed **once per distinct catalog object** and compared **per key**; the frozen `_CatalogView` is likewise built once per object and shared across its keys. Corruption semantics are unchanged and regression-pinned:

- a same-version object pinned under a second, WRONG digest still fails closed (the per-key comparison survives the memoization);
- the foreign-snapshot tolerance path is untouched;
- no digest computation or serialization changes anywhere — this is why the resolver-internal dedupe was chosen over memoizing `identity_sha256` on the frozen model itself (option (a)): it cannot interact with the identity contract at all, and `_index_catalogs` is the only seam with the 732-to-1 key-to-object fan-in.

`test_index_hashes_a_shared_catalog_object_once_and_shares_its_view` pins all three properties (one hash for 50 shared keys, shared view identity, wrong-second-digest still raises).

## Platform note

The platform ships a temporary identity-caching `NormalizedGatewayCatalog` subclass for the same hot path (platform #1168); it becomes removable at the engine pin bump that carries this change.

## Validation

- Full `uv run pytest -q`: 3390 passed, 6 skipped
- `ruff format` / `ruff check` / `ty check`: clean
- No `native/` changes; no crate bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)