### PR TITLE
feat(gateway): derive prompt_cache_key from sticky episode

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -342,7 +342,15 @@ every rung (dropping it would hand prose to a caller who asked for JSON) — and
 only on rungs dispatching tenant-owned (BYOK) credentials, where the caller pays the provider
 directly; host-funded rungs never emit it (the tier changes provider pricing while the gateway
 bills catalog rates) and a route with no eligible rung drops it with disclosure. Anthropic's own
-`service_tier` stays a recorded Messages-surface rejection. On `maximize_cache` pools, a cache-marked request dispatches
+`service_tier` stays a recorded Messages-surface rejection. `prompt_cache_key` stays a recorded
+metadata-only cache-routing hint and is never an end-user identity (it never feeds
+`attribution_label`): when a sticky project episode (a Responses continuation or a caller
+session/idempotency affinity key on a project alias) omits it, admission derives one stable
+hashed key from the tenant namespace, the episode digest, and the frozen activation reference, so
+every turn of one episode lands on the same provider cache bucket without disclosing any of those
+components; a caller-supplied key always wins. The effective key forwards only on OpenAI-family
+rungs dispatching tenant-owned (BYOK) credentials; every other rung omits it structurally, with
+no decline and no disclosure, because a cache hint changes cost, never semantics. On `maximize_cache` pools, a cache-marked request dispatches
 marker-honoring (Anthropic Messages) rungs before marker-dropping wires, stably within each
 group, so a shim rung can no longer silently bill every turn's full context uncached while the
 native rung stands ready; routes narrowing to only marker-dropping wires keep disclosing the

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -595,10 +595,11 @@ class GatewayRequest(ContractModel):
     include_usage: bool = False
     previous_response_id: str | None = Field(default=None, min_length=1, max_length=256)
     metadata: JsonObject = Field(default_factory=dict)
-    # End-user attribution / cache hints from the OpenAI request. Captured for
-    # gateway-side attribution and never forwarded to the model. `safety_identifier`
-    # is the current stable end-user identifier; `user` its deprecated predecessor;
-    # `prompt_cache_key` a same-prefix cache-routing hint (never an identity).
+    # End-user attribution / cache hints from the OpenAI request. Attribution
+    # (`safety_identifier`, its deprecated `user` predecessor) stays gateway-side
+    # and never reaches the model. `prompt_cache_key` is a same-prefix cache-routing
+    # hint (never an identity): a sticky project episode that omitted it gets a
+    # derived hashed key at admission, forwarded only on BYOK OpenAI-family rungs.
     safety_identifier: str | None = Field(default=None, max_length=1024)
     user: str | None = Field(default=None, max_length=1024)
     prompt_cache_key: str | None = Field(default=None, max_length=1024)

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -17,7 +17,12 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 
-from exp.runtime.gateway.contracts import AuthorizationSnapshot, DirectTarget, GatewayRequest
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    GatewayRequest,
+    ProjectTarget,
+)
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_execution import (
@@ -26,7 +31,11 @@ from exp.runtime.gateway.native_execution import (
     select_route_deployments,
 )
 from exp.runtime.gateway.native_responses import ContinuationContext
-from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
+from exp.runtime.gateway.routing import (
+    GatewayRoute,
+    GatewayRoutingError,
+    sticky_prompt_cache_key,
+)
 from exp.runtime.models.providers import preflight_gateway_request
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.capability_policy import (
@@ -417,27 +426,100 @@ def resolve_admission_route(
     """
     if isinstance(authorization.target, DirectTarget):
         return components.routes.resolve_direct(authorization)
+    return components.routes.resolve_project_blocking(
+        authorization=authorization,
+        request=request,
+        episode_namespace=admission_episode_namespace(
+            authorization, request, continuation=continuation
+        ),
+    )
+
+
+def admission_episode_namespace(
+    authorization: AuthorizationSnapshot,
+    request: GatewayRequest,
+    *,
+    continuation: ContinuationContext | None,
+) -> tuple[str, str, str, str]:
+    """Build the tenant-isolated sticky episode identity for one admission.
+
+    A Responses continuation carries its original turn's episode key, so a
+    continued request joins the same selection episode. Every other request
+    derives its episode from the caller-supplied affinity key, falling back
+    to the request ID for unkeyed calls.
+
+    Args:
+        authorization: Frozen authenticated alias revision and target.
+        request: Canonical request carrying the caller affinity headers.
+        continuation: Resolved Responses continuation state when present.
+
+    Returns:
+        Four-part namespace shared by router selection and cache-key
+        derivation, so the two can never drift.
+    """
     if continuation is not None:
-        episode = (
+        return (
             authorization.organization_id,
             authorization.identity_id,
             authorization.alias_revision_id,
             continuation.episode_key,
         )
-    else:
-        episode = episode_namespace(
-            namespace=ProtocolNamespace(
-                organization_id=authorization.organization_id,
-                identity_id=authorization.identity_id,
-                alias_revision_id=authorization.alias_revision_id,
-            ),
-            # The session-scoped correlation id is the stronger affinity
-            # scope; a per-operation idempotency key only pins retries.
-            caller_episode_key=request.client_request_id or request.idempotency_key,
-            request_id=authorization.request_id,
-        )
-    return components.routes.resolve_project_blocking(
-        authorization=authorization,
-        request=request,
-        episode_namespace=episode,
+    return episode_namespace(
+        namespace=ProtocolNamespace(
+            organization_id=authorization.organization_id,
+            identity_id=authorization.identity_id,
+            alias_revision_id=authorization.alias_revision_id,
+        ),
+        # The session-scoped correlation id is the stronger affinity
+        # scope; a per-operation idempotency key only pins retries.
+        caller_episode_key=request.client_request_id or request.idempotency_key,
+        request_id=authorization.request_id,
+    )
+
+
+def sticky_cache_request(
+    authorization: AuthorizationSnapshot,
+    request: GatewayRequest,
+    *,
+    continuation: ContinuationContext | None = None,
+) -> GatewayRequest:
+    """Fill an omitted ``prompt_cache_key`` from the sticky episode identity.
+
+    A caller-supplied key always wins and is returned untouched. Derivation
+    applies only when the request participates in a stable sticky episode: a
+    project target (whose frozen activation is the policy the episode sticks
+    to) plus either a Responses continuation or a caller affinity key. An
+    unkeyed one-shot request stays keyless, because a per-request unique key
+    would scatter identical prefixes across provider cache buckets. The
+    derived value is a hash of the tenant namespace, episode digest, and
+    activation reference, so it discloses no identity; it never feeds
+    ``attribution_label``.
+
+    Args:
+        authorization: Frozen authenticated alias revision and target.
+        request: Canonical request produced by the public protocol decoder.
+        continuation: Resolved Responses continuation state when present.
+
+    Returns:
+        The request with a derived ``prompt_cache_key``, or unchanged.
+    """
+    if request.prompt_cache_key is not None:
+        return request
+    target = authorization.target
+    if not isinstance(target, ProjectTarget):
+        return request
+    if (
+        continuation is None
+        and request.client_request_id is None
+        and request.idempotency_key is None
+    ):
+        return request
+    namespace = admission_episode_namespace(authorization, request, continuation=continuation)
+    return request.model_copy(
+        update={
+            "prompt_cache_key": sticky_prompt_cache_key(
+                namespace,
+                policy_id=target.activation_ref,
+            )
+        }
     )

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -13,18 +13,24 @@ from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
     GatewayMessage,
     GatewayRequest,
+    GatewayTarget,
     GatewayToolDefinition,
+    ProjectTarget,
 )
 from exp.runtime.gateway.native_admission import (
     _prefer_cache_capable_rungs,
+    admission_episode_namespace,
     admitted_route_requests,
     protocol_compatible_indexes,
     route_rejection,
+    sticky_cache_request,
 )
 from exp.runtime.gateway.native_dispatch import NativeWireClient
-from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.gateway.native_responses import ContinuationContext
+from exp.runtime.gateway.routing import GatewayRoute, sticky_prompt_cache_key
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderCapabilityError, ProviderParameterError
+from exp.runtime.openai_protocol.state import ProtocolNamespace
 
 
 def _deployment(
@@ -453,3 +459,126 @@ def test_disabled_thinking_on_an_adaptive_only_mixed_route_is_dropped_with_discl
     assert public.ignored_parameters == ("thinking.type->adaptive",)
     assert provider.provider_thinking_config is None
     assert accounting.recorded == 1
+
+
+def _project_target() -> ProjectTarget:
+    """Build one frozen project target for sticky cache-key tests."""
+    return ProjectTarget(
+        project_ref="project-one",
+        activation_ref="activation-one",
+        catalog_sha256="a" * 64,
+    )
+
+
+def _sticky_authorization(target: GatewayTarget) -> AuthorizationSnapshot:
+    """Build one frozen authorization over the given target."""
+    return AuthorizationSnapshot(
+        request_id="request-one",
+        organization_id="organization-one",
+        identity_id="identity-one",
+        virtual_key_id="key-one",
+        alias="coding",
+        alias_revision_id="revision-one",
+        target=target,
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        catalog_sha256="a" * 64,
+        canonical_request_sha256="d" * 64,
+        deadline_monotonic=1.0,
+    )
+
+
+def _sticky_request(
+    *,
+    client_request_id: str | None = None,
+    idempotency_key: str | None = None,
+    prompt_cache_key: str | None = None,
+    safety_identifier: str | None = None,
+) -> GatewayRequest:
+    """Build one chat request with optional affinity and cache-hint fields."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        client_request_id=client_request_id,
+        idempotency_key=idempotency_key,
+        prompt_cache_key=prompt_cache_key,
+        safety_identifier=safety_identifier,
+    )
+
+
+def test_sticky_cache_request_derives_a_key_for_a_keyed_project_episode() -> None:
+    """A project request with a session key and no cache key gets a derived one."""
+    authorization = _sticky_authorization(_project_target())
+    request = _sticky_request(client_request_id="session-one")
+
+    derived = sticky_cache_request(authorization, request)
+
+    assert derived.prompt_cache_key == sticky_prompt_cache_key(
+        admission_episode_namespace(authorization, request, continuation=None),
+        policy_id="activation-one",
+    )
+    # Deterministic: the same episode derives the same key on every turn.
+    assert sticky_cache_request(authorization, request).prompt_cache_key == (
+        derived.prompt_cache_key
+    )
+    # An idempotency key alone also names a stable episode.
+    retried = sticky_cache_request(authorization, _sticky_request(idempotency_key="op-one"))
+    assert retried.prompt_cache_key is not None
+    assert retried.prompt_cache_key != derived.prompt_cache_key
+
+
+def test_sticky_cache_request_preserves_a_caller_supplied_key() -> None:
+    """A caller-supplied prompt_cache_key always wins over derivation."""
+    authorization = _sticky_authorization(_project_target())
+    request = _sticky_request(client_request_id="session-one", prompt_cache_key="caller-key")
+
+    assert sticky_cache_request(authorization, request) is request
+
+
+def test_sticky_cache_request_leaves_unkeyed_and_direct_requests_alone() -> None:
+    """No sticky episode means no derived key: unkeyed one-shots and direct targets."""
+    unkeyed = _sticky_request()
+    assert sticky_cache_request(_sticky_authorization(_project_target()), unkeyed) is unkeyed
+
+    keyed = _sticky_request(client_request_id="session-one")
+    direct = _sticky_authorization(DirectTarget(pool_id="pool-one"))
+    assert sticky_cache_request(direct, keyed) is keyed
+
+
+def test_sticky_cache_request_joins_the_continuation_episode() -> None:
+    """A continued Responses turn derives from its original turn's episode key."""
+    authorization = _sticky_authorization(_project_target())
+    continuation = ContinuationContext(
+        namespace=ProtocolNamespace(
+            organization_id="organization-one",
+            identity_id="identity-one",
+            alias_revision_id="revision-one",
+        ),
+        episode_key="b" * 64,
+        response_id="resp_one",
+        messages=(),
+    )
+
+    derived = sticky_cache_request(authorization, _sticky_request(), continuation=continuation)
+
+    assert derived.prompt_cache_key == sticky_prompt_cache_key(
+        ("organization-one", "identity-one", "revision-one", "b" * 64),
+        policy_id="activation-one",
+    )
+
+
+def test_sticky_cache_request_never_touches_attribution() -> None:
+    """The derived key is a cache hint, never an end-user identity."""
+    authorization = _sticky_authorization(_project_target())
+    request = _sticky_request(client_request_id="session-one", safety_identifier="sha256:user")
+
+    derived = sticky_cache_request(authorization, request)
+
+    assert derived.prompt_cache_key is not None
+    assert derived.attribution_label == "sha256:user"
+    assert derived.prompt_cache_key != derived.attribution_label
+
+    anonymous = sticky_cache_request(
+        authorization, _sticky_request(client_request_id="session-one")
+    )
+    assert anonymous.prompt_cache_key is not None
+    assert anonymous.attribution_label is None

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -52,7 +52,11 @@ from exp.runtime.gateway.native_accounting import (
 from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
 )
-from exp.runtime.gateway.native_admission import admitted_route_requests, resolve_admission_route
+from exp.runtime.gateway.native_admission import (
+    admitted_route_requests,
+    resolve_admission_route,
+    sticky_cache_request,
+)
 from exp.runtime.gateway.native_batches import NativeBatchRelayMixin
 from exp.runtime.gateway.native_bridge_errors import (
     escalation as _escalation,
@@ -377,6 +381,10 @@ class NativeControlPlane(
             # Execution receives authenticated plaintext, but the bounded
             # continuation store keeps the post-guardrail history sealed.
             continuation_context.messages = retention_request.messages
+
+        # A sticky project episode that omitted prompt_cache_key gets a derived
+        # cache-routing key; a caller key is never touched (sticky_cache_request).
+        request = sticky_cache_request(authorization, request, continuation=continuation_context)
 
         # The ledger accepts the logical request before route selection, so a
         # keyed operation whose durable terminal already exists (or whose key

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -3530,6 +3530,50 @@ def test_project_alias_native_selection_matches_the_python_resolver(tmp_path: Pa
         thread.join(timeout=2)
 
 
+def test_project_alias_sticky_session_derives_a_prompt_cache_key(tmp_path: Path) -> None:
+    """A keyed project session forwards one stable derived prompt_cache_key.
+
+    The caller omitted ``prompt_cache_key``, so admission derives a stable
+    hashed key from the sticky episode identity and the BYOK OpenAI-family
+    rung forwards it. The same session key derives the same cache key on the
+    next turn, an unkeyed one-shot stays keyless, and a caller-supplied key
+    forwards verbatim instead of being replaced.
+    """
+    _manager, control, raw_key = _project_control_plane(tmp_path)
+
+    first = _admit_started(control, raw_key, _chat_body(), client_request_id="session-sticky")
+    payload = first["upstream_payload"]
+    assert isinstance(payload, dict)
+    derived = payload["prompt_cache_key"]
+    assert isinstance(derived, str)
+    assert derived.startswith("gateway-sticky-prompt-cache-")
+    assert "session-sticky" not in derived
+
+    second = _admit_started(control, raw_key, _chat_body(), client_request_id="session-sticky")
+    second_payload = second["upstream_payload"]
+    assert isinstance(second_payload, dict)
+    assert second_payload["prompt_cache_key"] == derived
+
+    other = _admit_started(control, raw_key, _chat_body(), client_request_id="session-other")
+    other_payload = other["upstream_payload"]
+    assert isinstance(other_payload, dict)
+    assert other_payload["prompt_cache_key"] != derived
+
+    unkeyed = _admit_started(control, raw_key, _chat_body())
+    unkeyed_payload = unkeyed["upstream_payload"]
+    assert isinstance(unkeyed_payload, dict)
+    assert "prompt_cache_key" not in unkeyed_payload
+
+    body = json.loads(_chat_body())
+    body["prompt_cache_key"] = "caller-cache-key"
+    supplied = _admit_started(
+        control, raw_key, json.dumps(body), client_request_id="session-sticky"
+    )
+    supplied_payload = supplied["upstream_payload"]
+    assert isinstance(supplied_payload, dict)
+    assert supplied_payload["prompt_cache_key"] == "caller-cache-key"
+
+
 def test_responses_continuation_reuses_the_original_selection_episode(
     tmp_path: Path,
 ) -> None:

--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -859,3 +859,39 @@ def project_episode_identity(
             "episode_key": episode_key,
         },
     )
+
+
+def sticky_prompt_cache_key(
+    namespace: tuple[ArtifactId, ArtifactId, ArtifactId, str],
+    *,
+    policy_id: str,
+) -> str:
+    """Derive one stable provider cache-routing key for a sticky episode.
+
+    The key is a content-addressed hash of the tenant namespace, the sticky
+    episode digest, and the frozen policy identity, so every request in one
+    sticky episode lands on the same provider cache bucket while the value
+    discloses none of those components. It is a cache-routing hint, never an
+    end-user identity: it must never feed ``attribution_label`` or any other
+    identity surface.
+
+    Args:
+        namespace: Organization, identity, alias revision, and sticky episode
+            digest, exactly as passed to router selection.
+        policy_id: Frozen activation reference whose selection the episode
+            sticks to; a new activation starts a fresh cache lineage.
+
+    Returns:
+        Stable content-addressed key safe to forward as ``prompt_cache_key``.
+    """
+    organization_id, identity_id, alias_revision_id, episode_key = namespace
+    return stable_id(
+        "gateway-sticky-prompt-cache",
+        {
+            "organization_id": organization_id,
+            "identity_id": identity_id,
+            "alias_revision_id": alias_revision_id,
+            "episode_key": episode_key,
+            "policy_id": policy_id,
+        },
+    )

--- a/exp/runtime/gateway/routing_test.py
+++ b/exp/runtime/gateway/routing_test.py
@@ -19,7 +19,11 @@ from exp.common.models.gateway_catalog import (
     NormalizedGatewayCatalog,
 )
 from exp.common.models.model import ModelCapabilities
-from exp.runtime.gateway.routing import CatalogRouteResolver
+from exp.runtime.gateway.routing import (
+    CatalogRouteResolver,
+    project_episode_identity,
+    sticky_prompt_cache_key,
+)
 
 _REVISION = "revision-one"
 
@@ -308,3 +312,46 @@ def test_index_serves_a_cross_version_catalog_under_its_pinned_digest() -> None:
     )
 
     assert metadata is not None
+
+
+def test_sticky_prompt_cache_key_is_stable_and_component_sensitive() -> None:
+    """One sticky episode derives one key; every identity component changes it."""
+    namespace = ("organization-one", "identity-one", "revision-one", "e" * 64)
+    key = sticky_prompt_cache_key(namespace, policy_id="activation-one")
+
+    assert key == sticky_prompt_cache_key(namespace, policy_id="activation-one")
+    assert key.startswith("gateway-sticky-prompt-cache-")
+    assert len(key) <= 1024
+
+    variants = {
+        sticky_prompt_cache_key(
+            ("organization-two", "identity-one", "revision-one", "e" * 64),
+            policy_id="activation-one",
+        ),
+        sticky_prompt_cache_key(
+            ("organization-one", "identity-two", "revision-one", "e" * 64),
+            policy_id="activation-one",
+        ),
+        sticky_prompt_cache_key(
+            ("organization-one", "identity-one", "revision-two", "e" * 64),
+            policy_id="activation-one",
+        ),
+        sticky_prompt_cache_key(
+            ("organization-one", "identity-one", "revision-one", "f" * 64),
+            policy_id="activation-one",
+        ),
+        sticky_prompt_cache_key(namespace, policy_id="activation-two"),
+    }
+    assert key not in variants
+    assert len(variants) == 5
+
+
+def test_sticky_prompt_cache_key_discloses_no_identity_component() -> None:
+    """The derived key is a hash: no namespace or policy component appears in it."""
+    namespace = ("orgsecret", "identitysecret", "revisionsecret", "a1b2" * 16)
+    key = sticky_prompt_cache_key(namespace, policy_id="activationsecret")
+
+    for component in (*namespace, "activationsecret"):
+        assert component not in key
+    # The cache key never collides with the selection episode identity itself.
+    assert key != project_episode_identity(namespace)

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -39,6 +39,7 @@ def openai_responses_stream_payload(
     reasoning_effort: str | None = None,
     sampling_requires_reasoning_none: bool = False,
     forwards_service_tier: bool = False,
+    forwards_prompt_cache_key: bool = False,
 ) -> JsonObject:
     """Translate one canonical request to native streaming Responses JSON.
 
@@ -132,6 +133,12 @@ def openai_responses_stream_payload(
         # BYOK-only: the caller pays this provider directly, so their tier
         # selection (and its pricing) is between them and the provider.
         payload["service_tier"] = request.service_tier
+    if request.prompt_cache_key is not None and forwards_prompt_cache_key:
+        # BYOK-only cache-routing hint (caller-supplied or derived from the
+        # sticky episode identity): it changes cache-hit cost, never
+        # semantics, so ineligible rungs omit it structurally with no
+        # decline and no disclosure.
+        payload["prompt_cache_key"] = request.prompt_cache_key
     # Native OpenAI Responses has no top-k request field. Never trust a
     # mistaken route declaration to send this extension to the API.
     del supports_top_k
@@ -169,6 +176,7 @@ def openai_compatible_stream_payload(
     sampling_requires_reasoning_none: bool = False,
     fireworks_reasoning_route_sha256: str | None = None,
     forwards_service_tier: bool = False,
+    forwards_prompt_cache_key: bool = False,
 ) -> JsonObject:
     """Translate one canonical request to streaming Chat Completions JSON.
 
@@ -244,6 +252,9 @@ def openai_compatible_stream_payload(
     if request.service_tier is not None and forwards_service_tier:
         # BYOK-only, matching the native Responses lane.
         payload["service_tier"] = request.service_tier
+    if request.prompt_cache_key is not None and forwards_prompt_cache_key:
+        # BYOK-only cache-routing hint, matching the native Responses lane.
+        payload["prompt_cache_key"] = request.prompt_cache_key
     if supports_reasoning and effective_reasoning_effort is not None:
         if reasoning_wire_format == "reasoning":
             payload["reasoning"] = {"effort": effective_reasoning_effort}

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -137,6 +137,7 @@ def dialect_stream_payload(
             reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
             forwards_service_tier=profile.billing_customer_managed,
+            forwards_prompt_cache_key=profile.billing_customer_managed,
         )
     if profile.dialect == "anthropic_messages":
         return anthropic_messages_stream_payload(
@@ -204,6 +205,7 @@ def dialect_stream_payload(
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
             fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
             forwards_service_tier=profile.billing_customer_managed,
+            forwards_prompt_cache_key=profile.billing_customer_managed,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")
 

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -3342,6 +3342,74 @@ def test_service_tier_route_shaping_forwards_on_byok_and_discloses_elsewhere() -
     assert foreign_provider.service_tier is None
 
 
+def _cache_keyed_request(surface: GatewayApiSurface) -> GatewayRequest:
+    """Build one streaming request carrying an explicit prompt cache key."""
+    return GatewayRequest(
+        surface=surface,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        prompt_cache_key="gateway-sticky-prompt-cache-0123456789abcdef0123",
+        stream=True,
+        include_usage=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("dialect", "surface"),
+    (
+        ("openai_compatible", GatewayApiSurface.CHAT_COMPLETIONS),
+        ("openai_responses", GatewayApiSurface.RESPONSES),
+    ),
+)
+def test_prompt_cache_key_forwards_only_on_byok_openai_dialects(
+    dialect: str,
+    surface: GatewayApiSurface,
+) -> None:
+    """Both OpenAI wire dialects carry the cache key verbatim on BYOK rungs only.
+
+    The key (caller-supplied or derived from the sticky episode) is a
+    cache-routing hint the caller's own provider account can honor; a
+    house-funded rung omits it structurally, never a decline, so the rung
+    stays in the route as a fallback.
+    """
+    byok = GatewayWireProfile(
+        dialect=dialect,
+        url="https://provider.test",
+        model_id="model-x",
+        billing_customer_managed=True,
+    )
+    payload = dialect_stream_payload(byok, _cache_keyed_request(surface))
+    assert payload["prompt_cache_key"] == "gateway-sticky-prompt-cache-0123456789abcdef0123"
+
+    hosted = GatewayWireProfile(dialect=dialect, url="https://provider.test", model_id="model-x")
+    hosted_payload = dialect_stream_payload(hosted, _cache_keyed_request(surface))
+    assert "prompt_cache_key" not in hosted_payload
+
+
+@pytest.mark.parametrize(
+    "dialect",
+    ("anthropic_messages", "gemini_generate_content", "bedrock_converse_stream"),
+)
+def test_prompt_cache_key_never_declines_a_foreign_dialect(dialect: str) -> None:
+    """A cache hint changes cost, not semantics: foreign wires serve without it.
+
+    Unlike ``service_tier`` (a pricing commitment that must decline where no
+    wire field preserves it), a dropped cache key only forgoes a provider
+    cache optimization, so the rung serves with the field omitted.
+    """
+    profile = GatewayWireProfile(
+        dialect=dialect,
+        url="https://provider.test",
+        model_id="model-x",
+        billing_customer_managed=True,
+    )
+
+    payload = dialect_stream_payload(
+        profile, _cache_keyed_request(GatewayApiSurface.CHAT_COMPLETIONS)
+    )
+
+    assert "prompt_cache_key" not in payload
+
+
 def test_narrowing_surfaces_the_first_rung_rejection_not_the_route_shape() -> None:
     """When no rung serves, the caller sees the first rung's own field-scoped reason."""
     anthropic = GatewayWireProfile(

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -78,10 +78,13 @@ CHAT_MANIFEST = CompatibilityManifest(
         # request). Admit it only once response normalization emits logprobs.
         _field("top_logprobs", CompatibilityDisposition.UNSUPPORTED),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
-        # End-user attribution / cache hints (OpenAI spec). Accepted and recorded
-        # gateway-side, never forwarded to the model: `safety_identifier` is the
-        # current stable end-user identifier, `user` its deprecated predecessor,
-        # `prompt_cache_key` a same-prefix cache-routing hint (not identity).
+        # End-user attribution / cache hints (OpenAI spec). `safety_identifier`
+        # (the current stable end-user identifier) and `user` (its deprecated
+        # predecessor) are accepted and recorded gateway-side, never forwarded.
+        # `prompt_cache_key` is a same-prefix cache-routing hint (not identity):
+        # recorded gateway-side, derived from the sticky episode identity when a
+        # keyed project request omits it, and forwarded only on BYOK
+        # OpenAI-family rungs; ineligible rungs omit it with no disclosure.
         _field("safety_identifier", CompatibilityDisposition.METADATA_ONLY),
         _field("user", CompatibilityDisposition.METADATA_ONLY),
         _field("prompt_cache_key", CompatibilityDisposition.METADATA_ONLY),
@@ -154,7 +157,9 @@ RESPONSES_MANIFEST = CompatibilityManifest(
         _field("prompt_cache_options", CompatibilityDisposition.SUPPORTED),
         _field("metadata", CompatibilityDisposition.METADATA_ONLY),
         # End-user attribution / cache hints (OpenAI spec), same handling as the
-        # Chat surface: accepted and recorded gateway-side, never forwarded.
+        # Chat surface: attribution fields stay gateway-side, and
+        # `prompt_cache_key` (derived from the sticky episode when omitted)
+        # forwards only on BYOK OpenAI-family rungs.
         _field("safety_identifier", CompatibilityDisposition.METADATA_ONLY),
         _field("user", CompatibilityDisposition.METADATA_ONLY),
         _field("prompt_cache_key", CompatibilityDisposition.METADATA_ONLY),

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -812,6 +812,18 @@ def test_chat_attribution_label_falls_back_to_deprecated_user() -> None:
     assert decoded.request.attribution_label == "u-1"
 
 
+def test_chat_decoder_leaves_an_omitted_prompt_cache_key_absent() -> None:
+    """Decode never invents a cache key; sticky derivation is admission-owned."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        client_request_id="session-one",
+    )
+    assert decoded.request.prompt_cache_key is None
+
+
 def test_prompt_cache_key_is_never_an_attribution_label() -> None:
     """prompt_cache_key is a cache-routing hint, not an end-user identity."""
     decoded = decode_chat(

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -404,7 +404,8 @@ class _ChatRequest(_WireModel):
     stream: bool = False
     stream_options: _ChatStreamOptions | None = None
     metadata: JsonObject = Field(default_factory=dict)
-    # End-user attribution / cache hints; captured, never forwarded to the model.
+    # End-user attribution / cache hints; attribution fields are captured and
+    # never forwarded; prompt_cache_key forwards only on BYOK OpenAI-family rungs.
     safety_identifier: str | None = Field(default=None, max_length=1024)
     user: str | None = Field(default=None, max_length=1024)
     prompt_cache_key: str | None = Field(default=None, max_length=1024)
@@ -732,7 +733,8 @@ class _ResponsesRequest(_WireModel):
     stream: bool = False
     client_metadata: JsonObject | None = None
     metadata: JsonObject = Field(default_factory=dict)
-    # End-user attribution / cache hints; captured, never forwarded to the model.
+    # End-user attribution / cache hints; attribution fields are captured and
+    # never forwarded; prompt_cache_key forwards only on BYOK OpenAI-family rungs.
     safety_identifier: str | None = Field(default=None, max_length=1024)
     user: str | None = Field(default=None, max_length=1024)
     prompt_cache_key: str | None = Field(default=None, max_length=1024)


### PR DESCRIPTION
## Motivation

A caller riding a sticky project episode (a session correlation id, an idempotency key, or a Responses continuation) keeps landing on the same frozen selection, so its turns share a long common prefix. When such a caller omits `prompt_cache_key`, OpenAI-family providers route those turns by prefix alone and the episode loses the cache affinity the caller could have had for free. Filling the gap with a raw session id would leak caller identity to the provider, so the gateway needs a derived, non-identifying key.

## Approach

- `sticky_prompt_cache_key` in `exp/runtime/gateway/routing.py`, next to the sticky selection bridge (`project_episode_identity`): a content-addressed hash of the tenant namespace (organization, identity, alias revision), the sticky episode digest, and the frozen activation reference (the policy the episode sticks to). The value discloses none of its components.
- `sticky_cache_request` in `exp/runtime/gateway/native_admission.py` applies it during admission, before any provider payload is built. Derivation runs only when the request has a stable sticky episode: a project target plus either a Responses continuation or a caller affinity key. A caller-supplied `prompt_cache_key` always wins and is returned untouched; unkeyed one-shots stay keyless (a per-request unique key would scatter identical prefixes across provider cache buckets). The episode namespace computation is shared with router selection through `admission_episode_namespace`, so the cache key and the selection episode cannot drift.
- The effective key (caller-supplied or derived) forwards only on OpenAI-family rungs dispatching tenant-owned (BYOK) credentials, mirroring the existing `service_tier` gating in `dialect_stream_payload`. Ineligible rungs omit it structurally: no decline and no disclosure, because a cache hint changes cost, never semantics.
- Semantics preserved: the manifest disposition stays METADATA_ONLY, `attribution_label` never reads `prompt_cache_key`, replay identity is unaffected (the canonical request digest is frozen from the caller's own body before derivation), and derivation is deterministic so retries produce byte-identical frozen dispatch bodies.
- Short note added to `docs/reference/gateway-architecture.md` next to the `service_tier` forwarding rules.

## Tests

- `routing_test.py`: the derived key is stable, sensitive to every namespace and policy component, and discloses none of them.
- `native_admission_test.py`: omit derives; present preserves; direct targets and unkeyed one-shots stay untouched; a continuation joins its original turn's episode; `attribution_label` is unchanged by derivation.
- `native_bridge_test.py`: end-to-end admission over a real project alias forwards one stable derived key across turns of the same session, a different session derives a different key, an unkeyed admit carries no key, and a caller-supplied key forwards verbatim.
- `requests_test.py`: decode never invents a key (derivation is admission-owned).
- `streaming_requests_test.py`: both OpenAI wire dialects forward the key on BYOK rungs only; hosted rungs and foreign dialects omit it without declining.

`uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` all pass. `uv run pytest -q` passes for every affected suite; the only failures in a full local run are pre-existing terminal-emulation issues in `exp/cli/shared/picker*` tests that reproduce identically on an unmodified `main` checkout in this environment.