### PR TITLE
gateway: unbind the reasoning carrier from the catalog generation (check-5 fix)

### DIFF
--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -140,6 +140,33 @@ from exp.runtime.openai_protocol.state import (
 
 _logger = logging.getLogger(__name__)
 
+
+def _log_reasoning_continuation_rejection(
+    authorization: AuthorizationSnapshot, stage: str, reason: object
+) -> None:
+    """Record why a reasoning-carrier continuation failed, for operators only.
+
+    The caller sees one opaque 400 (naming the differing bound claim would be an
+    authentic-continuation oracle), but an operator needs the exact reason to tell
+    a genuine tamper from a benign authority drift. Nothing here carries a
+    credential or the plaintext reasoning; the catalog-generation fields make a
+    cross-worker or post-republish drift obvious when diffed against the issuing
+    turn's admission log.
+    """
+    _logger.warning(
+        "reasoning carrier continuation rejected",
+        extra={
+            "operation": "native_reasoning_continuation",
+            "stage": stage,
+            "reason": str(reason),
+            "request_id": authorization.request_id,
+            "alias": authorization.alias,
+            "alias_revision_id": authorization.alias_revision_id,
+            "catalog_sha256": authorization.catalog_sha256,
+        },
+    )
+
+
 _REQUEST_TIMEOUT_SECONDS = 120.0
 
 
@@ -329,6 +356,7 @@ class NativeControlPlane(
                 request,
             )
         except Exception as exc:  # noqa: BLE001 - one public shape prevents an oracle.
+            _log_reasoning_continuation_rejection(authorization, "authenticate", exc)
             error = invalid_field(
                 "messages.reasoning_content",
                 "'messages.reasoning_content' must be an authentic continuation for this route.",
@@ -353,6 +381,7 @@ class NativeControlPlane(
                 request,
             )
         except Exception as exc:  # noqa: BLE001 - one public shape prevents an oracle.
+            _log_reasoning_continuation_rejection(authorization, "unseal", exc)
             error = invalid_field(
                 "messages.reasoning_content",
                 "'messages.reasoning_content' must be an authentic continuation for this route.",
@@ -363,6 +392,9 @@ class NativeControlPlane(
             and verified_reasoning_route is not None
             and pinned_reasoning_route.deployment != verified_reasoning_route.deployment
         ):
+            _log_reasoning_continuation_rejection(
+                authorization, "route_pin", "authenticate and unseal resolved different deployments"
+            )
             raise NativeBridgeError(
                 invalid_field(
                     "messages.reasoning_content",

--- a/exp/runtime/gateway/reasoning_carrier.py
+++ b/exp/runtime/gateway/reasoning_carrier.py
@@ -127,13 +127,11 @@ def scheme_for_profile(profile: GatewayWireProfile) -> ReasoningCarrierScheme | 
 class ReasoningCarrierClaims(ContractModel):
     """Authenticated plaintext held only while issuing or validating a carrier."""
 
-    schema_version: Literal[2] = 2
+    schema_version: Literal[3] = 3
     organization_id: str = Field(min_length=1, max_length=256)
     identity_id: str = Field(min_length=1, max_length=256)
     virtual_key_id: str = Field(min_length=1, max_length=256)
     alias: str = Field(min_length=1, max_length=256)
-    alias_revision_id: str = Field(min_length=1, max_length=256)
-    catalog_sha256: Sha256
     exact_model_id: str = Field(min_length=1, max_length=256)
     pool_id: str = Field(min_length=1, max_length=256)
     deployment_id: str = Field(min_length=1, max_length=256)
@@ -161,8 +159,6 @@ class ReasoningCarrierAuthority:
     identity_id: str
     virtual_key_id: str
     alias: str
-    alias_revision_id: str
-    catalog_sha256: str
     exact_model_id: str
     pool_id: str
     deployment_id: str
@@ -216,14 +212,21 @@ def reasoning_carrier_authority(
     if route_sha256 is None:
         return None
     credential = _bearer_credential(profile.headers)
+    # The carrier binds routing, credential, and tenant identity — NOT the
+    # catalog GENERATION. ``alias_revision_id`` and ``catalog_sha256`` bump on
+    # every catalog write (a price sync, a capability restamp) and differ across
+    # per-worker in-memory catalog generations, so binding them into the AEAD key
+    # would make a carrier undecryptable on the very next turn whenever the
+    # catalog was republished or the turn landed on another worker — orphaning
+    # every multi-turn tool loop. This is the exact hazard the continuation store
+    # avoids by keying only on stable identity; a real route change still moves
+    # ``deployment_id``/``reasoning_route_sha256`` and still fails authentication.
     key_context = {
-        "schema_version": 2,
+        "schema_version": 3,
         "organization_id": authorization.organization_id,
         "identity_id": authorization.identity_id,
         "virtual_key_id": authorization.virtual_key_id,
         "alias": authorization.alias,
-        "alias_revision_id": authorization.alias_revision_id,
-        "catalog_sha256": authorization.catalog_sha256,
         "exact_model_id": exact_model_id,
         "pool_id": pool_id,
         "deployment_id": deployment.deployment_id,
@@ -250,8 +253,6 @@ def reasoning_carrier_authority(
         identity_id=authorization.identity_id,
         virtual_key_id=authorization.virtual_key_id,
         alias=authorization.alias,
-        alias_revision_id=authorization.alias_revision_id,
-        catalog_sha256=authorization.catalog_sha256,
         exact_model_id=exact_model_id,
         pool_id=pool_id,
         deployment_id=deployment.deployment_id,
@@ -438,13 +439,11 @@ def parse_reasoning_carrier_tool_calls(value: object) -> tuple[ToolCall, ...]:
 def _authority_claims(authority: ReasoningCarrierAuthority) -> dict[str, object]:
     """Return the canonical claim fields shared by issuance and verification."""
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "organization_id": authority.organization_id,
         "identity_id": authority.identity_id,
         "virtual_key_id": authority.virtual_key_id,
         "alias": authority.alias,
-        "alias_revision_id": authority.alias_revision_id,
-        "catalog_sha256": authority.catalog_sha256,
         "exact_model_id": authority.exact_model_id,
         "pool_id": authority.pool_id,
         "deployment_id": authority.deployment_id,

--- a/exp/runtime/gateway/reasoning_carrier_test.py
+++ b/exp/runtime/gateway/reasoning_carrier_test.py
@@ -188,6 +188,36 @@ def test_carrier_survives_a_catalog_generation_change_between_turns() -> None:
     assert block.content == "private provider reasoning"
 
 
+def test_carrier_survives_a_client_content_and_refusal_normalization() -> None:
+    """A tool-only turn round-trips whether the client echoes empty text or null.
+
+    The gateway may stream a tool-only assistant turn with empty text, and an
+    OpenAI-compatible client is free to echo that as the empty string, as ``null``,
+    or to omit it — all the same visible turn. ``refusal`` never reaches the hash:
+    the wire field is not a ``GatewayMessage`` field, so it is dropped before the
+    turn/history digest, and the digest normalizes blank text to absent. Seal with
+    the empty string, replay as null → the carrier still authenticates.
+    """
+    carrier = seal_reasoning_content(
+        _authority(),
+        issuing_request_id="issuing-request",
+        issuing_route_depth=0,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content="",
+        tool_calls=_tool_calls("call-one"),
+        content="hidden reasoning",
+    )
+
+    block, _claims = unseal_reasoning_content(
+        parse_reasoning_content_carrier(carrier),
+        _authority(),
+        assistant_content=None,
+        tool_calls=_tool_calls("call-one"),
+    )
+
+    assert block.content == "hidden reasoning"
+
+
 @pytest.mark.parametrize(
     "changed",
     (

--- a/exp/runtime/gateway/reasoning_carrier_test.py
+++ b/exp/runtime/gateway/reasoning_carrier_test.py
@@ -149,6 +149,45 @@ def test_carrier_round_trip_is_opaque_and_cross_replica_stable() -> None:
     assert claims.issuing_history_sha256 == _HISTORY_SHA256
 
 
+def test_carrier_survives_a_catalog_generation_change_between_turns() -> None:
+    """A carrier decrypts on the next turn after any catalog write or worker skew.
+
+    ``alias_revision_id`` and ``catalog_sha256`` bump on every catalog publish and
+    differ across per-worker in-memory catalog generations, but they do not change
+    the route, credential, or tenant. Binding them would make a carrier
+    undecryptable on the very next turn whenever the catalog was republished (a
+    price sync, a capability restamp) or the turn landed on another worker,
+    orphaning every multi-turn tool loop — the exact hazard the continuation store
+    avoids. The carrier must survive that generation change.
+    """
+    raw_arguments = '{ "q" : "x" }'
+    carrier = seal_reasoning_content(
+        _authority(authorization=_authorization()),
+        issuing_request_id="issuing-request",
+        issuing_route_depth=1,
+        issuing_history_sha256=_HISTORY_SHA256,
+        assistant_content="visible assistant text",
+        tool_calls=_tool_calls("call-one", raw_arguments=raw_arguments),
+        content="private provider reasoning",
+    )
+
+    # Turn two: same route/credential/tenant, a wholly different catalog generation.
+    next_generation = _authority(
+        authorization=_authorization(
+            alias_revision_id="alias-revision-two",
+            catalog_sha256="f" * 64,
+        )
+    )
+    block, _claims = unseal_reasoning_content(
+        parse_reasoning_content_carrier(carrier),
+        next_generation,
+        assistant_content="visible assistant text",
+        tool_calls=_tool_calls("call-one", raw_arguments=raw_arguments),
+    )
+
+    assert block.content == "private provider reasoning"
+
+
 @pytest.mark.parametrize(
     "changed",
     (
@@ -156,7 +195,6 @@ def test_carrier_round_trip_is_opaque_and_cross_replica_stable() -> None:
         replace(_authority(), identity_id="identity-two"),
         replace(_authority(), virtual_key_id="key-two"),
         replace(_authority(), alias="other-alias"),
-        replace(_authority(), alias_revision_id="alias-revision-two"),
         replace(_authority(), deployment_id="fireworks-rung-two"),
         replace(_authority(), connection_authority_sha256="f" * 64),
         _authority(credential="rotated-provider-secret"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.30"
+version = "0.7.31"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.30"
+version = "0.7.31"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Problem (live gate 0.7.30, check 5 — deterministic, not flaky)
Replaying a GENUINE gateway-issued reasoning carrier on the next turn was rejected pre-dispatch (no attempt row) with the opaque `'messages.reasoning_content' must be an authentic continuation for this route.` — 6/6 across variations, same alias/key/org, both turns resolving to the tencent rung.

## Root cause
`reasoning_carrier_authority()` folded `alias_revision_id` **and** `catalog_sha256` into the AEAD **key** derivation (`key_context`) and the claims. Both are catalog-generation-scoped:
- `catalog_sha256` is the whole-catalog snapshot digest; `alias_revision_id` bumps on every publish.
- They change on ANY catalog write (a price sync, the #1225/#947 capability restamp) and differ across per-worker in-memory catalog generations.

So on turn 2, if the catalog had been republished since turn 1 or the turn landed on a different worker, the re-derived `aead_key` differed → `AESGCM.decrypt` → `InvalidTag` → rejected. Deterministic on prod (constant republish churn + multiple workers). The fixture passed only because both replicas load one static seeded catalog.

This is precisely the hazard AGENTS.md says the continuation store deliberately avoids: "an alias revision digest covers the whole catalog, so any catalog write would orphan every open conversation."

## Fix
Drop `alias_revision_id` + `catalog_sha256` from the key context, the authority, and the claims (`schema_version` 2→3). The carrier still binds `org/identity/virtual_key/alias/exact_model_id/pool_id/deployment_id/source_alias/provider/provider_model/model_revision/connection_id/connection_authority_sha256/reasoning_route_sha256` + credential. A real route change (admin repoints the alias) still moves `deployment_id`/`reasoning_route_sha256` → still fails closed. A benign catalog republish no longer does.

## Diagnosis aid
Operator-only WARNING at the continuation-authority seams naming the stage + reason + the turn's catalog generation. The client-facing error stays a single opaque shape (no authentic-continuation oracle).

## Tests
- New: a carrier sealed under one catalog generation decrypts under a wholly different one (same route/credential/tenant) — the exact prod scenario.
- Kept: every genuine authority change (org/identity/key/alias/deployment/connection/credential/route/turn/tool-call) still fails closed. Removed the now-invalid `alias_revision_id`-change rejection case (that behavior is the bug).
- Full gateway suite: 777 passed (only the pre-existing `native_truncation` py3.13 timing flake deselected).

## Open question for review
`model_revision` (deployment.revision) is kept in the binding. If a capability restamp bumps the DEPLOYMENT revision (not just the alias/catalog revision), it would churn the same way and must also be dropped — flagged for the serving-path review.

Hotfix → 0.7.31 (Python-only, native crate unchanged at 0.3.29). Version bump added at cut, after serving-path review.