### PR TITLE
gateway: recognize the TokenHub-intl origin as a Hunyuan reasoning route

### DIFF
--- a/exp/runtime/models/providers/hunyuan.py
+++ b/exp/runtime/models/providers/hunyuan.py
@@ -4,27 +4,50 @@
 Tencent's Hunyuan models (hy3/hy4) serve an OpenAI-compatible Chat Completions
 endpoint that returns the model's chain-of-thought in a native ``reasoning_content``
 response field and accepts it back on an assistant turn. This module identifies
-that exact endpoint so the gateway marks the rung as an exposable-plaintext
+those endpoints so the gateway marks the rung as an exposable-plaintext
 reasoning route whose replay is protected by a gateway-issued opaque carrier,
 mirroring :mod:`exp.runtime.models.providers.fireworks`.
+
+Two OpenAI-compatible origins serve these models:
+
+- ``https://api.hunyuan.cloud.tencent.com/v1`` — the mainland Hunyuan root.
+- ``https://tokenhub-intl.tencentcloudmaas.com/v1`` — Tencent's TokenHub
+  international (Singapore) MaaS gateway, which is the origin the platform's
+  Tencent lane actually dispatches through. TokenHub is multi-model, exactly
+  like the Fireworks host: recognizing it here resolves a reasoning-carrier
+  route for every rung served through it, but the plaintext reasoning is still
+  captured only from models that emit ``reasoning_content`` and exposed only on
+  rungs the catalog stamps ``reasoning_output_exposed``.
 """
 
 from __future__ import annotations
 
 from urllib.parse import urlsplit
 
+# Exact OpenAI-compatible hosts that return native ``reasoning_content``. The
+# TC3-HMAC-signed ``hunyuan.tencentcloudapi.com`` API is a different protocol
+# the gateway never speaks and is deliberately excluded. The site-bound TokenHub
+# siblings (``tokenhub-us`` and any mainland site) are omitted until a lane
+# actually dispatches through them, per the "no speculative surface" rule.
+_HUNYUAN_REASONING_HOSTS = frozenset(
+    {
+        "api.hunyuan.cloud.tencent.com",
+        "tokenhub-intl.tencentcloudmaas.com",
+    }
+)
+
 
 def is_hunyuan_base_url(base_url: str) -> bool:
-    """Return whether one endpoint is the exact public Hunyuan inference root.
+    """Return whether one endpoint is an exact Hunyuan reasoning inference root.
 
-    The OpenAI-compatible root is ``https://api.hunyuan.cloud.tencent.com/v1``;
-    the TC3-HMAC-signed ``hunyuan.tencentcloudapi.com`` host is a different API
-    the gateway never speaks and is deliberately not matched here.
+    Matches the mainland Hunyuan root and the TokenHub international MaaS origin
+    the platform's Tencent lane serves through, each on ``https``, the exact
+    ``/v1`` path, the default port, and no credentials, query, or fragment.
     """
     parsed = urlsplit(base_url)
     return (
         parsed.scheme == "https"
-        and parsed.hostname == "api.hunyuan.cloud.tencent.com"
+        and parsed.hostname in _HUNYUAN_REASONING_HOSTS
         and parsed.username is None
         and parsed.password is None
         and parsed.port in {None, 443}

--- a/exp/runtime/models/providers/hunyuan_test.py
+++ b/exp/runtime/models/providers/hunyuan_test.py
@@ -8,10 +8,21 @@ import pytest
 from exp.runtime.models.providers.hunyuan import is_hunyuan_base_url
 
 
-def test_matches_exact_public_hunyuan_root() -> None:
-    """The public OpenAI-compatible inference root is recognized."""
-    assert is_hunyuan_base_url("https://api.hunyuan.cloud.tencent.com/v1")
-    assert is_hunyuan_base_url("https://api.hunyuan.cloud.tencent.com/v1/")
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        # The mainland Hunyuan OpenAI-compatible inference root.
+        "https://api.hunyuan.cloud.tencent.com/v1",
+        "https://api.hunyuan.cloud.tencent.com/v1/",
+        # The TokenHub international MaaS origin the platform's Tencent lane
+        # dispatches through — the endpoint that must resolve a carrier route.
+        "https://tokenhub-intl.tencentcloudmaas.com/v1",
+        "https://tokenhub-intl.tencentcloudmaas.com/v1/",
+    ],
+)
+def test_matches_the_hunyuan_reasoning_roots(base_url: str) -> None:
+    """Both OpenAI-compatible reasoning origins are recognized."""
+    assert is_hunyuan_base_url(base_url)
 
 
 @pytest.mark.parametrize(
@@ -27,6 +38,14 @@ def test_matches_exact_public_hunyuan_root() -> None:
         "https://api.hunyuan.cloud.tencent.com/openai/v1",
         # A look-alike host must not match.
         "https://api.hunyuan.cloud.tencent.com.evil.test/v1",
+        # Site-bound TokenHub siblings are not served today and must not match
+        # until a lane dispatches through them.
+        "https://tokenhub-us.tencentcloudmaas.com/v1",
+        "https://tokenhub.tencentcloudmaas.com/v1",
+        # A TokenHub look-alike host must not match.
+        "https://tokenhub-intl.tencentcloudmaas.com.evil.test/v1",
+        "http://tokenhub-intl.tencentcloudmaas.com/v1",
+        "https://tokenhub-intl.tencentcloudmaas.com/openai/v1",
     ],
 )
 def test_rejects_non_canonical_endpoints(base_url: str) -> None:

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -480,3 +480,20 @@ def test_reasoning_exposure_requires_a_carrier_route_even_when_declared() -> Non
     ).gateway_wire_profile()
     assert profile.hunyuan_reasoning_route_sha256 is None
     assert profile.reasoning_output_exposed is False
+
+
+def test_tokenhub_intl_rung_resolves_a_carrier_route_and_exposes_when_declared() -> None:
+    """The TokenHub-intl origin the platform serves through is a Hunyuan route.
+
+    This is the endpoint the live Tencent lane dispatches through; recognizing
+    it is what makes the carrier route resolve so plaintext reasoning returns and
+    round-trips instead of being stripped.
+    """
+    profile = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        api_key="fake-key",
+        reasoning_output_exposed=True,
+    ).gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is not None
+    assert profile.reasoning_output_exposed is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.29"
+version = "0.7.30"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.29"
+version = "0.7.30"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Problem (live gate 0.7.29, checks 4-5)
The platform's Tencent lane dispatches hy4-preview through Tencent's **TokenHub international** MaaS origin `https://tokenhub-intl.tencentcloudmaas.com/v1`, not the mainland `api.hunyuan.cloud.tencent.com` root. `is_hunyuan_base_url` matched only the latter, so `hunyuan_reasoning_route_sha256` resolved to `None` on the live rung. The 0.7.29 per-rung exposure AND-gate (capability AND carrier route) then correctly failed closed: plaintext `reasoning_content` was stripped and the tool-loop round-trip 400'd, despite the rung being stamped `reasoning_output_exposed=true`.

## Fix
Recognize both OpenAI-compatible reasoning origins (mainland + TokenHub-intl), keeping the same strict scheme/`/v1`-path/no-creds/no-port rules. Site-bound TokenHub siblings (`tokenhub-us`, mainland `tokenhub`) are deliberately **not** matched until a lane dispatches through them (no speculative surface).

Reasoning capture is host-agnostic once the route resolves: the openai dialect reads the standard `reasoning_content` SSE delta gated on the route sha (exactly like the multi-model Fireworks host), so matching the host is sufficient **provided TokenHub-intl emits `reasoning_content`** — verified live before cut.

## Tests
- `hunyuan_test.py`: TokenHub-intl (with/without trailing slash) matches; `tokenhub-us`/mainland/look-alike/`http`/path-shifted variants rejected.
- `openai_compatible_test.py`: a TokenHub-intl rung resolves `hunyuan_reasoning_route_sha256` and exposes when the capability is declared.

Hotfix → 0.7.30 (Python-only; native crate unchanged at 0.3.29). Version bump added at cut.