### PR TITLE
catalog: capability slots for GPT-6 Astra Responses features (off by default)

### DIFF
--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -459,6 +459,23 @@ class GatewayDeploymentCapabilities(ContractModel):
     reports_refusals: bool = False
     reports_cached_input_tokens: bool = False
     reports_reasoning_tokens: bool = False
+    supports_async_tools: bool = False
+    """Whether a tool may be flagged ``async`` so the model keeps generating
+    while the caller runs it, with the result returned later on the tool call's
+    ORIGINAL ``call_id`` (GPT-6 Astra Responses). Declaration-driven and off
+    until the decoder + turn lifecycle honor it; a route that declares it must
+    not drop an async tool call. See the platform's astra_responses helpers."""
+    supports_mid_turn_steering: bool = False
+    """Whether the caller may inject additional input over the Responses
+    WebSocket WHILE the model is working, folded into a continuation that
+    preserves completed work (GPT-6 Astra). Off until the WS transport accepts
+    inbound mid-turn frames."""
+    supports_reasoning_effort_update: bool = False
+    """Whether a ``configuration_update`` input item may change reasoning effort
+    mid-conversation without invalidating the cached prompt prefix -- the
+    request-level ``reasoning.effort`` stays fixed (GPT-6 Astra). Off until the
+    decoder recognizes the item (it must not hit the unknown-item reject path)
+    and applies the effort forward."""
     time_to_first_byte_base_seconds: float | None = Field(default=None, gt=0)
     """Deployment override for the lane's flat time-to-first-byte allowance.
 

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -764,3 +764,22 @@ def test_declared_foundry_endpoint_spellings_keep_their_stored_identity() -> Non
 
     assert root.identity_sha256() == with_models.identity_sha256()
     assert root.identity_sha256() != with_v1_root.identity_sha256()
+
+
+def test_astra_responses_capability_slots_default_off() -> None:
+    """The three GPT-6 Astra Responses capability slots exist and default off.
+
+    These are declaration slots for async function calling, mid-turn steering,
+    and mid-conversation reasoning-effort updates. They default False (no
+    deployment advertises a behavior the decoder/turn lifecycle does not yet
+    honor) and, being defaulted, stay identity-invisible (see
+    gateway_catalog_test's identity-digest pin). The platform's
+    generation-capability vocabulary is drift-locked to these field names, so
+    they must remain present for that projection to admit the keys.
+    """
+    caps = GatewayDeploymentCapabilities()
+    assert caps.supports_async_tools is False
+    assert caps.supports_mid_turn_steering is False
+    assert caps.supports_reasoning_effort_update is False
+    # Defaulted addition contributes zero identity bytes.
+    assert caps.model_dump(mode="json", by_alias=True, exclude_defaults=True) == {}


### PR DESCRIPTION
## What
Adds three `GatewayDeploymentCapabilities` slots for the Responses API primitives GPT-6 **Astra** (`gpt-6-astra`) introduces ([OpenAI docs](https://developers.openai.com/api/docs/guides/latest-model)):

| slot | feature |
|---|---|
| `supports_async_tools` | async function calling — a tool flagged `async: true` lets the model keep generating while the caller runs it; result returns on the **original `call_id`** |
| `supports_mid_turn_steering` | injecting additional input over the Responses **WebSocket** mid-generation, folded into a continuation that preserves completed work |
| `supports_reasoning_effort_update` | a `configuration_update` **input item** changes reasoning effort mid-conversation **without** invalidating the cached prefix (request-level `reasoning.effort` stays fixed) |

All default **False**. This is *declaration only* — no deployment advertises a behavior the decoder/turn-lifecycle doesn't yet honor.

## Why now / safety
Being defaulted, the additions are **identity-invisible** — no `SNAPSHOT_SCHEMA_VERSION` bump, no digest repin — exactly the *"you ADDED a field: give it a default"* path in `test_identity_digest_is_pinned_until_a_deliberate_schema_version_bump` (three prior releases added capability flags this way). The new test pins that these three dump to nothing at their defaults.

It **unblocks the platform**: the platform's `generation_capabilities` vocabulary is drift-locked to these field names (`assert PROTOCOL_BOOLEAN_CAPABILITY_KEYS ⊆ GatewayDeploymentCapabilities.model_fields`), so the platform can't declare/advertise these until the fields exist here. See platform PR **experientiallabs/platform#1201** (wire-shape helpers + a skip-gated live suite that runs against real Astra).

## NOT in this PR (the protocol behavior — follow-up)
- async tool: keep the stream open past the `function_call`, accept a late `function_call_output` by original `call_id`.
- mid-turn steering: accept **inbound** frames on the Responses WS (today it's continuation-only), fold into the in-flight turn.
- `configuration_update`: decode the item (must not hit the unknown-item reject path) and apply effort forward without touching the cached prefix.
- **money hook:** an incremental-reservation callback for turns that grow via async tools / mid-turn input, so a mid-turn-steered Astra turn ($50/M out) can't blow past its upfront reservation.

## Validation
ruff clean. Local pytest not run — this sandbox has no ≥3.12 interpreter for a fresh clone (`type X = Y` collection error, unrelated to the change); identity-invariance is guaranteed by the defaulted-field contract and the new test asserts it. Engine CI validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)