### PR TITLE
fix(openai_protocol): accept store:false on Chat Completions (no-op retention opt-out)

### DIFF
--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -65,6 +65,13 @@ CHAT_MANIFEST = CompatibilityManifest(
         # Accepted only at its no-op default of 1 (the wire model enforces
         # the value): Copilot hardcodes n:1 on every Chat request.
         _field("n", CompatibilityDisposition.SUPPORTED),
+        # Retention request accepted only at its no-op default of false (the
+        # wire model enforces the value): OpenAI-style agents (omp, opencode,
+        # pi) hardcode store:false on every Chat request to opt out of
+        # provider-side retention. This gateway never retains Chat output on
+        # any rung, so false is already satisfied and store:true is rejected:
+        # silently dropping a retention request would be dishonest.
+        _field("store", CompatibilityDisposition.SUPPORTED),
         # top_logprobs stays UNSUPPORTED: the gateway response contract does not
         # project logprob arrays yet, so it cannot be honored on any rung —
         # rejecting is the honest outcome (never a silent drop of a probability
@@ -94,7 +101,6 @@ CHAT_MANIFEST = CompatibilityManifest(
                 "prompt_cache_options",
                 "prompt_cache_retention",
                 "seed",
-                "store",
                 "verbosity",
                 "web_search_options",
             )

--- a/exp/runtime/openai_protocol/manifest_test.py
+++ b/exp/runtime/openai_protocol/manifest_test.py
@@ -52,6 +52,9 @@ def test_manifests_classify_explicit_exclusions() -> None:
     # values Copilot hardcodes (n:1, truncation:"disabled",
     # prompt_cache_options:{"mode":"implicit"}).
     assert chat["n"] == CompatibilityDisposition.SUPPORTED
+    # Retention opt-out admitted at its no-op false (OpenAI agents hardcode it);
+    # store:true stays a named rejection in the Chat wire model.
+    assert chat["store"] == CompatibilityDisposition.SUPPORTED
     assert responses["truncation"] == CompatibilityDisposition.SUPPORTED
     assert responses["prompt_cache_options"] == CompatibilityDisposition.SUPPORTED
     assert chat["logprobs"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -720,6 +720,37 @@ def test_chat_decoder_rejects_unprojectable_top_logprobs() -> None:
     assert raised.value.detail.param == "top_logprobs"
 
 
+def test_chat_decoder_accepts_store_false_opt_out() -> None:
+    """OpenAI-style agents hardcode store:false and must not be rejected.
+
+    The gateway never retains Chat output, so store:false is a satisfied no-op
+    that decodes losslessly (it is not forwarded onto the canonical request).
+    """
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hello"}],
+            "store": False,
+        }
+    )
+    assert decoded.request.maximum_output_tokens is None
+    assert len(decoded.request.messages) == 1
+
+
+def test_chat_decoder_rejects_store_true_retention_request() -> None:
+    """store:true asks the gateway to retain output, which it never does."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hello"}],
+                "store": True,
+            }
+        )
+    assert captured.value.detail.code == "invalid_parameter"
+    assert captured.value.detail.param == "store"
+
+
 def test_chat_decoder_preserves_logprobs_for_route_validation() -> None:
     """The route gate distinguishes a semantic true request from a false no-op."""
     for value in (True, False):

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -373,6 +373,25 @@ class _ChatRequest(_WireModel):
             )
         return value
 
+    store: bool | None = None
+    """Provider-side retention opt-out, accepted only at its no-op of false.
+
+    OpenAI agents hardcode ``store: false`` on every Chat request to refuse
+    retention; this gateway never retains Chat output, so false is already
+    satisfied and any other value (true, which would ask the gateway to retain
+    for distillation/evals) stays a named rejection.
+    """
+
+    @field_validator("store")
+    @classmethod
+    def _require_no_retention(cls, value: bool | None) -> bool | None:
+        """Accept retention only as already satisfied (the gateway retains nothing)."""
+        if value:
+            raise ValueError(
+                "supported only at false: this gateway does not retain Chat completions output"
+            )
+        return value
+
     temperature: float | None = Field(default=None, ge=0, le=2)
     top_p: float | None = Field(default=None, ge=0, le=1)
     top_k: int | None = Field(default=None, ge=0)


### PR DESCRIPTION
## Problem

OpenAI-compatible agents (`omp`, `opencode`, `pi`) hardcode `store: false` on every Chat Completions request to opt out of provider-side retention. The gateway's Chat manifest declares `store` UNSUPPORTED, so these agents get a hard 400 before dispatch:

```
The parameter 'store' is not supported by this gateway profile. Remove the field and resend the request.
```

Reported against a fresh agent fleet (omp 18.1.3 against an experiential gateway): the agent could not produce a single reply.

## Root cause

`store` is genuinely supported on the **Responses** surface (it feeds `response_store`), but the **Chat** surface lists it under `UNSUPPORTED` in `CHAT_MANIFEST`, so `_validate_manifest` rejects it pre-dispatch. The gateway never retains Chat output on any rung, so `store: false`, the only value these agents send, is already satisfied.

## Fix

Mirror the existing `n`-field precedent (accepted only at its no-op default; any other value is a named rejection):

- `manifest.py`: declare `store` SUPPORTED in `CHAT_MANIFEST` (remove it from the UNSUPPORTED list), with a rationale.
- `wire_models.py`: add `store: bool | None` to `_ChatRequest` with a validator that accepts only `false`/absent and rejects `true`. A `store: true` request asks the gateway to retain output for distillation/evals, which it never does. Per the codebase's anti-silent-drop policy, that must be a named rejection, not a silent no-op.

## Tests

- `test_chat_decoder_accepts_store_false_opt_out`: the exact omp/opencode request shape now decodes.
- `test_chat_decoder_rejects_store_true_retention_request`: `store: true` stays a named `invalid_parameter` on `store`.
- `manifest_test`: chat `store` is now `SUPPORTED`.

Verified: the real 400-ing body (`store:false` plus `stream`, `stream_options`, `max_completion_tokens`, `reasoning_effort`) decodes cleanly. `requests_test.py` and `manifest_test.py` pass (163 tests).
