### PR TITLE
gateway: carry tool_result image blocks; degrade with disclosure off-route; name union misses

### DIFF
--- a/exp/common/models/content.py
+++ b/exp/common/models/content.py
@@ -297,6 +297,12 @@ class TextContentPart(ContractModel):
 
     kind: Literal["text"] = "text"
     text: str
+    cache_control: JsonObject | None = Field(default=None, exclude=True)
+    """Prompt-cache breakpoint the caller placed on this text block, re-emitted
+    verbatim when the block run itself re-emits (a tool_result's inner blocks
+    on Anthropic rungs) and dropped elsewhere: a cache hint changes cost, not
+    semantics. Like the other cache carriers it joins neither serialization
+    nor replay identity."""
 
 
 class ImageContentPart(ContractModel):

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -12,11 +12,13 @@ everywhere and carried on the surfaces the Anthropic wire caches natively
 top-level automatic marker), and dropped on wires that do not cache a marked
 block because a cache hint changes cost, not semantics; ``image`` and PDF
 ``document`` blocks are retained as canonical content parts so a route that
-declares the matching input capability carries them, while a document
-inside ``tool_result`` content is rejected loudly because the serving
-surface cannot preserve it there; ``video`` blocks are rejected because the
-wire defines none. Unknown or unsupported fields are rejected with a
-field-specific error, never silently dropped. Errors raise
+declares the matching input capability carries them — including ``image``
+sub-blocks inside ``tool_result`` content (tool screenshots), which ride the
+tool message's content parts; a document inside ``tool_result`` content is
+rejected loudly because the serving surface cannot preserve it there;
+``video`` blocks are rejected because the wire defines none. Unknown or
+unsupported fields are rejected with a field-specific error, never silently
+dropped. Errors raise
 :class:`OpenAIProtocolError` so the shared boundary stays single-authority;
 the HTTP layer renders them in the Anthropic envelope.
 """
@@ -128,7 +130,10 @@ class _ToolResultBlock(AnthropicWireModel):
 
     type: Literal["tool_result"]
     tool_use_id: str = Field(min_length=1, max_length=256)
-    content: str | tuple[_TextBlock, ...] | None = None
+    # Image sub-blocks are real Anthropic wire (tool screenshots: Claude Code's
+    # Read-on-image and computer-use tools emit them routinely); rejecting them
+    # wedges the caller's session because the block is baked into history.
+    content: str | tuple[_TextBlock | ImageBlock, ...] | None = None
     is_error: bool = False
     cache_control: CacheControl | None = None
 
@@ -521,10 +526,17 @@ def _validate_wire(payload: JsonObject) -> _MessagesRequest:
     try:
         return _MessagesRequest.model_validate(payload)
     except ValidationError as exc:
-        first = exc.errors(include_url=False)[0]
         hint = _rejected_block_hint(payload)
         if hint is not None:
-            raise invalid_field("messages", hint) from exc
+            param, message = hint
+            raise invalid_field(param, message) from exc
+        # A union miss reports one error PER ARM, and the first arm is the
+        # scalar one: naming it ("content.str: Input should be a valid
+        # string") misdirects a caller whose list merely held an unsupported
+        # block. The deepest location is the arm that actually matched the
+        # payload's shape, so its error names the offending element.
+        errors = exc.errors(include_url=False)
+        first = max(errors, key=lambda error: len(error["loc"]))
         raise _validation_error(first) from exc
 
 
@@ -540,8 +552,15 @@ def _validation_error(first: ErrorDetails) -> OpenAIProtocolError:
     cleaned: list[str] = []
     for part in location:
         text = str(part)
-        # Union member class names in pydantic locations are noise for callers.
-        if isinstance(part, str) and (part.startswith("_") or "[" in text):
+        # Union arm labels in pydantic locations are noise for callers: wire
+        # model class names (private or public), scalar type names, and
+        # constrained-type spellings. Real wire fields are snake_case.
+        if isinstance(part, str) and (
+            part.startswith("_")
+            or "[" in text
+            or text[:1].isupper()
+            or text in ("str", "int", "float", "bool", "none", "list", "dict")
+        ):
             continue
         cleaned.append(text)
     param = ".".join(cleaned) or "body"
@@ -557,32 +576,43 @@ def _validation_error(first: ErrorDetails) -> OpenAIProtocolError:
     return invalid_field(param, f"Invalid value for '{param}': {first['msg']}.")
 
 
-def _rejected_block_hint(payload: JsonObject) -> str | None:
-    """Return a targeted message when a known-but-unsupported block is present."""
+def _rejected_block_hint(payload: JsonObject) -> tuple[str, str] | None:
+    """Return the field path and message for a known-but-unsupported block.
+
+    The path names the exact offending block (and, for a ``tool_result``, the
+    offending sub-block), so the caller is never sent to the union's string
+    arm for a list-shaped problem.
+    """
     messages = payload.get("messages")
     if not isinstance(messages, list):
         return None
-    for message in messages:
+    for message_index, message in enumerate(messages):
         if not isinstance(message, dict) or not isinstance(message.get("content"), list):
             continue
-        for block in cast(list[object], message["content"]):
+        for block_index, block in enumerate(cast(list[object], message["content"])):
             if not isinstance(block, dict):
                 continue
             block_object = cast(JsonObject, block)
+            param = f"messages.{message_index}.content.{block_index}"
             hint = _REJECTED_BLOCK_HINTS.get(str(block_object.get("type")))
             if hint is not None:
-                return hint
+                return param, hint
             if block_object.get("type") == "tool_result" and isinstance(
                 block_object.get("content"), list
             ):
-                for inner in cast(list[object], block_object["content"]):
+                for inner_index, inner in enumerate(cast(list[object], block_object["content"])):
                     if not isinstance(inner, dict):
                         continue
-                    hint = _REJECTED_TOOL_RESULT_BLOCK_HINTS.get(
-                        str(cast(JsonObject, inner).get("type"))
-                    )
+                    inner_type = str(cast(JsonObject, inner).get("type"))
+                    inner_param = f"{param}.content.{inner_index}"
+                    hint = _REJECTED_TOOL_RESULT_BLOCK_HINTS.get(inner_type)
                     if hint is not None:
-                        return hint
+                        return inner_param, hint
+                    if inner_type not in ("text", "image"):
+                        return inner_param, (
+                            f"unsupported block type '{inner_type}' inside tool_result "
+                            "content; only text and image sub-blocks are supported."
+                        )
     return None
 
 
@@ -826,6 +856,7 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                 GatewayMessage(
                     role="tool",
                     content=_tool_result_text(block),
+                    content_parts=_tool_result_parts(block, f"{param}.content.{block_index}"),
                     tool_call_id=block.tool_use_id,
                     tool_is_error=block.is_error,
                     # The marker Claude Code puts on its conversation
@@ -854,4 +885,35 @@ def _tool_result_text(block: _ToolResultBlock) -> str:
         return ""
     if isinstance(block.content, str):
         return block.content
-    return "".join(part.text for part in block.content)
+    return "".join(part.text for part in block.content if isinstance(part, _TextBlock))
+
+
+def _tool_result_parts(block: _ToolResultBlock, param: str) -> tuple[MessageContentPart, ...]:
+    """Retain a tool result's ordered parts when it carries an image.
+
+    Text-only results keep the flattened ``content`` string and no parts, so
+    existing requests serialize and digest exactly as before. An image
+    sub-block (a tool screenshot) makes the result multimodal: every part is
+    retained in caller order so an image-capable Anthropic rung re-emits the
+    exact block run.
+
+    Args:
+        block: Validated tool_result wire block.
+        param: Public parameter path for reporting one invalid image.
+
+    Returns:
+        The ordered canonical parts, or ``()`` for a text-only result.
+    """
+    if isinstance(block.content, str) or block.content is None:
+        return ()
+    if not any(isinstance(part, ImageBlock) for part in block.content):
+        return ()
+    parts: list[MessageContentPart] = []
+    for index, part in enumerate(block.content):
+        if isinstance(part, ImageBlock):
+            parts.append(image_part_from_block(part, f"{param}.content.{index}"))
+        elif part.text:
+            # An empty text block adds no bytes to the flattened content and
+            # cannot ride a multimodal turn, mirroring the user-message path.
+            parts.append(TextContentPart(text=part.text))
+    return tuple(parts)

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -915,5 +915,14 @@ def _tool_result_parts(block: _ToolResultBlock, param: str) -> tuple[MessageCont
         elif part.text:
             # An empty text block adds no bytes to the flattened content and
             # cannot ride a multimodal turn, mirroring the user-message path.
-            parts.append(TextContentPart(text=part.text))
+            parts.append(
+                TextContentPart(
+                    text=part.text,
+                    cache_control=(
+                        part.cache_control.model_dump(mode="json", exclude_none=True)
+                        if part.cache_control is not None
+                        else None
+                    ),
+                )
+            )
     return tuple(parts)

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -381,6 +381,74 @@ def test_a_tool_result_image_re_emits_as_the_exact_block_run() -> None:
     ]
 
 
+def test_a_cache_marker_on_a_tool_result_text_block_round_trips() -> None:
+    """A breakpoint on an inner text block re-emits with the block run.
+
+    Claude Code marks the last block of recent user turns; in an agent loop
+    that block can be a text sub-block inside an image-bearing tool_result,
+    and losing it would silently un-cache the conversation prefix.
+    """
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "read the screenshot"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "call-1", "name": "computer", "input": {}}
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call-1",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "tool said:",
+                                    "cache_control": {"type": "ephemeral"},
+                                },
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/png",
+                                        "data": _PNG_BASE64,
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ]
+        )
+    )
+    _role, blocks = anthropic_blocks(decoded.request.messages[-1])
+    assert blocks == [
+        {
+            "type": "tool_result",
+            "tool_use_id": "call-1",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "tool said:",
+                    "cache_control": {"type": "ephemeral"},
+                },
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": _PNG_BASE64,
+                    },
+                },
+            ],
+        }
+    ]
+
+
 def test_malformed_image_source_is_rejected() -> None:
     """An image the gateway cannot forward is rejected at its own path."""
     with pytest.raises(OpenAIProtocolError) as excinfo:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -355,6 +355,32 @@ def test_an_empty_text_block_beside_an_image_never_re_emits() -> None:
     ]
 
 
+def test_a_tool_result_image_re_emits_as_the_exact_block_run() -> None:
+    """An Anthropic rung round-trips the tool screenshot losslessly."""
+    decoded = decode_messages(
+        _body(messages=_tool_result_image_messages(leading_text="tool said:"))
+    )
+    role, blocks = anthropic_blocks(decoded.request.messages[-1])
+    assert role == "user"
+    assert blocks == [
+        {
+            "type": "tool_result",
+            "tool_use_id": "call-1",
+            "content": [
+                {"type": "text", "text": "tool said:"},
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": _PNG_BASE64,
+                    },
+                },
+            ],
+        }
+    ]
+
+
 def test_malformed_image_source_is_rejected() -> None:
     """An image the gateway cannot forward is rejected at its own path."""
     with pytest.raises(OpenAIProtocolError) as excinfo:
@@ -391,6 +417,122 @@ def test_document_block_inside_tool_result_is_rejected() -> None:
             )
         )
     assert "document blocks are not supported" in excinfo.value.detail.message
+
+
+def _tool_result_image_messages(*, leading_text: str | None = None) -> list[JsonObject]:
+    """The owner-reported repro: text turn, tool_use, tool_result with an image."""
+    inner: list[JsonObject] = []
+    if leading_text is not None:
+        inner.append({"type": "text", "text": leading_text})
+    inner.append(
+        {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": _PNG_BASE64},
+        }
+    )
+    return [
+        {"role": "user", "content": "read the screenshot"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": "call-1", "name": "computer", "input": {}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "call-1", "content": inner}],
+        },
+    ]
+
+
+def test_image_blocks_inside_tool_results_ride_the_tool_message_parts() -> None:
+    """A tool screenshot decodes losslessly instead of 400ing the session.
+
+    Anthropic's real API accepts image sub-blocks in tool_result content, and
+    Claude Code's Read-on-image and computer-use tools emit them routinely;
+    the block is baked into history, so rejecting it wedges every later turn.
+    """
+    decoded = decode_messages(
+        _body(messages=_tool_result_image_messages(leading_text="tool said:"))
+    )
+    tool_message = decoded.request.messages[-1]
+    assert tool_message.role == "tool"
+    assert tool_message.tool_call_id == "call-1"
+    assert tool_message.content == "tool said:"
+    assert [part.kind for part in tool_message.content_parts] == ["text", "image"]
+    assert tool_message.images[0].data == _PNG_BASE64
+
+
+def test_an_image_only_tool_result_decodes_with_empty_content() -> None:
+    """The exact wedged-session repro: content is one bare image block."""
+    decoded = decode_messages(_body(messages=_tool_result_image_messages()))
+    tool_message = decoded.request.messages[-1]
+    assert tool_message.role == "tool"
+    assert tool_message.content == ""
+    assert [part.kind for part in tool_message.content_parts] == ["image"]
+
+
+def test_a_text_only_tool_result_retains_no_content_parts() -> None:
+    """Existing text-only results serialize and digest exactly as before."""
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call-1",
+                            "content": [{"type": "text", "text": "plain"}],
+                        }
+                    ],
+                }
+            ]
+        )
+    )
+    tool_message = decoded.request.messages[-1]
+    assert tool_message.content == "plain"
+    assert tool_message.content_parts == ()
+
+
+def test_an_unknown_tool_result_sub_block_names_its_index_and_type() -> None:
+    """A union miss must name the offending block, never the string arm.
+
+    The misleading "content.str: Input should be a valid string" rendering
+    sent an entire diagnosis chain toward the caller's request shape when the
+    real problem was one unsupported sub-block in the list arm.
+    """
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages(
+            _body(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "call-1",
+                                "content": [{"type": "mystery"}],
+                            }
+                        ],
+                    }
+                ]
+            )
+        )
+    assert excinfo.value.detail.param == "messages.0.content.0.content.0"
+    assert "unsupported block type 'mystery'" in excinfo.value.detail.message
+    assert ".str" not in (excinfo.value.detail.param or "")
+
+
+def test_a_union_miss_never_reports_the_string_arm() -> None:
+    """A structurally bad list block reports its own path, not content.str."""
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages(
+            _body(messages=[{"role": "user", "content": [{"type": "text", "text": 7}]}])
+        )
+    param = excinfo.value.detail.param or ""
+    assert ".str" not in param
+    assert param.startswith("messages.0.content.0")
 
 
 _PDF_BASE64 = "JVBERi0xLjQKJSBtaW5pbWFsIHBkZgo="

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -345,10 +345,17 @@ class GatewayMessage(ContractModel):
             if (self.content or "") not in ("".join(texts), "\n\n".join(texts)):
                 raise ValueError("provider text blocks must flatten to the message content")
         if self.content_parts:
-            if self.role != "user":
-                raise ValueError("content parts are valid only for user messages")
+            # Tool messages carry attachments too: Anthropic tool_result blocks
+            # accept image sub-blocks (tool screenshots), and the block is baked
+            # into caller history, so the canonical model must be able to hold it.
+            if self.role not in ("user", "tool"):
+                raise ValueError("content parts are valid only for user and tool messages")
             if all(part.kind == "text" for part in self.content_parts):
                 raise ValueError("content parts are retained only for multimodal messages")
+            if self.role == "tool" and any(
+                part.kind not in ("text", "image") for part in self.content_parts
+            ):
+                raise ValueError("tool messages carry only text and image parts")
             texts = [part.text for part in self.content_parts if part.kind == "text"]
             if (self.content or "") != "".join(texts):
                 raise ValueError("content parts must flatten to the message content")

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -971,3 +971,41 @@ def test_service_tier_is_serialization_inert_but_binds_replay_identity() -> None
             messages=messages,
             service_tier="flex",
         )
+
+
+def test_tool_messages_carry_text_and_image_parts_only() -> None:
+    """A tool screenshot rides the tool message; other media kinds stay out."""
+    from exp.common.models.content import (
+        DocumentContentPart,
+        ImageContentPart,
+        TextContentPart,
+    )
+
+    message = GatewayMessage(
+        role="tool",
+        tool_call_id="call-1",
+        content="tool said:",
+        content_parts=(
+            TextContentPart(text="tool said:"),
+            ImageContentPart(media_type="image/png", data="aGk="),
+        ),
+    )
+    assert [part.kind for part in message.content_parts] == ["text", "image"]
+    assert message.images
+
+    with pytest.raises(ValidationError, match="text and image parts"):
+        GatewayMessage(
+            role="tool",
+            tool_call_id="call-1",
+            content="",
+            content_parts=(DocumentContentPart(media_type="application/pdf", data="aGk="),),
+        )
+    with pytest.raises(ValidationError, match="valid only for user and tool"):
+        GatewayMessage(
+            role="assistant",
+            content="hi",
+            content_parts=(
+                TextContentPart(text="hi"),
+                ImageContentPart(media_type="image/png", data="aGk="),
+            ),
+        )

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -3,6 +3,9 @@
 import base64
 from typing import Literal, cast
 
+import pytest
+
+from exp.common.core.artifacts import JsonObject
 from exp.common.models.catalog import GatewayDeploymentCapabilities, GatewayDeploymentMetadata
 from exp.common.models.content import (
     AudioContentPart,
@@ -525,4 +528,143 @@ def test_disabled_thinking_on_an_adaptive_only_mixed_route_is_dropped_with_discl
     assert tuple(item.deployment_id for item in narrowed.deployments) == ("native", "shim")
     assert public.ignored_parameters == ("thinking.type->adaptive",)
     assert provider.provider_thinking_config is None
+    assert accounting.recorded == 1
+
+
+_TOOL_IMAGE_PNG = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+"""One valid single-pixel PNG, base64 encoded (the owner-reported repro image)."""
+
+
+def _tool_screenshot_route_request(*, stream: bool) -> GatewayRequest:
+    """Decode the owner-reported wedged-session repro through the real surface.
+
+    The exact wire body: a user text turn, an assistant ``tool_use``, and a
+    user ``tool_result`` whose content is one base64 PNG image sub-block.
+    """
+    from exp.runtime.anthropic_protocol.requests import decode_messages
+
+    body: JsonObject = {
+        "model": "coding",
+        "max_tokens": 128,
+        "stream": stream,
+        "messages": [
+            {"role": "user", "content": "read the screenshot"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "call-1", "name": "computer", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call-1",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": _TOOL_IMAGE_PNG,
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+    return decode_messages(body).request.model_copy(update={"include_usage": True})
+
+
+class _AdmissionCoercionCounter:
+    """Count coercion recordings without a live ledger."""
+
+    def __init__(self) -> None:
+        self.recorded = 0
+
+    def record_admission_coercions(self, count: int) -> None:
+        self.recorded += count
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_tool_result_image_passes_through_on_a_vision_anthropic_route(stream: bool) -> None:
+    """The repro serves verbatim on an image-capable Anthropic route."""
+    from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+
+    vision = GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+            supports_image_input=True,
+        )
+    )
+    deployments = (_deployment("claude", provider="anthropic", gateway=vision),)
+    route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.MESSAGES)
+    client = cast(NativeWireClient, object())
+    wires = (
+        (GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test"), client),
+    )
+    accounting = _AdmissionCoercionCounter()
+
+    _narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        wires,
+        _tool_screenshot_route_request(stream=stream),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+
+    tool_message = provider.messages[-1]
+    assert tool_message.role == "tool"
+    assert [part.kind for part in tool_message.content_parts] == ["image"]
+    assert tool_message.images[0].data == _TOOL_IMAGE_PNG
+    assert public.ignored_parameters == ()
+    assert accounting.recorded == 0
+
+
+@pytest.mark.parametrize("stream", [True, False])
+def test_tool_result_image_degrades_with_disclosure_on_a_non_vision_route(stream: bool) -> None:
+    """The repro serves with a disclosed placeholder instead of a 400.
+
+    The image is baked into the caller's history, so a rejection wedges every
+    later turn of the session; a fable-5.1-style non-vision route answers the
+    degraded request while ``ignored_parameters`` tells the caller what was
+    dropped.
+    """
+    from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+    from exp.runtime.models.providers.streaming_requests import (
+        TOOL_RESULT_IMAGE_DROP_DISCLOSURE,
+        TOOL_RESULT_IMAGE_PLACEHOLDER,
+    )
+
+    text_only = GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        )
+    )
+    deployments = (_deployment("claude", provider="anthropic", gateway=text_only),)
+    route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.MESSAGES)
+    client = cast(NativeWireClient, object())
+    wires = (
+        (GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test"), client),
+    )
+    accounting = _AdmissionCoercionCounter()
+
+    _narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        wires,
+        _tool_screenshot_route_request(stream=stream),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+
+    tool_message = provider.messages[-1]
+    assert tool_message.content_parts == ()
+    assert tool_message.content == TOOL_RESULT_IMAGE_PLACEHOLDER
+    assert TOOL_RESULT_IMAGE_DROP_DISCLOSURE in public.ignored_parameters
     assert accounting.recorded == 1

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -37,7 +37,11 @@ from exp.runtime.models.providers.reasoning_compat import (
     anthropic_adaptive_only_thinking,
     efforts_by_nearness,
 )
-from exp.runtime.models.providers.streaming_requests import route_generation_parameter_requests
+from exp.runtime.models.providers.streaming_requests import (
+    TOOL_RESULT_IMAGE_DROP_DISCLOSURE,
+    route_generation_parameter_requests,
+    strip_tool_result_images,
+)
 
 if TYPE_CHECKING:
     from exp.runtime.models.providers.base import GatewayWireProfile
@@ -217,13 +221,18 @@ def _coerce_disabled_thinking(
 def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoercion | None:
     """Build the disclosed coercion for one preflight capability rejection.
 
-    Two capabilities are coercible, both only here — after every rung declined
-    the verbatim request — and both only as a disclosed drop. Degrading
+    Three coercions exist, all only here — after every rung declined the
+    verbatim request — and all only as a disclosed substitution. Degrading
     ``strict: true`` tools to best-effort schemas weakens a correctness
     guarantee. Dropping ``service_tier`` changes pricing and latency
     semantics, which the caller can act on only when told, so the drop is
-    disclosed rather than silent. Every other capability names a feature with
-    no approximation and stays fail-closed.
+    disclosed rather than silent. Images inside TOOL results degrade to
+    placeholder text on an image-incapable route because the block is baked
+    into the caller's history and a rejection wedges the whole session; a
+    top-level user image keeps the fail-closed contract (the caller can
+    re-send it), so ``image_input`` coerces only when every image in the
+    request lives in a tool message. Every other capability names a feature
+    with no approximation and stays fail-closed.
 
     Args:
         capability: Stable capability literal from the preflight rejection.
@@ -233,6 +242,16 @@ def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoerci
         The disclosed substitution to retry with, or ``None`` when the
         capability cannot be coerced.
     """
+    if capability == "image_input":
+        if any(message.role != "tool" and message.images for message in request.messages):
+            return None
+        stripped = strip_tool_result_images(request.messages)
+        if stripped is None:
+            return None
+        return RequestCoercion(
+            request=request.model_copy(update={"messages": stripped}),
+            disclosures=(TOOL_RESULT_IMAGE_DROP_DISCLOSURE,),
+        )
     if capability == "service_tier":
         if request.service_tier is None:
             return None

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -464,3 +464,67 @@ def test_disabled_thinking_drops_only_on_adaptive_only_anthropic_routes() -> Non
         coerce_generation_parameters((adaptive_only, shim), request, admits=lambda _c: False)
         is None
     )
+
+
+def _tool_image_request(*, user_image: bool = False) -> GatewayRequest:
+    """One request whose only (or not only) images live in a tool result."""
+    from exp.common.models.content import ImageContentPart, TextContentPart
+
+    messages: list[GatewayMessage] = [GatewayMessage(role="user", content="go")]
+    if user_image:
+        messages[0] = GatewayMessage(
+            role="user",
+            content="go",
+            content_parts=(
+                TextContentPart(text="go"),
+                ImageContentPart(media_type="image/png", data="aGk="),
+            ),
+        )
+    messages.append(
+        GatewayMessage(
+            role="tool",
+            tool_call_id="call-1",
+            content="tool said:",
+            content_parts=(
+                TextContentPart(text="tool said:"),
+                ImageContentPart(media_type="image/png", data="aGk="),
+            ),
+        )
+    )
+    return GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=tuple(messages),
+    )
+
+
+def test_tool_result_images_degrade_with_placeholder_on_a_non_vision_route() -> None:
+    """A route-wide image_input rejection coerces when every image is a tool
+    screenshot: the block is baked into history, so a rejection wedges the
+    caller's whole session while a disclosed placeholder keeps it alive."""
+    from exp.runtime.models.providers.streaming_requests import (
+        TOOL_RESULT_IMAGE_DROP_DISCLOSURE,
+        TOOL_RESULT_IMAGE_PLACEHOLDER,
+    )
+
+    coercion = coerce_capability("image_input", _tool_image_request())
+    assert coercion is not None
+    tool_message = coercion.request.messages[-1]
+    assert tool_message.content_parts == ()
+    assert tool_message.content == "tool said:" + TOOL_RESULT_IMAGE_PLACEHOLDER
+    assert coercion.disclosures == (TOOL_RESULT_IMAGE_DROP_DISCLOSURE,)
+
+
+def test_top_level_user_images_keep_the_fail_closed_contract() -> None:
+    """A user image the caller can re-send never degrades silently."""
+    assert coerce_capability("image_input", _tool_image_request(user_image=True)) is None
+    # And a request with no images at all offers nothing to coerce.
+    assert (
+        coerce_capability(
+            "image_input",
+            GatewayRequest(
+                surface=GatewayApiSurface.MESSAGES,
+                messages=(GatewayMessage(role="user", content="go"),),
+            ),
+        )
+        is None
+    )

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
+    GatewayMessage,
     GatewayNamedToolChoice,
     GatewayRequest,
 )
@@ -50,6 +51,47 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 _ANTHROPIC_REQUIRED_MAX_TOKENS_DEFAULT = 4096
+
+TOOL_RESULT_IMAGE_DROP_DISCLOSURE = "messages.content.tool_result.image->placeholder"
+"""Disclosure recorded when tool-result images degrade to placeholder text.
+
+A tool screenshot is baked into the caller's conversation history: rejecting
+it wedges every later turn of a multi-turn session, which is strictly worse
+than a disclosed degrade. Top-level user images keep the fail-closed contract
+because the caller can re-send those differently.
+"""
+
+TOOL_RESULT_IMAGE_PLACEHOLDER = "[image omitted: this model route cannot carry tool-result images]"
+"""Text substituted for each dropped tool-result image, in block position."""
+
+
+def strip_tool_result_images(
+    messages: tuple[GatewayMessage, ...],
+) -> tuple[GatewayMessage, ...] | None:
+    """Replace tool-message image parts with positional placeholder text.
+
+    Args:
+        messages: The request's canonical messages.
+
+    Returns:
+        The degraded messages, or ``None`` when no tool message carries an
+        image (nothing to strip).
+    """
+    if not any(message.role == "tool" and message.images for message in messages):
+        return None
+    out: list[GatewayMessage] = []
+    for message in messages:
+        if message.role != "tool" or not message.images:
+            out.append(message)
+            continue
+        content = "".join(
+            part.text if part.kind == "text" else TOOL_RESULT_IMAGE_PLACEHOLDER
+            for part in message.content_parts
+        )
+        out.append(message.model_copy(update={"content": content, "content_parts": ()}))
+    return tuple(out)
+
+
 GATEWAY_GENERATION_PARAMETER_CONTRACT_VERSION = 2
 """Version of the route admission and provider wire-translation contract."""
 
@@ -500,6 +542,22 @@ def route_generation_parameter_requests(
             param=path,
             code="unsupported_parameter",
         )
+
+    # Only the Anthropic wire defines an image carrier inside a tool result.
+    # A route with any other dialect degrades tool-result images to positional
+    # placeholder text with disclosure instead of rejecting: the block is baked
+    # into the caller's history, so a rejection wedges the whole session, and a
+    # silent drop at encoding would misstate what the model saw. All-Anthropic
+    # routes keep the images; a non-vision rung then rejects at preflight and
+    # the route-wide coercion applies the same disclosed degrade.
+    if any(message.role == "tool" and message.images for message in request.messages) and not all(
+        profile.dialect == "anthropic_messages" for profile in profiles
+    ):
+        stripped = strip_tool_result_images(request.messages)
+        if stripped is not None:
+            provider_updates["messages"] = stripped
+            if TOOL_RESULT_IMAGE_DROP_DISCLOSURE not in ignored:
+                ignored.append(TOOL_RESULT_IMAGE_DROP_DISCLOSURE)
 
     if any(message.tool_is_error for message in request.messages) and not all(
         profile.dialect == "anthropic_messages" for profile in profiles

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -35,6 +35,8 @@ from exp.runtime.models.providers.generation_route_compat import (
     compatible_generation_parameter_profile_indexes,
 )
 from exp.runtime.models.providers.streaming_requests import (
+    TOOL_RESULT_IMAGE_DROP_DISCLOSURE,
+    TOOL_RESULT_IMAGE_PLACEHOLDER,
     anthropic_messages_stream_payload,
     bedrock_converse_stream_payload,
     dialect_stream_payload,
@@ -402,6 +404,56 @@ def test_route_rejects_reasoning_summary_outside_native_responses() -> None:
 
     assert raised.value.code == "unsupported_parameter"
     assert raised.value.param == "reasoning.generate_summary"
+
+
+def _tool_image_message() -> GatewayMessage:
+    """One tool message carrying a screenshot beside its text."""
+    return GatewayMessage(
+        role="tool",
+        tool_call_id="call-1",
+        content="tool said:",
+        content_parts=(
+            TextContentPart(text="tool said:"),
+            ImageContentPart(media_type="image/png", data="aGk="),
+        ),
+    )
+
+
+def test_a_mixed_route_degrades_tool_result_images_with_disclosure() -> None:
+    """A non-Anthropic rung cannot express a tool-result image, so the route
+    substitutes positional placeholder text and discloses the drop instead of
+    rejecting a block the caller cannot remove from history."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="go"), _tool_image_message()),
+    )
+    profiles = (
+        GatewayWireProfile(dialect="anthropic_messages", url="https://a.test"),
+        GatewayWireProfile(dialect="openai_compatible", url="https://b.test"),
+    )
+
+    public_request, provider_request = route_generation_parameter_requests(profiles, request)
+
+    tool_message = provider_request.messages[-1]
+    assert tool_message.content_parts == ()
+    assert tool_message.content == "tool said:" + TOOL_RESULT_IMAGE_PLACEHOLDER
+    assert TOOL_RESULT_IMAGE_DROP_DISCLOSURE in public_request.ignored_parameters
+    # The public request keeps the caller's original history.
+    assert public_request.messages[-1].images
+
+
+def test_an_all_anthropic_route_keeps_tool_result_images() -> None:
+    """Single-dialect Anthropic routes carry the screenshot verbatim."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="go"), _tool_image_message()),
+    )
+    profiles = (GatewayWireProfile(dialect="anthropic_messages", url="https://a.test"),)
+
+    public_request, provider_request = route_generation_parameter_requests(profiles, request)
+
+    assert provider_request.messages[-1].images
+    assert TOOL_RESULT_IMAGE_DROP_DISCLOSURE not in public_request.ignored_parameters
 
 
 def test_route_accepts_reasoning_summary_on_native_anthropic() -> None:

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -183,6 +183,17 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             "tool_use_id": message.tool_call_id or "",
             "content": message.content or "",
         }
+        if message.content_parts:
+            # A tool screenshot re-emits as the caller's exact block run:
+            # image parts become image blocks in their original positions.
+            # The canonical model restricts tool messages to these two kinds.
+            run: list[JsonObject] = []
+            for part in message.content_parts:
+                if part.kind == "image":
+                    run.append(anthropic_image_block(part))
+                elif part.kind == "text":
+                    run.append({"type": "text", "text": part.text})
+            result["content"] = run
         # Only the Anthropic wire can express a failed tool invocation; the
         # marker is emitted solely when set so existing payloads are unchanged.
         if message.tool_is_error:

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -192,7 +192,10 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
                 if part.kind == "image":
                     run.append(anthropic_image_block(part))
                 elif part.kind == "text":
-                    run.append({"type": "text", "text": part.text})
+                    block: JsonObject = {"type": "text", "text": part.text}
+                    if part.cache_control is not None:
+                        block["cache_control"] = part.cache_control
+                    run.append(block)
             result["content"] = run
         # Only the Anthropic wire can express a failed tool invocation; the
         # marker is emitted solely when set so existing payloads are unchanged.


### PR DESCRIPTION
## Incident (owner-reported, wedged live Claude Code session)

The Messages-surface wire model rejected image sub-blocks inside `tool_result.content` — real Anthropic wire that Claude Code's Read-on-image and computer-use tools emit routinely — and the pydantic union leaked the misleading error `Invalid value for 'messages.N.content.str': Input should be a valid string`, naming the union's string arm when the actual problem was an unsupported sub-block in the list arm. The block is baked into conversation history, so the 400 wedged every later turn of the session, and the misleading error sent the diagnosis chain toward the caller's request shape.

## Fix 1: accept, then route by capability

- `_ToolResultBlock.content` accepts `image` sub-blocks; they decode into the tool message's `content_parts` (the canonical model now allows text+image parts on `role="tool"`; text-only results keep the exact prior serialization and digests, regression-pinned).
- **All-Anthropic, image-capable route:** verbatim pass-through — `anthropic_blocks` re-emits the caller's exact block run (ordered text/image blocks, cache markers preserved via the shared media helpers).
- **Route with any non-Anthropic rung:** no other wire defines a tool-result image carrier, so route shaping substitutes positional placeholder text (`[image omitted: this model route cannot carry tool-result images]`) with an `ignored_parameters` disclosure (`messages.content.tool_result.image->placeholder`), mirroring the `context_management` precedent — never a silent drop at encoding, never a 400.
- **All-Anthropic, NON-vision route** (fable-5.1's current route): per-rung preflight rejects `image_input` as before, and the route-wide rejection now coerces to the same disclosed placeholder degrade — but ONLY when every image in the request lives in a tool message. Top-level user images keep the fail-closed contract (the caller can re-send those; a history block they cannot remove).

## Fix 2: union-miss error rendering

- The deepest-location pydantic error is rendered instead of the first arm's, so a list-shaped problem never reports `content.str`; CamelCase arm labels and scalar type spellings are stripped from public paths.
- The pre-scan hint names the exact offending block path, and an unknown `tool_result` sub-block type gets its own message: `messages.N.content.i.content.j: unsupported block type 'X' inside tool_result content; only text and image sub-blocks are supported.`

## Regression fixtures (as ordered)

The exact repro (user text; assistant `tool_use`; user `tool_result` whose content is one base64 1×1 PNG) is decoded through the real surface decoder and driven through `admitted_route_requests` × (vision-capable route → verbatim pass-through, non-vision route → disclosed placeholder + coercion accounting) × (streamed, non-streamed); plus decode/round-trip/coercion/validator unit fixtures and the never-`content.str` error pins.

## Notes

- Python-only: no `native/` changes, no crate bump. Rides the next train.
- **Inherited red:** the `gate` check is failing on main itself at bc8c1566 — #772 pushed `exp/runtime/gateway/native_bridge.py` to 1030 lines, tripping the 999-line repo-layout test. This PR's full suite is green except that pre-existing failure (3563 passed, 1 failed = the layout test on an untouched file).

## Validation

- `uv run pytest -q`: 3563 passed, 6 skipped, 1 failed (the inherited main-red layout test above)
- `ruff format` / `ruff check` / `ty check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)