### PR TITLE
gateway: Hunyuan (hy4-preview) preserved-thinking round-trip (native 0.3.29)

### DIFF
--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -431,6 +431,17 @@ class ModelCapabilities(ContractModel):
     reasoning_effort: ReasoningEffort | None = None
     sampling_requires_reasoning_none: bool = False
     """Whether temperature and top-p are valid only with ``reasoning_effort='none'``."""
+    reasoning_output_exposed: bool = False
+    """Whether this rung's native plaintext reasoning is surfaced to the caller.
+
+    Off by default so hidden-reasoning providers (OpenAI o-series) never leak
+    chain-of-thought. Turned on per rung only for the exposable-plaintext
+    category (e.g. Tencent Hunyuan) so the caller sees the thinking it is already
+    billed for; the tool-loop round-trip token always stays the domain-separated
+    opaque carrier regardless of this flag. Exposure is additionally gated at the
+    wire on a carrier-route identity, so an absent capability fails closed and
+    reasoning stays stripped even on an otherwise-exposable endpoint.
+    """
     chat_max_tokens_field: ChatMaxTokensField | None = None
     minimum_temperature: float | None = Field(default=None, ge=0, le=2)
     maximum_temperature: float | None = Field(default=None, ge=0, le=2)
@@ -511,6 +522,7 @@ class ModelCapabilities(ContractModel):
             "supports_reasoning",
             "reasoning_effort",
             "sampling_requires_reasoning_none",
+            "reasoning_output_exposed",
             "chat_max_tokens_field",
             "minimum_temperature",
             "maximum_temperature",

--- a/exp/common/models/model_test.py
+++ b/exp/common/models/model_test.py
@@ -117,6 +117,7 @@ def test_model_request_keeps_tool_contract_and_capabilities_deterministic() -> N
         "supports_reasoning": False,
         "reasoning_effort": None,
         "sampling_requires_reasoning_none": False,
+        "reasoning_output_exposed": False,
         "chat_max_tokens_field": None,
         "minimum_temperature": None,
         "maximum_temperature": None,

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -445,6 +445,8 @@ class GatewayRequest(ContractModel):
     logprobs: bool | None = None
     top_logprobs: int | None = Field(default=None, ge=0, le=20)
     reasoning_effort: ReasoningEffort | None = None
+    # Level-less enable-thinking; the route seam resolves the concrete effort.
+    thinking_default_enable: bool = False
     reasoning_summary: Literal["auto", "concise", "detailed"] | None = None
     reasoning_summary_parameters: tuple[
         Literal["reasoning.generate_summary", "reasoning.summary"], ...

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.28"
+version = "0.3.29"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/admission.rs
+++ b/exp/runtime/gateway/native/src/admission.rs
@@ -62,6 +62,13 @@ impl Admission {
         }
     }
 
+    /// Whether the rung at `depth` returns plaintext reasoning to the caller.
+    pub(crate) fn reasoning_exposed_at(&self, depth: usize) -> bool {
+        self.route
+            .get(depth)
+            .is_some_and(|wire| wire.reasoning_output_exposed)
+    }
+
     /// The per-chunk transport bound of the deployment serving `depth`.
     pub(crate) fn phase_timeout(&self, depth: usize) -> Duration {
         let seconds = self

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -177,6 +177,7 @@ pub struct ChatSseEncoder {
     usage: Option<Usage>,
     reasoning: ReasoningCarrierState,
     reasoning_content_carrier: Option<String>,
+    reasoning_output_exposed: bool,
 }
 
 impl ChatSseEncoder {
@@ -201,12 +202,24 @@ impl ChatSseEncoder {
             usage: None,
             reasoning: ReasoningCarrierState::default(),
             reasoning_content_carrier: None,
+            reasoning_output_exposed: false,
         }
     }
 
     /// Attach an authenticated carrier before the terminal is encoded.
     pub fn set_reasoning_content_carrier(&mut self, carrier: String) {
         self.reasoning_content_carrier = Some(carrier);
+    }
+
+    /// Expose the model's plaintext reasoning to the caller on output.
+    ///
+    /// Off by default so hidden-reasoning providers (OpenAI o-series, which
+    /// carry no plaintext reasoning event at all) never leak. Turned on only for
+    /// rungs the catalog marks `reasoning_output_exposed`, so a Tencent/DeepSeek
+    /// client sees the `reasoning_content` deltas it is already billed for. The
+    /// sealed round-trip carrier at the terminal is independent of this.
+    pub fn set_reasoning_output_exposed(&mut self, exposed: bool) {
+        self.reasoning_output_exposed = exposed;
     }
 
     /// Return the validated candidate accumulated by a live stream.
@@ -249,9 +262,21 @@ impl ChatSseEncoder {
             Event::ProviderRefusalDelta { delta, .. } => {
                 Ok(vec![self.chunk(json!({"refusal": delta}), None)])
             }
-            Event::ReasoningContentDelta { .. } => Ok(Vec::new()),
-            // The Chat wire has no reasoning representation, so provider
-            // reasoning follows the summary path and is deliberately dropped.
+            Event::ReasoningContentDelta { delta, .. } => {
+                // On an exposure-gated rung (Tencent/DeepSeek), the model's
+                // plaintext reasoning is returned to the caller as
+                // `choices[].delta.reasoning_content` — the tokens are already
+                // billed. Elsewhere it stays dropped (the Chat wire has no
+                // reasoning field by default); the sealed round-trip carrier at
+                // the terminal is emitted independently regardless.
+                if self.reasoning_output_exposed && !delta.is_empty() {
+                    Ok(vec![self.chunk(json!({"reasoning_content": delta}), None)])
+                } else {
+                    Ok(Vec::new())
+                }
+            }
+            // The Chat wire has no reasoning representation, so provider summary
+            // and opaque reasoning follow the summary path and are dropped.
             Event::ProviderOutputItemStarted { .. }
             | Event::ProviderOutputItemCompleted { .. }
             | Event::ReasoningSummaryDelta { .. }
@@ -487,6 +512,7 @@ pub fn completed_chat_body_with_ignored(
     created_at: i64,
     events: &[Event],
     ignored_parameters: &[String],
+    reasoning_output_exposed: bool,
 ) -> Result<AggregatedCompletion, PublicError> {
     completed_chat_body_with_carrier(
         request_id,
@@ -495,6 +521,7 @@ pub fn completed_chat_body_with_ignored(
         events,
         ignored_parameters,
         None,
+        reasoning_output_exposed,
     )
 }
 
@@ -506,6 +533,7 @@ pub fn completed_chat_body_with_carrier(
     events: &[Event],
     ignored_parameters: &[String],
     reasoning_content_carrier: Option<&str>,
+    reasoning_output_exposed: bool,
 ) -> Result<AggregatedCompletion, PublicError> {
     let terminal = events.iter().rev().find(|event| event.is_terminal());
     let terminal = match terminal {
@@ -591,6 +619,9 @@ pub fn completed_chat_body_with_carrier(
         "tool_calls": if tool_calls.is_empty() { Value::Null } else { Value::Array(tool_calls) },
     });
     if matches!(terminal, Event::Completed) && has_tool_calls && reasoning.is_some() {
+        // A tool turn's reasoning round-trips as the sealed opaque carrier
+        // (never raw plaintext — that would be a CoT-injection vector on the
+        // way back in), so `reasoning_content` carries the carrier.
         let carrier = reasoning_content_carrier.ok_or_else(|| {
             invalid_provider_stream(
                 "Chat reasoning content was not sealed by the gateway authority.",
@@ -603,6 +634,27 @@ pub fn completed_chat_body_with_carrier(
                 "reasoning_content".to_string(),
                 Value::String(carrier.to_string()),
             );
+    } else if reasoning_output_exposed {
+        // A non-tool reasoning turn on an exposure-gated rung
+        // (Tencent/DeepSeek) has no carrier to round-trip, so the plaintext
+        // reasoning is returned for display only. The tokens are already
+        // billed; every other rung keeps reasoning stripped.
+        let reasoning_text: String = events
+            .iter()
+            .filter_map(|event| match event {
+                Event::ReasoningContentDelta { delta, .. } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect();
+        if !reasoning_text.is_empty() {
+            message
+                .as_object_mut()
+                .expect("chat message is an object")
+                .insert(
+                    "reasoning_content".to_string(),
+                    Value::String(reasoning_text),
+                );
+        }
     }
     let mut body = json!({
         "id": stable_public_id("chatcmpl", request_id),
@@ -696,6 +748,7 @@ mod tests {
             &events,
             &[],
             Some("authenticated-carrier-v2"),
+            false,
         )
         .expect("completed body must preserve the carrier");
         assert_eq!(
@@ -717,6 +770,7 @@ mod tests {
             1_700_000_000,
             &events,
             &[],
+            false,
         )
         .is_err());
 
@@ -801,11 +855,86 @@ mod tests {
             1_700_000_000,
             &[Event::Completed],
             &ignored,
+            false,
         )
         .expect("completed body must encode");
         assert_eq!(
             completed.body["x-experiential-ignored-parameters"],
             json!(["top_p", "reasoning_effort"])
+        );
+    }
+
+    /// A non-tool reasoning turn on an exposure-gated rung returns the model's
+    /// plaintext reasoning for display, both streaming and non-streaming; an
+    /// unexposed rung keeps it stripped. There is no tool call, so no carrier.
+    #[test]
+    fn exposed_rung_returns_plaintext_reasoning_without_a_carrier() {
+        let events = vec![
+            Event::ReasoningContentDelta {
+                route_sha256: "d".repeat(64),
+                delta: "let me think: 17*23".to_string(),
+            },
+            Event::TextDelta("391".to_string()),
+            Event::Completed,
+        ];
+
+        // Streaming: the plaintext streams as reasoning_content deltas.
+        let mut exposed = ChatSseEncoder::new_with_ignored(
+            "request-1",
+            "hy4-preview",
+            1_700_000_000,
+            false,
+            Vec::new(),
+        );
+        exposed.set_reasoning_output_exposed(true);
+        let mut frames = exposed.start().expect("stream start must encode");
+        for event in &events {
+            frames.extend(exposed.feed(event).expect("event must encode"));
+        }
+        let public = frames.join("");
+        assert!(public.contains("let me think: 17*23"));
+        assert!(public.contains("\"reasoning_content\""));
+
+        // An unexposed rung drops the very same reasoning stream.
+        let mut hidden = ChatSseEncoder::new_with_ignored(
+            "request-1",
+            "hy4-preview",
+            1_700_000_000,
+            false,
+            Vec::new(),
+        );
+        let mut hidden_frames = hidden.start().expect("stream start must encode");
+        for event in &events {
+            hidden_frames.extend(hidden.feed(event).expect("event must encode"));
+        }
+        assert!(!hidden_frames.join("").contains("let me think"));
+
+        // Non-streaming: exposed returns plaintext, unexposed omits the field.
+        let shown = completed_chat_body_with_ignored(
+            "request-1",
+            "hy4-preview",
+            1_700_000_000,
+            &events,
+            &[],
+            true,
+        )
+        .expect("completed body must encode");
+        assert_eq!(
+            shown.body["choices"][0]["message"]["reasoning_content"],
+            json!("let me think: 17*23")
+        );
+        let stripped = completed_chat_body_with_ignored(
+            "request-1",
+            "hy4-preview",
+            1_700_000_000,
+            &events,
+            &[],
+            false,
+        )
+        .expect("completed body must encode");
+        assert_eq!(
+            stripped.body["choices"][0]["message"].get("reasoning_content"),
+            None
         );
     }
 }

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -290,8 +290,9 @@ async fn settled_chat_response(
             let error = collection_public_error(&failure.clone().boundary());
             if admission.stream {
                 // The withheld refusal output and its failing terminal flush
-                // outward as the stream's only frames.
-                let body = match encode_chat_sse(admission, created_at, &events, None) {
+                // outward as the stream's only frames. This settled path never
+                // carries reasoning, so plaintext exposure is off throughout.
+                let body = match encode_chat_sse(admission, created_at, &events, None, false) {
                     Ok(body) => body,
                     Err(error) => return error_response(&error),
                 };
@@ -311,7 +312,7 @@ async fn settled_chat_response(
     let mut headers = commit_independent(admission, client_request_id.as_deref());
     headers.extend(commit_dependent(admission, settled.depth));
     if admission.stream {
-        let body = match encode_chat_sse(admission, created_at, &events, None) {
+        let body = match encode_chat_sse(admission, created_at, &events, None, false) {
             Ok(body) => body,
             Err(error) => return error_response(&error),
         };
@@ -337,6 +338,7 @@ async fn settled_chat_response(
         created_at,
         &events,
         &admission.ignored_parameters,
+        false,
     ) {
         Ok(aggregated) => aggregated,
         Err(error) => return error_response(&error),
@@ -369,6 +371,7 @@ fn encode_chat_sse(
     created_at: i64,
     events: &[Event],
     reasoning_content_carrier: Option<&str>,
+    reasoning_output_exposed: bool,
 ) -> Result<Vec<u8>, PublicError> {
     let mut encoder = ChatSseEncoder::new_with_ignored(
         &admission.request_id,
@@ -377,6 +380,7 @@ fn encode_chat_sse(
         admission.include_usage,
         admission.ignored_parameters.clone(),
     );
+    encoder.set_reasoning_output_exposed(reasoning_output_exposed);
     if let Some(carrier) = reasoning_content_carrier {
         encoder.set_reasoning_content_carrier(carrier.to_string());
     }
@@ -502,6 +506,7 @@ async fn respond_from_chat_events(
         &events,
         &admission.ignored_parameters,
         carrier.as_deref(),
+        admission.reasoning_exposed_at(depth),
     ) {
         Ok(aggregated) => aggregated,
         Err(error) => {
@@ -581,7 +586,13 @@ async fn respond_from_chat_events(
     let mut headers = commit_independent(&admission, client_request_id.as_deref());
     headers.extend(commit_dependent(&admission, depth));
     if stream_body {
-        let body = match encode_chat_sse(&admission, created_at, &events, carrier.as_deref()) {
+        let body = match encode_chat_sse(
+            &admission,
+            created_at,
+            &events,
+            carrier.as_deref(),
+            admission.reasoning_exposed_at(depth),
+        ) {
             Ok(body) => body,
             Err(error) => return error_response(&error),
         };
@@ -780,6 +791,7 @@ async fn stream_response(
             include_usage,
             admission.ignored_parameters.clone(),
         );
+        encoder.set_reasoning_output_exposed(admission.reasoning_exposed_at(committed.depth));
         let mut usage: Option<Usage> = committed.usage.take();
         let mut tool_names: Vec<String> = std::mem::take(&mut committed.tool_names);
         let mut visible_refusal = committed.visible_refusal;

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -68,6 +68,11 @@ pub struct DeploymentWire {
     pub upstream_body: Option<String>,
     #[serde(default)]
     pub fireworks_reasoning_route_sha256: Option<String>,
+    /// Tencent Hunyuan preserved-thinking route identity; like the Fireworks
+    /// field it turns on provider reasoning-content capture and stamps each
+    /// delta with this exact route, but seals under the Hunyuan carrier scheme.
+    #[serde(default)]
+    pub hunyuan_reasoning_route_sha256: Option<String>,
     /// When true, this rung returns the model's plaintext `reasoning_content`
     /// to the caller for display (Tencent/DeepSeek think mode). The sealed
     /// round-trip carrier is emitted independently; elsewhere reasoning stays
@@ -528,7 +533,11 @@ async fn run_attempt(
         }
     };
     guard.mark_opened();
-    let mut relay = match wire.fireworks_reasoning_route_sha256.clone() {
+    let mut relay = match wire
+        .fireworks_reasoning_route_sha256
+        .clone()
+        .or_else(|| wire.hunyuan_reasoning_route_sha256.clone())
+    {
         Some(route_sha256) => UpstreamRelay::new_with_reasoning_content_route(
             response,
             dialect,
@@ -712,6 +721,7 @@ mod tests {
             upstream_payload: Value::Null,
             upstream_body: None,
             fireworks_reasoning_route_sha256: None,
+            hunyuan_reasoning_route_sha256: None,
             reasoning_output_exposed: false,
             idempotency_key: "op".to_string(),
             time_to_first_byte_base_seconds: base,

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -68,6 +68,12 @@ pub struct DeploymentWire {
     pub upstream_body: Option<String>,
     #[serde(default)]
     pub fireworks_reasoning_route_sha256: Option<String>,
+    /// When true, this rung returns the model's plaintext `reasoning_content`
+    /// to the caller for display (Tencent/DeepSeek think mode). The sealed
+    /// round-trip carrier is emitted independently; elsewhere reasoning stays
+    /// stripped. Defaults false so every other provider is unchanged.
+    #[serde(default)]
+    pub reasoning_output_exposed: bool,
     pub idempotency_key: String,
     /// Deployment override for the flat first-byte allowance; the serving
     /// configuration's default applies when absent.
@@ -706,6 +712,7 @@ mod tests {
             upstream_payload: Value::Null,
             upstream_body: None,
             fireworks_reasoning_route_sha256: None,
+            reasoning_output_exposed: false,
             idempotency_key: "op".to_string(),
             time_to_first_byte_base_seconds: base,
             time_to_first_byte_seconds_per_million_input_tokens: slope,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -109,6 +109,7 @@ from exp.runtime.gateway.reasoning_carrier import (
     parse_reasoning_carrier_tool_calls,
     reasoning_carrier_authority,
     reasoning_history_sha256,
+    scheme_for_profile,
     seal_reasoning_content,
 )
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
@@ -527,13 +528,17 @@ class NativeControlPlane(
                         body_sha256=sha256_bytes(upstream_body.encode("utf-8")),
                     )
                 )
+                carrier_scheme = scheme_for_profile(profile)
                 carrier_authorities.append(
-                    reasoning_carrier_authority(
+                    None
+                    if carrier_scheme is None
+                    else reasoning_carrier_authority(
                         authorization=authorization,
                         exact_model_id=route.snapshot.exact_model_id,
                         pool_id=route.snapshot.pool_id,
                         deployment=deployment,
                         profile=profile,
+                        scheme=carrier_scheme,
                     )
                 )
             if continuation_context is not None:
@@ -798,6 +803,7 @@ class NativeControlPlane(
                 assistant_content=assistant_content,
                 tool_calls=tool_calls,
                 content=content,
+                scheme=authority.scheme,
             )
         except Exception as exc:  # noqa: BLE001 - never disclose authority or content.
             raise NativeBridgeError(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -468,7 +468,7 @@ def test_hunyuan_exposes_plaintext_reasoning_and_round_trips_only_as_carrier(
     _manager, raw_key = _configured_gateway(
         tmp_path,
         base_url="https://api.hunyuan.cloud.tencent.com/v1",
-        capabilities=ModelCapabilities(supports_tools=True),
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
     )
     control = NativeControlPlane(
         load_gateway_components(
@@ -560,6 +560,35 @@ def test_hunyuan_exposes_plaintext_reasoning_and_round_trips_only_as_carrier(
     with pytest.raises(NativeBridgeError) as modified:
         _admit(replica, raw_key, json.dumps(modified_turn))
     assert json.loads(modified.value.public_error_json)["param"] == "messages.reasoning_content"
+
+
+def test_hunyuan_endpoint_without_exposure_capability_strips_reasoning(
+    tmp_path: Path,
+) -> None:
+    """A Hunyuan-endpoint rung that does not declare exposure keeps reasoning stripped.
+
+    Exposure is gated on the explicit per-rung capability, not the base URL, so a
+    model added to the Tencent endpoint without ``reasoning_output_exposed`` fails
+    closed: the data plane still recognizes the carrier route (round-trips stay
+    sealed) but never surfaces plaintext ``reasoning_content`` to the caller.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://api.hunyuan.cloud.tencent.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-hunyuan-secret"},
+        )
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    # No exposure capability -> plaintext stays stripped even on the Hunyuan URL,
+    # while the carrier route identity still resolves so replay stays sealed.
+    assert initial["reasoning_output_exposed"] is False
+    assert isinstance(initial["hunyuan_reasoning_route_sha256"], str)
+    assert initial["fireworks_reasoning_route_sha256"] is None
 
 
 def test_fireworks_continuation_pins_the_exact_issuing_fallback_rung(tmp_path: Path) -> None:

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -453,6 +453,115 @@ def test_fireworks_carrier_round_trip_rejects_tamper_and_credential_rotation(
     assert "reasoning_content" not in rotated_messages[1]
 
 
+def test_hunyuan_exposes_plaintext_reasoning_and_round_trips_only_as_carrier(
+    tmp_path: Path,
+) -> None:
+    """Hunyuan returns plaintext reasoning for display yet round-trips it sealed.
+
+    The rung is marked as an exposed-plaintext reasoning route on the wire (so
+    the data plane returns ``reasoning_content`` to the caller), while the
+    tool-loop round-trip token stays the domain-separated opaque carrier: a
+    second replica unseals the exact turn and forwards the plaintext upstream,
+    the Fireworks-only ``reasoning_history`` wire flag never appears, and a
+    tampered turn fails closed.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://api.hunyuan.cloud.tencent.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-hunyuan-secret"},
+        )
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    # The rung declares plaintext exposure and a Hunyuan carrier route identity,
+    # and is not a Fireworks route.
+    assert initial["reasoning_output_exposed"] is True
+    assert initial["fireworks_reasoning_route_sha256"] is None
+    route_sha256 = initial["hunyuan_reasoning_route_sha256"]
+    assert isinstance(route_sha256, str)
+
+    hidden = "let me reason about the tool call privately"
+    seal_argument = json.dumps(
+        {
+            "request_id": initial["request_id"],
+            "route_depth": initial["route_depth"],
+            "route_sha256": route_sha256,
+            "content": hidden,
+            "assistant_content": None,
+            "tool_calls": [{"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}],
+        }
+    )
+    sealed = json.loads(control.seal_reasoning_content(seal_argument))["carrier"]
+    # The carrier is opaque under the Hunyuan scheme and leaks neither the
+    # plaintext reasoning nor the provider credential.
+    assert sealed.startswith("x-experiential-hunyuan-reasoning-v1:")
+    assert hidden not in sealed
+    assert "shared-hunyuan-secret" not in sealed
+    assert (
+        control.settle(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "attempt_id": initial["attempt_id"],
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 3, "output_tokens": 2},
+                    "tool_names": ["lookup"],
+                    "failure": None,
+                }
+            )
+        )
+        == "{}"
+    )
+
+    continuation_body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": sealed,
+                    "tool_calls": [
+                        {
+                            "id": "call-one",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+            ],
+        }
+    )
+    replica = NativeControlPlane(
+        load_gateway_components(
+            tmp_path,
+            environment={"TEST_PROVIDER_KEY": "shared-hunyuan-secret"},
+        )
+    )
+    continued = _admit(replica, raw_key, continuation_body)
+    route = cast("list[JsonObject]", continued["route"])
+    payload = cast("JsonObject", route[0]["upstream_payload"])
+    messages = cast("list[JsonObject]", payload["messages"])
+    assert continued["route_reason"] == "reasoning_continuation"
+    # The sealed carrier unseals to the exact plaintext forwarded upstream on the
+    # assistant turn, and Hunyuan omits the Fireworks-only reasoning_history flag.
+    assert messages[1]["reasoning_content"] == hidden
+    assert "reasoning_history" not in payload
+
+    # A tampered tool turn fails closed at the carrier authority.
+    modified_turn = json.loads(continuation_body)
+    modified_turn["messages"][1]["tool_calls"][0]["function"]["arguments"] = '{"tampered":true}'
+    with pytest.raises(NativeBridgeError) as modified:
+        _admit(replica, raw_key, json.dumps(modified_turn))
+    assert json.loads(modified.value.public_error_json)["param"] == "messages.reasoning_content"
+
+
 def test_fireworks_continuation_pins_the_exact_issuing_fallback_rung(tmp_path: Path) -> None:
     """A fallback-issued carrier replays only to its exact deployment and credential."""
     _manager, raw_key = _configured_pool_gateway(

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -571,6 +571,7 @@ def deployment_wire_entry(
         "upstream_payload": None if upstream_body is not None else upstream_payload,
         "upstream_body": upstream_body,
         "fireworks_reasoning_route_sha256": profile.fireworks_reasoning_route_sha256,
+        "hunyuan_reasoning_route_sha256": profile.hunyuan_reasoning_route_sha256,
         "reasoning_output_exposed": profile.reasoning_output_exposed,
         "idempotency_key": deployment_operation_key(route, deployment),
         # First-byte allowance overrides; the data plane falls back to its

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -571,6 +571,7 @@ def deployment_wire_entry(
         "upstream_payload": None if upstream_body is not None else upstream_payload,
         "upstream_body": upstream_body,
         "fireworks_reasoning_route_sha256": profile.fireworks_reasoning_route_sha256,
+        "reasoning_output_exposed": profile.reasoning_output_exposed,
         "idempotency_key": deployment_operation_key(route, deployment),
         # First-byte allowance overrides; the data plane falls back to its
         # serving defaults when a deployment declares nothing.

--- a/exp/runtime/gateway/native_reasoning.py
+++ b/exp/runtime/gateway/native_reasoning.py
@@ -8,6 +8,7 @@ from exp.runtime.gateway.native_execution import resolve_route_profiles
 from exp.runtime.gateway.reasoning_carrier import (
     ReasoningCarrierAuthority,
     reasoning_carrier_authority,
+    scheme_for_carrier,
     unseal_reasoning_content,
 )
 from exp.runtime.gateway.routing import GatewayRoute
@@ -117,6 +118,15 @@ def _process_reasoning_history(
         ):
             raise ValueError("reasoning carrier must accompany one assistant tool turn")
         carrier = sealed[0]
+        # The provider scheme is fixed by the carrier's own opaque prefix, so
+        # authority derivation and decryption use the exact scheme it was sealed
+        # under. The scheme's per-rung gate field then requires the resolved route
+        # to be that same provider (a Hunyuan carrier on a Fireworks rung reads a
+        # None gate → no authority), and the domain-separated key rejects any
+        # cross-provider carrier at the AEAD tag even if a gate were mis-set.
+        scheme = scheme_for_carrier(carrier.carrier)
+        if scheme is None:
+            raise ValueError("reasoning carrier prefix names no known provider scheme")
         cached = routes.get(carrier.deployment_hint)
         if cached is None:
             route = components.routes.resolve_deployment_hint(
@@ -133,9 +143,10 @@ def _process_reasoning_history(
                 pool_id=route.snapshot.pool_id,
                 deployment=route.deployment,
                 profile=profile,
+                scheme=scheme,
             )
             if authority is None:
-                raise ValueError("reasoning carrier route is not Fireworks")
+                raise ValueError("reasoning carrier route does not authorize preserved thinking")
             cached = (route, authority)
             routes[carrier.deployment_hint] = cached
         route, authority = cached
@@ -145,6 +156,7 @@ def _process_reasoning_history(
             assistant_content=message.content,
             tool_calls=message.tool_calls,
             history_prefix=tuple(messages[:index]) if verify_history else (),
+            scheme=scheme,
         )
         if reveal:
             messages[index] = message.model_copy(update={"provider_reasoning": (block,)})

--- a/exp/runtime/gateway/reasoning_carrier.py
+++ b/exp/runtime/gateway/reasoning_carrier.py
@@ -90,6 +90,24 @@ HUNYUAN_SCHEME = ReasoningCarrierScheme(
 FIREWORKS_REASONING_CONTENT_PREFIX = FIREWORKS_SCHEME.prefix
 """Public marker for a gateway-authenticated, caller-opaque Fireworks carrier."""
 
+REASONING_CARRIER_SCHEMES: tuple[ReasoningCarrierScheme, ...] = (FIREWORKS_SCHEME, HUNYUAN_SCHEME)
+"""Every provider carrier scheme, matched against an inbound carrier by prefix."""
+
+
+def scheme_for_carrier(value: str) -> ReasoningCarrierScheme | None:
+    """Return the carrier scheme whose public prefix this string carries, or None.
+
+    The scheme is identified from the caller-opaque prefix alone, before any key
+    derivation or route resolution, so the parse/authority/unseal path always
+    uses the exact provider scheme the carrier was sealed under: a Fireworks
+    carrier never resolves to Hunyuan's key domain, and vice-versa. A string with
+    no known prefix (raw client text) matches nothing and is rejected upstream.
+    """
+    for scheme in REASONING_CARRIER_SCHEMES:
+        if value.startswith(scheme.prefix):
+            return scheme
+    return None
+
 
 class ReasoningCarrierClaims(ContractModel):
     """Authenticated plaintext held only while issuing or validating a carrier."""

--- a/exp/runtime/gateway/reasoning_carrier.py
+++ b/exp/runtime/gateway/reasoning_carrier.py
@@ -1,4 +1,10 @@
-"""Authenticated Fireworks reasoning carriers bound to exact gateway authority."""
+"""Authenticated, provider-scoped reasoning carriers bound to exact gateway authority.
+
+One AEAD scheme serves every provider that round-trips gateway-sealed reasoning
+(Fireworks, Hunyuan): a ``ReasoningCarrierScheme`` supplies the public prefix and
+two DISTINCT domain separators per provider, so a carrier is isolated to the
+provider whose credential sealed it.
+"""
 
 from __future__ import annotations
 
@@ -33,9 +39,6 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
 
-FIREWORKS_REASONING_CONTENT_PREFIX = "x-experiential-fireworks-reasoning-v2:"
-"""Public marker for a gateway-authenticated, caller-opaque Fireworks carrier."""
-
 MAXIMUM_REASONING_CONTENT_BYTES = 8 * 1024 * 1024
 """Maximum decrypted provider reasoning retained for one tool continuation."""
 
@@ -45,10 +48,47 @@ MAXIMUM_REASONING_CARRIER_BYTES = 4 * ((_MAXIMUM_ENVELOPE_BYTES + 2) // 3) + 512
 """Maximum caller-supplied carrier size before any base64 or AEAD work."""
 
 _NONCE_BYTES = 12
-_KEY_DERIVATION_DOMAIN = b"experiential/fireworks-reasoning-carrier/aes256gcm/v2\0"
-_CREDENTIAL_IDENTITY_DOMAIN = b"experiential/fireworks-reasoning-credential/v2\0"
 _EXACT_INTEGER_LIMIT = 2**53
 """First magnitude where a JSON float stops naming exactly one integer."""
+
+
+@dataclass(frozen=True)
+class ReasoningCarrierScheme:
+    """Per-provider carrier identity: a public prefix plus two DISTINCT domain
+    separators for the AEAD key and credential fingerprint.
+
+    Two providers must NEVER share a key-derivation or credential-identity
+    domain: the domain separation is what makes a carrier sealed under one
+    provider's credential unable to authenticate on another provider's route.
+    """
+
+    prefix: str
+    key_derivation_domain: bytes
+    credential_identity_domain: bytes
+    route_sha256_field: str
+
+
+FIREWORKS_SCHEME = ReasoningCarrierScheme(
+    prefix="x-experiential-fireworks-reasoning-v2:",
+    key_derivation_domain=b"experiential/fireworks-reasoning-carrier/aes256gcm/v2\0",
+    credential_identity_domain=b"experiential/fireworks-reasoning-credential/v2\0",
+    route_sha256_field="fireworks_reasoning_route_sha256",
+)
+
+HUNYUAN_SCHEME = ReasoningCarrierScheme(
+    prefix="x-experiential-hunyuan-reasoning-v1:",
+    # Distinct from every other provider's key-derivation domain: this byte string
+    # MUST NOT collide with Fireworks', or a Fireworks-credential carrier could
+    # derive the same AEAD key and authenticate on a Hunyuan route (and vice-versa).
+    key_derivation_domain=b"experiential/hunyuan-reasoning-carrier/aes256gcm/v1\0",
+    # Distinct from every other provider's credential-identity domain, for the same
+    # cross-provider isolation reason; MUST NOT collide with Fireworks'.
+    credential_identity_domain=b"experiential/hunyuan-reasoning-credential/v1\0",
+    route_sha256_field="hunyuan_reasoning_route_sha256",
+)
+
+FIREWORKS_REASONING_CONTENT_PREFIX = FIREWORKS_SCHEME.prefix
+"""Public marker for a gateway-authenticated, caller-opaque Fireworks carrier."""
 
 
 class ReasoningCarrierClaims(ContractModel):
@@ -104,14 +144,14 @@ class ReasoningCarrierAuthority:
     aead_key: bytes = field(repr=False)
 
 
-def parse_reasoning_content_carrier(value: str) -> SealedReasoningContentBlock:
+def parse_reasoning_content_carrier(
+    value: str, *, scheme: ReasoningCarrierScheme = FIREWORKS_SCHEME
+) -> SealedReasoningContentBlock:
     """Validate one carrier's bounded public envelope without decrypting it."""
     raw = _ascii_bytes(value)
-    if len(raw) > MAXIMUM_REASONING_CARRIER_BYTES or not value.startswith(
-        FIREWORKS_REASONING_CONTENT_PREFIX
-    ):
+    if len(raw) > MAXIMUM_REASONING_CARRIER_BYTES or not value.startswith(scheme.prefix):
         raise ValueError("reasoning_content is not a bounded gateway carrier")
-    encoded = value.removeprefix(FIREWORKS_REASONING_CONTENT_PREFIX)
+    encoded = value.removeprefix(scheme.prefix)
     deployment_text, separator, envelope_text = encoded.partition(":")
     if not separator or not deployment_text or not envelope_text or ":" in envelope_text:
         raise ValueError("reasoning_content is not a complete gateway carrier")
@@ -133,9 +173,10 @@ def reasoning_carrier_authority(
     pool_id: str,
     deployment: ExactModelDeployment,
     profile: GatewayWireProfile,
+    scheme: ReasoningCarrierScheme = FIREWORKS_SCHEME,
 ) -> ReasoningCarrierAuthority | None:
-    """Derive one replica-stable Fireworks authority from resolved credential material."""
-    route_sha256 = profile.fireworks_reasoning_route_sha256
+    """Derive one replica-stable carrier authority from resolved credential material."""
+    route_sha256 = getattr(profile, scheme.route_sha256_field)
     if route_sha256 is None:
         return None
     credential = _bearer_credential(profile.headers)
@@ -160,12 +201,12 @@ def reasoning_carrier_authority(
     }
     aead_key = hmac.new(
         credential,
-        _KEY_DERIVATION_DOMAIN + canonical_json_bytes(key_context),
+        scheme.key_derivation_domain + canonical_json_bytes(key_context),
         hashlib.sha256,
     ).digest()
     credential_identity = hmac.new(
         aead_key,
-        _CREDENTIAL_IDENTITY_DOMAIN,
+        scheme.credential_identity_domain,
         hashlib.sha256,
     ).hexdigest()
     return ReasoningCarrierAuthority(
@@ -199,6 +240,7 @@ def seal_reasoning_content(
     assistant_content: str | None,
     tool_calls: tuple[ToolCall, ...],
     content: str,
+    scheme: ReasoningCarrierScheme = FIREWORKS_SCHEME,
 ) -> str:
     """Seal provider reasoning for one exact issuing turn and waterfall rung."""
     tool_call_ids = _require_tool_calls(tool_calls)
@@ -221,10 +263,10 @@ def seal_reasoning_content(
     if len(plaintext) > _MAXIMUM_CLAIMS_BYTES:
         raise ValueError("reasoning carrier claims exceed the authenticated bound")
     deployment_text = _encode_urlsafe(authority.deployment_id.encode("utf-8"))
-    associated_data = _associated_data(deployment_text)
+    associated_data = _associated_data(deployment_text, scheme=scheme)
     nonce = secrets.token_bytes(_NONCE_BYTES)
     envelope = nonce + AESGCM(authority.aead_key).encrypt(nonce, plaintext, associated_data)
-    carrier = f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment_text}:{_encode_urlsafe(envelope)}"
+    carrier = f"{scheme.prefix}{deployment_text}:{_encode_urlsafe(envelope)}"
     if len(carrier.encode("ascii")) > MAXIMUM_REASONING_CARRIER_BYTES:
         raise ValueError("reasoning carrier exceeds the public envelope bound")
     return carrier
@@ -237,16 +279,17 @@ def unseal_reasoning_content(
     assistant_content: str | None,
     tool_calls: tuple[ToolCall, ...],
     history_prefix: tuple[GatewayMessage, ...] = (),
+    scheme: ReasoningCarrierScheme = FIREWORKS_SCHEME,
 ) -> tuple[OpaqueReasoningContentBlock, ReasoningCarrierClaims]:
     """Authenticate and decrypt one carrier against current exact authority."""
     tool_call_ids = _require_tool_calls(tool_calls)
-    parsed = parse_reasoning_content_carrier(block.carrier)
+    parsed = parse_reasoning_content_carrier(block.carrier, scheme=scheme)
     if (
         parsed.deployment_hint != block.deployment_hint
         or block.deployment_hint != authority.deployment_id
     ):
         raise ValueError("reasoning carrier deployment differs from current authority")
-    encoded = block.carrier.removeprefix(FIREWORKS_REASONING_CONTENT_PREFIX)
+    encoded = block.carrier.removeprefix(scheme.prefix)
     deployment_text, _separator, envelope_text = encoded.partition(":")
     envelope = _decode_urlsafe(envelope_text, maximum_bytes=_MAXIMUM_ENVELOPE_BYTES)
     if len(envelope) <= _NONCE_BYTES + 16:
@@ -257,7 +300,7 @@ def unseal_reasoning_content(
         plaintext = AESGCM(authority.aead_key).decrypt(
             nonce,
             ciphertext,
-            _associated_data(deployment_text),
+            _associated_data(deployment_text, scheme=scheme),
         )
     except InvalidTag as exc:
         raise ValueError("reasoning carrier authentication failed") from exc
@@ -453,9 +496,11 @@ def _normalized_arguments(value: JsonValue) -> JsonValue:
     return value
 
 
-def _associated_data(deployment_text: str) -> bytes:
+def _associated_data(
+    deployment_text: str, *, scheme: ReasoningCarrierScheme = FIREWORKS_SCHEME
+) -> bytes:
     """Bind the public routing hint and carrier version against retagging."""
-    return f"{FIREWORKS_REASONING_CONTENT_PREFIX}{deployment_text}".encode("ascii")
+    return f"{scheme.prefix}{deployment_text}".encode("ascii")
 
 
 def _ascii_bytes(value: str) -> bytes:

--- a/exp/runtime/gateway/reasoning_carrier.py
+++ b/exp/runtime/gateway/reasoning_carrier.py
@@ -109,6 +109,21 @@ def scheme_for_carrier(value: str) -> ReasoningCarrierScheme | None:
     return None
 
 
+def scheme_for_profile(profile: GatewayWireProfile) -> ReasoningCarrierScheme | None:
+    """Return the carrier scheme a rung authorizes, or None if it is not a
+    reasoning-carrier rung.
+
+    At most one per-provider route gate is set on a rung, so this selects the
+    exact scheme whose key domain and prefix the rung's carriers use — a Hunyuan
+    rung seals/authenticates only Hunyuan carriers, a Fireworks rung only
+    Fireworks. A rung with no reasoning-carrier gate returns None (no authority).
+    """
+    for scheme in REASONING_CARRIER_SCHEMES:
+        if getattr(profile, scheme.route_sha256_field) is not None:
+            return scheme
+    return None
+
+
 class ReasoningCarrierClaims(ContractModel):
     """Authenticated plaintext held only while issuing or validating a carrier."""
 
@@ -160,6 +175,9 @@ class ReasoningCarrierAuthority:
     credential_identity_sha256: str
     reasoning_route_sha256: str
     aead_key: bytes = field(repr=False)
+    # The provider scheme this authority was derived under; carried so seal/unseal
+    # use the exact prefix + domains that match the aead_key (never a mismatch).
+    scheme: ReasoningCarrierScheme = FIREWORKS_SCHEME
 
 
 def parse_reasoning_content_carrier(
@@ -246,6 +264,7 @@ def reasoning_carrier_authority(
         credential_identity_sha256=credential_identity,
         reasoning_route_sha256=route_sha256,
         aead_key=aead_key,
+        scheme=scheme,
     )
 
 

--- a/exp/runtime/gateway/reasoning_carrier_test.py
+++ b/exp/runtime/gateway/reasoning_carrier_test.py
@@ -19,6 +19,8 @@ from exp.runtime.gateway.contracts import (
 )
 from exp.runtime.gateway.reasoning_carrier import (
     FIREWORKS_REASONING_CONTENT_PREFIX,
+    FIREWORKS_SCHEME,
+    HUNYUAN_SCHEME,
     MAXIMUM_REASONING_CARRIER_BYTES,
     ReasoningCarrierAuthority,
     parse_reasoning_content_carrier,
@@ -394,4 +396,104 @@ def test_later_carrier_binds_earlier_authenticated_reasoning() -> None:
             assistant_content=None,
             tool_calls=_tool_calls("call-later"),
             history_prefix=second_prefix,
+        )
+
+
+def _hunyuan_authority(
+    *,
+    credential: str = "replica-shared-provider-secret",
+    route_sha256: str = _ROUTE_SHA256,
+) -> ReasoningCarrierAuthority:
+    """Derive one Hunyuan carrier authority from the SAME route/credential material.
+
+    Deliberately shares the credential and route sha with the Fireworks helper so
+    the test proves the DOMAIN separation (not the credential) is what isolates the
+    two providers.
+    """
+    authority = reasoning_carrier_authority(
+        authorization=_authorization(),
+        exact_model_id="deepseek-exact",
+        pool_id="pool-one",
+        deployment=_deployment(),
+        profile=GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://hunyuan.tencentcloudapi.com/v1/chat/completions",
+            headers={"Authorization": f"Bearer {credential}"},
+            model_id="hunyuan-hy4-preview",
+            hunyuan_reasoning_route_sha256=route_sha256,
+        ),
+        scheme=HUNYUAN_SCHEME,
+    )
+    assert authority is not None
+    return authority
+
+
+def test_carrier_domains_isolate_fireworks_and_hunyuan() -> None:
+    """A carrier sealed for one provider can never authenticate on the other's route.
+
+    Same credential and route context, so the ONLY thing separating them is the
+    per-scheme key-derivation + credential-identity domain. Proven, not asserted by
+    construction: (1) the two authorities derive different AEAD keys and fingerprints;
+    (2) each carrier is rejected — with one opaque error — when replayed under the
+    other provider's scheme+authority.
+    """
+    fireworks = _authority()
+    hunyuan = _hunyuan_authority()
+
+    # Domain separation makes the same credential+route yield distinct keys/fingerprints.
+    assert fireworks.aead_key != hunyuan.aead_key
+    assert fireworks.credential_identity_sha256 != hunyuan.credential_identity_sha256
+
+    fireworks_carrier = seal_reasoning_content(
+        fireworks,
+        issuing_request_id="issuing-request",
+        issuing_route_depth=1,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content="visible",
+        tool_calls=_tool_calls("call-one"),
+        content="fireworks private reasoning",
+    )
+    hunyuan_carrier = seal_reasoning_content(
+        hunyuan,
+        issuing_request_id="issuing-request",
+        issuing_route_depth=1,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content="visible",
+        tool_calls=_tool_calls("call-one"),
+        content="hunyuan private reasoning",
+        scheme=HUNYUAN_SCHEME,
+    )
+    assert fireworks_carrier.startswith(FIREWORKS_SCHEME.prefix)
+    assert hunyuan_carrier.startswith(HUNYUAN_SCHEME.prefix)
+
+    # A Fireworks carrier replayed on a Hunyuan route: the Hunyuan scheme's prefix
+    # gate refuses it before any AEAD work.
+    with pytest.raises(ValueError):
+        unseal_reasoning_content(
+            parse_reasoning_content_carrier(fireworks_carrier, scheme=HUNYUAN_SCHEME),
+            hunyuan,
+            assistant_content="visible",
+            tool_calls=_tool_calls("call-one"),
+            scheme=HUNYUAN_SCHEME,
+        )
+    # And the reverse.
+    with pytest.raises(ValueError):
+        unseal_reasoning_content(
+            parse_reasoning_content_carrier(hunyuan_carrier, scheme=FIREWORKS_SCHEME),
+            fireworks,
+            assistant_content="visible",
+            tool_calls=_tool_calls("call-one"),
+            scheme=FIREWORKS_SCHEME,
+        )
+
+    # Deeper: even bypassing the prefix (force the Fireworks scheme to parse the
+    # Fireworks carrier) but presenting the Hunyuan authority key, the AEAD tag fails
+    # — the domain-separated key cannot decrypt the other provider's envelope.
+    with pytest.raises(ValueError, match="authentication failed"):
+        unseal_reasoning_content(
+            parse_reasoning_content_carrier(fireworks_carrier, scheme=FIREWORKS_SCHEME),
+            hunyuan,
+            assistant_content="visible",
+            tool_calls=_tool_calls("call-one"),
+            scheme=FIREWORKS_SCHEME,
         )

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -180,6 +180,20 @@ class GatewayWireProfile:
     fireworks_reasoning_route_sha256: str | None = None
     """Exact Fireworks route identity that authorizes opaque reasoning replay."""
 
+    hunyuan_reasoning_route_sha256: str | None = None
+    """Exact Hunyuan (Tencent) route identity that authorizes gateway-sealed
+    preserved-thinking replay, mirroring ``fireworks_reasoning_route_sha256``:
+    non-None marks this rung as a reasoning-carrier rung whose native
+    ``reasoning_content`` round-trips through a gateway-issued opaque carrier."""
+
+    reasoning_output_exposed: bool = False
+    """Whether this rung's plaintext reasoning is exposed to the caller on output.
+
+    Off by default so OpenAI-hidden reasoning (o-series: only opaque/summary
+    events exist) never leaks. Turned on per rung for the exposable-plaintext
+    category (Tencent/DeepSeek/Anthropic) so the caller sees the model's thinking
+    it is already billed for; the round-trip token stays the sealed carrier."""
+
     token_limit_key: ChatMaxTokensField = "max_tokens"
     """Wire field carrying the output-token ceiling on Chat Completions."""
 

--- a/exp/runtime/models/providers/fireworks.py
+++ b/exp/runtime/models/providers/fireworks.py
@@ -110,13 +110,11 @@ def _require_active_carrier(
     """Require one route-matched carrier on an assistant tool-call message."""
     if message.role != "assistant" or not message.tool_calls or len(blocks) != 1:
         raise _reasoning_parameter_error(
-            "Active Fireworks reasoning_content requires one assistant tool-call carrier."
+            "Active reasoning_content requires one assistant tool-call carrier."
         )
     block = blocks[0]
     if route_sha256 is None or getattr(block, "route_sha256", None) != route_sha256:
-        raise _reasoning_parameter_error(
-            "Fireworks reasoning_content belongs to a different provider route."
-        )
+        raise _reasoning_parameter_error("reasoning_content belongs to a different provider route.")
 
 
 def _require_complete_tool_results(messages: Sequence[GatewayMessage]) -> None:
@@ -133,13 +131,11 @@ def _require_complete_tool_results(messages: Sequence[GatewayMessage]) -> None:
         if message.role == "assistant":
             if pending:
                 raise _reasoning_parameter_error(
-                    "Fireworks reasoning_content tool calls need complete tool results."
+                    "reasoning_content tool calls need complete tool results."
                 )
             call_ids = tuple(call.call_id for call in message.tool_calls)
             if len(call_ids) != len(set(call_ids)) or window_call_ids.intersection(call_ids):
-                raise _reasoning_parameter_error(
-                    "Fireworks reasoning_content tool-call IDs must be unique."
-                )
+                raise _reasoning_parameter_error("reasoning_content tool-call IDs must be unique.")
             window_call_ids.update(call_ids)
             if any(block.kind == "reasoning_content" for block in message.provider_reasoning):
                 pending = set(call_ids)
@@ -147,11 +143,11 @@ def _require_complete_tool_results(messages: Sequence[GatewayMessage]) -> None:
             call_id = message.tool_call_id
             if call_id not in window_call_ids or call_id in completed_call_ids:
                 raise _reasoning_parameter_error(
-                    "Fireworks reasoning_content requires exactly one result per tool call."
+                    "reasoning_content requires exactly one result per tool call."
                 )
             pending.discard(call_id)
             completed_call_ids.add(call_id)
     if pending or not messages or messages[-1].role != "tool":
         raise _reasoning_parameter_error(
-            "Fireworks reasoning_content can replay only in a completed tool continuation."
+            "reasoning_content can replay only in a completed tool continuation."
         )

--- a/exp/runtime/models/providers/hunyuan.py
+++ b/exp/runtime/models/providers/hunyuan.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""Tencent Hunyuan preserved-thinking route detection.
+
+Tencent's Hunyuan models (hy3/hy4) serve an OpenAI-compatible Chat Completions
+endpoint that returns the model's chain-of-thought in a native ``reasoning_content``
+response field and accepts it back on an assistant turn. This module identifies
+that exact endpoint so the gateway marks the rung as an exposable-plaintext
+reasoning route whose replay is protected by a gateway-issued opaque carrier,
+mirroring :mod:`exp.runtime.models.providers.fireworks`.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+
+def is_hunyuan_base_url(base_url: str) -> bool:
+    """Return whether one endpoint is the exact public Hunyuan inference root.
+
+    The OpenAI-compatible root is ``https://api.hunyuan.cloud.tencent.com/v1``;
+    the TC3-HMAC-signed ``hunyuan.tencentcloudapi.com`` host is a different API
+    the gateway never speaks and is deliberately not matched here.
+    """
+    parsed = urlsplit(base_url)
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname == "api.hunyuan.cloud.tencent.com"
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.port in {None, 443}
+        and parsed.path.rstrip("/") == "/v1"
+        and not parsed.query
+        and not parsed.fragment
+    )

--- a/exp/runtime/models/providers/hunyuan_test.py
+++ b/exp/runtime/models/providers/hunyuan_test.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""Hunyuan OpenAI-compatible endpoint detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.runtime.models.providers.hunyuan import is_hunyuan_base_url
+
+
+def test_matches_exact_public_hunyuan_root() -> None:
+    """The public OpenAI-compatible inference root is recognized."""
+    assert is_hunyuan_base_url("https://api.hunyuan.cloud.tencent.com/v1")
+    assert is_hunyuan_base_url("https://api.hunyuan.cloud.tencent.com/v1/")
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        # The TC3-HMAC-signed API host is a different protocol entirely.
+        "https://hunyuan.tencentcloudapi.com/v1",
+        # Plaintext, credential-bearing, ported, or path-shifted variants.
+        "http://api.hunyuan.cloud.tencent.com/v1",
+        "https://user:pass@api.hunyuan.cloud.tencent.com/v1",
+        "https://api.hunyuan.cloud.tencent.com:8443/v1",
+        "https://api.hunyuan.cloud.tencent.com/v1/chat/completions",
+        "https://api.hunyuan.cloud.tencent.com/openai/v1",
+        # A look-alike host must not match.
+        "https://api.hunyuan.cloud.tencent.com.evil.test/v1",
+    ],
+)
+def test_rejects_non_canonical_endpoints(base_url: str) -> None:
+    """Only the exact scheme/host/path with no extras is a Hunyuan route."""
+    assert not is_hunyuan_base_url(base_url)

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -440,6 +440,7 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         reasoning_effort: str | None = None,
         chat_max_tokens_field: ChatMaxTokensField | None = None,
         sampling_requires_reasoning_none: bool = False,
+        reasoning_output_exposed: bool = False,
     ) -> None:
         """Create one compatible client with explicit model wire capabilities."""
         super().__init__(
@@ -460,6 +461,7 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         self._reasoning_effort = reasoning_effort
         self._token_limit_key: ChatMaxTokensField = chat_max_tokens_field or self.token_limit_key
         self._sampling_requires_reasoning_none = sampling_requires_reasoning_none
+        self._reasoning_output_exposed = reasoning_output_exposed
         self._fireworks_reasoning_route_sha256 = (
             reasoning_content_route_sha256(model) if is_fireworks_base_url(self._base_url) else None
         )
@@ -494,7 +496,13 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             sampling_requires_reasoning_none=self._sampling_requires_reasoning_none,
             fireworks_reasoning_route_sha256=self._fireworks_reasoning_route_sha256,
             hunyuan_reasoning_route_sha256=self._hunyuan_reasoning_route_sha256,
-            reasoning_output_exposed=self._hunyuan_reasoning_route_sha256 is not None,
+            # Expose plaintext reasoning only when the rung explicitly declares
+            # it AND resolves a reasoning-carrier route: an absent capability
+            # fails closed and stays stripped even on the Hunyuan endpoint, so
+            # exposure is per-rung, never per-endpoint.
+            reasoning_output_exposed=(
+                self._reasoning_output_exposed and self._hunyuan_reasoning_route_sha256 is not None
+            ),
         )
 
     def _completion_path(self) -> str:

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -47,6 +47,7 @@ from exp.runtime.models.providers.fireworks import (
     is_fireworks_base_url,
     reasoning_content_route_sha256,
 )
+from exp.runtime.models.providers.hunyuan import is_hunyuan_base_url
 from exp.runtime.models.providers.reasoning_compat import (
     openai_reasoning_effort,
     require_sampling_reasoning_compatibility,
@@ -462,6 +463,13 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         self._fireworks_reasoning_route_sha256 = (
             reasoning_content_route_sha256(model) if is_fireworks_base_url(self._base_url) else None
         )
+        # Tencent Hunyuan returns the model's plaintext reasoning natively and
+        # accepts it back; the gateway exposes it for display and round-trips it
+        # through a domain-separated opaque carrier, so this rung is both a
+        # carrier route and an exposed-plaintext route.
+        self._hunyuan_reasoning_route_sha256 = (
+            reasoning_content_route_sha256(model) if is_hunyuan_base_url(self._base_url) else None
+        )
 
     def gateway_wire_profile(self) -> GatewayWireProfile:
         """Return the Chat Completions wire profile for this connection."""
@@ -485,6 +493,8 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             token_limit_key=self._token_limit_key,
             sampling_requires_reasoning_none=self._sampling_requires_reasoning_none,
             fireworks_reasoning_route_sha256=self._fireworks_reasoning_route_sha256,
+            hunyuan_reasoning_route_sha256=self._hunyuan_reasoning_route_sha256,
+            reasoning_output_exposed=self._hunyuan_reasoning_route_sha256 is not None,
         )
 
     def _completion_path(self) -> str:

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -437,3 +437,46 @@ def test_openai_compatible_refusal_is_typed_without_exposing_content() -> None:
 
     assert error.value.signal is ProviderRefusalSignal.CONTENT_POLICY
     assert canary not in str(error.value)
+
+
+_HUNYUAN_BASE_URL = "https://api.hunyuan.cloud.tencent.com/v1"
+
+
+def test_hunyuan_rung_exposes_reasoning_only_when_the_capability_is_declared() -> None:
+    """Plaintext reasoning is exposed per rung, never inferred from the endpoint."""
+    exposed = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url=_HUNYUAN_BASE_URL,
+        api_key="fake-key",
+        reasoning_output_exposed=True,
+    ).gateway_wire_profile()
+    assert exposed.hunyuan_reasoning_route_sha256 is not None
+    assert exposed.reasoning_output_exposed is True
+
+
+def test_hunyuan_rung_without_the_capability_stays_stripped_but_keeps_its_carrier_route() -> None:
+    """An undeclared rung on the Hunyuan endpoint fails closed on exposure.
+
+    The carrier route identity still resolves so tool-loop replay stays sealed,
+    but the caller never sees plaintext ``reasoning_content`` — closing the hole
+    where endpoint detection alone would expose every model on the endpoint.
+    """
+    profile = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url=_HUNYUAN_BASE_URL,
+        api_key="fake-key",
+    ).gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is not None
+    assert profile.reasoning_output_exposed is False
+
+
+def test_reasoning_exposure_requires_a_carrier_route_even_when_declared() -> None:
+    """A declared capability without a carrier route exposes nothing (both gates)."""
+    profile = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url="https://example.test/v1",
+        api_key="fake-key",
+        reasoning_output_exposed=True,
+    ).gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is None
+    assert profile.reasoning_output_exposed is False

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -168,6 +168,7 @@ def openai_compatible_stream_payload(
     reasoning_effort: str | None = None,
     sampling_requires_reasoning_none: bool = False,
     fireworks_reasoning_route_sha256: str | None = None,
+    hunyuan_reasoning_route_sha256: str | None = None,
     forwards_service_tier: bool = False,
 ) -> JsonObject:
     """Translate one canonical request to streaming Chat Completions JSON.
@@ -186,23 +187,27 @@ def openai_compatible_stream_payload(
     Returns:
         Chat Completions request that always asks the provider for terminal usage.
     """
-    messages, active_fireworks_reasoning = prepare_gateway_reasoning_history(
+    # A rung is a preserved-thinking route under exactly one provider scheme;
+    # its block must name that route to forward. Fireworks additionally toggles
+    # the wire-native `reasoning_history` field, which Hunyuan does not use.
+    reasoning_route_sha256 = fireworks_reasoning_route_sha256 or hunyuan_reasoning_route_sha256
+    messages, active_reasoning = prepare_gateway_reasoning_history(
         request.messages,
-        route_sha256=fireworks_reasoning_route_sha256,
+        route_sha256=reasoning_route_sha256,
     )
     payload: JsonObject = {
         "model": model_id,
         "messages": [
             openai_chat_message(
                 message,
-                fireworks_reasoning_route_sha256=fireworks_reasoning_route_sha256,
+                reasoning_route_sha256=reasoning_route_sha256,
             )
             for message in messages
         ],
         "stream": True,
         "stream_options": {"include_usage": True},
     }
-    if active_fireworks_reasoning:
+    if active_reasoning and fireworks_reasoning_route_sha256 is not None:
         payload["reasoning_history"] = "interleaved"
     add_openai_tools(payload, request, responses=False)
     if request.parallel_tool_calls is not None:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -203,6 +203,7 @@ def dialect_stream_payload(
             reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
             fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
+            hunyuan_reasoning_route_sha256=profile.hunyuan_reasoning_route_sha256,
             forwards_service_tier=profile.billing_customer_managed,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -389,6 +389,34 @@ def route_generation_parameter_requests(
         penalty_honored(profile, presence=True) for profile in profiles
     ):
         ignore("presence_penalty", "presence_penalty->dropped(unsupported_by_provider)")
+    if request.thinking_default_enable and request.reasoning_effort is None:
+        # A level-less "enable thinking" (from a translated thinking:{enabled} or
+        # chat_template_kwargs:{enable_thinking:true}) resolves to the model's own
+        # default effort here, at the serving route: a route-wide required default
+        # when portable, else the LOWEST portable non-none tier (default-not-high
+        # avoids surprising cost). A route that supports no reasoning effort cannot
+        # enable thinking, so it surfaces rather than silently not thinking.
+        portable = set(REASONING_EFFORTS)
+        for profile in profiles:
+            portable.intersection_update(_profile_reasoning_efforts(profile))
+        portable_non_none = tuple(e for e in REASONING_EFFORTS if e in portable and e != "none")
+        if not portable_non_none:
+            raise ProviderParameterError(
+                message=(
+                    "This model route cannot enable thinking: it supports no reasoning "
+                    "effort. Remove the enable-thinking field or choose a reasoning model."
+                ),
+                param=effort_path,
+                code="unsupported_parameter",
+            )
+        required_defaults = {
+            profile.reasoning_effort
+            for profile in profiles
+            if profile.reasoning_effort_required and profile.reasoning_effort in portable_non_none
+        }
+        provider_updates["reasoning_effort"] = (
+            next(iter(required_defaults)) if len(required_defaults) == 1 else portable_non_none[0]
+        )
     if request.reasoning_effort is not None:
         portable_efforts = set(REASONING_EFFORTS)
         for profile in profiles:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1205,6 +1205,55 @@ def test_genuinely_unsupported_sampling_still_hard_rejects() -> None:
     assert raised.value.param == "temperature"
 
 
+def test_thinking_default_enable_resolves_the_required_default_effort() -> None:
+    """A level-less enable resolves to the route's required default effort."""
+    profile = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://p.test",
+        model_id="provider/reasoner",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_effort="medium",
+        supported_reasoning_efforts=("none", "low", "medium", "high"),
+        reasoning_effort_required=True,
+    )
+    request = _chat_request().model_copy(update={"thinking_default_enable": True})
+
+    _public, provider = route_generation_parameter_requests((profile,), request)
+
+    assert provider.reasoning_effort == "medium"
+
+
+def test_thinking_default_enable_falls_back_to_the_lowest_non_none_effort() -> None:
+    """When the model requires no default, a level-less enable picks the lowest tier."""
+    profile = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://p.test",
+        model_id="provider/optional-reasoner",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        supported_reasoning_efforts=("none", "low", "high"),
+    )
+    request = _chat_request().model_copy(update={"thinking_default_enable": True})
+
+    _public, provider = route_generation_parameter_requests((profile,), request)
+
+    assert provider.reasoning_effort == "low"
+
+
+def test_thinking_default_enable_on_a_non_reasoning_route_surfaces() -> None:
+    """A route that supports no reasoning effort cannot enable thinking → rejects."""
+    profile = GatewayWireProfile(
+        dialect="openai_compatible", url="https://p.test", model_id="provider/plain"
+    )
+    request = _chat_request().model_copy(update={"thinking_default_enable": True})
+
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((profile,), request)
+
+    assert raised.value.code == "unsupported_parameter"
+
+
 def test_payload_builder_rejects_conditional_sampling_without_admission() -> None:
     """Direct provider use retains the same local guard as gateway admission."""
     with pytest.raises(ProviderParameterError, match="reasoning_effort is 'none'"):

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -306,9 +306,14 @@ def anthropic_request_headers(
 def openai_chat_message(
     message: GatewayMessage,
     *,
-    fireworks_reasoning_route_sha256: str | None = None,
+    reasoning_route_sha256: str | None = None,
 ) -> JsonObject:
-    """Translate one gateway message to OpenAI Chat wire JSON."""
+    """Translate one gateway message to OpenAI Chat wire JSON.
+
+    ``reasoning_route_sha256`` is the active preserved-thinking route identity
+    for this rung (Fireworks or Hunyuan); an unsealed ``reasoning_content``
+    block forwards to the provider only when it names that exact route.
+    """
     if message.role == "tool":
         return {
             "role": "tool",
@@ -349,8 +354,8 @@ def openai_chat_message(
         block = message.provider_reasoning[0]
         if (
             block.kind != "reasoning_content"
-            or fireworks_reasoning_route_sha256 is None
-            or block.route_sha256 != fireworks_reasoning_route_sha256
+            or reasoning_route_sha256 is None
+            or block.route_sha256 != reasoning_route_sha256
         ):
             raise ProviderResponseError("reasoning carrier belongs to a different Chat route")
         payload["reasoning_content"] = block.content

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -494,6 +494,9 @@ class RuntimeModelCatalog:
             http_kwargs["sampling_requires_reasoning_none"] = (
                 capabilities.sampling_requires_reasoning_none
             )
+            http_kwargs["reasoning_output_exposed"] = _supports_flag(
+                capabilities, "reasoning_output_exposed"
+            )
         http_client = factory(**http_kwargs)
         embedding_client = (
             http_client

--- a/exp/runtime/openai_protocol/enable_thinking.py
+++ b/exp/runtime/openai_protocol/enable_thinking.py
@@ -1,0 +1,123 @@
+"""Translate alternate enable-thinking Chat request shapes to canonical reasoning.
+
+Clients express "turn thinking on" three non-canonical ways on
+/v1/chat/completions: the Responses-style nested ``reasoning:{effort}``, the
+Anthropic-style ``thinking:{type}``, and the vLLM-native
+``chat_template_kwargs:{enable_thinking}``. Each is admitted and translated here
+to the canonical flat ``reasoning_effort`` (never dropped — dropping would leave
+thinking silently off), so one caller payload works in any shape. The
+model-aware default effort for a level-less enable is resolved later, at the
+route adaptation seam, via ``GatewayRequest.thinking_default_enable``.
+"""
+
+from __future__ import annotations
+
+from exp.common.models.model import ReasoningEffort
+from exp.runtime.openai_protocol.errors import invalid_field
+from exp.runtime.openai_protocol.wire_models import _ChatRequest
+
+# Disclosure tokens (unified path->action(reason) vocabulary).
+_TRANSLATED = "{path}->translated(reasoning_effort)"
+_IGNORED = "{path}->ignored(explicit_reasoning_effort)"
+_BUDGET_DROPPED = "budget_tokens->dropped(not_carried)"
+
+
+class _EnableThinkingResult:
+    """The resolved canonical reasoning controls plus caller disclosures."""
+
+    __slots__ = ("reasoning_effort", "thinking_default_enable", "disclosures")
+
+    def __init__(
+        self,
+        reasoning_effort: ReasoningEffort | None,
+        thinking_default_enable: bool,
+        disclosures: tuple[str, ...],
+    ) -> None:
+        self.reasoning_effort = reasoning_effort
+        self.thinking_default_enable = thinking_default_enable
+        self.disclosures = disclosures
+
+
+def translate_enable_thinking(request: _ChatRequest) -> _EnableThinkingResult:
+    """Resolve the effective reasoning control from the flat and alternate fields.
+
+    The explicit flat ``reasoning_effort`` always wins; a level-less enable defers
+    to the model default (``thinking_default_enable``). Alternate fields that
+    disagree on enable-vs-disable are a caller error and rejected by name.
+    """
+    # (path, effort-or-None, is_present-with-intent) for each alternate field.
+    reasoning_effort = request.reasoning.effort if request.reasoning is not None else None
+    reasoning_present = request.reasoning is not None and request.reasoning.effort is not None
+
+    thinking_enable: bool | None = None
+    thinking_present = request.thinking is not None
+    if request.thinking is not None:
+        thinking_enable = request.thinking.type == "enabled"
+
+    cck_enable = (
+        request.chat_template_kwargs.enable_thinking
+        if request.chat_template_kwargs is not None
+        else None
+    )
+    cck_present = cck_enable is not None
+
+    budget_present = request.thinking is not None and request.thinking.budget_tokens is not None
+
+    # Explicit flat reasoning_effort wins: every present alternate field is a no-op
+    # the caller is told about, and the flat value is passed through unchanged.
+    if request.reasoning_effort is not None:
+        disclosures: list[str] = []
+        if reasoning_present:
+            disclosures.append(_IGNORED.format(path="reasoning"))
+        if thinking_present:
+            disclosures.append(_IGNORED.format(path="thinking"))
+        if cck_present:
+            disclosures.append(_IGNORED.format(path="chat_template_kwargs"))
+        return _EnableThinkingResult(request.reasoning_effort, False, tuple(disclosures))
+
+    # No explicit flat value: fold the alternate fields into one intent. Each
+    # present field votes enable ("on", possibly at a level) or disable ("none").
+    def _intent(effort_or_enable: ReasoningEffort | bool | None) -> bool | None:
+        if effort_or_enable is None:
+            return None
+        if isinstance(effort_or_enable, bool):
+            return effort_or_enable
+        return effort_or_enable != "none"  # a concrete effort: "none" disables
+
+    votes = [
+        vote
+        for vote in (
+            _intent(reasoning_effort if reasoning_present else None),
+            _intent(thinking_enable if thinking_present else None),
+            _intent(cck_enable if cck_present else None),
+        )
+        if vote is not None
+    ]
+    if votes and any(vote != votes[0] for vote in votes):
+        raise invalid_field(
+            "thinking",
+            "conflicting enable-thinking fields: reasoning/thinking/chat_template_kwargs "
+            "must all enable or all disable.",
+        )
+
+    disclosures = []
+    if budget_present:
+        disclosures.append(_BUDGET_DROPPED)
+    if reasoning_present:
+        disclosures.append(_TRANSLATED.format(path="reasoning"))
+    if thinking_present:
+        disclosures.append(_TRANSLATED.format(path="thinking"))
+    if cck_present:
+        disclosures.append(_TRANSLATED.format(path="chat_template_kwargs"))
+
+    if not votes:
+        # No alternate field carried an intent (absent, or an empty object).
+        return _EnableThinkingResult(None, False, tuple(disclosures))
+    if votes[0] is False:
+        # All present fields disable → canonical none.
+        return _EnableThinkingResult("none", False, tuple(disclosures))
+    # Enabled: a nested reasoning effort pins the level; otherwise defer the
+    # model-aware default to the adaptation seam.
+    if reasoning_present and reasoning_effort is not None:
+        return _EnableThinkingResult(reasoning_effort, False, tuple(disclosures))
+    return _EnableThinkingResult(None, True, tuple(disclosures))

--- a/exp/runtime/openai_protocol/enable_thinking_test.py
+++ b/exp/runtime/openai_protocol/enable_thinking_test.py
@@ -1,0 +1,90 @@
+"""Tests for enable-thinking field translation to canonical reasoning_effort."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+from exp.runtime.openai_protocol.requests import decode_chat
+
+
+def _decode(**overrides: object) -> GatewayRequest:
+    body: dict[str, object] = {
+        "model": "coding",
+        "messages": [{"role": "user", "content": "hi"}],
+        **overrides,
+    }
+    return decode_chat(cast(JsonObject, body)).request
+
+
+def test_nested_reasoning_effort_translates_to_flat_effort() -> None:
+    request = _decode(reasoning={"effort": "high"})
+    assert request.reasoning_effort == "high"
+    assert request.thinking_default_enable is False
+    assert request.ignored_parameters == ("reasoning->translated(reasoning_effort)",)
+
+
+def test_thinking_enabled_defers_to_the_model_default() -> None:
+    request = _decode(thinking={"type": "enabled"})
+    assert request.reasoning_effort is None
+    assert request.thinking_default_enable is True
+    assert request.ignored_parameters == ("thinking->translated(reasoning_effort)",)
+
+
+def test_thinking_enabled_budget_tokens_is_disclosed_not_carried() -> None:
+    request = _decode(thinking={"type": "enabled", "budget_tokens": 4096})
+    assert request.thinking_default_enable is True
+    assert request.ignored_parameters == (
+        "budget_tokens->dropped(not_carried)",
+        "thinking->translated(reasoning_effort)",
+    )
+
+
+def test_chat_template_kwargs_enable_defers_to_the_model_default() -> None:
+    request = _decode(chat_template_kwargs={"enable_thinking": True})
+    assert request.reasoning_effort is None
+    assert request.thinking_default_enable is True
+    assert request.ignored_parameters == ("chat_template_kwargs->translated(reasoning_effort)",)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("thinking", {"type": "disabled"}),
+        ("chat_template_kwargs", {"enable_thinking": False}),
+    ],
+)
+def test_disable_shapes_translate_to_reasoning_none(field: str, value: object) -> None:
+    request = _decode(**{field: value})
+    assert request.reasoning_effort == "none"
+    assert request.thinking_default_enable is False
+    assert request.ignored_parameters == (f"{field}->translated(reasoning_effort)",)
+
+
+def test_explicit_flat_reasoning_effort_wins_over_translate_fields() -> None:
+    request = _decode(
+        reasoning_effort="low",
+        thinking={"type": "enabled"},
+        chat_template_kwargs={"enable_thinking": True},
+    )
+    assert request.reasoning_effort == "low"
+    assert request.thinking_default_enable is False
+    assert request.ignored_parameters == (
+        "thinking->ignored(explicit_reasoning_effort)",
+        "chat_template_kwargs->ignored(explicit_reasoning_effort)",
+    )
+
+
+def test_conflicting_enable_and_disable_fields_are_rejected() -> None:
+    with pytest.raises(OpenAIProtocolError):
+        _decode(thinking={"type": "enabled"}, chat_template_kwargs={"enable_thinking": False})
+
+
+def test_agreeing_enable_fields_prefer_the_nested_level() -> None:
+    request = _decode(reasoning={"effort": "medium"}, thinking={"type": "enabled"})
+    assert request.reasoning_effort == "medium"
+    assert request.thinking_default_enable is False

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -55,6 +55,15 @@ CHAT_MANIFEST = CompatibilityManifest(
             "structured_output",
         ),
         _field("reasoning_effort", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
+        # Alternate enable-thinking shapes admitted and TRANSLATED to the canonical
+        # reasoning_effort at decode (the Responses-style nested `reasoning`, the
+        # Anthropic-style `thinking`, the vLLM-native `chat_template_kwargs`), so a
+        # caller's one payload turns thinking on in any shape.
+        _field("reasoning", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
+        _field("thinking", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
+        _field(
+            "chat_template_kwargs", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"
+        ),
         _field("top_k", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "top_k"),
         _field("logprobs", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "logprobs"),
         # Sampling penalties: admitted and adapted per rung — honored where the

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -41,6 +41,7 @@ from exp.runtime.gateway.embeddings_contracts import EmbeddingsRequest
 from exp.runtime.gateway.reasoning_carrier import (
     FIREWORKS_REASONING_CONTENT_PREFIX,
     parse_reasoning_content_carrier,
+    scheme_for_carrier,
 )
 from exp.runtime.openai_protocol.cache_control import (
     drop_opencode_cache_control,
@@ -660,8 +661,16 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
         )
         provider_reasoning: tuple[SealedReasoningContentBlock, ...] = ()
         if message.reasoning_content is not None:
+            # The scheme is fixed by the carrier's own opaque prefix; raw client
+            # text (no known prefix) matches none and is rejected here. Each
+            # provider's carrier only parses under its own scheme.
+            scheme = scheme_for_carrier(message.reasoning_content)
             try:
-                provider_reasoning = (parse_reasoning_content_carrier(message.reasoning_content),)
+                if scheme is None:
+                    raise ValueError("reasoning_content is not a gateway-issued carrier")
+                provider_reasoning = (
+                    parse_reasoning_content_carrier(message.reasoning_content, scheme=scheme),
+                )
             except ValueError as exc:
                 param = f"{prefix}.{message_index}.reasoning_content"
                 raise invalid_field(param, f"'{param}' must be a gateway-issued carrier.") from exc

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -46,6 +46,7 @@ from exp.runtime.gateway.reasoning_carrier import (
 from exp.runtime.openai_protocol.cache_control import (
     drop_opencode_cache_control,
 )
+from exp.runtime.openai_protocol.enable_thinking import translate_enable_thinking
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
@@ -181,6 +182,12 @@ def decode_chat(
         if isinstance(request.stop, str)
         else request.stop
     )
+    thinking = translate_enable_thinking(request)
+    json_object_disclosure = (
+        (JSON_OBJECT_TRANSLATION_DISCLOSURE,)
+        if request.response_format is not None and request.response_format.type == "json_object"
+        else ()
+    )
     try:
         canonical = GatewayRequest(
             surface=GatewayApiSurface.CHAT_COMPLETIONS,
@@ -189,12 +196,7 @@ def decode_chat(
             tool_choice=_chat_tool_choice(request.tool_choice),
             parallel_tool_calls=request.parallel_tool_calls,
             structured_text=chat_structured_text(request.response_format),
-            ignored_parameters=(
-                (JSON_OBJECT_TRANSLATION_DISCLOSURE,)
-                if request.response_format is not None
-                and request.response_format.type == "json_object"
-                else ()
-            ),
+            ignored_parameters=(*json_object_disclosure, *thinking.disclosures),
             maximum_output_tokens=maximum,
             maximum_output_tokens_parameter=(
                 "max_completion_tokens"
@@ -211,7 +213,8 @@ def decode_chat(
             presence_penalty=request.presence_penalty,
             logprobs=request.logprobs,
             top_logprobs=request.top_logprobs,
-            reasoning_effort=request.reasoning_effort,
+            reasoning_effort=thinking.reasoning_effort,
+            thinking_default_enable=thinking.thinking_default_enable,
             stream=request.stream,
             include_usage=(
                 request.stream_options is not None and request.stream_options.include_usage

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -342,6 +342,35 @@ class _ChatStreamOptions(_WireModel):
     include_usage: bool = False
 
 
+class _ChatReasoning(_WireModel):
+    """Nested ``reasoning`` object on a Chat request (the Responses shape some
+    clients also send on /v1/chat/completions). Translated to the canonical flat
+    ``reasoning_effort``; only ``effort`` is accepted here."""
+
+    effort: ReasoningEffort | None = None
+
+
+class _ThinkingConfig(_WireModel):
+    """Anthropic-style ``thinking`` enable/disable config on a Chat request.
+
+    Translated to the canonical reasoning control: ``enabled`` turns thinking on
+    at the model's default effort, ``disabled`` maps to ``reasoning_effort=none``.
+    ``budget_tokens`` has no canonical equivalent and is disclosed as not carried.
+    """
+
+    type: Literal["enabled", "disabled"]
+    budget_tokens: int | None = Field(default=None, ge=0)
+
+
+class _ChatTemplateKwargs(_WireModel):
+    """vLLM/Hunyuan-native ``chat_template_kwargs`` on a Chat request.
+
+    Only ``enable_thinking`` is recognized and translated to the canonical
+    reasoning control; the field is never forwarded verbatim to any wire."""
+
+    enable_thinking: bool | None = None
+
+
 class _ChatRequest(_WireModel):
     """Closed gateway Chat Completions request profile."""
 
@@ -381,6 +410,9 @@ class _ChatRequest(_WireModel):
     logprobs: bool | None = None
     top_logprobs: int | None = Field(default=None, ge=0, le=20)
     reasoning_effort: ReasoningEffort | None = None
+    reasoning: _ChatReasoning | None = None
+    thinking: _ThinkingConfig | None = None
+    chat_template_kwargs: _ChatTemplateKwargs | None = None
     response_format: _ChatResponseFormat | None = None
     stream: bool = False
     stream_options: _ChatStreamOptions | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.28,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.29,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.28"
+version = "0.7.29"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.28"
+version = "0.7.29"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.28"
+version = "0.3.29"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
Tencent hy4-preview (Hunyuan) preserved-thinking so a Harbor/Terminus-2 tool loop works through Explabs without BYOK TokenHub. Security design + the full owner-approved mapping table, both halves. **Rides 0.7.29** (native `exp-gateway-native` 0.3.29). Acceptance = the owner's 6-check gate, all green in engine fixtures.

## Acceptance gate — all 6 green
| # | Check | Where |
|---|---|---|
| 1 | `reasoning:{effort}` (nested) → 200, translated | `enable_thinking_test.py` |
| 2 | `thinking:{type:"enabled"}` → 200, translated | `enable_thinking_test.py` |
| 3 | `chat_template_kwargs:{enable_thinking:true}` → 200, translated | `enable_thinking_test.py` |
| 4 | `reasoning_content` RETURNED (not stripped) | Rust `encode.rs::exposed_rung_returns_plaintext_reasoning_without_a_carrier` |
| 5 | round-trip carrier accepted on a tool turn | `native_bridge_test.py` seal→feed-back→unseal across replicas |
| 6 | Fireworks carrier byte-identical | `reasoning_carrier_test.py` **0 deletions**, 19 pass |

## Security model (design lead-approved)
Mirror the proven Fireworks AES-256-GCM carrier via a domain-separated `ReasoningCarrierScheme` (FIREWORKS + HUNYUAN, distinct commented key/credential domains — cross-provider forgery rejected at BOTH the prefix gate and the AEAD tag, in a test). Carrier key derived from the provider credential (no new secret). The scheme travels ON the authority (`scheme_for_profile(profile)` at admission → `seal(scheme=authority.scheme)`), so a Hunyuan rung seals a Hunyuan carrier, Fireworks stays Fireworks. **The sealed opaque carrier is the ONLY round-trip token** (raw client CoT still rejected — zero injection surface); plaintext `reasoning_content` is display-only, gated per-rung by `reasoning_output_exposed` (OpenAI o-series stays stripped — no plaintext event exists). Preserved-thinking pins to the issuing rung (accepted failover loss).

## Input translation (owner-locked table)
The three enable-thinking shapes were unknown Chat fields (hard 400); now admitted + translated to canonical `reasoning_effort`: `reasoning:{effort:X}`→X; `thinking:{enabled}`/`chat_template_kwargs:{enable_thinking:true}`→model's default enable effort (resolved model-aware at the adaptation seam, else lowest non-none); disable→`none` (adaptive-only discloses, mirrors #753); explicit flat `reasoning_effort` WINS; conflicting enable+disable rejected; `budget_tokens` disclosed dropped. Unified `path->action(reason)` disclosures.

## Two build findings
1. Output emit alone wasn't enough — the Rust relay only captured `ReasoningContentDelta` on a reasoning-route sha (Fireworks-only), dropping Hunyuan reasoning upstream. Fixed: `hunyuan_reasoning_route_sha256` added to the Rust `DeploymentWire` + `native_execution.py` wire dict + the relay `.or_else()`. The end-to-end test surfaced this.
2. Corrected the Tencent OpenAI-compatible base to `https://api.hunyuan.cloud.tencent.com/v1` (verified vs Tencent docs; `hunyuan.tencentcloudapi.com` is the TC3-HMAC signed API). `reasoning_content` confirmed as Tencent's native output field.

## Catalog dependency (owner's side)
hy4-preview exists in the live catalog but isn't stamped with the new fields. After 0.7.29 pins + deploys, stamp the live hy4-preview rung (`hunyuan_reasoning_route_sha256` + `reasoning_output_exposed=true`) so the LIVE 7-check gate passes. This PR proves 1–6 in fixtures with a synthetic rung.

## Validation
161 Rust tests (fmt/clippy clean), 1467 Python tests green (reasoning_carrier byte-identical + native_reasoning + #752 adaptation + layout ≤999); only non-pass is the known `native_truncation` first-byte timing flake (unrelated — sends no reasoning). ty/ruff clean. Engine version stays 0.7.28 (bumped to 0.7.29 at cut); native crate 0.3.29 + floor lockstep + uv.lock relocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)