### PR TITLE
gateway: an output-less Responses turn stays continuable from its id (crate 0.3.28)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.27"
+version = "0.3.28"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/responses_retention.rs
+++ b/exp/runtime/gateway/native/src/responses_retention.rs
@@ -6,11 +6,13 @@ use serde_json::{json, Value};
 
 use crate::dialects::MAXIMUM_RETAINED_OUTPUT_BYTES;
 use crate::encode::compact_json;
+use crate::errors::PublicError;
 use crate::events::{
     CompletedToolCall, Event, ProviderAssistantMessagePhase, ProviderOutputItemKind,
     ProviderOutputItemStatus,
 };
 use crate::relay::event_retained_bytes;
+use crate::server::AppState;
 
 #[derive(Default)]
 struct RetainedMessage {
@@ -264,6 +266,32 @@ pub(crate) fn remember_argument(
     }))
 }
 
+/// Retain one finished Responses continuation before the terminal frames
+/// flush, mirroring the python service's ordering. Returns the public error
+/// when bounded retention fails closed.
+///
+/// An output-less turn (thinking spent the whole output budget, so the
+/// response is `incomplete` with no items) is retained too: the caller holds
+/// its response id, and `previous_response_id` naming it must resolve to the
+/// conversation so far rather than `previous_response_not_found`.
+pub(crate) async fn remember_continuation(
+    state: &AppState,
+    request_id: &str,
+    retention: &ResponsesRetention,
+    reasoning_content_carrier: Option<&str>,
+) -> Result<(), PublicError> {
+    if retention.overflowed || retention.refusal() {
+        return Ok(());
+    }
+    state
+        .bridge
+        .call(
+            "remember",
+            remember_argument(request_id, retention, reasoning_content_carrier),
+        )
+        .await
+        .map(|_| ())
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/exp/runtime/gateway/native/src/responses_retention.rs
+++ b/exp/runtime/gateway/native/src/responses_retention.rs
@@ -219,16 +219,6 @@ impl ResponsesRetention {
     pub(crate) fn refusal(&self) -> bool {
         self.refusal
     }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.text.is_empty()
-            && self.messages.is_empty()
-            && self.tool_calls.is_empty()
-            && self
-                .reasoning
-                .values()
-                .all(|reasoning| reasoning.encrypted_content.is_empty())
-    }
 }
 
 /// Build the retention payload consumed by the control plane's `remember`.
@@ -405,7 +395,6 @@ mod tests {
             retention.track(event);
         }
 
-        assert!(!retention.is_empty());
         let payload: Value =
             serde_json::from_str(&remember_argument("request-1", &retention, None))
                 .expect("retention payload is JSON");

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -211,6 +211,7 @@ pub(crate) async fn chat(
         // Bytes over four approximates input tokens; a timeout heuristic
         // only, never a billing quantity.
         approximate_input_tokens: (body_text.len() as f64) / 4.0,
+        output_less_retention: None,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -173,6 +173,7 @@ pub(crate) async fn messages(
         // Bytes over four approximates input tokens; a timeout heuristic
         // only, never a billing quantity.
         approximate_input_tokens: (body_text.len() as f64) / 4.0,
+        output_less_retention: None,
     };
     let won = acquire_attempt(&context, &mut guard).await;
 

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -209,6 +209,13 @@ pub(crate) async fn responses(
         // Bytes over four approximates input tokens; a timeout heuristic
         // only, never a billing quantity.
         approximate_input_tokens: (body_text.len() as f64) / 4.0,
+        // A turn that ends before any semantic output is still a response
+        // the caller can continue from; the waterfall retains it in flight.
+        output_less_retention: Some(remember_argument(
+            &admission.request_id,
+            &ResponsesRetention::default(),
+            None,
+        )),
     };
     let won = acquire_attempt(&context, &mut guard).await;
 
@@ -275,16 +282,21 @@ pub(crate) async fn responses(
     }
 }
 
-/// Retain one completed Responses continuation before the terminal frames
+/// Retain one finished Responses continuation before the terminal frames
 /// flush, mirroring the python service's ordering. Returns the public error
 /// when bounded retention fails closed.
+///
+/// An output-less turn (thinking spent the whole output budget, so the
+/// response is `incomplete` with no items) is retained too: the caller holds
+/// its response id, and `previous_response_id` naming it must resolve to the
+/// conversation so far rather than `previous_response_not_found`.
 async fn remember_continuation(
     state: &AppState,
     request_id: &str,
     retention: &ResponsesRetention,
     reasoning_content_carrier: Option<&str>,
 ) -> Result<(), PublicError> {
-    if retention.overflowed || retention.refusal() || retention.is_empty() {
+    if retention.overflowed || retention.refusal() {
         return Ok(());
     }
     state

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -33,7 +33,7 @@ use crate::respond::{
     escalation_error, finish_stream_terminal, json_response, latin1_header, read_body,
     send_bounded, settle_stream_end, sse_body_response,
 };
-use crate::responses_retention::{remember_argument, ResponsesRetention};
+use crate::responses_retention::{remember_argument, remember_continuation, ResponsesRetention};
 use crate::route_chat::{seal_reasoning_candidate, seal_reasoning_events};
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
@@ -282,32 +282,6 @@ pub(crate) async fn responses(
     }
 }
 
-/// Retain one finished Responses continuation before the terminal frames
-/// flush, mirroring the python service's ordering. Returns the public error
-/// when bounded retention fails closed.
-///
-/// An output-less turn (thinking spent the whole output budget, so the
-/// response is `incomplete` with no items) is retained too: the caller holds
-/// its response id, and `previous_response_id` naming it must resolve to the
-/// conversation so far rather than `previous_response_not_found`.
-async fn remember_continuation(
-    state: &AppState,
-    request_id: &str,
-    retention: &ResponsesRetention,
-    reasoning_content_carrier: Option<&str>,
-) -> Result<(), PublicError> {
-    if retention.overflowed || retention.refusal() {
-        return Ok(());
-    }
-    state
-        .bridge
-        .call(
-            "remember",
-            remember_argument(request_id, retention, reasoning_content_carrier),
-        )
-        .await
-        .map(|_| ())
-}
 /// Answer one Responses attempt that the waterfall already settled: a
 /// successful terminal with no semantic output, or an exhausted ladder
 /// flushing withheld refusal output ahead of the failing terminal.

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -114,6 +114,14 @@ pub struct WaterfallContext<'a> {
     /// divided by four. An allowance heuristic only, never a billing
     /// quantity.
     pub approximate_input_tokens: f64,
+    /// The bridge `remember` argument retaining an output-less turn: a
+    /// successful terminal reached before any semantic output still answers
+    /// the caller with a response id, and a response id the caller received
+    /// must stay continuable (api.openai.com persists `incomplete` responses
+    /// too). Only the Responses route carries one; it runs ahead of the
+    /// attempt's settlement so the control plane can still resolve the
+    /// request's continuation context.
+    pub output_less_retention: Option<String>,
 }
 
 /// The effective first-byte allowance for one attempt: the deployment's (or
@@ -247,6 +255,9 @@ enum AttemptEnd {
     },
     /// Accounting failed mid-attempt; the request is answered internal.
     Accounting,
+    /// The attempt settled, but retaining its output-less continuation
+    /// failed; the public retention error answers the caller.
+    Retention(PublicError),
 }
 
 /// Run one certified waterfall to its committed or terminal attempt.
@@ -342,6 +353,7 @@ pub async fn acquire_attempt(ctx: &WaterfallContext<'_>, guard: &mut AttemptGuar
             AttemptEnd::Committed(committed) => return Won::Committed(committed),
             AttemptEnd::Settled(settled) => return Won::Settled(settled),
             AttemptEnd::Accounting => return Won::Failed(PublicError::internal()),
+            AttemptEnd::Retention(error) => return Won::Failed(error),
             AttemptEnd::Ladder {
                 failure,
                 refusal_eligible,
@@ -642,9 +654,15 @@ async fn run_attempt(
                         opened: true,
                     };
                 }
-                // A successful terminal with no semantic output: settle, then
-                // answer with the tracked usage ahead of the terminal so the
-                // encoders keep the client-visible token accounting.
+                // A successful terminal with no semantic output: retain the
+                // output-less continuation while the attempt is still in
+                // flight, settle, then answer with the tracked usage ahead of
+                // the terminal so the encoders keep the client-visible token
+                // accounting.
+                let retention_failure = match &ctx.output_less_retention {
+                    Some(argument) => ctx.bridge.call("remember", argument.clone()).await.err(),
+                    None => None,
+                };
                 let outcome = if matches!(event, Event::Incomplete) {
                     "incomplete"
                 } else {
@@ -655,6 +673,12 @@ async fn run_attempt(
                     .await
                 {
                     return AttemptEnd::Accounting;
+                }
+                if let Some(error) = retention_failure {
+                    // The provider outcome settled above, exactly like a
+                    // committed attempt's retention failure; only the HTTP
+                    // result reports it.
+                    return AttemptEnd::Retention(error);
                 }
                 let mut events = Vec::with_capacity(2);
                 if let Some(tracked) = usage {

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -910,14 +910,17 @@ class NativeControlPlane(
         return json.dumps(scope, separators=(",", ":"))
 
     def remember(self, argument: str) -> str:
-        """Retain one completed Responses continuation within strict bounds.
+        """Retain one finished Responses continuation within strict bounds.
 
         Args:
             argument: JSON object with ``request_id``, aggregated ``text``,
-                ``refusal`` presence, and completed ``tool_calls``.
+                ``refusal`` presence, and completed ``tool_calls``; an
+                output-less turn carries all of them empty and is retained as
+                the conversation so far.
 
         Returns:
-            An empty JSON object; retention that does not apply is a no-op.
+            An empty JSON object; retention that does not apply (a
+            ``store: false`` caller, a refusal) is a no-op.
 
         Raises:
             NativeBridgeError: The continuation exceeds the bounded store or

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3078,6 +3078,37 @@ def test_responses_continuation_round_trip_and_fail_closed(tmp_path: Path) -> No
     assert crossed.value.detail.code == "previous_response_not_found"
 
 
+def test_responses_output_less_turn_is_continuable(tmp_path: Path) -> None:
+    """A turn retained with no text, items, or calls continues as the input so far.
+
+    The data plane remembers an output-less turn (thinking exhausted the
+    budget, terminal ``incomplete``) with every retention field empty; the
+    control plane must retain the conversation rather than treat empty output
+    as nothing to remember, or the response id it already handed out dies
+    ``previous_response_not_found`` on the next turn.
+    """
+    control, raw_key = _control_plane(tmp_path)
+    first = _admit_responses(control, raw_key, _responses_body())
+    assert (
+        control.remember(
+            json.dumps(
+                {
+                    "request_id": first["request_id"],
+                    "text": "",
+                    "message_outputs": [],
+                    "refusal": False,
+                    "encrypted_reasoning": [],
+                    "tool_calls": [],
+                }
+            )
+        )
+        == "{}"
+    )
+    response_id = stable_public_id("resp", _admitted_request_id(first))
+    second = _admit_responses(control, raw_key, _responses_body(previous_response_id=response_id))
+    assert [message["role"] for message in _payload_messages(second)] == ["user", "user"]
+
+
 def test_fallback_served_alias_continuation_degrades_to_resend_not_503(tmp_path: Path) -> None:
     """A continuation on an alias served via its last-good fallback still fails
     with the 400 'resend the full conversation' error when it cannot resolve —

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -183,13 +183,19 @@ def remember_turn(
     data: JsonObject,
     route_binding: ContinuationRouteBinding | None = None,
 ) -> None:
-    """Retain one completed Responses continuation within strict bounds.
+    """Retain one finished Responses continuation within strict bounds.
 
-    Retention is strict: refusal output and unidentifiable empty assistant
-    turns are never retained, while provider-identified message items retain
-    their exact lifecycle metadata even when their visible text is empty. One
-    oversize continuation fails closed with the shared public error before the
-    data plane flushes its terminal frames.
+    Retention is strict about content, not about completion: refusal output is
+    never retained, provider-identified message items retain their exact
+    lifecycle metadata even when their visible text is empty, and a turn that
+    produced no retainable output at all (thinking spent the whole output
+    budget, so the response is ``incomplete`` with no items) is retained as the
+    conversation so far — the caller holds that response id, and
+    ``previous_response_id`` naming it must continue the conversation, as
+    api.openai.com does for its own ``incomplete`` responses, instead of
+    answering ``previous_response_not_found``. One oversize continuation fails
+    closed with the shared public error before the data plane flushes its
+    terminal frames.
 
     Args:
         continuations: The gateway's shared bounded continuation store.
@@ -382,15 +388,6 @@ def remember_turn(
         raise ValueError(
             "Responses retained assistant text requires provider item identity and order"
         )
-    if (
-        not text
-        and not unindexed_calls
-        and not unindexed_natives
-        and not indexed_output
-        and sealed_carrier is None
-    ):
-        return
-
     output_items: list[tuple[int, str, object]] = [
         *((index, "reasoning", block) for index, block in encrypted),
         *((index, "call", call) for index, call in indexed_calls),

--- a/exp/runtime/gateway/native_responses_test.py
+++ b/exp/runtime/gateway/native_responses_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from dataclasses import replace
 from typing import cast
 
 import pytest
@@ -398,3 +399,28 @@ def test_remember_turn_rejects_malformed_openai_encrypted_reasoning(encrypted: o
                 },
             ),
         )
+
+
+def test_remember_turn_retains_an_output_less_turn_as_the_conversation_so_far() -> None:
+    """An incomplete, output-less turn stays continuable from its response id.
+
+    Gemini at a small ``max_output_tokens`` spends the whole budget thinking
+    and finishes ``incomplete`` with no items; the caller still received a
+    response id, so ``previous_response_id`` must resolve to the retained
+    input rather than ``previous_response_not_found`` (staging, 2026-09-03).
+    """
+    store = BoundedContinuationStore()
+    context = replace(_context(), messages=(GatewayMessage(role="user", content="think hard"),))
+
+    remember_turn(
+        store,
+        context=context,
+        data={"text": "", "refusal": False, "message_outputs": [], "tool_calls": []},
+    )
+
+    state = store.resolve_now(
+        namespace=context.namespace,
+        previous_response_id=context.response_id,
+    )
+    assert state.messages == context.messages
+    assert state.episode_key == context.episode_key

--- a/exp/runtime/gateway/tests/native_waterfall_test.py
+++ b/exp/runtime/gateway/tests/native_waterfall_test.py
@@ -138,7 +138,9 @@ class _PrimaryUpstream(BaseHTTPRequestHandler):
 
     ``always-500`` fails every dispatch, ``retry-then-succeed`` fails once
     per process then answers, ``refuse`` streams a refusal-only completion,
-    and anything else streams a plain success.
+    ``silent-length`` exhausts the output budget with no content (a
+    thinking-only turn: ``finish_reason: length``, zero deltas), and anything
+    else streams a plain success.
     """
 
     retry_counts: dict[str, int] = {}
@@ -179,6 +181,20 @@ class _PrimaryUpstream(BaseHTTPRequestHandler):
         self.send_header("content-type", "text/event-stream")
         self.end_headers()
         try:
+            if prompt == "silent-length":
+                self.wfile.write(
+                    _sse_frame({"choices": [{"index": 0, "delta": {}, "finish_reason": "length"}]})
+                )
+                self.wfile.write(
+                    _sse_frame(
+                        {
+                            "choices": [],
+                            "usage": {"prompt_tokens": 2, "completion_tokens": 16},
+                        }
+                    )
+                )
+                self.wfile.write(b"data: [DONE]\n\n")
+                return
             if prompt == "refuse":
                 self.wfile.write(
                     _sse_frame(
@@ -486,6 +502,56 @@ def test_keyed_responses_replays_the_owner_response_exactly(
     assert rows == [(0, 0, "completed")]
 
 
+@pytest.mark.parametrize("stream", [False, True], ids=["json", "sse"])
+def test_output_less_incomplete_response_stays_continuable(
+    engine: _ServingEngine, stream: bool
+) -> None:
+    """A response id handed to the caller is continuable whatever its finish state.
+
+    The first turn's provider spends the whole output budget without emitting
+    a single delta (Gemini thinking at a small ``max_output_tokens``), so the
+    attempt reaches ``length`` before any semantic output: the waterfall
+    settles it output-less and the caller gets an ``incomplete`` response
+    with no items. api.openai.com persists such a response, and so must the
+    gateway: the next turn's ``previous_response_id`` resolves to the
+    conversation so far and is served, never ``previous_response_not_found``
+    (reproduced 2/3 on staging gemini-3.7-flash, 2026-09-03).
+    """
+    headers = {"authorization": f"Bearer {engine.raw_key}"}
+    first_payload: JsonObject = {"model": "coding", "input": "silent-length", "stream": stream}
+    first = httpx.post(
+        f"{engine.base}/v1/responses", headers=headers, json=first_payload, timeout=30.0
+    )
+    assert first.status_code == 200, first.text
+    if stream:
+        completed = [
+            json.loads(line[len("data: ") :])
+            for line in first.text.splitlines()
+            if line.startswith("data: ")
+        ]
+        terminal = completed[-1]
+        assert terminal["type"] == "response.incomplete", terminal
+        response = terminal["response"]
+    else:
+        response = first.json()
+    assert response["status"] == "incomplete"
+    assert response["output"] == []
+    response_id = response["id"]
+    assert response_id.startswith("resp_")
+    assert _attempt_rows(engine, first.headers["x-request-id"]) == [(0, 0, "incomplete")]
+
+    second = httpx.post(
+        f"{engine.base}/v1/responses",
+        headers=headers,
+        json={"model": "coding", "input": "second turn", "previous_response_id": response_id},
+        timeout=30.0,
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["status"] == "completed"
+    assert second.json()["output"][0]["content"][0]["text"] == "from-primary"
+    assert _attempt_rows(engine, second.headers["x-request-id"]) == [(0, 0, "completed")]
+
+
 def test_persistent_primary_failure_fails_over_to_the_second_deployment(
     engine: _ServingEngine,
 ) -> None:
@@ -554,7 +620,9 @@ def test_ledger_conserves_every_admitted_request(engine: _ServingEngine) -> None
     )
     assert response.status_code == 200
     report = httpx.get(f"{engine.base}/usage.json", timeout=5.0).json()
-    assert report["totals"]["requests"] == 8
+    # Seven scenario requests, the output-less continuation scenario's four
+    # (two first turns and their two continuations), and this probe.
+    assert report["totals"]["requests"] == 12
     terminal_attempts = sum(int(count["attempts"]) for count in report["totals"]["terminal_counts"])
     with sqlite3.connect(engine.database_path) as connection:
         (total_attempts,) = connection.execute("SELECT count(*) FROM gateway_attempts").fetchone()
@@ -562,4 +630,6 @@ def test_ledger_conserves_every_admitted_request(engine: _ServingEngine) -> None
             "SELECT count(*) FROM gateway_attempts WHERE state IN ('dispatched', 'running')"
         ).fetchone()
     assert open_attempts == 0
-    assert terminal_attempts == total_attempts == 12
+    # Twelve single-dispatch requests plus the four extra physical attempts the
+    # redial and failover scenarios spend.
+    assert terminal_attempts == total_attempts == 16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.27,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.28,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.27"
+version = "0.3.28"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Defect

A `/v1/responses` first turn whose provider spends the whole output budget without emitting a delta (Gemini thinking at a small `max_output_tokens`: terminal `length`, zero items, response status `incomplete`) hands the caller a response id that the next turn's `previous_response_id` cannot resolve — 400 `previous_response_not_found`. Reproduced 2/3 on platform staging `gemini-3.7-flash` (2026-09-03, staging-surface-verifier): the ledger shows the first turns `incomplete`, and `gateway_continuations` holds no row for them, while the one Gemini turn that produced `"\n"` was retained and continued fine. Luna/Sonnet controls served.

api.openai.com persists `incomplete` responses and lets callers continue from them. A response the caller received with an id must be continuable regardless of finish state and dialect.

## Where the write was dropped

1. **Waterfall settled path** — a "successful terminal with no semantic output" is settled inside `acquire_attempt` and answered by `settled_responses_response`, which never built a retention or called `remember`. The finalizing settlement also drops the control plane's in-flight entry, so any later `remember` would have been a silent no-op.
2. **Committed path** — `remember_continuation` skipped `retention.is_empty()`, and the control plane's `remember_turn` returned early on the same emptiness.

## Fix

- `WaterfallContext::output_less_retention: Option<String>` — the Responses route passes the pre-built `remember` argument for an output-less turn (`remember_argument(request_id, ResponsesRetention::default(), None)`); chat and messages pass `None`. In the no-semantic-output branch the waterfall calls `remember` **before** `guard.settle`, so the control plane can still resolve the request's continuation context; a retention failure settles the provider outcome and returns `AttemptEnd::Retention(error)` → `Won::Failed(error)`, the same "outcome settled, HTTP reports the retention error" contract the committed path has.
- `remember_continuation` no longer skips an empty retention (`is_empty` removed as dead code); `remember_turn` retains an output-less turn as the conversation so far (`context.messages`). Refusals and `store: false` are unchanged.
- Crate 0.3.27 → 0.3.28 (Cargo.toml, Cargo.lock, crate pyproject, parent floor, uv.lock).

## Tests

- `native_waterfall_test::test_output_less_incomplete_response_stays_continuable[json|sse]` — live engine over the mock pool: first turn `silent-length` (provider streams only `finish_reason: length` + usage) → 200, `status: incomplete`, `output: []`, ledger `(0, 0, "incomplete")`; second turn with `previous_response_id` → 200 `from-primary`, ledger `completed`. Module conservation counts updated (12 requests / 16 attempts).
- `native_bridge_test::test_responses_output_less_turn_is_continuable` — empty retention → continuation admits as `[user, user]`.
- `native_responses_test::test_remember_turn_retains_an_output_less_turn_as_the_conversation_so_far`.
- `cargo test --no-default-features` 160 passed, clippy `-D warnings` clean, `cargo fmt --check` clean, ruff clean, `uv lock --check` clean.

Platform side: no change needed — `PostgresContinuationStore.remember_now` already stores whatever the engine hands it; the row was simply never written. Platform pin bump follows the next engine release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Production exposure

Reproduced on production (platform 01272140, 2026-09-03 18:46Z) by the staging-surface-verifier: gemini-3.7-flash first turn at `max_output_tokens: 16` → 200 `status: incomplete` (request-9efc859989604e2fa832b65e51323f21), second turn with that `previous_response_id` → 400 `previous_response_not_found` (x-correlation-id df617132088e4a0486537765f639a6b7); gpt-5.6-luna control continued fine. A Gemini first turn that happened to emit one byte continued, consistent with the empty-retention root cause.
