### PR TITLE
gateway: batch failures name the provider's reason on the batch object

### DIFF
--- a/exp/runtime/gateway/batch/contracts.py
+++ b/exp/runtime/gateway/batch/contracts.py
@@ -159,21 +159,37 @@ class BatchJob(ContractModel):
     settled: bool = False
 
     def public_object(self) -> JsonObject:
-        """Render the OpenAI Batch API object for this job."""
-        errors: JsonObject | None = None
-        if self.line_errors:
-            errors = {
-                "object": "list",
-                "data": [
-                    {
-                        "code": error.code,
-                        "message": error.message,
-                        "line": error.line_number,
-                        "custom_id": error.custom_id,
-                    }
-                    for error in self.line_errors
-                ],
+        """Render the OpenAI Batch API object for this job.
+
+        ``errors`` carries every reason the caller can act on: the submit-time
+        per-line rejections, plus the job-level failure reason (a provider
+        rejection, an interrupted dispatch, an elapsed window) under the
+        terminal status as its code, the same code the error file stamps on
+        each line that never ran. A terminal job also stamps the matching
+        ``*_at`` timestamp, so a failed batch never reads as completed.
+        """
+        error_items: list[JsonObject] = [
+            {
+                "code": error.code,
+                "message": error.message,
+                "line": error.line_number,
+                "custom_id": error.custom_id,
             }
+            for error in self.line_errors
+        ]
+        if self.failure_message is not None:
+            error_items.append(
+                {
+                    "code": self.status.value,
+                    "message": self.failure_message,
+                    "line": None,
+                    "custom_id": None,
+                }
+            )
+        errors: JsonObject | None = None
+        if error_items:
+            errors = {"object": "list", "data": error_items}
+        finalized = None if self.finalized_at is None else int(self.finalized_at.timestamp())
         return {
             "id": self.batch_id,
             "object": "batch",
@@ -186,10 +202,10 @@ class BatchJob(ContractModel):
             "error_file_id": self.error_file_id,
             "created_at": int(self.created_at.timestamp()),
             "expires_at": int(self.expires_at.timestamp()),
-            "completed_at": (
-                None if self.finalized_at is None else int(self.finalized_at.timestamp())
-            ),
-            "failed_at": None,
+            "completed_at": finalized if self.status is BatchStatus.COMPLETED else None,
+            "failed_at": finalized if self.status is BatchStatus.FAILED else None,
+            "expired_at": finalized if self.status is BatchStatus.EXPIRED else None,
+            "cancelled_at": finalized if self.status is BatchStatus.CANCELLED else None,
             "request_counts": {
                 "total": self.counts.total,
                 "completed": self.counts.completed,

--- a/exp/runtime/gateway/batch/contracts_test.py
+++ b/exp/runtime/gateway/batch/contracts_test.py
@@ -99,6 +99,48 @@ def test_job_public_object_is_openai_batch_shaped() -> None:
     assert isinstance(rendered["created_at"], int)
 
 
+def test_job_public_object_reports_the_failure_reason_and_failed_at() -> None:
+    """A failed job lists its failure under errors and stamps failed_at only."""
+    finalized = datetime(2026, 9, 1, 1, tzinfo=UTC)
+    rendered = _job(
+        status=BatchStatus.FAILED,
+        failure_message="provider rejected the batch submission: status 400: bad model",
+        finalized_at=finalized,
+    ).public_object()
+    assert rendered["errors"] == {
+        "object": "list",
+        "data": [
+            {
+                "code": "failed",
+                "message": "provider rejected the batch submission: status 400: bad model",
+                "line": None,
+                "custom_id": None,
+            }
+        ],
+    }
+    assert rendered["failed_at"] == int(finalized.timestamp())
+    assert rendered["completed_at"] is None
+    assert rendered["expired_at"] is None
+    assert rendered["cancelled_at"] is None
+
+
+def test_job_public_object_stamps_the_terminal_timestamp_by_status() -> None:
+    """Each terminal status owns exactly one ``*_at`` field."""
+    finalized = datetime(2026, 9, 1, 1, tzinfo=UTC)
+    stamp = int(finalized.timestamp())
+    by_status = {
+        BatchStatus.COMPLETED: "completed_at",
+        BatchStatus.EXPIRED: "expired_at",
+        BatchStatus.CANCELLED: "cancelled_at",
+    }
+    for status, field in by_status.items():
+        rendered = _job(status=status, finalized_at=finalized).public_object()
+        assert rendered[field] == stamp, status
+        others = {"completed_at", "failed_at", "expired_at", "cancelled_at"} - {field}
+        assert all(rendered[other] is None for other in others), status
+    assert _job(status=BatchStatus.IN_PROGRESS).public_object()["errors"] is None
+
+
 def test_file_public_object_is_openai_file_shaped() -> None:
     """The public file object carries the compatibility fields."""
     record = BatchFile(

--- a/exp/runtime/gateway/batch/engine.py
+++ b/exp/runtime/gateway/batch/engine.py
@@ -495,6 +495,12 @@ class BatchEngine:
                 # received, so nothing was accepted: fail now with the reason.
                 # Ambiguous responses and transport losses raise other errors
                 # and take the fail-closed interrupted path on the next poll.
+                _LOGGER.warning(
+                    "batch %s: %s rejected the submission: %s",
+                    job.batch_id,
+                    job.provider,
+                    rejection.message,
+                )
                 await self._finalize(
                     job.model_copy(update={"dispatch_started": True}),
                     BatchStatus.FAILED,

--- a/exp/runtime/gateway/batch/engine_test.py
+++ b/exp/runtime/gateway/batch/engine_test.py
@@ -500,6 +500,16 @@ def test_definitive_submit_rejection_fails_immediately_with_the_reason() -> None
     assert "provider rejected the batch submission" in final.failure_message
     assert "status 401" in final.failure_message
     assert ledger.released == [("a", "failed")]
+    public = final.public_object()
+    errors = public["errors"]
+    assert isinstance(errors, dict)
+    data = errors["data"]
+    assert isinstance(data, list)
+    reason = data[-1]
+    assert isinstance(reason, dict)
+    assert reason["code"] == "failed"
+    assert reason["message"] == final.failure_message
+    assert public["failed_at"] is not None and public["completed_at"] is None
 
 
 def test_validation_and_binding_share_one_catalog_resolution() -> None:

--- a/exp/runtime/gateway/batch/providers.py
+++ b/exp/runtime/gateway/batch/providers.py
@@ -123,7 +123,7 @@ def provider_error_detail(response: httpx.Response) -> str | None:
     malformed line, an exhausted quota). Only that field is read: a body that
     is not JSON, or that carries no message string, yields None, so an HTML
     error page or an unexpected shape never reaches the caller. The message
-    is whitespace-normalized and bounded.
+    is reduced to printable characters, whitespace-normalized, and bounded.
     """
     try:
         parsed = response.json()
@@ -135,7 +135,11 @@ def provider_error_detail(response: httpx.Response) -> str | None:
     message = error.get("message") if isinstance(error, dict) else error
     if not isinstance(message, str):
         return None
-    detail = " ".join(message.split())
+    # Printable characters only: the detail reaches the caller's batch
+    # object and the worker log, so a control character (ESC, NUL, a
+    # terminal escape) in a malformed upstream body must never pass through.
+    printable = "".join(char for char in message if char.isprintable() or char.isspace())
+    detail = " ".join(printable.split())
     if not detail:
         return None
     return detail[:_PROVIDER_ERROR_DETAIL_LIMIT]

--- a/exp/runtime/gateway/batch/providers.py
+++ b/exp/runtime/gateway/batch/providers.py
@@ -112,16 +112,48 @@ def _usage_tokens(body: JsonObject | None) -> tuple[int, int]:
     return (input_tokens, output_tokens)
 
 
+_PROVIDER_ERROR_DETAIL_LIMIT = 400
+
+
+def provider_error_detail(response: httpx.Response) -> str | None:
+    """Return the provider's own error message from one failed response.
+
+    OpenAI, Anthropic, and OpenRouter all answer failures with a JSON body
+    whose ``error.message`` names the rejection (an unknown model, a
+    malformed line, an exhausted quota). Only that field is read: a body that
+    is not JSON, or that carries no message string, yields None, so an HTML
+    error page or an unexpected shape never reaches the caller. The message
+    is whitespace-normalized and bounded.
+    """
+    try:
+        parsed = response.json()
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    error = parsed.get("error")
+    message = error.get("message") if isinstance(error, dict) else error
+    if not isinstance(message, str):
+        return None
+    detail = " ".join(message.split())
+    if not detail:
+        return None
+    return detail[:_PROVIDER_ERROR_DETAIL_LIMIT]
+
+
 async def _checked(response: httpx.Response, *, action: str) -> JsonObject:
     """Return the JSON object body of one successful provider response.
 
     Raises:
-        BatchSubmitError: With a content-free provider status summary when the
-            call failed or the body is not a JSON object.
+        BatchSubmitError: When the call failed (status plus the provider's
+            own ``error.message`` when it carries one) or the body is not a
+            JSON object.
     """
     if response.status_code >= 400:
+        summary = f"provider {action} failed with status {response.status_code}"
+        detail = provider_error_detail(response)
         raise BatchSubmitError(
-            f"provider {action} failed with status {response.status_code}",
+            summary if detail is None else f"{summary}: {detail}",
             code="provider_error",
         )
     try:

--- a/exp/runtime/gateway/batch/providers_test.py
+++ b/exp/runtime/gateway/batch/providers_test.py
@@ -28,6 +28,7 @@ from exp.runtime.gateway.batch.providers import (
     AnthropicBatchClient,
     OpenAIBatchClient,
     OpenRouterBatchClient,
+    provider_error_detail,
     require_exact_host,
 )
 
@@ -163,14 +164,58 @@ def test_openai_cancel_posts_the_cancel_route() -> None:
 
 
 def test_openai_provider_error_maps_to_submit_error() -> None:
-    """A 500 from the provider raises the content-free provider_error."""
+    """A 500 from the provider raises provider_error naming the status."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, json={"error": "boom"})
 
     client = OpenAIBatchClient(transport=_transport(handler))
-    with pytest.raises(BatchSubmitError, match="status 500"):
+    with pytest.raises(BatchSubmitError, match="status 500: boom"):
         asyncio.run(client.poll(job=_job("openai"), api_key="sk"))
+
+
+def test_provider_rejection_carries_the_provider_message() -> None:
+    """A 400 on submit names the provider's own error.message, bounded."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": {
+                    "message": "  openai/gpt-4.1-nano:batch is not a valid\n model ID  ",
+                    "code": 400,
+                }
+            },
+        )
+
+    client = OpenRouterBatchClient(transport=_transport(handler))
+    with pytest.raises(BatchSubmitError) as raised:
+        asyncio.run(client.submit(job=_job("openrouter"), api_key="ork"))
+    assert raised.value.code == "provider_error"
+    assert raised.value.message == (
+        "provider batch create failed with status 400: "
+        "openai/gpt-4.1-nano:batch is not a valid model ID"
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(502, text="<html>Bad gateway</html>"),
+        httpx.Response(400, json={"error": {"type": "invalid_request_error"}}),
+        httpx.Response(400, json={"error": {"message": "   "}}),
+        httpx.Response(400, json=["not", "an", "object"]),
+    ],
+)
+def test_provider_error_without_a_message_stays_status_only(response: httpx.Response) -> None:
+    """Bodies that are not JSON or carry no message string add nothing."""
+    assert provider_error_detail(response) is None
+
+
+def test_provider_error_detail_is_bounded() -> None:
+    """A runaway provider message is cut at the detail limit."""
+    detail = provider_error_detail(httpx.Response(400, json={"error": {"message": "x" * 1000}}))
+    assert detail == "x" * 400
 
 
 def test_anthropic_submit_sends_inline_requests_with_version_header() -> None:

--- a/exp/runtime/gateway/batch/providers_test.py
+++ b/exp/runtime/gateway/batch/providers_test.py
@@ -212,6 +212,14 @@ def test_provider_error_without_a_message_stays_status_only(response: httpx.Resp
     assert provider_error_detail(response) is None
 
 
+def test_provider_error_detail_drops_control_characters() -> None:
+    """Terminal escapes and NULs in an upstream message never pass through."""
+    detail = provider_error_detail(
+        httpx.Response(400, json={"error": {"message": "bad\x1b[31m model\x00 id\r\n\ttry again"}})
+    )
+    assert detail == "bad[31m model id try again"
+
+
 def test_provider_error_detail_is_bounded() -> None:
     """A runaway provider message is cut at the detail limit."""
     detail = provider_error_detail(httpx.Response(400, json={"error": {"message": "x" * 1000}}))


### PR DESCRIPTION
## What

A production batch on the platform host (2026-09-03, openrouter lane) failed 8 seconds after submit and the caller saw: status \`failed\`, \`request_counts.failed=1\`, \`errors: null\`, \`completed_at\` set, no output file. The only reason anywhere was the job document's private \`failure_message\`, and even that said just "provider batch create failed with status 400" because the client seam discarded the provider's response body.

This PR makes a failed batch always say why, on the surface the OpenAI Batch API defines for it:

- \`providers.py\`: \`_checked\` reads the provider's own \`error.message\` (OpenAI, Anthropic, and OpenRouter all answer failures in that shape) and appends it to the \`provider_error\` message. Only that field is read, only from a JSON object body, whitespace-normalized and bounded at 400 chars, so an HTML error page or an unexpected shape adds nothing. \`provider_error_detail\` is the one place this happens.
- \`contracts.py\`: \`BatchJob.public_object\` lists the job-level failure under \`errors.data\` (code = the terminal status, the same code the error file stamps on each line that never ran, message = \`failure_message\`), alongside the submit-time per-line errors. Terminal timestamps now follow the status: \`completed_at\` only for completed jobs, plus \`failed_at\`, \`expired_at\`, \`cancelled_at\` (all fields of the official Batch object). A failed job no longer renders as completed.
- \`engine.py\`: a definitive provider rejection is logged at warning level with the batch id, provider, and reason (it was previously silent: the exception path only logged unexpected errors).

## Why the message is no longer content-free

The rejection names what the provider refused (an unknown model id, a malformed line, an exhausted quota). That is the caller's own request being described, scoped to the owning organization, exactly what the synchronous lane already relays for a provider 4xx. Without it the caller cannot distinguish a wrong model id from a provider outage.

## Tests

- \`providers_test.py\`: a 400 with an \`error.message\` yields the bounded message on the \`BatchSubmitError\`; bodies that are not JSON, not an object, or carry no message string stay status-only; the 400-char bound.
- \`contracts_test.py\`: the public object of a failed job lists the reason under \`errors\` and stamps \`failed_at\` only; each terminal status owns exactly one \`*_at\`; an in-progress job keeps \`errors: null\`.
- \`engine_test.py\`: the existing definitive-rejection test also asserts the public object.
- \`ruff check\`, \`ruff format --check\`, \`ty check\` clean; \`exp/runtime/gateway/batch\` 63 passed; \`exp/runtime/gateway/tests/native_batches_test.py\` 6 passed.

No native crate change. No release cut here; the platform host picks this up at its next pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)