### PR TITLE
gateway: batch routes answer an invalid key with the uniform 401

### DIFF
--- a/exp/runtime/gateway/batch/plane.py
+++ b/exp/runtime/gateway/batch/plane.py
@@ -18,6 +18,7 @@ from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.batch.contracts import BatchSubmitError
 from exp.runtime.gateway.batch.engine import BatchEngine
 from exp.runtime.gateway.interfaces import GatewayControlStore
+from exp.runtime.gateway.sqlite.store import InvalidVirtualKeyError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ _ERROR_STATUS: dict[str, int] = {
     "insufficient_quota": 402,
     "not_found": 404,
     "cancel_unsupported": 409,
+    "internal_error": 500,
     "provider_error": 502,
 }
 
@@ -49,10 +51,13 @@ class BatchControlPlane:
         An absent, invalid, expired, or revoked key answers the same 401
         ``invalid_key`` envelope the synchronous routes use, so one key
         failure reads identically on every surface of the gateway and the
-        batch routes leak nothing a synchronous route would not.
+        batch routes leak nothing a synchronous route would not. Any other
+        failure of the lookup itself (a store outage) is an internal error,
+        never a verdict on the key.
 
         Raises:
-            BatchSubmitError: When the key is absent or invalid.
+            BatchSubmitError: When the key is absent or invalid, or the
+                lookup failed.
         """
         raw_key = argument.get("bearer_key")
         if not isinstance(raw_key, str) or not raw_key:
@@ -60,8 +65,11 @@ class BatchControlPlane:
         try:
             self._control.authenticate_key(raw_key=raw_key)
             return self._control.authenticated_identity(raw_key=raw_key)
-        except Exception as exc:
+        except InvalidVirtualKeyError as exc:
             raise BatchSubmitError("invalid or revoked key", code="invalid_key") from exc
+        except Exception as exc:
+            _LOGGER.exception("batch key lookup failed")
+            raise BatchSubmitError("the gateway request failed", code="internal_error") from exc
 
     @staticmethod
     def _decode(argument: str) -> JsonObject:

--- a/exp/runtime/gateway/batch/plane.py
+++ b/exp/runtime/gateway/batch/plane.py
@@ -23,6 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _ERROR_STATUS: dict[str, int] = {
     "invalid_request_error": 400,
+    "invalid_key": 401,
     "insufficient_quota": 402,
     "not_found": 404,
     "cancel_unsupported": 409,
@@ -45,17 +46,22 @@ class BatchControlPlane:
     def _identity(self, argument: JsonObject) -> tuple[str, str]:
         """Authenticate the carried bearer key into an owning identity.
 
+        An absent, invalid, expired, or revoked key answers the same 401
+        ``invalid_key`` envelope the synchronous routes use, so one key
+        failure reads identically on every surface of the gateway and the
+        batch routes leak nothing a synchronous route would not.
+
         Raises:
             BatchSubmitError: When the key is absent or invalid.
         """
         raw_key = argument.get("bearer_key")
         if not isinstance(raw_key, str) or not raw_key:
-            raise BatchSubmitError("missing bearer key", code="not_found")
+            raise BatchSubmitError("missing bearer key", code="invalid_key")
         try:
             self._control.authenticate_key(raw_key=raw_key)
             return self._control.authenticated_identity(raw_key=raw_key)
         except Exception as exc:
-            raise BatchSubmitError("invalid or revoked key", code="not_found") from exc
+            raise BatchSubmitError("invalid or revoked key", code="invalid_key") from exc
 
     @staticmethod
     def _decode(argument: str) -> JsonObject:
@@ -81,13 +87,19 @@ class BatchControlPlane:
     def _error(error: BatchSubmitError) -> str:
         """Render one OpenAI-envelope error for the data plane."""
         status = _ERROR_STATUS.get(error.code, 400)
+        if status == 401:
+            error_type = "authentication_error"
+        elif status < 500:
+            error_type = "invalid_request_error"
+        else:
+            error_type = "api_error"
         return json.dumps(
             {
                 "status": status,
                 "body": {
                     "error": {
                         "message": error.message,
-                        "type": "invalid_request_error" if status < 500 else "api_error",
+                        "type": error_type,
                         "code": error.code,
                     }
                 },

--- a/exp/runtime/gateway/batch/plane_test.py
+++ b/exp/runtime/gateway/batch/plane_test.py
@@ -16,15 +16,18 @@ from exp.runtime.gateway.batch.engine_test import (
     _chat_line,
 )
 from exp.runtime.gateway.batch.plane import BatchControlPlane
+from exp.runtime.gateway.sqlite.store import InvalidVirtualKeyError
 
 
 class MemoryControl:
     """GatewayControlStore double accepting exactly one key."""
 
     def authenticate_key(self, *, raw_key: str) -> None:
-        """Accept only the fixture key."""
+        """Accept only the fixture key; a lookup outage is a distinct failure."""
+        if raw_key == "xpl_outage":
+            raise RuntimeError("store unreachable")
         if raw_key != "xpl_good":
-            raise PermissionError("unknown key")
+            raise InvalidVirtualKeyError("unknown key")
 
     def authenticated_identity(self, *, raw_key: str) -> tuple[str, str]:
         """Return the fixture identity."""
@@ -73,6 +76,17 @@ def test_invalid_key_maps_to_the_uniform_401() -> None:
             "type": "authentication_error",
             "code": "invalid_key",
         }
+
+
+def test_key_lookup_outage_is_an_internal_error_not_a_key_verdict() -> None:
+    """A failing control store answers 500, never 401: the key was not judged."""
+    parsed = json.loads(_plane().batch_list(json.dumps({"bearer_key": "xpl_outage"})))
+    assert parsed["status"] == 500
+    assert parsed["body"]["error"] == {
+        "message": "the gateway request failed",
+        "type": "api_error",
+        "code": "internal_error",
+    }
 
 
 def test_file_roundtrip_and_batch_lifecycle_through_the_plane() -> None:

--- a/exp/runtime/gateway/batch/plane_test.py
+++ b/exp/runtime/gateway/batch/plane_test.py
@@ -62,13 +62,17 @@ def _call(plane: BatchControlPlane, method: str, **payload: object) -> tuple[int
     return parsed["status"], parsed["body"]
 
 
-def test_invalid_key_maps_to_not_found_status() -> None:
-    """A bad bearer key produces the uniform 404 envelope."""
+def test_invalid_key_maps_to_the_uniform_401() -> None:
+    """A bad or missing bearer key produces the synchronous lane's 401 envelope."""
     plane = _plane()
-    rendered = plane.batch_list(json.dumps({"bearer_key": "xpl_bad"}))
-    parsed = json.loads(rendered)
-    assert parsed["status"] == 404
-    assert parsed["body"]["error"]["code"] == "not_found"
+    for argument in ({"bearer_key": "xpl_bad"}, {"bearer_key": ""}, {}):
+        parsed = json.loads(plane.batch_list(json.dumps(argument)))
+        assert parsed["status"] == 401, argument
+        assert parsed["body"]["error"] == {
+            "message": parsed["body"]["error"]["message"],
+            "type": "authentication_error",
+            "code": "invalid_key",
+        }
 
 
 def test_file_roundtrip_and_batch_lifecycle_through_the_plane() -> None:

--- a/exp/runtime/gateway/tests/native_batches_test.py
+++ b/exp/runtime/gateway/tests/native_batches_test.py
@@ -141,7 +141,8 @@ def test_batch_routes_serve_the_full_job_lifecycle_over_real_http(
             unauthorized = client.get(
                 f"{base}/v1/batches", headers={"Authorization": "Bearer xpl_wrong"}
             )
-            assert unauthorized.status_code == 404
+            assert unauthorized.status_code == 401
+            assert unauthorized.json()["error"]["code"] == "invalid_key"
     finally:
         shutdown.request_shutdown()
         thread.join(timeout=10)


### PR DESCRIPTION
## What

A present-but-invalid bearer on \`GET /v1/batches\` (and every other batch and file route) answered \`404 {"code":"not_found","message":"invalid or revoked key"}\`, while \`/v1/models\` and every synchronous route answer \`401 invalid_key\`. Observed on the platform's production gateway on 2026-09-03. The gateway's contract is one uniform 401 for an unknown key on every surface; the batch plane was the one exception.

\`BatchControlPlane._identity\` now raises \`invalid_key\` for a missing, empty, or rejected key, \`_ERROR_STATUS\` maps it to 401, and the envelope's \`type\` is \`authentication_error\` for that status (matching \`GatewayFailureClass.AUTHENTICATION\` in the OpenAI protocol errors), \`invalid_request_error\` for other 4xx, \`api_error\` for 5xx.

Unknown batch and file ids keep their owner-scoped 404 \`not_found\`; the batch-only did-you-mean pointer on the synchronous routes already withheld itself on 401 and is unchanged.

## Tests

- \`plane_test.py\`: bad, empty, and absent keys all render the 401 \`invalid_key\` / \`authentication_error\` envelope.
- \`native_batches_test.py\`: the wire-level wrong-key assertion moves from 404 to 401 \`invalid_key\`.
- \`ruff check\`, \`ruff format --check\`, \`ty check\` clean; batch package + native batches wire tests 61 passed.

No native crate change (the Rust relay maps the envelope status through). No release cut here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)