### PR TITLE
feat(router): cache-aware rare-switch sticky policy

### DIFF
--- a/docs/reference/router_optimization_config.md
+++ b/docs/reference/router_optimization_config.md
@@ -110,6 +110,33 @@ result = report_router(store, fit, report_config)
 `fit_router` locks the policy before `report_router` reads held-out evidence. `optimize_router`
 performs both calls in that order for a complete `RouterOptimizationConfig`.
 
+## Cache-aware rare-switch sticky routing
+
+A retained episode alias keeps its provider prompt cache warm, so the frozen runtime treats a
+mid-episode alias change as a priced decision rather than a free improvement. `KnnGuard` carries a
+`cache_switch` gate with two optional fields:
+
+| Field | Meaning |
+|---|---|
+| `enabled` | Defaults to `true`. Setting `false` restores unconditional episode stickiness. |
+| `switch_gain_per_amortized_usd` | Fitted quality gain required per US dollar of forfeited prompt-cache write amortization. Defaults to `10.0` and must be positive and finite. |
+
+When a fresh guarded selection proposes a different alias for an episode that already holds a
+sticky decision, the runtime prices the remaining amortization from the frozen pricing snapshot:
+the proposed alias's cache-write rate (never below its ordinary input rate) against the sticky
+alias's cached-read rate, over the conservative request token ceiling. The switch happens only
+when the workload-weighted fitted quality gain of the proposed alias strictly exceeds
+`switch_gain_per_amortized_usd` times that amortization. A capability-rejected sticky alias still
+switches to an eligible candidate. Missing fit pairing between the two candidates, or a pricing
+snapshot without either candidate row, fails closed to the sticky alias with no silent zero
+substitution.
+
+Every weighed comparison is recorded on the `RoutingDecision` as `switch_outcome`, either
+`"switched"` or `"switch_suppressed_cache"`, and the field stays absent for turns that never
+weighed a switch. A guard whose gate keeps all defaults serializes without the `cache_switch`
+field, so existing policy bytes, replayed policy identities, and persisted decision identities are
+unchanged.
+
 ## Separate world-model fidelity measurement
 
 Fidelity testing is an explicit common-evaluation workflow. Call

--- a/exp/common/routing/__init__.py
+++ b/exp/common/routing/__init__.py
@@ -17,11 +17,19 @@ from exp.common.routing.features import (
     RouterFeatureExtractor,
     RouterFeatureRecord,
 )
-from exp.common.routing.policy import KnnGuard, KnnRouterPolicy, RouterPolicy, RoutingDecision
+from exp.common.routing.policy import (
+    CacheSwitchGuard,
+    KnnGuard,
+    KnnRouterPolicy,
+    RouterPolicy,
+    RoutingDecision,
+    SwitchOutcome,
+)
 
 __all__ = [
     "ROUTER_FEATURE_EXTRACTOR_ID",
     "ROUTER_FEATURE_SCHEMA_SHA256",
+    "CacheSwitchGuard",
     "KnnGuard",
     "KnnRouterPolicy",
     "RouterFeatureExtractor",
@@ -29,6 +37,7 @@ __all__ = [
     "RouterEmbeddingReservation",
     "RouterPolicy",
     "RoutingDecision",
+    "SwitchOutcome",
     "FrozenEmbedding",
     "FrozenEmbeddingClient",
     "FrozenEmbeddingSet",

--- a/exp/common/routing/decision.py
+++ b/exp/common/routing/decision.py
@@ -166,6 +166,38 @@ def policy_content_sha256(policy: KnnRouterPolicy) -> Sha256:
     return sha256_json(policy)
 
 
+def fitted_quality_gain(
+    bank: KnnEvidenceBank,
+    *,
+    incumbent_alias: str,
+    challenger_alias: str,
+) -> float | None:
+    """Return the fit-evidence quality gain of one challenger over one incumbent.
+
+    The gain is the workload-weighted mean score difference over fit tasks where
+    both candidates were scored. It is a pure function of the frozen bank, so a
+    sticky-switch comparison never needs a request embedding or provider call.
+
+    Args:
+        bank: Verified fit-only evidence arrays.
+        incumbent_alias: Candidate column currently retained by a sticky episode.
+        challenger_alias: Candidate column proposed by a fresh guarded selection.
+
+    Returns:
+        Weighted mean score gain of the challenger, or ``None`` when the two
+        candidates share no jointly scored fit task.
+    """
+    incumbent_column = bank.candidate_aliases.index(incumbent_alias)
+    challenger_column = bank.candidate_aliases.index(challenger_alias)
+    incumbent_scores = bank.scores[:, incumbent_column].astype(np.float64)
+    challenger_scores = bank.scores[:, challenger_column].astype(np.float64)
+    paired = ~np.isnan(incumbent_scores) & ~np.isnan(challenger_scores)
+    if not bool(np.any(paired)):
+        return None
+    differences = challenger_scores[paired] - incumbent_scores[paired]
+    return float(np.average(differences, weights=bank.workload_weights[paired]))
+
+
 def _require_policy_bank_match(
     policy: KnnRouterPolicy,
     manifest: KnnBankManifest,

--- a/exp/common/routing/decision_test.py
+++ b/exp/common/routing/decision_test.py
@@ -1,0 +1,55 @@
+"""Tests for pure fit-evidence helpers used by cache-aware sticky routing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from exp.common.routing.bank import KnnEvidenceBank
+from exp.common.routing.decision import fitted_quality_gain
+
+
+def _bank(scores: tuple[tuple[float, float], ...]) -> KnnEvidenceBank:
+    """Build one minimal two-candidate bank around the given sparse score cells.
+
+    Args:
+        scores: Per-task ``(baseline, cheap)`` scores, using NaN for unscored cells.
+
+    Returns:
+        A validated bank with workload weights ``1, 1, 3`` over three fit tasks.
+    """
+    return KnnEvidenceBank(
+        task_ids=("task-1", "task-2", "task-3"),
+        candidate_aliases=("baseline", "cheap"),
+        embeddings=np.asarray(((1.0, 0.0), (0.0, 1.0), (1.0, 0.0)), dtype=np.float32),
+        scores=np.asarray(scores, dtype=np.float32),
+        candidate_costs=np.asarray(((0.5, 0.1),) * 3, dtype=np.float64),
+        score_counts=np.ones((3, 2), dtype=np.int32),
+        cost_counts=np.ones((3, 2), dtype=np.int32),
+        workload_weights=np.asarray((1.0, 1.0, 3.0), dtype=np.float64),
+        novelty_floor=0.0,
+    )
+
+
+def test_fitted_quality_gain_weights_jointly_scored_fit_tasks() -> None:
+    """Only jointly scored tasks contribute, weighted by their workload weights."""
+    bank = _bank(((0.2, 0.8), (0.5, float("nan")), (0.4, 0.9)))
+
+    gain = fitted_quality_gain(bank, incumbent_alias="baseline", challenger_alias="cheap")
+
+    assert gain == pytest.approx((1.0 * 0.6 + 3.0 * 0.5) / 4.0, abs=1e-6)
+    inverse = fitted_quality_gain(bank, incumbent_alias="cheap", challenger_alias="baseline")
+    assert inverse == pytest.approx(-(1.0 * 0.6 + 3.0 * 0.5) / 4.0, abs=1e-6)
+
+
+def test_fitted_quality_gain_is_none_without_a_jointly_scored_task() -> None:
+    """Disjoint score coverage yields no gain estimate instead of a silent zero."""
+    bank = _bank(
+        (
+            (0.2, float("nan")),
+            (float("nan"), 0.8),
+            (0.3, float("nan")),
+        )
+    )
+
+    assert fitted_quality_gain(bank, incumbent_alias="baseline", challenger_alias="cheap") is None

--- a/exp/common/routing/policy.py
+++ b/exp/common/routing/policy.py
@@ -16,6 +16,32 @@ from pydantic import (
 from exp.common.core.artifacts import ArtifactEnvelope, ArtifactId, ContractModel, Sha256
 from exp.common.models import ModelAlias, ModelSnapshot, RoutedCandidateSnapshot
 
+SwitchOutcome = Literal["switched", "switch_suppressed_cache"]
+"""How one sticky-episode decision resolved a proposed mid-episode alias change."""
+
+
+class CacheSwitchGuard(ContractModel):
+    """Cache-amortization gate on switching a sticky episode to a different alias.
+
+    A retained episode alias keeps its provider prompt cache warm. Switching to a
+    slightly better candidate forfeits that amortization, so an enabled gate allows
+    a mid-episode switch only when the fitted quality gain of the proposed alias
+    over the sticky alias strictly exceeds ``switch_gain_per_amortized_usd`` times
+    the conservative remaining prompt-cache write amortization in US dollars.
+    Disabling the gate restores unconditional episode stickiness.
+    """
+
+    enabled: bool = True
+    switch_gain_per_amortized_usd: float = Field(default=10.0, gt=0)
+
+    @field_validator("switch_gain_per_amortized_usd")
+    @classmethod
+    def _require_finite_rate(cls, value: float) -> float:
+        """Reject a non-finite quality-gain exchange rate."""
+        if not math.isfinite(value):
+            raise ValueError("cache-switch gain per amortized USD must be finite")
+        return value
+
 
 class KnnGuard(ContractModel):
     """Conservative evidence thresholds used by the offline guarded kNN policy."""
@@ -25,6 +51,7 @@ class KnnGuard(ContractModel):
     relative_similarity_threshold: float = Field(ge=0, le=1)
     uncertainty_multiplier: float = Field(gt=0)
     quality_tolerance: float
+    cache_switch: CacheSwitchGuard = Field(default_factory=CacheSwitchGuard)
 
     @field_validator("relative_similarity_threshold", "uncertainty_multiplier", "quality_tolerance")
     @classmethod
@@ -38,6 +65,23 @@ class KnnGuard(ContractModel):
         if self.minimum_paired_observations > self.maximum_neighbors:
             raise ValueError("minimum paired observations cannot exceed maximum neighbors")
         return self
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_default_cache_switch(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, object]:
+        """Omit an all-default cache-switch gate so default guard bytes stay stable.
+
+        Args:
+            handler: Standard field-by-field guard serializer.
+
+        Returns:
+            Serialized guard carrying the cache-switch gate only when configured.
+        """
+        serialized: dict[str, object] = handler(self)
+        if self.cache_switch == CacheSwitchGuard():
+            serialized.pop("cache_switch", None)
+        return serialized
 
 
 class RoutingDecision(ContractModel):
@@ -56,6 +100,7 @@ class RoutingDecision(ContractModel):
     estimated_quality_difference: float | None = None
     uncertainty: float | None = Field(default=None, ge=0)
     fallback_reason: str | None = Field(default=None, max_length=512)
+    switch_outcome: SwitchOutcome | None = None
 
     @field_validator("best_similarity", "estimated_quality_difference", "uncertainty")
     @classmethod
@@ -71,6 +116,23 @@ class RoutingDecision(ContractModel):
                 "routing decisions cannot have more paired observations than neighbors"
             )
         return self
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_absent_switch_outcome(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, object]:
+        """Omit an absent switch outcome so switch-free decision bytes stay stable.
+
+        Args:
+            handler: Standard field-by-field decision serializer.
+
+        Returns:
+            Serialized decision carrying the switch outcome only when one was weighed.
+        """
+        serialized: dict[str, object] = handler(self)
+        if self.switch_outcome is None:
+            serialized.pop("switch_outcome", None)
+        return serialized
 
 
 class KnnRouterPolicy(ArtifactEnvelope):

--- a/exp/common/routing/policy_test.py
+++ b/exp/common/routing/policy_test.py
@@ -9,7 +9,13 @@ from pydantic import TypeAdapter, ValidationError
 
 from exp.common.core.artifacts import sha256_json
 from exp.common.models import BillingSource, ModelSnapshot, RoutedCandidateSnapshot
-from exp.common.routing import KnnGuard, KnnRouterPolicy, RouterPolicy, RoutingDecision
+from exp.common.routing import (
+    CacheSwitchGuard,
+    KnnGuard,
+    KnnRouterPolicy,
+    RouterPolicy,
+    RoutingDecision,
+)
 
 _DIGEST = "a" * 64
 
@@ -124,6 +130,80 @@ def test_policy_rejects_unpinned_baseline_and_nonfinite_guard_values() -> None:
             neighbor_count=2,
             paired_count=3,
         )
+
+
+def test_cache_switch_gate_defaults_on_and_stays_out_of_default_guard_bytes() -> None:
+    """The gate is enabled by default and an all-default gate keeps legacy guard digests."""
+    policy = _policy()
+    assert policy.guard.cache_switch == CacheSwitchGuard(
+        enabled=True, switch_gain_per_amortized_usd=10.0
+    )
+
+    legacy_payload = policy.model_dump(mode="json")
+    assert "cache_switch" not in legacy_payload["guard"]
+
+    reloaded = KnnRouterPolicy.model_validate(legacy_payload)
+    assert reloaded.guard.cache_switch.enabled is True
+    assert sha256_json(reloaded) == sha256_json(legacy_payload)
+
+
+def test_configured_cache_switch_gate_serializes_and_round_trips() -> None:
+    """An explicitly disabled or re-priced gate is persisted and reloaded exactly."""
+    policy = _policy()
+    disabled = policy.model_copy(
+        update={
+            "guard": policy.guard.model_copy(
+                update={
+                    "cache_switch": CacheSwitchGuard(
+                        enabled=False, switch_gain_per_amortized_usd=25.0
+                    )
+                }
+            )
+        }
+    )
+    payload = disabled.model_dump(mode="json")
+
+    assert payload["guard"]["cache_switch"] == {
+        "enabled": False,
+        "switch_gain_per_amortized_usd": 25.0,
+    }
+    assert KnnRouterPolicy.model_validate(payload) == disabled
+    assert sha256_json(disabled) != sha256_json(policy)
+
+
+@pytest.mark.parametrize("rate", [0, -1.0, float("inf"), float("nan")])
+def test_cache_switch_gate_rejects_a_nonpositive_or_nonfinite_exchange_rate(
+    rate: float,
+) -> None:
+    """The gain-per-amortized-USD rate must stay a positive finite threshold."""
+    with pytest.raises(ValidationError, match="switch_gain_per_amortized_usd|finite"):
+        CacheSwitchGuard(switch_gain_per_amortized_usd=rate)
+
+
+def test_decision_switch_outcome_is_optional_bounded_and_absent_from_legacy_bytes() -> None:
+    """A recorded outcome round-trips while switch-free decisions keep their exact bytes."""
+    decision = RoutingDecision(
+        decision_id="decision-1",
+        policy_id="router-policy-v1",
+        policy_sha256=_DIGEST,
+        request_sha256=_DIGEST,
+        episode_id_sha256=_DIGEST,
+        selected_alias="candidate-economy",
+        baseline_alias="candidate-incumbent",
+        neighbor_count=2,
+        paired_count=2,
+    )
+    assert decision.switch_outcome is None
+    assert "switch_outcome" not in decision.model_dump(mode="json")
+
+    suppressed = decision.model_copy(update={"switch_outcome": "switch_suppressed_cache"})
+    payload = suppressed.model_dump(mode="json")
+    assert payload["switch_outcome"] == "switch_suppressed_cache"
+    assert RoutingDecision.model_validate(payload) == suppressed
+    assert sha256_json(suppressed) != sha256_json(decision)
+
+    with pytest.raises(ValidationError, match="switch_outcome"):
+        RoutingDecision.model_validate({**payload, "switch_outcome": "maybe"})
 
 
 def test_stored_policy_rejects_a_pre_design_threshold_guard() -> None:

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -23,6 +23,7 @@ from exp.common.models.gateway_catalog import (
     FailoverMode,
 )
 from exp.common.models.model import ReasoningEffort, ToolCall
+from exp.common.routing.policy import SwitchOutcome
 
 GatewayAliasName = ArtifactId
 OrganizationId = ArtifactId
@@ -957,6 +958,7 @@ class ProjectSelection(ContractModel):
     selected_alias: ArtifactId
     activation_ref: ActivationRef
     fallback_reason: str | None = Field(default=None, max_length=512)
+    switch_outcome: SwitchOutcome | None = None
 
 
 class AuthorizationSnapshot(ContractModel):

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -471,6 +471,7 @@ def select_route_deployments(
         fallback_deployments=selected[1:],
         route_reason=route.route_reason,
         fallback_reason=route.fallback_reason,
+        switch_outcome=route.switch_outcome,
     )
 
 
@@ -528,6 +529,7 @@ def reorder_route_deployments(
         fallback_deployments=selected[1:],
         route_reason=route.route_reason,
         fallback_reason=route.fallback_reason,
+        switch_outcome=route.switch_outcome,
     )
 
 

--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -19,7 +19,7 @@ from exp.common.models.gateway_catalog import (
     NormalizedGatewayCatalog,
     is_foreign_snapshot,
 )
-from exp.common.routing.policy import RoutingDecision
+from exp.common.routing.policy import RoutingDecision, SwitchOutcome
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     DirectTarget,
@@ -52,6 +52,7 @@ class GatewayRoute(ContractModel):
     fallback_deployments: tuple[ExactModelDeployment, ...] = ()
     route_reason: str
     fallback_reason: str | None = None
+    switch_outcome: SwitchOutcome | None = None
 
     @property
     def deployments(self) -> tuple[ExactModelDeployment, ...]:
@@ -270,6 +271,7 @@ class CatalogRouteResolver:
             pool=pool,
             route_reason="learned_router",
             fallback_reason=selection.fallback_reason,
+            switch_outcome=selection.switch_outcome,
         )
 
     def resolve_direct(self, authorization: AuthorizationSnapshot) -> GatewayRoute:
@@ -409,6 +411,7 @@ class CatalogRouteResolver:
         pool: ExactModelPool,
         route_reason: str,
         fallback_reason: str | None,
+        switch_outcome: SwitchOutcome | None = None,
     ) -> GatewayRoute:
         """Build one ordered execution route from a certified exact-model pool."""
         deployments: list[ExactModelDeployment] = []
@@ -429,6 +432,7 @@ class CatalogRouteResolver:
             fallback_deployments=tuple(deployments[1:]),
             route_reason=route_reason,
             fallback_reason=fallback_reason,
+            switch_outcome=switch_outcome,
         )
 
 
@@ -808,6 +812,7 @@ class RouterProjectTargetResolver:
             selected_alias=decision.selected_alias,
             activation_ref=target.activation_ref,
             fallback_reason=decision.fallback_reason,
+            switch_outcome=decision.switch_outcome,
         )
 
 

--- a/exp/runtime/gateway/routing_test.py
+++ b/exp/runtime/gateway/routing_test.py
@@ -1,9 +1,11 @@
-"""Tests for catalog-backed public alias metadata lookup."""
+"""Tests for catalog-backed public alias metadata lookup and route construction."""
 
 from __future__ import annotations
 
+import time
 import unittest.mock
 from datetime import UTC, datetime
+from typing import cast
 
 import pytest
 
@@ -19,6 +21,15 @@ from exp.common.models.gateway_catalog import (
     NormalizedGatewayCatalog,
 )
 from exp.common.models.model import ModelCapabilities
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    ProjectSelection,
+    ProjectTarget,
+)
+from exp.runtime.gateway.interfaces import ProjectTargetResolver
 from exp.runtime.gateway.routing import CatalogRouteResolver
 
 _REVISION = "revision-one"
@@ -232,6 +243,75 @@ def test_published_metadata_stays_closed_when_the_revision_has_no_direct_pool() 
         )
         is None
     )
+
+
+def test_project_route_threads_the_learned_selection_switch_outcome() -> None:
+    """A recorded sticky-switch outcome survives from selection into the built route."""
+    deployment = _deployment(deployment_id="deployment-one", source_alias="candidate-cheap")
+    catalog, digest = _catalog(
+        (deployment,),
+        (
+            ExactModelPool(
+                pool_id="pool-one",
+                exact_model_id="exact-one",
+                deployment_ids=("deployment-one",),
+            ),
+        ),
+    )
+    target = ProjectTarget(
+        project_ref="project-one",
+        activation_ref="activation-one",
+        catalog_sha256=digest,
+    )
+
+    class _StubProjectResolver:
+        """Selection-only stub returning one suppressed sticky-switch outcome."""
+
+        def select_blocking(
+            self,
+            *,
+            target: ProjectTarget,
+            request: GatewayRequest,
+            episode_namespace: tuple[str, str, str, str],
+            deadline_monotonic: float,
+        ) -> ProjectSelection:
+            """Return one frozen selection carrying a suppressed switch outcome."""
+            del request, episode_namespace, deadline_monotonic
+            return ProjectSelection(
+                exact_model_id="exact-one",
+                selected_alias="candidate-cheap",
+                activation_ref=target.activation_ref,
+                switch_outcome="switch_suppressed_cache",
+            )
+
+    resolver = CatalogRouteResolver(
+        {(_REVISION, digest): catalog},
+        project_resolver=cast(ProjectTargetResolver, _StubProjectResolver()),
+    )
+    route = resolver.resolve_project_blocking(
+        authorization=AuthorizationSnapshot(
+            request_id="request-one",
+            organization_id="org-one",
+            identity_id="identity-one",
+            virtual_key_id="key-one",
+            alias="coding",
+            alias_revision_id=_REVISION,
+            target=target,
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            catalog_sha256=digest,
+            canonical_request_sha256="e" * 64,
+            deadline_monotonic=time.monotonic() + 5,
+        ),
+        request=GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="route"),),
+        ),
+        episode_namespace=("org-one", "identity-one", _REVISION, "episode-one"),
+    )
+
+    assert route.route_reason == "learned_router"
+    assert route.switch_outcome == "switch_suppressed_cache"
+    assert route.deployment.deployment_id == "deployment-one"
 
 
 def _single_pool_catalog() -> NormalizedGatewayCatalog:

--- a/exp/runtime/router/journal_test.py
+++ b/exp/runtime/router/journal_test.py
@@ -269,9 +269,8 @@ def _decision(lineage_id: str, request: ModelRequest | None = None) -> RoutingDe
         "uncertainty": None,
         "fallback_reason": None,
     }
-    return RoutingDecision(
-        decision_id=stable_id("routing-decision", material),
-        **material,
+    return RoutingDecision.model_validate(
+        {"decision_id": stable_id("routing-decision", material), **material}
     )
 
 

--- a/exp/runtime/router/runtime.py
+++ b/exp/runtime/router/runtime.py
@@ -45,6 +45,9 @@ from exp.runtime.router.economics import (
 )
 from exp.runtime.router.runtime_selection import PreparedSelection, retained_selection
 from exp.runtime.router.runtime_support import (
+    cache_aware_episode_decision as _cache_aware_episode_decision,
+)
+from exp.runtime.router.runtime_support import (
     candidate_completion_economics as _candidate_completion_economics,
 )
 from exp.runtime.router.runtime_support import (
@@ -430,10 +433,11 @@ class RouterRuntime:
                 self._request_embedding_dispositions[request_key] = prepared.disposition
                 return existing
             episode_decision = self._episode_decisions.get(identity_sha256)
-            selected = (
-                _sticky_decision(episode_decision, request_sha256)
-                if episode_decision is not None
-                else decision
+            selected = self._episode_selection(
+                episode_decision,
+                decision,
+                request_sha256=request_sha256,
+                feature=feature,
             )
             return self._publish_decision(
                 request=request,
@@ -821,6 +825,38 @@ class RouterRuntime:
             RoutedSpendDisposition.LOCALLY_PRICED,
         )
 
+    def _episode_selection(
+        self,
+        episode_decision: RoutingDecision | None,
+        proposed: RoutingDecision,
+        *,
+        request_sha256: Sha256,
+        feature: str,
+    ) -> RoutingDecision:
+        """Reconcile one fresh proposal against retained sticky episode state.
+
+        Args:
+            episode_decision: Retained episode decision, or ``None`` for a fresh episode.
+            proposed: Fresh guarded selection computed for this turn.
+            request_sha256: Canonical request-feature digest for this turn.
+            feature: Exact request-visible router feature for this turn.
+
+        Returns:
+            The proposal for a fresh episode, otherwise the cache-aware sticky
+            or switched decision for the retained episode alias.
+        """
+        if episode_decision is None:
+            return proposed
+        return _cache_aware_episode_decision(
+            policy=self.policy,
+            bank=self.bank,
+            episode_decision=episode_decision,
+            proposed=proposed,
+            request_sha256=request_sha256,
+            feature=feature,
+            candidate_prices=self._candidate_prices,
+        )
+
     def _publish_decision(
         self,
         *,
@@ -843,6 +879,13 @@ class RouterRuntime:
             bank=self.bank,
             resolve=self._resolve,
         )
+        if (
+            episode_decision is not None
+            and decision.selected_alias != episode_decision.selected_alias
+            and decision.switch_outcome != "switched"
+        ):
+            marked = decision.model_copy(update={"switch_outcome": "switched"})
+            decision = marked.model_copy(update={"decision_id": _decision_content_id(marked)})
         self._record(decision)
         if episode_decision is None or decision.selected_alias != episode_decision.selected_alias:
             if episode_decision is not None:

--- a/exp/runtime/router/runtime_selection.py
+++ b/exp/runtime/router/runtime_selection.py
@@ -107,10 +107,11 @@ def retained_selection(
                     disposition=runtime._request_embedding_dispositions[request_key],  # noqa: SLF001
                 )
             episode_decision = runtime._episode_decisions.get(identity_sha256)  # noqa: SLF001
-            decision = (
-                sticky_decision(episode_decision, request_sha256)
-                if episode_decision is not None
-                else proposed
+            decision = runtime._episode_selection(  # noqa: SLF001
+                episode_decision,
+                proposed,
+                request_sha256=request_sha256,
+                feature=feature,
             )
             published = runtime._publish_decision(  # noqa: SLF001
                 request=request,

--- a/exp/runtime/router/runtime_support.py
+++ b/exp/runtime/router/runtime_support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 import numpy as np
 
@@ -18,7 +18,8 @@ from exp.common.models import (
 )
 from exp.common.routing import KnnRouterPolicy, RoutingDecision, router_feature_token_upper_bound
 from exp.common.routing.bank import KnnEvidenceBank
-from exp.common.routing.decision import policy_content_sha256
+from exp.common.routing.decision import fitted_quality_gain, policy_content_sha256
+from exp.common.routing.policy import SwitchOutcome
 from exp.runtime.models import ResolvedModel
 from exp.runtime.router.economics import (
     RoutedProviderComponent,
@@ -405,18 +406,124 @@ def fallback_decision(
 def sticky_decision(
     episode_decision: RoutingDecision,
     request_sha256: str,
+    *,
+    switch_outcome: SwitchOutcome | None = None,
 ) -> RoutingDecision:
     """Bind a later episode turn to the original selected alias and evidence.
 
     Args:
         episode_decision: First retained decision for the sticky episode.
         request_sha256: Canonical digest for the later turn.
+        switch_outcome: Optional record of how this turn weighed an alias switch.
+            The default clears any outcome inherited from the episode decision,
+            because the outcome describes one turn's comparison, not the episode.
 
     Returns:
         Content-addressed later-turn decision with the original selected alias.
     """
-    material = episode_decision.model_copy(update={"request_sha256": request_sha256})
+    material = episode_decision.model_copy(
+        update={"request_sha256": request_sha256, "switch_outcome": switch_outcome}
+    )
     return material.model_copy(update={"decision_id": decision_content_id(material)})
+
+
+def cache_switch_amortization_usd(
+    *,
+    prompt_token_upper_bound: int,
+    sticky_price: CandidateTokenPrice | None,
+    proposed_price: CandidateTokenPrice | None,
+) -> float | None:
+    """Price the remaining prompt-cache write amortization forfeited by a switch.
+
+    The amortization is the conservative extra input cost of rebuilding the
+    request prompt cold on the proposed alias (its cache-write rate when
+    declared, never below its ordinary input rate) instead of replaying it warm
+    on the sticky alias (its cached-read rate when declared, otherwise its
+    ordinary input rate). Frozen snapshot rates are used exactly as declared,
+    with no silent zero substitution for an absent price row.
+
+    Args:
+        prompt_token_upper_bound: Conservative request-visible token ceiling.
+        sticky_price: Frozen price row for the retained sticky alias, if any.
+        proposed_price: Frozen price row for the proposed alias, if any.
+
+    Returns:
+        Nonnegative forfeited amortization in US dollars, or ``None`` when the
+        frozen pricing snapshot lacks either candidate row.
+    """
+    if sticky_price is None or proposed_price is None:
+        return None
+    warm_rate = (
+        sticky_price.cached_input_usd_per_million_tokens
+        if sticky_price.cached_input_usd_per_million_tokens is not None
+        else sticky_price.input_usd_per_million_tokens
+    )
+    write_rate = proposed_price.cache_write_usd_per_million_tokens
+    cold_rate = max(
+        proposed_price.input_usd_per_million_tokens,
+        write_rate if write_rate is not None else proposed_price.input_usd_per_million_tokens,
+    )
+    return max(0.0, prompt_token_upper_bound * (cold_rate - warm_rate) / 1_000_000)
+
+
+def cache_aware_episode_decision(
+    *,
+    policy: KnnRouterPolicy,
+    bank: KnnEvidenceBank,
+    episode_decision: RoutingDecision,
+    proposed: RoutingDecision,
+    request_sha256: str,
+    feature: str,
+    candidate_prices: Mapping[str, CandidateTokenPrice],
+) -> RoutingDecision:
+    """Reconcile one fresh guarded proposal against a retained sticky episode alias.
+
+    A proposal that keeps the sticky alias binds to it exactly as before. A
+    proposal for a different alias switches only when the policy's cache-switch
+    gate is enabled and the fitted quality gain of the proposed alias strictly
+    exceeds the gate's exchange rate times the remaining prompt-cache write
+    amortization. Unknown fit evidence or an incomplete pricing snapshot fails
+    closed to the sticky alias, and every weighed switch records its outcome.
+
+    Args:
+        policy: Frozen router policy owning the cache-switch gate.
+        bank: Frozen fit-only evidence bank.
+        episode_decision: Retained first decision of the sticky episode.
+        proposed: Fresh guarded selection computed for this turn.
+        request_sha256: Canonical request-feature digest for this turn.
+        feature: Exact request-visible router feature for this turn.
+        candidate_prices: Frozen pricing-snapshot rows keyed by candidate alias.
+
+    Returns:
+        The sticky-bound or switched content-addressed decision for this turn.
+    """
+    if proposed.selected_alias == episode_decision.selected_alias:
+        return sticky_decision(episode_decision, request_sha256)
+    gate = policy.guard.cache_switch
+    if not gate.enabled:
+        return sticky_decision(episode_decision, request_sha256)
+    gain = fitted_quality_gain(
+        bank,
+        incumbent_alias=episode_decision.selected_alias,
+        challenger_alias=proposed.selected_alias,
+    )
+    amortization = cache_switch_amortization_usd(
+        prompt_token_upper_bound=router_feature_token_upper_bound(feature),
+        sticky_price=candidate_prices.get(episode_decision.selected_alias),
+        proposed_price=candidate_prices.get(proposed.selected_alias),
+    )
+    if (
+        gain is not None
+        and amortization is not None
+        and gain > gate.switch_gain_per_amortized_usd * amortization
+    ):
+        switched = proposed.model_copy(update={"switch_outcome": "switched"})
+        return switched.model_copy(update={"decision_id": decision_content_id(switched)})
+    return sticky_decision(
+        episode_decision,
+        request_sha256,
+        switch_outcome="switch_suppressed_cache",
+    )
 
 
 def sealed_bank(bank: KnnEvidenceBank) -> KnnEvidenceBank:

--- a/exp/runtime/router/runtime_support_test.py
+++ b/exp/runtime/router/runtime_support_test.py
@@ -1,0 +1,206 @@
+"""Tests for cache-amortization pricing and cache-aware sticky reconciliation."""
+
+from __future__ import annotations
+
+import hashlib
+
+from exp.common.models import CandidateTokenPrice
+from exp.common.routing import CacheSwitchGuard, KnnRouterPolicy, RoutingDecision
+from exp.common.routing.decision import policy_content_sha256
+from exp.runtime.router.runtime_support import (
+    cache_aware_episode_decision,
+    cache_switch_amortization_usd,
+    decision_content_id,
+    sticky_decision,
+)
+from exp.runtime.router.runtime_test import _fixture
+
+_REQUEST_SHA = "c" * 64
+_FEATURE = "feature " * 8
+
+
+def _price(
+    alias: str,
+    *,
+    input_rate: float,
+    cached: float | None = None,
+    write: float | None = None,
+) -> CandidateTokenPrice:
+    """Build one frozen candidate price row for amortization tests."""
+    return CandidateTokenPrice(
+        candidate_alias=alias,
+        input_usd_per_million_tokens=input_rate,
+        output_usd_per_million_tokens=1.0,
+        cached_input_usd_per_million_tokens=cached,
+        cache_write_usd_per_million_tokens=write,
+    )
+
+
+def _decision(policy: KnnRouterPolicy, *, alias: str, episode_id: str) -> RoutingDecision:
+    """Build one content-addressed decision selecting ``alias`` for tests."""
+    provisional = RoutingDecision(
+        decision_id="routing-decision-provisional",
+        policy_id=policy.policy_id,
+        policy_sha256=policy_content_sha256(policy),
+        request_sha256="d" * 64,
+        episode_id_sha256=hashlib.sha256(episode_id.encode("utf-8")).hexdigest(),
+        selected_alias=alias,
+        baseline_alias=policy.baseline_alias,
+        neighbor_count=8,
+        paired_count=8,
+        best_similarity=1.0,
+    )
+    return provisional.model_copy(update={"decision_id": decision_content_id(provisional)})
+
+
+def test_amortization_prices_cold_rebuild_against_warm_replay() -> None:
+    """The forfeited amortization spans the cache-write and cached-read rate gap."""
+    amortization = cache_switch_amortization_usd(
+        prompt_token_upper_bound=2_000_000,
+        sticky_price=_price("baseline", input_rate=3.0, cached=0.5),
+        proposed_price=_price("cheap", input_rate=2.0, write=3.75),
+    )
+
+    assert amortization == 2_000_000 * (3.75 - 0.5) / 1_000_000
+
+
+def test_amortization_uses_ordinary_rates_when_cache_rates_are_undeclared() -> None:
+    """Undeclared cache rates fall back to each candidate's ordinary input rate."""
+    assert (
+        cache_switch_amortization_usd(
+            prompt_token_upper_bound=1_000_000,
+            sticky_price=_price("baseline", input_rate=3.0),
+            proposed_price=_price("cheap", input_rate=2.0),
+        )
+        == 0.0
+    )
+    assert cache_switch_amortization_usd(
+        prompt_token_upper_bound=1_000_000,
+        sticky_price=_price("baseline", input_rate=1.0),
+        proposed_price=_price("cheap", input_rate=4.0),
+    ) == (4.0 - 1.0)
+
+
+def test_amortization_is_unknown_without_both_frozen_price_rows() -> None:
+    """A pricing snapshot missing either candidate row prices nothing silently."""
+    price = _price("baseline", input_rate=3.0)
+
+    assert (
+        cache_switch_amortization_usd(
+            prompt_token_upper_bound=1_000, sticky_price=None, proposed_price=price
+        )
+        is None
+    )
+    assert (
+        cache_switch_amortization_usd(
+            prompt_token_upper_bound=1_000, sticky_price=price, proposed_price=None
+        )
+        is None
+    )
+
+
+def test_same_alias_and_disabled_gate_keep_pure_sticky_behavior() -> None:
+    """No outcome is recorded when nothing switches or the gate is disabled."""
+    policy, _, bank, _, _ = _fixture()
+    episode = _decision(policy, alias="baseline", episode_id="episode-a")
+    same = cache_aware_episode_decision(
+        policy=policy,
+        bank=bank,
+        episode_decision=episode,
+        proposed=_decision(policy, alias="baseline", episode_id="episode-a"),
+        request_sha256=_REQUEST_SHA,
+        feature=_FEATURE,
+        candidate_prices={},
+    )
+
+    assert same == sticky_decision(episode, _REQUEST_SHA)
+    assert same.switch_outcome is None
+
+    disabled_policy = policy.model_copy(
+        update={
+            "guard": policy.guard.model_copy(
+                update={"cache_switch": CacheSwitchGuard(enabled=False)}
+            )
+        }
+    )
+    legacy = cache_aware_episode_decision(
+        policy=disabled_policy,
+        bank=bank,
+        episode_decision=episode,
+        proposed=_decision(disabled_policy, alias="cheap", episode_id="episode-a"),
+        request_sha256=_REQUEST_SHA,
+        feature=_FEATURE,
+        candidate_prices={
+            "baseline": _price("baseline", input_rate=0.5),
+            "cheap": _price("cheap", input_rate=0.1),
+        },
+    )
+
+    assert legacy.selected_alias == "baseline"
+    assert legacy.switch_outcome is None
+
+
+def test_large_fitted_gain_over_cleared_amortization_switches_and_is_recorded() -> None:
+    """A gain above the amortized threshold adopts the proposal as ``switched``."""
+    policy, _, bank, _, _ = _fixture()
+    episode = _decision(policy, alias="baseline", episode_id="episode-a")
+    proposed = _decision(policy, alias="cheap", episode_id="episode-a")
+
+    switched = cache_aware_episode_decision(
+        policy=policy,
+        bank=bank,
+        episode_decision=episode,
+        proposed=proposed,
+        request_sha256=_REQUEST_SHA,
+        feature=_FEATURE,
+        candidate_prices={
+            "baseline": _price("baseline", input_rate=0.5),
+            "cheap": _price("cheap", input_rate=0.1),
+        },
+    )
+
+    assert switched.selected_alias == "cheap"
+    assert switched.switch_outcome == "switched"
+    assert switched.decision_id == decision_content_id(switched)
+
+
+def test_small_gain_or_unknown_economics_suppresses_the_switch() -> None:
+    """An unamortized or unpriceable switch stays sticky and records suppression."""
+    policy, _, bank, _, _ = _fixture()
+    strict_policy = policy.model_copy(
+        update={
+            "guard": policy.guard.model_copy(
+                update={"cache_switch": CacheSwitchGuard(switch_gain_per_amortized_usd=1e9)}
+            )
+        }
+    )
+    episode = _decision(strict_policy, alias="baseline", episode_id="episode-a")
+    proposed = _decision(strict_policy, alias="cheap", episode_id="episode-a")
+    warm_prices = {
+        "baseline": _price("baseline", input_rate=0.5, cached=0.05),
+        "cheap": _price("cheap", input_rate=0.1, write=50.0),
+    }
+
+    suppressed = cache_aware_episode_decision(
+        policy=strict_policy,
+        bank=bank,
+        episode_decision=episode,
+        proposed=proposed,
+        request_sha256=_REQUEST_SHA,
+        feature=_FEATURE,
+        candidate_prices=warm_prices,
+    )
+    unpriced = cache_aware_episode_decision(
+        policy=policy,
+        bank=bank,
+        episode_decision=_decision(policy, alias="baseline", episode_id="episode-a"),
+        proposed=_decision(policy, alias="cheap", episode_id="episode-a"),
+        request_sha256=_REQUEST_SHA,
+        feature=_FEATURE,
+        candidate_prices={},
+    )
+
+    for decision in (suppressed, unpriced):
+        assert decision.selected_alias == "baseline"
+        assert decision.switch_outcome == "switch_suppressed_cache"
+        assert decision.decision_id == decision_content_id(decision)

--- a/exp/runtime/router/runtime_test.py
+++ b/exp/runtime/router/runtime_test.py
@@ -40,7 +40,7 @@ from exp.common.models import (
     Usage,
 )
 from exp.common.project import ArtifactStore, ProjectPaths, artifact_input
-from exp.common.routing import KnnGuard, KnnRouterPolicy
+from exp.common.routing import CacheSwitchGuard, KnnGuard, KnnRouterPolicy
 from exp.common.routing.bank import (
     CandidateEvidenceCount,
     KnnBankManifest,
@@ -197,6 +197,178 @@ def test_episode_stickiness_uses_caller_identity_and_tools_affect_request_hash()
         hashlib.sha256(b"episode-b").hexdigest(),
     }
     assert "episode-a" not in first.model_dump_json()
+
+
+def _cache_runtime(
+    *,
+    cache_switch: CacheSwitchGuard | None = None,
+    prices: tuple[CandidateTokenPrice, ...] | None = None,
+) -> tuple[RouterRuntime, _Client]:
+    """Build one runtime with an optional cache-switch gate and frozen prices.
+
+    Args:
+        cache_switch: Optional gate overriding the policy default.
+        prices: Optional pricing rows in fit-time candidate order.
+
+    Returns:
+        Activated runtime and its deterministic shared client.
+    """
+    policy, manifest, bank, snapshots, client = _fixture()
+    if cache_switch is not None:
+        policy = policy.model_copy(
+            update={"guard": policy.guard.model_copy(update={"cache_switch": cache_switch})}
+        )
+    runtime = RouterRuntime(
+        policy,
+        manifest,
+        bank,
+        cast(RuntimeModelCatalog, _Catalog(snapshots, client)),
+        pricing_snapshot_id="pricing-a",
+        pricing_snapshot_sha256=_DIGEST,
+        pricing_candidate_aliases=bank.candidate_aliases,
+        pricing_candidate_prices=prices,
+    )
+    return runtime, client
+
+
+def _sticky_baseline_with_fresh_cheap_proposal(
+    runtime: RouterRuntime,
+    client: _Client,
+) -> tuple[ModelRequest, _PreparedSelection]:
+    """Retain a baseline sticky episode, then compute one fresh cheap proposal.
+
+    Args:
+        runtime: Activated runtime under test.
+        client: Shared deterministic embedding client.
+
+    Returns:
+        The proposal's request and its unretained prepared selection.
+    """
+    client.embedding_values = RuntimeError("embed failed")
+    first = runtime.select(_request(), episode_id="episode-cache")
+    assert first.selected_alias == "baseline"
+    assert first.switch_outcome is None
+    client.embedding_values = (Embedding(values=(1.0, 0.0)),)
+    request = _request(tool_name="write")
+    prepared = runtime._select_unretained(request, episode_id="episode-cache")  # noqa: SLF001
+    assert prepared.decision.selected_alias == "cheap"
+    assert prepared.decision.switch_outcome is None
+    return request, prepared
+
+
+def test_warm_sticky_episode_suppresses_a_small_quality_gain_switch() -> None:
+    """A fresh proposal below the amortized threshold stays on the sticky alias."""
+    runtime, client = _cache_runtime(
+        cache_switch=CacheSwitchGuard(switch_gain_per_amortized_usd=1e9),
+        prices=(
+            CandidateTokenPrice(
+                candidate_alias="baseline",
+                input_usd_per_million_tokens=0.5,
+                output_usd_per_million_tokens=1.5,
+                cached_input_usd_per_million_tokens=0.05,
+            ),
+            CandidateTokenPrice(
+                candidate_alias="cheap",
+                input_usd_per_million_tokens=0.1,
+                output_usd_per_million_tokens=0.4,
+                cache_write_usd_per_million_tokens=50.0,
+            ),
+        ),
+    )
+    request, prepared = _sticky_baseline_with_fresh_cheap_proposal(runtime, client)
+
+    retained = runtime._retain_prepared_selection(  # noqa: SLF001 - gateway seam
+        request,
+        episode_id="episode-cache",
+        prepared=prepared,
+    )
+
+    assert retained.selected_alias == "baseline"
+    assert retained.switch_outcome == "switch_suppressed_cache"
+    assert runtime.select(request, episode_id="episode-cache") == retained
+    assert client.embed_calls == 2
+
+
+def test_missing_pricing_rows_fail_closed_to_the_sticky_alias() -> None:
+    """A snapshot without candidate rows cannot prove the switch is amortization free."""
+    runtime, client = _cache_runtime()
+    request, prepared = _sticky_baseline_with_fresh_cheap_proposal(runtime, client)
+
+    retained = runtime._retain_prepared_selection(  # noqa: SLF001 - gateway seam
+        request,
+        episode_id="episode-cache",
+        prepared=prepared,
+    )
+
+    assert retained.selected_alias == "baseline"
+    assert retained.switch_outcome == "switch_suppressed_cache"
+
+
+def test_large_fitted_gain_switches_the_sticky_episode_and_is_recorded() -> None:
+    """A gain above the amortized threshold adopts the proposal and resets the episode."""
+    runtime, client = _cache_runtime(
+        prices=(
+            CandidateTokenPrice(
+                candidate_alias="baseline",
+                input_usd_per_million_tokens=0.5,
+                output_usd_per_million_tokens=1.5,
+            ),
+            CandidateTokenPrice(
+                candidate_alias="cheap",
+                input_usd_per_million_tokens=0.1,
+                output_usd_per_million_tokens=0.4,
+            ),
+        ),
+    )
+    request, prepared = _sticky_baseline_with_fresh_cheap_proposal(runtime, client)
+
+    retained = runtime._retain_prepared_selection(  # noqa: SLF001 - gateway seam
+        request,
+        episode_id="episode-cache",
+        prepared=prepared,
+    )
+    later = runtime.select(_request(), episode_id="episode-cache")
+
+    assert retained.selected_alias == "cheap"
+    assert retained.switch_outcome == "switched"
+    assert later.selected_alias == "cheap"
+    assert later.switch_outcome is None
+    assert client.embed_calls == 2
+
+
+def test_disabled_cache_switch_gate_keeps_legacy_unconditional_stickiness() -> None:
+    """An explicitly disabled gate never switches and records no outcome."""
+    runtime, client = _cache_runtime(
+        cache_switch=CacheSwitchGuard(enabled=False),
+        prices=(
+            CandidateTokenPrice(
+                candidate_alias="baseline",
+                input_usd_per_million_tokens=0.5,
+                output_usd_per_million_tokens=1.5,
+            ),
+            CandidateTokenPrice(
+                candidate_alias="cheap",
+                input_usd_per_million_tokens=0.1,
+                output_usd_per_million_tokens=0.4,
+            ),
+        ),
+    )
+    request, prepared = _sticky_baseline_with_fresh_cheap_proposal(runtime, client)
+
+    retained = runtime._retain_prepared_selection(  # noqa: SLF001 - gateway seam
+        request,
+        episode_id="episode-cache",
+        prepared=prepared,
+    )
+
+    assert retained.selected_alias == "baseline"
+    assert retained.switch_outcome is None
+    assert retained == sticky_decision(
+        runtime._episode_decisions[  # noqa: SLF001 - legacy equivalence regression
+            hashlib.sha256(b"episode-cache").hexdigest()
+        ],
+        retained.request_sha256,
+    )
 
 
 def test_artifact_mutation_and_pricing_or_alias_drift_block_activation() -> None:

--- a/exp/runtime/router/snapshot_test.py
+++ b/exp/runtime/router/snapshot_test.py
@@ -176,9 +176,8 @@ def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
         "uncertainty": None,
         "fallback_reason": None,
     }
-    return RoutingDecision(
-        decision_id=stable_id("routing-decision", material),
-        **material,
+    return RoutingDecision.model_validate(
+        {"decision_id": stable_id("routing-decision", material), **material}
     )
 
 

--- a/exp/runtime/router/tests/runtime_capability_test.py
+++ b/exp/runtime/router/tests/runtime_capability_test.py
@@ -188,7 +188,9 @@ def test_capability_fallback_replaces_the_sticky_episode_model() -> None:
     assert first.selected_alias == "cheap"
     assert fallback.selected_alias == "baseline"
     assert fallback.fallback_reason == "capability_eligibility"
+    assert fallback.switch_outcome == "switched"
     assert later.selected_alias == "baseline"
+    assert later.switch_outcome is None
     assert replayed_first.selected_alias == "baseline"
 
     result = runtime.complete(_request(tool_name="read"), episode_id="eligible")

--- a/exp/simulation/retrieval/refresh_test.py
+++ b/exp/simulation/retrieval/refresh_test.py
@@ -220,9 +220,8 @@ def _decision(lineage_id: str, request: ModelRequest) -> RoutingDecision:
         "uncertainty": None,
         "fallback_reason": None,
     }
-    return RoutingDecision(
-        decision_id=stable_id("routing-decision", material),
-        **material,
+    return RoutingDecision.model_validate(
+        {"decision_id": stable_id("routing-decision", material), **material}
     )
 
 


### PR DESCRIPTION
## Motivation

A sticky episode alias keeps its provider prompt cache warm. When a fresh guarded selection proposes a slightly better neighbor mid-episode, switching silently forfeits the remaining prompt-cache write amortization: the next turn pays the proposed alias's cold cache-write rate instead of the sticky alias's cached-read rate. The router should treat that switch as a priced decision, not a free improvement, and it should say which way it decided. (Part of the OSC bulk newfeature batch.)

## Approach

- **Policy contract** (`exp/common/routing/policy.py`): `KnnGuard` gains an optional `cache_switch: CacheSwitchGuard` gate with `enabled` (default on) and `switch_gain_per_amortized_usd` (positive, finite, default `10.0`). Because the gate rides on the guard, it is configurable through every existing fit surface (`RouterOptimizationConfig`, `RouterFitConfig`, `RouterOptimizationSpec`) with no new plumbing. An all-default gate is omitted from serialization (same pattern as the existing empty-coverage omission), so frozen policy bytes, replayed policy identities, and `write_or_verify_exact` replay are unchanged.
- **Decision contract**: `RoutingDecision.switch_outcome` records `"switched"` or `"switch_suppressed_cache"` and is omitted when absent, so persisted decision ids and journal validation of prior evidence are untouched.
- **Fitted gain** (`exp/common/routing/decision.py`): `fitted_quality_gain` is the workload-weighted mean score difference over jointly scored fit tasks, a pure function of the frozen bank, so the comparison needs no request embedding or provider call.
- **Amortization pricing** (`exp/runtime/router/runtime_support.py`): `cache_switch_amortization_usd` prices the cold rebuild on the proposed alias (cache-write rate, never below its ordinary input rate) against the warm replay on the sticky alias (cached-read rate when declared), over the conservative request token ceiling. A pricing snapshot missing either candidate row yields `None` rather than a silent zero; economics stay in the existing frozen-float pricing conventions with no coercion, matching the snapshot's `CandidateTokenPrice` units.
- **Runtime seams** (`exp/runtime/router/runtime.py`, `runtime_selection.py`): where a fresh selection meets a retained episode decision (the retain-prepared and single-flight publication paths), `cache_aware_episode_decision` switches only when the fitted gain strictly exceeds `switch_gain_per_amortized_usd` times the amortization, recording the outcome either way. Unknown gain or unknown economics fails closed to the sticky alias. A capability-rejected sticky alias still switches (marked `switched` in `_publish_decision`). Disabling the gate restores byte-identical legacy stickiness. Pure sticky reuse stays embedding-free.
- **Gateway passthrough** (`exp/runtime/gateway/contracts.py`, `routing.py`, `native_execution.py`): `ProjectSelection` and `GatewayRoute` carry the outcome alongside `fallback_reason`, preserved through the native route rebuilds.
- **Docs**: `docs/reference/router_optimization_config.md` gains a short cache-aware rare-switch section.

## Test plan

All run locally with `uv run pytest -q` (Linux, CPython 3.12):

- `exp/common/routing/policy_test.py`: gate defaults on, explicit disable round-trips, all-default gate keeps legacy guard digests, nonpositive or nonfinite rates rejected, `switch_outcome` bounded and absent from legacy decision bytes.
- `exp/common/routing/decision_test.py` (new): weighted fitted gain and the no-jointly-scored-task `None` case.
- `exp/runtime/router/runtime_support_test.py` (new): amortization math, undeclared-rate fallbacks, missing-row `None`, and the reconcile outcomes (same alias, disabled, switch, suppress, unpriced).
- `exp/runtime/router/runtime_test.py`: warm sticky plus small quality delta suppresses with `switch_suppressed_cache`; large fitted delta switches, resets the episode, and later turns stay sticky on the new alias; missing pricing rows fail closed; disabled gate reproduces exact legacy sticky decisions; sticky miss selects fresh with no outcome.
- `exp/runtime/router/tests/runtime_capability_test.py`: a capability fallback off the sticky alias is recorded as `switched`.
- `exp/runtime/gateway/routing_test.py`: the outcome threads from `ProjectSelection` into the built `GatewayRoute`.

Full gates pass: `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, and `uv run pytest -q` (3423 passed; the only failures are 11 `exp/cli/shared/picker*` terminal-rendering tests that fail identically on `main` in this headless environment). No live provider evidence is claimed; all validation is offline unit and integration testing against frozen fixtures.