### PR TITLE
gateway: haiku-4.5 budgeted-enabled reasoning + thinking-history fail-safe + provider-error attribution

### DIFF
--- a/exp/common/models/discovery.py
+++ b/exp/common/models/discovery.py
@@ -179,10 +179,17 @@ def resolve_discovered_model(discovered: DiscoveredModel) -> ResolvedDiscoveredM
         discovered.supports_top_k,
         known.supports_top_k if known else None,
     )
-    supports_reasoning = _proven(
-        discovered.supports_reasoning,
-        known.supports_reasoning_effort if known else None,
-    )
+    # An explicit known.supports_reasoning wins (a budgeted-enabled model
+    # reasons without an effort ladder); absent it, the historical derivation
+    # from supports_reasoning_effort is preserved for backward compatibility.
+    known_reasoning: bool | None = None
+    if known is not None:
+        known_reasoning = (
+            known.supports_reasoning
+            if known.supports_reasoning is not None
+            else known.supports_reasoning_effort
+        )
+    supports_reasoning = _proven(discovered.supports_reasoning, known_reasoning)
     capabilities = ModelCapabilities(
         supports_tools=_proven(
             discovered.supports_tools,

--- a/exp/common/models/discovery_test.py
+++ b/exp/common/models/discovery_test.py
@@ -57,8 +57,11 @@ def test_maintained_sampling_pins_flow_into_resolved_capabilities() -> None:
     assert not pinned.capabilities.supports_temperature
     assert pinned.capabilities.supports_reasoning
     assert pinned.capabilities.reasoning_effort == "medium"
+    # haiku is budgeted-enabled reasoning: it reasons and keeps ordinary
+    # sampling (no temperature pin), but carries no effort-ladder pin of its
+    # own beyond the shared default.
     assert unpinned.capabilities.supports_temperature
-    assert unpinned.capabilities.reasoning_effort is None
+    assert unpinned.capabilities.supports_reasoning
 
 
 def test_unknown_model_keeps_every_capability_and_price_unknown() -> None:
@@ -144,9 +147,7 @@ def test_catalog_request_shaping_capability_reaches_openai_runtime_metadata() ->
 def test_reasoning_capable_models_resolve_with_the_default_medium_pin() -> None:
     """Models proven to accept reasoning effort default to medium; others stay unpinned."""
     reasoning = resolve_discovered_model(DiscoveredModel(provider="openai", model="gpt-5.6-luna"))
-    plain = resolve_discovered_model(
-        DiscoveredModel(provider="anthropic", model="claude-haiku-4-5")
-    )
+    plain = resolve_discovered_model(DiscoveredModel(provider="openai", model="gpt-4o"))
     embedding = resolve_discovered_model(
         DiscoveredModel(provider="openai", model="text-embedding-3-small")
     )

--- a/exp/common/models/known_models.py
+++ b/exp/common/models/known_models.py
@@ -36,6 +36,16 @@ class KnownModel:
     supports_frequency_penalty: bool | None = None
     supports_presence_penalty: bool | None = None
     supports_reasoning_effort: bool = False
+    supports_reasoning: bool | None = None
+    """Whether the model reasons at all, independent of effort-ladder control.
+
+    ``None`` defers to ``supports_reasoning_effort`` (the historical
+    derivation, kept for backward compatibility). An explicit ``True`` marks a
+    reasoning-capable model whose depth is NOT an OpenAI-style effort ladder —
+    for example an Anthropic budgeted-enabled model whose thinking is expressed
+    through ``budget_tokens`` — so its thinking config is honored even though
+    ``supports_reasoning_effort`` is ``False``.
+    """
     reasoning_effort: (
         Literal["none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"] | None
     ) = None
@@ -69,6 +79,7 @@ def _chat(
     supports_logprobs: bool = False,
     supports_structured_output: bool = True,
     supports_reasoning_effort: bool = False,
+    supports_reasoning: bool | None = None,
     reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"]
     | None = None,
     sampling_requires_reasoning_none: bool = False,
@@ -96,6 +107,8 @@ def _chat(
         supports_structured_output: Whether the model supports structured outputs.
         supports_reasoning_effort: Whether the model accepts an explicit reasoning-effort
             parameter on the OpenAI Responses API.
+        supports_reasoning: Whether the model reasons at all when it does not accept an
+            effort ladder; ``None`` defers to ``supports_reasoning_effort``.
         reasoning_effort: Valid default effort for this exact model.
         sampling_requires_reasoning_none: Whether sampling controls require exact effort none.
         chat_max_tokens_field: Exact Chat Completions output-limit field, when applicable.
@@ -119,6 +132,7 @@ def _chat(
         supports_top_k=supports_top_k,
         supports_logprobs=supports_logprobs,
         supports_reasoning_effort=supports_reasoning_effort,
+        supports_reasoning=supports_reasoning,
         reasoning_effort=(reasoning_effort or "medium" if supports_reasoning_effort else None),
         sampling_requires_reasoning_none=sampling_requires_reasoning_none,
         chat_max_tokens_field=chat_max_tokens_field,
@@ -146,8 +160,19 @@ def _anthropic_chat(
     context_window_tokens: int | None = None,
     maximum_output_tokens: int | None = None,
     adaptive_reasoning: bool = False,
+    supports_reasoning: bool | None = None,
+    sampling_requires_reasoning_none: bool = False,
 ) -> KnownModel:
-    """Describe one native Anthropic Messages model's exact generation controls."""
+    """Describe one native Anthropic Messages model's exact generation controls.
+
+    ``adaptive_reasoning`` is the xhigh-effort adaptive generation: it pins
+    temperature and top_p to their thinking-on values for the whole route. A
+    budgeted-enabled model instead passes ``supports_reasoning=True`` with
+    ``sampling_requires_reasoning_none=True`` and keeps ordinary sampling —
+    its thinking is optional, so a global temperature pin would reject every
+    legitimate thinking-off request; the srn hatch resolves the "temperature
+    must be 1 with thinking on" conflict per request instead.
+    """
     return _chat(
         input_usd=input_usd,
         output_usd=output_usd,
@@ -157,6 +182,8 @@ def _anthropic_chat(
         maximum_output_tokens=maximum_output_tokens,
         supports_top_k=not adaptive_reasoning,
         supports_reasoning_effort=adaptive_reasoning,
+        supports_reasoning=supports_reasoning,
+        sampling_requires_reasoning_none=sampling_requires_reasoning_none,
         minimum_temperature=1.0 if adaptive_reasoning else 0.0,
         maximum_temperature=1.0,
         minimum_top_p=0.99 if adaptive_reasoning else 0.0,
@@ -560,6 +587,13 @@ _ANTHROPIC_MODELS: dict[str, KnownModel] = {
         output_usd=5.0,
         context_window_tokens=200_000,
         maximum_output_tokens=64_000,
+        # Budgeted-enabled reasoning: haiku honors a caller thinking config
+        # (budget_tokens), but it is NOT the adaptive/effort-ladder generation,
+        # so its depth is not effort-controlled. srn carries the "temperature
+        # must be 1 with thinking on" conflict per request instead of pinning
+        # sampling for the whole route.
+        supports_reasoning=True,
+        sampling_requires_reasoning_none=True,
     ),
     "claude-opus-4-8": _anthropic_chat(
         input_usd=5.0,

--- a/exp/common/models/known_models_test.py
+++ b/exp/common/models/known_models_test.py
@@ -330,6 +330,14 @@ def test_anthropic_point_releases_inherit_generation_controls_never_prices() -> 
     # Real two-segment model ids never fall through to a bogus generation.
     haiku = known_model_metadata("anthropic", "claude-haiku-4-5")
     assert haiku is not None and haiku.input_cost_per_million_tokens_usd == 1.0
+    # Budgeted-enabled reasoning: haiku reasons (its thinking config is
+    # honored) without the adaptive effort ladder, and it keeps ordinary
+    # sampling behind the srn hatch rather than a temperature pin.
+    assert haiku.supports_reasoning is True
+    assert haiku.supports_reasoning_effort is False
+    assert haiku.sampling_requires_reasoning_none is True
+    assert haiku.supports_temperature is True
+    assert haiku.supports_top_k is True
 
 
 # The exact /v1/models listing served to a plain key, captured 2026-09-01

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -30,6 +30,7 @@ from exp.runtime.gateway.contracts import (
     GatewayUsage,
 )
 from exp.runtime.gateway.interfaces import GatewayClock
+from exp.runtime.gateway.ledger_valuation import estimated_cost_micro_usd, optional_int
 from exp.runtime.gateway.sqlite.migrations import initialize_database, persistent_connection
 from exp.runtime.gateway.sqlite.store import SystemGatewayClock
 
@@ -515,7 +516,7 @@ class SQLiteAttemptLedger:
         # Both published tier schedules reprice the WHOLE request once
         # provider-reported input tokens reach the frozen threshold, so the
         # tier's rates replace the base rates rather than composing with them.
-        threshold = _optional_int(row["long_context_threshold_tokens"])
+        threshold = optional_int(row["long_context_threshold_tokens"])
         long_context = (
             threshold is not None
             and usage is not None
@@ -523,15 +524,15 @@ class SQLiteAttemptLedger:
             and usage.input_tokens >= threshold
         )
         prefix = "long_context_" if long_context else ""
-        cost = _estimated_cost(
+        cost = estimated_cost_micro_usd(
             usage,
-            input_rate=_optional_int(row[f"{prefix}input_rate"]),
-            cached_input_rate=_optional_int(row[f"{prefix}cached_input_rate"]),
-            output_rate=_optional_int(row[f"{prefix}output_rate"]),
-            reasoning_rate=_optional_int(row[f"{prefix}reasoning_rate"]),
+            input_rate=optional_int(row[f"{prefix}input_rate"]),
+            cached_input_rate=optional_int(row[f"{prefix}cached_input_rate"]),
+            output_rate=optional_int(row[f"{prefix}output_rate"]),
+            reasoning_rate=optional_int(row[f"{prefix}reasoning_rate"]),
         )
         budget_settlement = (
-            cost if cost is not None else _optional_int(row["budget_reserved_micro_usd"])
+            cost if cost is not None else optional_int(row["budget_reserved_micro_usd"])
         )
         if budget_settlement is not None and budget_settlement > MAXIMUM_MICRO_USD:
             raise GatewayLedgerError("attempt cost exceeds SQLite integer capacity")
@@ -968,41 +969,3 @@ def _terminal_values(
         )
     assert terminal_event is not None
     return terminal_event.kind.value, None, None, terminal_event.usage
-
-
-def _estimated_cost(
-    usage: GatewayUsage | None,
-    *,
-    input_rate: int | None,
-    cached_input_rate: int | None,
-    output_rate: int | None,
-    reasoning_rate: int | None,
-) -> int | None:
-    """Compute attributed integer micro-USD or preserve unknown pricing.
-
-    Cached-input and reasoning counts are subsets of their total token counts. Price the
-    differently priced subsets at their configured rates and the fresh remainders at the base
-    rates, clamping malformed detail counts to the corresponding total. A missing rate for a
-    reported subset preserves unknown pricing rather than silently falling back to the base rate.
-    """
-    if usage is None or not usage.has_token_counts:
-        return None
-    assert usage.input_tokens is not None
-    assert usage.output_tokens is not None
-    cached_input_tokens = min(usage.cached_input_tokens or 0, usage.input_tokens)
-    reasoning_tokens = min(usage.reasoning_tokens or 0, usage.output_tokens)
-    dimensions = (
-        (usage.input_tokens - cached_input_tokens, input_rate),
-        (cached_input_tokens, cached_input_rate),
-        (usage.output_tokens - reasoning_tokens, output_rate),
-        (reasoning_tokens, reasoning_rate),
-    )
-    if any(tokens > 0 and rate is None for tokens, rate in dimensions):
-        return None
-    numerator = sum(tokens * (rate or 0) for tokens, rate in dimensions)
-    return (numerator + 500_000) // 1_000_000
-
-
-def _optional_int(value: int | None) -> int | None:
-    """Convert one nullable SQLite integer value to its precise type."""
-    return None if value is None else int(value)

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -491,7 +491,9 @@ class SQLiteAttemptLedger:
             finalize_request: Whether this attempt is the final route for its parent request.
             first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
         """
-        state, normalized_failure, usage = _terminal_values(terminal_event, failure)
+        state, normalized_failure, failure_message, usage = _terminal_values(
+            terminal_event, failure
+        )
         row = connection.execute(
             """
             SELECT request_id, state, input_rate, cached_input_rate,
@@ -538,6 +540,7 @@ class SQLiteAttemptLedger:
             """
             UPDATE gateway_attempts
             SET state = ?, terminal_at = ?, first_token_at = ?, failure_class = ?,
+                failure_message = ?,
                 input_tokens = ?, cached_input_tokens = ?, output_tokens = ?,
                 reasoning_tokens = ?, usage_source = ?, estimated_cost_micro_usd = ?,
                 budget_settled_micro_usd = ?
@@ -548,6 +551,7 @@ class SQLiteAttemptLedger:
                 terminal_at,
                 None if first_token_at is None else utc_text(first_token_at),
                 normalized_failure,
+                failure_message,
                 None if usage is None else usage.input_tokens,
                 None if usage is None else usage.cached_input_tokens,
                 None if usage is None else usage.output_tokens,
@@ -601,8 +605,8 @@ class SQLiteAttemptLedger:
             authorization: Frozen authority identifying the accepted request.
             failure: Sanitized pre-dispatch terminal failure.
         """
-        state, normalized_failure, _ = _terminal_values(None, failure)
-        del normalized_failure
+        state, normalized_failure, _failure_message, _ = _terminal_values(None, failure)
+        del normalized_failure, _failure_message
         row = connection.execute(
             """
             SELECT organization_id, terminal_state FROM gateway_requests
@@ -935,8 +939,13 @@ class SQLiteAttemptLedger:
 def _terminal_values(
     terminal_event: GatewayEvent | None,
     failure: GatewayFailure | None,
-) -> tuple[str, str | None, GatewayUsage | None]:
-    """Normalize one finish call to state, safe failure class, and usage."""
+) -> tuple[str, str | None, str | None, GatewayUsage | None]:
+    """Normalize one finish call to state, failure class, message, and usage.
+
+    The failure message is the provider's own sanitized explanation
+    (``provider_detail``); it is present only for a client-error rejection and
+    is the same bounded, credential-free sentence the caller already receives.
+    """
     event_failure = None if terminal_event is None else terminal_event.failure
     normalized = failure or event_failure
     if terminal_event is None and normalized is None:
@@ -954,10 +963,11 @@ def _terminal_values(
         return (
             state,
             normalized.failure_class.value,
+            normalized.provider_detail,
             (None if terminal_event is None else terminal_event.usage),
         )
     assert terminal_event is not None
-    return terminal_event.kind.value, None, terminal_event.usage
+    return terminal_event.kind.value, None, None, terminal_event.usage
 
 
 def _estimated_cost(

--- a/exp/runtime/gateway/ledger_test.py
+++ b/exp/runtime/gateway/ledger_test.py
@@ -524,6 +524,82 @@ def test_failed_attempt_terminalizes_its_parent_request(tmp_path: Path) -> None:
     assert attempt_state == "failed"
 
 
+def test_failed_attempt_records_the_sanitized_provider_error_text(tmp_path: Path) -> None:
+    """A provider client-error rejection keeps its sanitized sentence on the row."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("rejected-request"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization),
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+    )
+    failure = GatewayFailure(
+        failure_class=GatewayFailureClass.INVALID_REQUEST,
+        safe_message="provider rejected the request; verify the request fields",
+        # The sanitized provider sentence: no headers, no request echo, no
+        # credentials (the Rust upstream already enforced that shape).
+        provider_detail="max_tokens must be greater than thinking budget_tokens.",
+    )
+
+    ledger.finish_attempt(attempt_id=attempt_id, terminal_event=None, failure=failure)
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        failure_class, failure_message = connection.execute(
+            "SELECT failure_class, failure_message FROM gateway_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert failure_class == "invalid_request"
+    assert failure_message == "max_tokens must be greater than thinking budget_tokens."
+
+
+def test_failed_attempt_without_provider_detail_leaves_the_message_null(tmp_path: Path) -> None:
+    """A failure carrying no provider explanation records a NULL message."""
+    clock = FakeLedgerClock()
+    store, ledger, raw_key = _authority_fixture(tmp_path, clock)
+    authorization = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request("bare-failure"),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    ledger.accept_request(authorization=authorization)
+    attempt_id = ledger.start_attempt(
+        snapshot=_execution(authorization),
+        deployment=_deployment(),
+        attempt_ordinal=0,
+        route_depth=0,
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=None,
+        failure=GatewayFailure(
+            failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+            safe_message="provider service failed",
+        ),
+    )
+
+    connection = sqlite3.connect(tmp_path / "gateway.db")
+    try:
+        failure_message = connection.execute(
+            "SELECT failure_message FROM gateway_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert failure_message is None
+
+
 def test_predispatch_failure_terminalizes_real_sqlite_request(tmp_path: Path) -> None:
     """Accepted routing failures cannot remain unterminated without an attempt row."""
     clock = FakeLedgerClock()

--- a/exp/runtime/gateway/ledger_valuation.py
+++ b/exp/runtime/gateway/ledger_valuation.py
@@ -1,0 +1,43 @@
+"""Pure cost attribution helpers for the content-free attempt ledger."""
+
+from __future__ import annotations
+
+from exp.runtime.gateway.contracts import GatewayUsage
+
+
+def estimated_cost_micro_usd(
+    usage: GatewayUsage | None,
+    *,
+    input_rate: int | None,
+    cached_input_rate: int | None,
+    output_rate: int | None,
+    reasoning_rate: int | None,
+) -> int | None:
+    """Compute attributed integer micro-USD or preserve unknown pricing.
+
+    Cached-input and reasoning counts are subsets of their total token counts. Price the
+    differently priced subsets at their configured rates and the fresh remainders at the base
+    rates, clamping malformed detail counts to the corresponding total. A missing rate for a
+    reported subset preserves unknown pricing rather than silently falling back to the base rate.
+    """
+    if usage is None or not usage.has_token_counts:
+        return None
+    assert usage.input_tokens is not None
+    assert usage.output_tokens is not None
+    cached_input_tokens = min(usage.cached_input_tokens or 0, usage.input_tokens)
+    reasoning_tokens = min(usage.reasoning_tokens or 0, usage.output_tokens)
+    dimensions = (
+        (usage.input_tokens - cached_input_tokens, input_rate),
+        (cached_input_tokens, cached_input_rate),
+        (usage.output_tokens - reasoning_tokens, output_rate),
+        (reasoning_tokens, reasoning_rate),
+    )
+    if any(tokens > 0 and rate is None for tokens, rate in dimensions):
+        return None
+    numerator = sum(tokens * (rate or 0) for tokens, rate in dimensions)
+    return (numerator + 500_000) // 1_000_000
+
+
+def optional_int(value: int | None) -> int | None:
+    """Convert one nullable SQLite integer value to its precise type."""
+    return None if value is None else int(value)

--- a/exp/runtime/gateway/ledger_valuation_test.py
+++ b/exp/runtime/gateway/ledger_valuation_test.py
@@ -1,0 +1,84 @@
+"""Tests for the pure ledger cost-attribution helpers."""
+
+from exp.runtime.gateway.contracts import GatewayUsage
+from exp.runtime.gateway.ledger_valuation import estimated_cost_micro_usd, optional_int
+
+
+def test_subset_tokens_price_at_their_own_rates() -> None:
+    """Cached-input and reasoning subsets bill at their rates, remainders at base."""
+    usage = GatewayUsage(
+        input_tokens=1_000,
+        cached_input_tokens=400,
+        output_tokens=200,
+        reasoning_tokens=50,
+    )
+    cost = estimated_cost_micro_usd(
+        usage,
+        input_rate=10_000_000,
+        cached_input_rate=1_000_000,
+        output_rate=20_000_000,
+        reasoning_rate=40_000_000,
+    )
+    # 600*10 + 400*1 + 150*20 + 50*40 = 11_400 micro-USD.
+    assert cost == 11_400
+
+
+def test_missing_rate_for_a_reported_subset_preserves_unknown_pricing() -> None:
+    """A priced base rate never silently substitutes for a missing subset rate."""
+    usage = GatewayUsage(input_tokens=100, cached_input_tokens=10, output_tokens=5)
+    assert (
+        estimated_cost_micro_usd(
+            usage,
+            input_rate=1_000_000,
+            cached_input_rate=None,
+            output_rate=1_000_000,
+            reasoning_rate=None,
+        )
+        is None
+    )
+
+
+def test_malformed_subset_counts_clamp_to_their_totals() -> None:
+    """Detail counts exceeding their totals clamp instead of going negative."""
+    usage = GatewayUsage(
+        input_tokens=10,
+        cached_input_tokens=50,
+        output_tokens=4,
+        reasoning_tokens=9,
+    )
+    cost = estimated_cost_micro_usd(
+        usage,
+        input_rate=1_000_000,
+        cached_input_rate=2_000_000,
+        output_rate=3_000_000,
+        reasoning_rate=5_000_000,
+    )
+    # 0*1 + 10*2 + 0*3 + 4*5 = 40 micro-USD.
+    assert cost == 40
+
+
+def test_absent_usage_or_counts_preserve_unknown_cost() -> None:
+    """No usage, or usage without token counts, yields no estimate."""
+    assert (
+        estimated_cost_micro_usd(
+            None, input_rate=1, cached_input_rate=1, output_rate=1, reasoning_rate=1
+        )
+        is None
+    )
+    tool_only = GatewayUsage(tool_names=("web_search",))
+    assert (
+        estimated_cost_micro_usd(
+            tool_only,
+            input_rate=1,
+            cached_input_rate=1,
+            output_rate=1,
+            reasoning_rate=1,
+        )
+        is None
+    )
+
+
+def test_optional_int_preserves_null_and_narrows_values() -> None:
+    """SQLite nullable integers convert precisely and keep None."""
+    assert optional_int(None) is None
+    assert optional_int(7) == 7

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.29"
+version = "0.3.30"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.29"
+version = "0.3.30"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.29"
+version = "0.3.30"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/settlement.rs
+++ b/exp/runtime/gateway/native/src/settlement.rs
@@ -81,6 +81,10 @@ fn settle_argument(
         "failure": failure.map(|failure| json!({
             "failure_class": failure.failure_class.as_str(),
             "safe_message": failure.safe_message,
+            // The provider's own sanitized rejection sentence (client-error
+            // class only); accounting persists it on the failed-attempt row so
+            // an operator sees WHY the provider refused the call.
+            "provider_detail": failure.provider_detail,
         })),
         "finalize": finalize,
         "opened": opened,
@@ -447,5 +451,46 @@ mod tests {
         let without = settle_argument("req", "att", "completed", None, &[], None, true, true, None);
         let parsed: Value = serde_json::from_str(&without).expect("valid json");
         assert_eq!(parsed["first_token_at"], Value::Null);
+    }
+
+    #[test]
+    fn settle_argument_carries_the_sanitized_provider_detail_on_a_failed_attempt() {
+        let failure = Failure::new(FailureClass::InvalidRequest, "provider rejected")
+            .with_provider_detail(Some(
+                "max_tokens must be greater than thinking budget.".into(),
+            ));
+        let argument = settle_argument(
+            "req",
+            "att",
+            "failed",
+            None,
+            &[],
+            Some(&failure),
+            true,
+            true,
+            None,
+        );
+        let parsed: Value = serde_json::from_str(&argument).expect("valid json");
+        assert_eq!(parsed["failure"]["failure_class"], "invalid_request");
+        assert_eq!(
+            parsed["failure"]["provider_detail"],
+            "max_tokens must be greater than thinking budget."
+        );
+        // A failure with no provider explanation carries an explicit null, which
+        // the control plane parses back to None.
+        let bare = Failure::new(FailureClass::ProviderInternal, "provider failed");
+        let bare_argument = settle_argument(
+            "req",
+            "att",
+            "failed",
+            None,
+            &[],
+            Some(&bare),
+            true,
+            true,
+            None,
+        );
+        let parsed: Value = serde_json::from_str(&bare_argument).expect("valid json");
+        assert_eq!(parsed["failure"]["provider_detail"], Value::Null);
     }
 }

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -43,9 +43,13 @@ def terminal_from_settlement(
     failure_payload = data.get("failure")
     failure = None
     if isinstance(failure_payload, dict):
+        provider_detail = failure_payload.get("provider_detail")
         failure = GatewayFailure(
             failure_class=GatewayFailureClass(str(failure_payload["failure_class"])),
             safe_message=str(failure_payload["safe_message"]),
+            provider_detail=(
+                provider_detail if isinstance(provider_detail, str) and provider_detail else None
+            ),
         )
     kind = _TERMINAL_KINDS[str(data["outcome"])]
     terminal = GatewayEvent(

--- a/exp/runtime/gateway/native_settlement_test.py
+++ b/exp/runtime/gateway/native_settlement_test.py
@@ -85,3 +85,38 @@ def test_terminal_from_settlement_normalizes_failure() -> None:
     assert failure is not None
     assert failure.failure_class == GatewayFailureClass.TRANSPORT
     assert terminal.failure == failure
+
+
+def test_terminal_from_settlement_carries_the_provider_detail() -> None:
+    """A client-error settlement threads the sanitized provider sentence through."""
+    _terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "usage": None,
+            "tool_names": [],
+            "failure": {
+                "failure_class": "invalid_request",
+                "safe_message": "provider rejected the request",
+                "provider_detail": "max_tokens must be greater than thinking budget.",
+            },
+        }
+    )
+
+    assert failure is not None
+    assert failure.provider_detail == "max_tokens must be greater than thinking budget."
+
+    # An empty or absent detail resolves to None rather than an empty string.
+    _t, blank = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "usage": None,
+            "tool_names": [],
+            "failure": {
+                "failure_class": "invalid_request",
+                "safe_message": "provider rejected the request",
+                "provider_detail": "",
+            },
+        }
+    )
+    assert blank is not None
+    assert blank.provider_detail is None

--- a/exp/runtime/gateway/routing.py
+++ b/exp/runtime/gateway/routing.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping
 from concurrent.futures import Future, wait
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
+from typing import Protocol
 
 from exp.common.core.artifacts import ArtifactId, ContractModel, stable_id
 from exp.common.models import ModelRequest
@@ -57,6 +58,41 @@ class GatewayRoute(ContractModel):
     def deployments(self) -> tuple[ExactModelDeployment, ...]:
         """Return every certified deployment in deterministic operational order."""
         return (self.deployment, *self.fallback_deployments)
+
+
+class RouteResolver(Protocol):
+    """Structural contract for the gateway's authorized route resolver.
+
+    ``CatalogRouteResolver`` is the engine's implementation; a platform wrapper
+    that composes or delegates to it annotates itself against this Protocol so
+    ``ty`` statically catches a missing or drifted resolution method instead of
+    surfacing it at runtime. It captures ONLY the public resolution seam — the
+    three ways an authorization becomes a frozen :class:`GatewayRoute`; the
+    catalog-swap, metadata, and lifecycle methods are implementation detail and
+    deliberately excluded so a wrapper need not re-expose them.
+    """
+
+    def resolve_direct(self, authorization: AuthorizationSnapshot) -> GatewayRoute:
+        """Resolve one direct-target authorization without event-loop work."""
+        ...
+
+    def resolve_deployment_hint(
+        self,
+        authorization: AuthorizationSnapshot,
+        deployment_id: str,
+    ) -> GatewayRoute:
+        """Resolve one canonical carrier-hint deployment inside current authority."""
+        ...
+
+    def resolve_project_blocking(
+        self,
+        *,
+        authorization: AuthorizationSnapshot,
+        request: GatewayRequest,
+        episode_namespace: tuple[str, str, str, str],
+    ) -> GatewayRoute:
+        """Resolve one project target from a caller thread without an event loop."""
+        ...
 
 
 @dataclass(frozen=True)
@@ -309,7 +345,27 @@ class CatalogRouteResolver:
         authorization: AuthorizationSnapshot,
         deployment_id: str,
     ) -> GatewayRoute:
-        """Resolve one untrusted carrier hint only inside current alias authority."""
+        """Resolve one untrusted carrier hint only inside current alias authority.
+
+        The ``deployment_id`` MUST be a CANONICAL pool member of the authorized
+        alias revision: pool membership is checked against ``pool.deployment_ids``,
+        which names canonicals only, so a BYOK or org-variant deployment id will
+        NOT resolve here. Mapping a variant back to its canonical is the CALLER
+        resolver's responsibility; this method receives an already-canonical id
+        and fails closed on anything the current authority's pools do not name.
+
+        Args:
+            authorization: Frozen authenticated alias revision and target.
+            deployment_id: Canonical deployment id carried on a reasoning
+                continuation, resolved only within the authorized revision.
+
+        Returns:
+            Frozen single-deployment route pinned to the hinted deployment.
+
+        Raises:
+            GatewayRoutingError: The snapshot is inactive, the id is not an
+                unambiguous canonical pool member, or its identity is invalid.
+        """
         view = self._catalogs.get((authorization.alias_revision_id, authorization.catalog_sha256))
         if view is None:
             raise GatewayRoutingError("authorized catalog snapshot is not active for this revision")

--- a/exp/runtime/gateway/routing_test.py
+++ b/exp/runtime/gateway/routing_test.py
@@ -19,9 +19,20 @@ from exp.common.models.gateway_catalog import (
     NormalizedGatewayCatalog,
 )
 from exp.common.models.model import ModelCapabilities
-from exp.runtime.gateway.routing import CatalogRouteResolver
+from exp.runtime.gateway.routing import CatalogRouteResolver, RouteResolver
 
 _REVISION = "revision-one"
+
+
+def test_catalog_route_resolver_satisfies_the_route_resolver_protocol() -> None:
+    """CatalogRouteResolver structurally satisfies the exported Protocol.
+
+    The annotated binding makes ``ty`` verify the public resolution seam at
+    type-check time, so a wrapper annotated ``RouteResolver`` catches a missing
+    or drifted resolve_* method statically.
+    """
+    resolver: RouteResolver = CatalogRouteResolver({})
+    assert resolver is not None
 
 
 def _deployment(

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 16
 
 
 class GatewaySchemaError(RuntimeError):
@@ -659,6 +659,15 @@ _MIGRATION_15 = (
     "DROP TABLE gateway_schema_refresh_v15",
 )
 
+# v16: retain the provider's own sanitized explanation of a failed attempt.
+# The Rust upstream already extracts one bounded, single-line, credential- and
+# infrastructure-free sentence from a client-error body (param_attribution);
+# this column persists that text on the failed attempt so an operator can see
+# WHY a provider rejected the call without re-deriving it from logs. It is the
+# same sanitized text the caller already receives, so it does not widen the
+# ledger's content-free posture.
+_MIGRATION_16 = ("ALTER TABLE gateway_attempts ADD COLUMN failure_message TEXT",)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -675,6 +684,7 @@ _MIGRATIONS = {
     13: _MIGRATION_13,
     14: _MIGRATION_14,
     15: _MIGRATION_15,
+    16: _MIGRATION_16,
 }
 
 

--- a/exp/runtime/gateway/sqlite/migrations_test.py
+++ b/exp/runtime/gateway/sqlite/migrations_test.py
@@ -140,6 +140,8 @@ def test_initial_database_is_private_wal_with_foreign_keys(tmp_path: Path) -> No
         assert "budget_period_start" in attempt_columns
         assert "budget_reserved_micro_usd" in attempt_columns
         assert "budget_settled_micro_usd" in attempt_columns
+        # v16 retains the provider's sanitized rejection sentence.
+        assert "failure_message" in attempt_columns
         assert (
             connection.execute(
                 "SELECT 1 FROM sqlite_master WHERE name = 'gateway_monthly_budgets'"

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -65,6 +65,10 @@ THINKING_TRANSLATED_DISCLOSURE = "thinking.type->enabled"
 """Disclosure recorded when an adaptive thinking config is translated to a
 budgeted ``enabled`` config for a budgeted-enabled Anthropic route."""
 
+THINKING_BUDGET_IGNORED_DISCLOSURE = "thinking.budget_tokens"
+"""Disclosure recorded when a caller budget was illegal and a derived budget
+replaced it in the translated ``enabled`` config."""
+
 CLOSED_SCHEMA_DISCLOSURE = "json_schema.additionalProperties->false"
 """Disclosure recorded when an open structured-output schema is closed."""
 
@@ -153,11 +157,17 @@ def _coerce_adaptive_budget(
         return None
     budget = _caller_or_derived_budget(config, request.maximum_output_tokens)
     if budget is not None:
+        disclosures: tuple[str, ...] = (THINKING_TRANSLATED_DISCLOSURE,)
+        if config.get("budget_tokens") is not None and config.get("budget_tokens") != budget:
+            # The caller named an illegal depth; the substitution changes the
+            # requested reasoning depth and cost, so it is disclosed by itself
+            # rather than hiding behind the type translation.
+            disclosures = (*disclosures, THINKING_BUDGET_IGNORED_DISCLOSURE)
         return RequestCoercion(
             request=request.model_copy(
                 update={"provider_thinking_config": {"type": "enabled", "budget_tokens": budget}}
             ),
-            disclosures=(THINKING_TRANSLATED_DISCLOSURE,),
+            disclosures=disclosures,
         )
     # No legal budget fits: drop every reasoning signal so the surviving effort
     # cannot re-emit adaptive thinking through output_config.

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -22,7 +22,8 @@ from typing import TYPE_CHECKING
 from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
-from exp.runtime.gateway.contracts import GatewayMessage, GatewayRequest
+from exp.common.models.known_models import known_model_metadata
+from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -65,11 +66,6 @@ _MAXIMUM_THINKING_BUDGET_TOKENS = 16384
 """Ceiling on a gateway-derived thinking budget when the caller supplied none."""
 
 
-def _thinking_history_disclosure(reason: str) -> str:
-    """Disclosure recorded when stale history thinking blocks are stripped."""
-    return f"thinking_history->dropped({reason})"
-
-
 CLOSED_SCHEMA_DISCLOSURE = "json_schema.additionalProperties->false"
 """Disclosure recorded when an open structured-output schema is closed."""
 
@@ -88,49 +84,15 @@ class RequestCoercion:
     disclosures: tuple[str, ...]
 
 
-_STALE_THINKING_KINDS = frozenset({"thinking", "redacted_thinking"})
-"""Anthropic reasoning-block kinds the provider rejects once thinking is off."""
-
-
-def _strip_history_thinking(request: GatewayRequest) -> tuple[GatewayRequest, bool]:
-    """Drop replayed thinking blocks from prior assistant turns.
-
-    Anthropic 400s a continuation whose history carries ``thinking`` or
-    ``redacted_thinking`` blocks once thinking is disabled or dropped for the
-    dispatch, so a coercion that removes the thinking config must remove those
-    stale blocks from the SAME request copy. The honored path never calls this:
-    when thinking is preserved the signed blocks must round-trip byte-exact.
-
-    Args:
-        request: Request whose thinking config was just dropped or disabled.
-
-    Returns:
-        The request with stale blocks removed and whether anything changed.
-    """
-    changed = False
-    new_messages: list[GatewayMessage] = []
-    for message in request.messages:
-        retained = tuple(
-            block for block in message.provider_reasoning if block.kind not in _STALE_THINKING_KINDS
-        )
-        if len(retained) != len(message.provider_reasoning):
-            changed = True
-            new_messages.append(message.model_copy(update={"provider_reasoning": retained}))
-        else:
-            new_messages.append(message)
-    if not changed:
-        return request, False
-    return request.model_copy(update={"messages": tuple(new_messages)}), True
-
-
 def _thinking_budget_tokens(maximum_output_tokens: int | None) -> int | None:
     """Return a legal ``budget_tokens`` for a translated enabled config, or None.
 
     Anthropic requires ``1024 <= budget_tokens < max_tokens`` for an enabled
     thinking config. With no effort→budget table to consult, the budget is
-    half the caller's output ceiling, clamped to a sane band. When the ceiling
-    is too small to admit any legal budget the translation is impossible and
-    the caller must fall through to the drop path.
+    half the caller's output ceiling, clamped to a sane band. An unbounded
+    caller (no ceiling) takes the band ceiling. When the ceiling is too small
+    to admit any legal budget the translation is impossible and the caller
+    must fall through to the drop path.
 
     Args:
         maximum_output_tokens: The caller's output-token ceiling, if any.
@@ -139,7 +101,7 @@ def _thinking_budget_tokens(maximum_output_tokens: int | None) -> int | None:
         A legal budget, or ``None`` when no budget fits the ceiling.
     """
     if maximum_output_tokens is None:
-        return None
+        return _MAXIMUM_THINKING_BUDGET_TOKENS
     budget = min(
         max(maximum_output_tokens // 2, _MINIMUM_THINKING_BUDGET_TOKENS),
         _MAXIMUM_THINKING_BUDGET_TOKENS,
@@ -149,19 +111,43 @@ def _thinking_budget_tokens(maximum_output_tokens: int | None) -> int | None:
     return None
 
 
-def _all_budgeted_enabled_anthropic(profiles: Sequence[GatewayWireProfile]) -> bool:
-    """Whether every rung is an Anthropic budgeted-enabled reasoning route.
+def _anthropic_budgeted_enabled_only(model_id: str) -> bool:
+    """Whether an Anthropic model reasons via a token budget but rejects adaptive.
 
-    A budgeted-enabled rung reasons (``supports_reasoning``) and honors a
-    ``thinking: {type: enabled, budget_tokens}`` config, which is exactly the
-    Anthropic routes that are NOT the adaptive-only generation. A mixed or
-    non-reasoning route is not one, so an adaptive config there drops instead
-    of translating.
+    haiku-4-5 is marked ``supports_reasoning`` yet is NOT the effort/adaptive
+    generation (``supports_reasoning_effort`` is False), so it honors a
+    budgeted ``thinking: {type: enabled, budget_tokens}`` config while rejecting
+    ``thinking: {type: adaptive}`` by name. The effort generation (sonnet-4-6,
+    opus-5, fable-5-1, ...) carries ``supports_reasoning_effort`` and accepts
+    the adaptive object verbatim, so it is NOT one of these and its adaptive
+    config is left alone rather than translated.
+
+    Args:
+        model_id: Exact Anthropic model identifier.
+
+    Returns:
+        ``True`` only for a reasoning model whose depth is a token budget and
+        which rejects an adaptive thinking config.
+    """
+    known = known_model_metadata("anthropic", model_id)
+    if known is None:
+        return False
+    return known.supports_reasoning is True and not known.supports_reasoning_effort
+
+
+def _all_budgeted_enabled_anthropic(profiles: Sequence[GatewayWireProfile]) -> bool:
+    """Whether every rung is an Anthropic budgeted-enabled-only reasoning route.
+
+    A budgeted-enabled-only rung reasons and honors a ``thinking: {type:
+    enabled, budget_tokens}`` config but rejects ``adaptive`` by name (haiku-4-5).
+    A mixed, non-reasoning, or adaptive-accepting route (the effort generation)
+    is not one, so an adaptive config there is dropped or left verbatim rather
+    than translated.
     """
     if not profiles or not all(profile.dialect == "anthropic_messages" for profile in profiles):
         return False
     return all(
-        profile.supports_reasoning and not anthropic_adaptive_only_thinking(profile.model_id)
+        profile.supports_reasoning and _anthropic_budgeted_enabled_only(profile.model_id)
         for profile in profiles
     )
 
@@ -179,8 +165,9 @@ def _coerce_adaptive_budget(
     reading here is to translate it to ``enabled`` with a derived budget. When
     the caller already carried a budget the config is left verbatim; when no
     legal budget fits the output ceiling the translation is impossible, so the
-    config and any effort channel drop and stale history thinking blocks are
-    stripped, all disclosed.
+    config and any effort channel drop, all disclosed. History thinking blocks
+    are left untouched: Anthropic accepts replayed thinking blocks with no live
+    thinking config, so a coercion never strips them.
 
     Args:
         profiles: Ordered wire profiles for every live route deployment.
@@ -208,38 +195,37 @@ def _coerce_adaptive_budget(
             disclosures=(THINKING_TRANSLATED_DISCLOSURE,),
         )
     # No legal budget fits: drop every reasoning signal so the surviving effort
-    # cannot re-emit adaptive thinking through output_config, and strip the
-    # stale signed history blocks the provider would otherwise 400 on.
-    dropped, disclosures = _drop_thinking_and_effort(request, reason="untranslatable_budget")
+    # cannot re-emit adaptive thinking through output_config.
+    dropped, disclosures = _drop_thinking_and_effort(request)
     return RequestCoercion(request=dropped, disclosures=disclosures)
 
 
 def _drop_thinking_and_effort(
     request: GatewayRequest,
-    *,
-    reason: str,
 ) -> tuple[GatewayRequest, tuple[str, ...]]:
-    """Null the thinking config and effort channels and strip stale history.
+    """Null the thinking config and effort channels for a route that cannot reason.
 
-    Shared drop for the routes that cannot honor any reasoning: the thinking
-    config, the caller effort, and the Messages ``output_config.effort`` channel
-    all go, and prior thinking blocks are removed so the continuation replays
-    clean. Every removal is disclosed.
+    Shared drop for the routes that cannot honor a reasoning signal: the
+    thinking config, the caller effort, and the Messages ``output_config.effort``
+    channel all go, and a ``clear_thinking`` context edit rides on the thinking
+    config and is stripped with it. Every removal is disclosed. History thinking
+    blocks are NOT touched — Anthropic accepts replayed blocks without a live
+    thinking config.
     """
     updates: dict[str, object] = {"provider_thinking_config": None}
-    disclosures: list[str] = [THINKING_DROP_DISCLOSURE]
+    disclosures: list[str] = []
     if request.reasoning_effort is not None:
         updates["reasoning_effort"] = None
         disclosures.append(EFFORT_DROP_DISCLOSURE)
+    disclosures.append(THINKING_DROP_DISCLOSURE)
     if request.provider_output_config is not None and "effort" in request.provider_output_config:
         remaining = {
             key: value for key, value in request.provider_output_config.items() if key != "effort"
         }
         updates["provider_output_config"] = remaining or None
-    dropped, stripped = _strip_history_thinking(request.model_copy(update=updates))
-    if stripped:
-        disclosures.append(_thinking_history_disclosure(reason))
-    return dropped, tuple(disclosures)
+    if request.context_management is not None:
+        updates["context_management"] = _without_clear_thinking_edits(request.context_management)
+    return request.model_copy(update=updates), tuple(disclosures)
 
 
 def coerce_generation_parameters(
@@ -285,14 +271,25 @@ def coerce_generation_parameters(
         if admits is not None and not admits(adaptive_budget.request):
             return None
         return adaptive_budget
-    if request.reasoning_effort is None:
-        return None
     ladder: set[str] = set()
     for profile in profiles:
         ladder.update(profile_reasoning_efforts(profile))
+    adaptive_thinking = (
+        request.provider_thinking_config is not None
+        and request.provider_thinking_config.get("type") == "adaptive"
+    )
+    # An adaptive config with no effort beside it still cannot survive a route
+    # with no reasoning rung (the provider rejects it by name), so it reaches
+    # the drop path below instead of returning here. A budgeted-enabled route
+    # already translated it in ``_coerce_adaptive_budget``; a route that
+    # accepts adaptive verbatim keeps a non-empty ladder and returns here.
+    if request.reasoning_effort is None and not (adaptive_thinking and not ladder):
+        return None
     if not ladder:
         updates: dict[str, object] = {"reasoning_effort": None}
-        disclosures: tuple[str, ...] = (EFFORT_DROP_DISCLOSURE,)
+        disclosures: tuple[str, ...] = (
+            (EFFORT_DROP_DISCLOSURE,) if request.reasoning_effort is not None else ()
+        )
         if request.provider_output_config is not None:
             # The Messages surface carries the same effort verbatim inside
             # output_config; a dropped effort must not reach the provider
@@ -303,29 +300,25 @@ def coerce_generation_parameters(
                 if key != "effort"
             }
             updates["provider_output_config"] = remaining or None
-        if (
-            request.provider_thinking_config is not None
-            and request.provider_thinking_config.get("type") == "adaptive"
-        ):
+        if adaptive_thinking:
             # Adaptive thinking is the effort's own channel on the Messages
             # surface (the model picks its depth from output_config.effort),
             # so a route with no reasoning rung cannot honor it either and
-            # the provider rejects it by name. A budgeted config is left
-            # verbatim: its semantics do not depend on an effort level.
+            # the provider rejects it by name, with or without an effort beside
+            # it. A budgeted config is left verbatim: its semantics do not
+            # depend on an effort level. A clear_thinking context edit rides on
+            # the thinking config and is stripped with it.
             updates["provider_thinking_config"] = None
-            disclosures = (EFFORT_DROP_DISCLOSURE, THINKING_DROP_DISCLOSURE)
+            disclosures = (*disclosures, THINKING_DROP_DISCLOSURE)
+            if request.context_management is not None:
+                updates["context_management"] = _without_clear_thinking_edits(
+                    request.context_management
+                )
         dropped_request = request.model_copy(update=updates)
-        if "provider_thinking_config" in updates:
-            # Thinking was just dropped for a genuinely non-reasoning route;
-            # the replayed signed history blocks would 400 the continuation,
-            # so strip them from the same copy and disclose it.
-            dropped_request, stripped = _strip_history_thinking(dropped_request)
-            if stripped:
-                disclosures = (*disclosures, _thinking_history_disclosure("no_reasoning_route"))
         if admits is not None and not admits(dropped_request):
             return None
         return RequestCoercion(request=dropped_request, disclosures=disclosures)
-    if request.reasoning_effort in ladder:
+    if request.reasoning_effort is None or request.reasoning_effort in ladder:
         # The effort itself is portable; the verbatim failure lies elsewhere
         # and a snap would change semantics for nothing.
         return None
@@ -390,15 +383,40 @@ def _coerce_disabled_thinking(
         anthropic_adaptive_only_thinking(profile.model_id) for profile in anthropic_profiles
     ):
         return None
-    dropped, stripped = _strip_history_thinking(
-        request.model_copy(update={"provider_thinking_config": None})
+    return RequestCoercion(
+        request=request.model_copy(update={"provider_thinking_config": None}),
+        disclosures=(THINKING_DISABLED_DISCLOSURE,),
     )
-    disclosures = (THINKING_DISABLED_DISCLOSURE,)
-    if stripped:
-        # The caller asked to turn thinking off; any replayed thinking blocks
-        # in history would 400 the continuation, so they strip with the config.
-        disclosures = (*disclosures, _thinking_history_disclosure("thinking_disabled"))
-    return RequestCoercion(request=dropped, disclosures=disclosures)
+
+
+def _without_clear_thinking_edits(context_management: JsonObject) -> JsonObject | None:
+    """Return the context-management object without ``clear_thinking_*`` edits.
+
+    A ``clear_thinking`` context edit requires an active thinking config, so it
+    is stripped alongside a dropped thinking config; the provider rejects it by
+    name once the config is gone. Other edits are preserved verbatim.
+
+    Args:
+        context_management: Verbatim caller ``context_management`` object.
+
+    Returns:
+        The same object minus clear-thinking edits, or ``None`` when no edit
+        survives so the field is omitted entirely.
+    """
+    edits = context_management.get("edits")
+    if not isinstance(edits, list):
+        return context_management
+    retained = [
+        edit
+        for edit in edits
+        if not (isinstance(edit, dict) and str(edit.get("type", "")).startswith("clear_thinking"))
+    ]
+    if len(retained) == len(edits):
+        return context_management
+    if not retained:
+        remaining = {key: value for key, value in context_management.items() if key != "edits"}
+        return remaining or None
+    return {**context_management, "edits": retained}
 
 
 def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoercion | None:

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING
 from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
-from exp.common.models.known_models import known_model_metadata
 from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
@@ -35,7 +34,10 @@ from exp.runtime.models.providers.generation_route_compat import (
     compatible_generation_parameter_profile_indexes,
 )
 from exp.runtime.models.providers.reasoning_compat import (
+    MINIMUM_THINKING_BUDGET_TOKENS,
     anthropic_adaptive_only_thinking,
+    anthropic_budgeted_enabled_only,
+    anthropic_thinking_budget_tokens,
     efforts_by_nearness,
 )
 from exp.runtime.models.providers.streaming_requests import (
@@ -63,13 +65,6 @@ THINKING_TRANSLATED_DISCLOSURE = "thinking.type->enabled"
 """Disclosure recorded when an adaptive thinking config is translated to a
 budgeted ``enabled`` config for a budgeted-enabled Anthropic route."""
 
-_MINIMUM_THINKING_BUDGET_TOKENS = 1024
-"""Smallest budget Anthropic accepts for an ``enabled`` thinking config."""
-
-_MAXIMUM_THINKING_BUDGET_TOKENS = 16384
-"""Ceiling on a gateway-derived thinking budget when the caller supplied none."""
-
-
 CLOSED_SCHEMA_DISCLOSURE = "json_schema.additionalProperties->false"
 """Disclosure recorded when an open structured-output schema is closed."""
 
@@ -88,57 +83,6 @@ class RequestCoercion:
     disclosures: tuple[str, ...]
 
 
-def _thinking_budget_tokens(maximum_output_tokens: int | None) -> int | None:
-    """Return a legal ``budget_tokens`` for a translated enabled config, or None.
-
-    Anthropic requires ``1024 <= budget_tokens < max_tokens`` for an enabled
-    thinking config. With no effort→budget table to consult, the budget is
-    half the caller's output ceiling, clamped to a sane band. An unbounded
-    caller (no ceiling) takes the band ceiling. When the ceiling is too small
-    to admit any legal budget the translation is impossible and the caller
-    must fall through to the drop path.
-
-    Args:
-        maximum_output_tokens: The caller's output-token ceiling, if any.
-
-    Returns:
-        A legal budget, or ``None`` when no budget fits the ceiling.
-    """
-    if maximum_output_tokens is None:
-        return _MAXIMUM_THINKING_BUDGET_TOKENS
-    budget = min(
-        max(maximum_output_tokens // 2, _MINIMUM_THINKING_BUDGET_TOKENS),
-        _MAXIMUM_THINKING_BUDGET_TOKENS,
-    )
-    if _MINIMUM_THINKING_BUDGET_TOKENS <= budget < maximum_output_tokens:
-        return budget
-    return None
-
-
-def _anthropic_budgeted_enabled_only(model_id: str) -> bool:
-    """Whether an Anthropic model reasons via a token budget but rejects adaptive.
-
-    haiku-4-5 is marked ``supports_reasoning`` yet is NOT the effort/adaptive
-    generation (``supports_reasoning_effort`` is False), so it honors a
-    budgeted ``thinking: {type: enabled, budget_tokens}`` config while rejecting
-    ``thinking: {type: adaptive}`` by name. The effort generation (sonnet-4-6,
-    opus-5, fable-5-1, ...) carries ``supports_reasoning_effort`` and accepts
-    the adaptive object verbatim, so it is NOT one of these and its adaptive
-    config is left alone rather than translated.
-
-    Args:
-        model_id: Exact Anthropic model identifier.
-
-    Returns:
-        ``True`` only for a reasoning model whose depth is a token budget and
-        which rejects an adaptive thinking config.
-    """
-    known = known_model_metadata("anthropic", model_id)
-    if known is None:
-        return False
-    return known.supports_reasoning is True and not known.supports_reasoning_effort
-
-
 def _all_budgeted_enabled_anthropic(profiles: Sequence[GatewayWireProfile]) -> bool:
     """Whether every rung is an Anthropic budgeted-enabled-only reasoning route.
 
@@ -151,7 +95,7 @@ def _all_budgeted_enabled_anthropic(profiles: Sequence[GatewayWireProfile]) -> b
     if not profiles or not all(profile.dialect == "anthropic_messages" for profile in profiles):
         return False
     return all(
-        profile.supports_reasoning and _anthropic_budgeted_enabled_only(profile.model_id)
+        profile.supports_reasoning and anthropic_budgeted_enabled_only(profile.model_id)
         for profile in profiles
     )
 
@@ -170,9 +114,9 @@ def _caller_or_derived_budget(
     caller_budget = config.get("budget_tokens")
     if isinstance(caller_budget, int) and not isinstance(caller_budget, bool):
         ceiling = maximum_output_tokens if maximum_output_tokens is not None else caller_budget + 1
-        if _MINIMUM_THINKING_BUDGET_TOKENS <= caller_budget < ceiling:
+        if MINIMUM_THINKING_BUDGET_TOKENS <= caller_budget < ceiling:
             return caller_budget
-    return _thinking_budget_tokens(maximum_output_tokens)
+    return anthropic_thinking_budget_tokens(maximum_output_tokens)
 
 
 def _coerce_adaptive_budget(

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -15,7 +15,7 @@ admission metrics.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -156,6 +156,25 @@ def _all_budgeted_enabled_anthropic(profiles: Sequence[GatewayWireProfile]) -> b
     )
 
 
+def _caller_or_derived_budget(
+    config: Mapping[str, object],
+    maximum_output_tokens: int | None,
+) -> int | None:
+    """Return the budget for a translated enabled config, or None to drop.
+
+    A caller-supplied ``budget_tokens`` names the depth and is honored when it
+    is legal (``1024 <= budget < max_tokens``); an illegal or absent one falls
+    back to the derived budget so the translated config never carries a value
+    the provider would reject.
+    """
+    caller_budget = config.get("budget_tokens")
+    if isinstance(caller_budget, int) and not isinstance(caller_budget, bool):
+        ceiling = maximum_output_tokens if maximum_output_tokens is not None else caller_budget + 1
+        if _MINIMUM_THINKING_BUDGET_TOKENS <= caller_budget < ceiling:
+            return caller_budget
+    return _thinking_budget_tokens(maximum_output_tokens)
+
+
 def _coerce_adaptive_budget(
     profiles: Sequence[GatewayWireProfile],
     request: GatewayRequest,
@@ -166,8 +185,10 @@ def _coerce_adaptive_budget(
     adaptive`` by name — that is the effort-ladder generation's channel — but
     accepts a budgeted ``enabled`` config. Claude Code, configured for an
     adaptive model, pins ``adaptive`` on every model, so the serviceable
-    reading here is to translate it to ``enabled`` with a derived budget. When
-    the caller already carried a budget the config is left verbatim; when no
+    reading here is to translate it to ``enabled`` with a budget — the
+    caller's own when they carried a legal one, a derived one otherwise
+    (the model rejects ``adaptive`` by NAME, so leaving a budget-carrying
+    adaptive config verbatim would still fail at the provider). When no
     legal budget fits the output ceiling the translation is impossible, so the
     config and any effort channel drop, all disclosed. History thinking blocks
     are left untouched: Anthropic accepts replayed thinking blocks with no live
@@ -184,13 +205,9 @@ def _coerce_adaptive_budget(
     config = request.provider_thinking_config
     if config is None or config.get("type") != "adaptive":
         return None
-    if config.get("budget_tokens") is not None:
-        # A caller-supplied budget already names the depth; leave it verbatim
-        # under the budgeted posture rather than overwriting it.
-        return None
     if not _all_budgeted_enabled_anthropic(profiles):
         return None
-    budget = _thinking_budget_tokens(request.maximum_output_tokens)
+    budget = _caller_or_derived_budget(config, request.maximum_output_tokens)
     if budget is not None:
         return RequestCoercion(
             request=request.model_copy(

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
-from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.gateway.contracts import GatewayMessage, GatewayRequest
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -54,6 +54,22 @@ THINKING_DROP_DISCLOSURE = "thinking"
 THINKING_DISABLED_DISCLOSURE = "thinking.type->adaptive"
 """Disclosure recorded when an adaptive-only route overrides a disabled thinking config."""
 
+THINKING_TRANSLATED_DISCLOSURE = "thinking.type->enabled"
+"""Disclosure recorded when an adaptive thinking config is translated to a
+budgeted ``enabled`` config for a budgeted-enabled Anthropic route."""
+
+_MINIMUM_THINKING_BUDGET_TOKENS = 1024
+"""Smallest budget Anthropic accepts for an ``enabled`` thinking config."""
+
+_MAXIMUM_THINKING_BUDGET_TOKENS = 16384
+"""Ceiling on a gateway-derived thinking budget when the caller supplied none."""
+
+
+def _thinking_history_disclosure(reason: str) -> str:
+    """Disclosure recorded when stale history thinking blocks are stripped."""
+    return f"thinking_history->dropped({reason})"
+
+
 CLOSED_SCHEMA_DISCLOSURE = "json_schema.additionalProperties->false"
 """Disclosure recorded when an open structured-output schema is closed."""
 
@@ -70,6 +86,160 @@ class RequestCoercion:
 
     request: GatewayRequest
     disclosures: tuple[str, ...]
+
+
+_STALE_THINKING_KINDS = frozenset({"thinking", "redacted_thinking"})
+"""Anthropic reasoning-block kinds the provider rejects once thinking is off."""
+
+
+def _strip_history_thinking(request: GatewayRequest) -> tuple[GatewayRequest, bool]:
+    """Drop replayed thinking blocks from prior assistant turns.
+
+    Anthropic 400s a continuation whose history carries ``thinking`` or
+    ``redacted_thinking`` blocks once thinking is disabled or dropped for the
+    dispatch, so a coercion that removes the thinking config must remove those
+    stale blocks from the SAME request copy. The honored path never calls this:
+    when thinking is preserved the signed blocks must round-trip byte-exact.
+
+    Args:
+        request: Request whose thinking config was just dropped or disabled.
+
+    Returns:
+        The request with stale blocks removed and whether anything changed.
+    """
+    changed = False
+    new_messages: list[GatewayMessage] = []
+    for message in request.messages:
+        retained = tuple(
+            block for block in message.provider_reasoning if block.kind not in _STALE_THINKING_KINDS
+        )
+        if len(retained) != len(message.provider_reasoning):
+            changed = True
+            new_messages.append(message.model_copy(update={"provider_reasoning": retained}))
+        else:
+            new_messages.append(message)
+    if not changed:
+        return request, False
+    return request.model_copy(update={"messages": tuple(new_messages)}), True
+
+
+def _thinking_budget_tokens(maximum_output_tokens: int | None) -> int | None:
+    """Return a legal ``budget_tokens`` for a translated enabled config, or None.
+
+    Anthropic requires ``1024 <= budget_tokens < max_tokens`` for an enabled
+    thinking config. With no effort→budget table to consult, the budget is
+    half the caller's output ceiling, clamped to a sane band. When the ceiling
+    is too small to admit any legal budget the translation is impossible and
+    the caller must fall through to the drop path.
+
+    Args:
+        maximum_output_tokens: The caller's output-token ceiling, if any.
+
+    Returns:
+        A legal budget, or ``None`` when no budget fits the ceiling.
+    """
+    if maximum_output_tokens is None:
+        return None
+    budget = min(
+        max(maximum_output_tokens // 2, _MINIMUM_THINKING_BUDGET_TOKENS),
+        _MAXIMUM_THINKING_BUDGET_TOKENS,
+    )
+    if _MINIMUM_THINKING_BUDGET_TOKENS <= budget < maximum_output_tokens:
+        return budget
+    return None
+
+
+def _all_budgeted_enabled_anthropic(profiles: Sequence[GatewayWireProfile]) -> bool:
+    """Whether every rung is an Anthropic budgeted-enabled reasoning route.
+
+    A budgeted-enabled rung reasons (``supports_reasoning``) and honors a
+    ``thinking: {type: enabled, budget_tokens}`` config, which is exactly the
+    Anthropic routes that are NOT the adaptive-only generation. A mixed or
+    non-reasoning route is not one, so an adaptive config there drops instead
+    of translating.
+    """
+    if not profiles or not all(profile.dialect == "anthropic_messages" for profile in profiles):
+        return False
+    return all(
+        profile.supports_reasoning and not anthropic_adaptive_only_thinking(profile.model_id)
+        for profile in profiles
+    )
+
+
+def _coerce_adaptive_budget(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+) -> RequestCoercion | None:
+    """Translate an adaptive thinking config for a budgeted-enabled route.
+
+    A budgeted-enabled Anthropic model (haiku-4-5) rejects ``thinking.type:
+    adaptive`` by name — that is the effort-ladder generation's channel — but
+    accepts a budgeted ``enabled`` config. Claude Code, configured for an
+    adaptive model, pins ``adaptive`` on every model, so the serviceable
+    reading here is to translate it to ``enabled`` with a derived budget. When
+    the caller already carried a budget the config is left verbatim; when no
+    legal budget fits the output ceiling the translation is impossible, so the
+    config and any effort channel drop and stale history thinking blocks are
+    stripped, all disclosed.
+
+    Args:
+        profiles: Ordered wire profiles for every live route deployment.
+        request: Decoded public request that no rung accepted verbatim.
+
+    Returns:
+        The disclosed translation or drop, or ``None`` when the request is not
+        an adaptive config on a budgeted-enabled Anthropic route.
+    """
+    config = request.provider_thinking_config
+    if config is None or config.get("type") != "adaptive":
+        return None
+    if config.get("budget_tokens") is not None:
+        # A caller-supplied budget already names the depth; leave it verbatim
+        # under the budgeted posture rather than overwriting it.
+        return None
+    if not _all_budgeted_enabled_anthropic(profiles):
+        return None
+    budget = _thinking_budget_tokens(request.maximum_output_tokens)
+    if budget is not None:
+        return RequestCoercion(
+            request=request.model_copy(
+                update={"provider_thinking_config": {"type": "enabled", "budget_tokens": budget}}
+            ),
+            disclosures=(THINKING_TRANSLATED_DISCLOSURE,),
+        )
+    # No legal budget fits: drop every reasoning signal so the surviving effort
+    # cannot re-emit adaptive thinking through output_config, and strip the
+    # stale signed history blocks the provider would otherwise 400 on.
+    dropped, disclosures = _drop_thinking_and_effort(request, reason="untranslatable_budget")
+    return RequestCoercion(request=dropped, disclosures=disclosures)
+
+
+def _drop_thinking_and_effort(
+    request: GatewayRequest,
+    *,
+    reason: str,
+) -> tuple[GatewayRequest, tuple[str, ...]]:
+    """Null the thinking config and effort channels and strip stale history.
+
+    Shared drop for the routes that cannot honor any reasoning: the thinking
+    config, the caller effort, and the Messages ``output_config.effort`` channel
+    all go, and prior thinking blocks are removed so the continuation replays
+    clean. Every removal is disclosed.
+    """
+    updates: dict[str, object] = {"provider_thinking_config": None}
+    disclosures: list[str] = [THINKING_DROP_DISCLOSURE]
+    if request.reasoning_effort is not None:
+        updates["reasoning_effort"] = None
+        disclosures.append(EFFORT_DROP_DISCLOSURE)
+    if request.provider_output_config is not None and "effort" in request.provider_output_config:
+        remaining = {
+            key: value for key, value in request.provider_output_config.items() if key != "effort"
+        }
+        updates["provider_output_config"] = remaining or None
+    dropped, stripped = _strip_history_thinking(request.model_copy(update=updates))
+    if stripped:
+        disclosures.append(_thinking_history_disclosure(reason))
+    return dropped, tuple(disclosures)
 
 
 def coerce_generation_parameters(
@@ -110,6 +280,11 @@ def coerce_generation_parameters(
         if admits is not None and not admits(disabled_thinking.request):
             return None
         return disabled_thinking
+    adaptive_budget = _coerce_adaptive_budget(profiles, request)
+    if adaptive_budget is not None:
+        if admits is not None and not admits(adaptive_budget.request):
+            return None
+        return adaptive_budget
     if request.reasoning_effort is None:
         return None
     ladder: set[str] = set()
@@ -140,6 +315,13 @@ def coerce_generation_parameters(
             updates["provider_thinking_config"] = None
             disclosures = (EFFORT_DROP_DISCLOSURE, THINKING_DROP_DISCLOSURE)
         dropped_request = request.model_copy(update=updates)
+        if "provider_thinking_config" in updates:
+            # Thinking was just dropped for a genuinely non-reasoning route;
+            # the replayed signed history blocks would 400 the continuation,
+            # so strip them from the same copy and disclose it.
+            dropped_request, stripped = _strip_history_thinking(dropped_request)
+            if stripped:
+                disclosures = (*disclosures, _thinking_history_disclosure("no_reasoning_route"))
         if admits is not None and not admits(dropped_request):
             return None
         return RequestCoercion(request=dropped_request, disclosures=disclosures)
@@ -208,10 +390,15 @@ def _coerce_disabled_thinking(
         anthropic_adaptive_only_thinking(profile.model_id) for profile in anthropic_profiles
     ):
         return None
-    return RequestCoercion(
-        request=request.model_copy(update={"provider_thinking_config": None}),
-        disclosures=(THINKING_DISABLED_DISCLOSURE,),
+    dropped, stripped = _strip_history_thinking(
+        request.model_copy(update={"provider_thinking_config": None})
     )
+    disclosures = (THINKING_DISABLED_DISCLOSURE,)
+    if stripped:
+        # The caller asked to turn thinking off; any replayed thinking blocks
+        # in history would 400 the continuation, so they strip with the config.
+        disclosures = (*disclosures, _thinking_history_disclosure("thinking_disabled"))
+    return RequestCoercion(request=dropped, disclosures=disclosures)
 
 
 def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoercion | None:

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -9,6 +9,7 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayToolDefinition,
     StructuredTextFormat,
+    ThinkingBlock,
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.capability_policy import (
@@ -17,6 +18,35 @@ from exp.runtime.models.providers.capability_policy import (
     coerce_structured_text_schema,
 )
 from exp.runtime.models.providers.reasoning_compat import efforts_by_nearness
+
+
+def _budgeted_haiku_profile() -> GatewayWireProfile:
+    """Build one Anthropic budgeted-enabled reasoning wire profile (haiku-4-5)."""
+    return GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        model_id="claude-haiku-4-5",
+        supports_reasoning=True,
+        reasoning_wire_format="anthropic_adaptive",
+    )
+
+
+def _messages_request(**overrides: object) -> GatewayRequest:
+    """Build one canonical Messages-surface request with overrides applied."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+    )
+    return request.model_copy(update=dict(overrides))
+
+
+def _replayed_thinking_turn() -> GatewayMessage:
+    """Build one assistant history turn carrying a signed thinking block."""
+    return GatewayMessage(
+        role="assistant",
+        content="answer",
+        provider_reasoning=(ThinkingBlock(text="prior reasoning", signature="sig"),),
+    )
 
 
 def _request(**overrides: object) -> GatewayRequest:
@@ -464,3 +494,108 @@ def test_disabled_thinking_drops_only_on_adaptive_only_anthropic_routes() -> Non
         coerce_generation_parameters((adaptive_only, shim), request, admits=lambda _c: False)
         is None
     )
+
+
+def test_disabled_thinking_drop_strips_stale_history_thinking_blocks() -> None:
+    """Turning thinking off also removes replayed thinking blocks, disclosed."""
+    adaptive_only = GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        model_id="claude-opus-5",
+        supports_reasoning=True,
+        reasoning_wire_format="anthropic_adaptive",
+    )
+    request = _messages_request(
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            _replayed_thinking_turn(),
+            GatewayMessage(role="user", content="again"),
+        ),
+        provider_thinking_config={"type": "disabled"},
+    )
+    coercion = coerce_generation_parameters((adaptive_only,), request)
+    assert coercion is not None
+    assert coercion.request.provider_thinking_config is None
+    assert all(not message.provider_reasoning for message in coercion.request.messages)
+    assert coercion.disclosures == (
+        "thinking.type->adaptive",
+        "thinking_history->dropped(thinking_disabled)",
+    )
+
+
+def test_adaptive_thinking_translates_to_a_budget_on_a_budgeted_route() -> None:
+    """A no-budget adaptive config becomes a legal enabled config, disclosed."""
+    request = _messages_request(
+        provider_thinking_config={"type": "adaptive"},
+        maximum_output_tokens=8_000,
+    )
+    coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), request)
+    assert coercion is not None
+    # min(max(8000 // 2, 1024), 16384) == 4000, and 1024 <= 4000 < 8000.
+    assert coercion.request.provider_thinking_config == {
+        "type": "enabled",
+        "budget_tokens": 4_000,
+    }
+    assert coercion.disclosures == ("thinking.type->enabled",)
+
+
+def test_adaptive_thinking_drops_when_no_legal_budget_fits_max_tokens() -> None:
+    """A ceiling too small for any legal budget drops thinking and its history."""
+    request = _messages_request(
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            _replayed_thinking_turn(),
+            GatewayMessage(role="user", content="again"),
+        ),
+        provider_thinking_config={"type": "adaptive"},
+        # No budget in [1024, max_tokens) exists when max_tokens <= 1024.
+        maximum_output_tokens=1_024,
+    )
+    coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), request)
+    assert coercion is not None
+    assert coercion.request.provider_thinking_config is None
+    assert all(not message.provider_reasoning for message in coercion.request.messages)
+    assert coercion.disclosures == (
+        "thinking",
+        "thinking_history->dropped(untranslatable_budget)",
+    )
+
+
+def test_forced_drop_on_a_non_reasoning_anthropic_route_strips_history() -> None:
+    """A genuinely non-reasoning route drops thinking and its stale history."""
+    non_reasoning = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    request = _messages_request(
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            _replayed_thinking_turn(),
+            GatewayMessage(role="user", content="again"),
+        ),
+        reasoning_effort="high",
+        provider_thinking_config={"type": "adaptive"},
+    )
+    coercion = coerce_generation_parameters((non_reasoning,), request)
+    assert coercion is not None
+    assert coercion.request.reasoning_effort is None
+    assert coercion.request.provider_thinking_config is None
+    assert all(not message.provider_reasoning for message in coercion.request.messages)
+    assert coercion.disclosures == (
+        "reasoning_effort",
+        "thinking",
+        "thinking_history->dropped(no_reasoning_route)",
+    )
+
+
+def test_caller_budgeted_config_is_left_verbatim_on_a_budgeted_route() -> None:
+    """A caller enabled+budget config needs no coercion; history is untouched."""
+    request = _messages_request(
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            _replayed_thinking_turn(),
+            GatewayMessage(role="user", content="again"),
+        ),
+        provider_thinking_config={"type": "enabled", "budget_tokens": 2_048},
+        maximum_output_tokens=8_000,
+    )
+    # An enabled config the route honors is not adaptive, so nothing coerces
+    # and the signed history blocks survive for byte-exact replay.
+    assert coerce_generation_parameters((_budgeted_haiku_profile(),), request) is None

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -496,33 +496,6 @@ def test_disabled_thinking_drops_only_on_adaptive_only_anthropic_routes() -> Non
     )
 
 
-def test_disabled_thinking_drop_strips_stale_history_thinking_blocks() -> None:
-    """Turning thinking off also removes replayed thinking blocks, disclosed."""
-    adaptive_only = GatewayWireProfile(
-        dialect="anthropic_messages",
-        url="https://anthropic.test",
-        model_id="claude-opus-5",
-        supports_reasoning=True,
-        reasoning_wire_format="anthropic_adaptive",
-    )
-    request = _messages_request(
-        messages=(
-            GatewayMessage(role="user", content="hi"),
-            _replayed_thinking_turn(),
-            GatewayMessage(role="user", content="again"),
-        ),
-        provider_thinking_config={"type": "disabled"},
-    )
-    coercion = coerce_generation_parameters((adaptive_only,), request)
-    assert coercion is not None
-    assert coercion.request.provider_thinking_config is None
-    assert all(not message.provider_reasoning for message in coercion.request.messages)
-    assert coercion.disclosures == (
-        "thinking.type->adaptive",
-        "thinking_history->dropped(thinking_disabled)",
-    )
-
-
 def test_adaptive_thinking_translates_to_a_budget_on_a_budgeted_route() -> None:
     """A no-budget adaptive config becomes a legal enabled config, disclosed."""
     request = _messages_request(
@@ -540,7 +513,11 @@ def test_adaptive_thinking_translates_to_a_budget_on_a_budgeted_route() -> None:
 
 
 def test_adaptive_thinking_drops_when_no_legal_budget_fits_max_tokens() -> None:
-    """A ceiling too small for any legal budget drops thinking and its history."""
+    """A ceiling too small for any legal budget drops thinking, disclosed.
+
+    History thinking blocks are left in place: Anthropic accepts replayed
+    thinking blocks with no live thinking config, so the drop never strips them.
+    """
     request = _messages_request(
         messages=(
             GatewayMessage(role="user", content="hi"),
@@ -554,35 +531,68 @@ def test_adaptive_thinking_drops_when_no_legal_budget_fits_max_tokens() -> None:
     coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), request)
     assert coercion is not None
     assert coercion.request.provider_thinking_config is None
-    assert all(not message.provider_reasoning for message in coercion.request.messages)
-    assert coercion.disclosures == (
-        "thinking",
-        "thinking_history->dropped(untranslatable_budget)",
-    )
+    # The replayed thinking block survives; the coercion only drops the config.
+    assert any(message.provider_reasoning for message in coercion.request.messages)
+    assert coercion.disclosures == ("thinking",)
 
 
-def test_forced_drop_on_a_non_reasoning_anthropic_route_strips_history() -> None:
-    """A genuinely non-reasoning route drops thinking and its stale history."""
-    non_reasoning = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
-    request = _messages_request(
-        messages=(
-            GatewayMessage(role="user", content="hi"),
-            _replayed_thinking_turn(),
-            GatewayMessage(role="user", content="again"),
-        ),
-        reasoning_effort="high",
-        provider_thinking_config={"type": "adaptive"},
+def test_adaptive_thinking_drops_on_a_zero_reasoning_route_without_an_effort() -> None:
+    """Adaptive thinking alone (no effort beside it) still drops, disclosed.
+
+    Claude Code pins ``thinking: {type: adaptive}`` on every request but sends
+    an effort only when one is configured; a genuinely non-reasoning model
+    rejects the adaptive object by name either way, so it drops here rather than
+    reaching the provider. A budgeted-enabled route (haiku) instead translates
+    the same config; an adaptive-accepting reasoning route keeps it verbatim. A
+    clear-thinking context edit rides on the thinking config and goes with it,
+    while other edits stay verbatim.
+    """
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    adaptive_only = _request().model_copy(
+        update={
+            "surface": GatewayApiSurface.MESSAGES,
+            "provider_thinking_config": {"type": "adaptive"},
+            "context_management": {
+                "edits": [
+                    {"type": "clear_thinking_20251015", "keep": "all"},
+                    {"type": "clear_tool_uses_20250919"},
+                ]
+            },
+        }
     )
-    coercion = coerce_generation_parameters((non_reasoning,), request)
+    coercion = coerce_generation_parameters((anthropic,), adaptive_only)
     assert coercion is not None
     assert coercion.request.reasoning_effort is None
     assert coercion.request.provider_thinking_config is None
-    assert all(not message.provider_reasoning for message in coercion.request.messages)
-    assert coercion.disclosures == (
-        "reasoning_effort",
-        "thinking",
-        "thinking_history->dropped(no_reasoning_route)",
+    assert coercion.request.context_management == {"edits": [{"type": "clear_tool_uses_20250919"}]}
+    assert coercion.disclosures == ("thinking",)
+
+    only_clear_thinking = adaptive_only.model_copy(
+        update={"context_management": {"edits": [{"type": "clear_thinking_20251015"}]}}
     )
+    coercion = coerce_generation_parameters((anthropic,), only_clear_thinking)
+    assert coercion is not None
+    assert coercion.request.context_management is None
+
+    # A budgeted config on its own is honored by the model and is not coerced.
+    budgeted_only = adaptive_only.model_copy(
+        update={
+            "provider_thinking_config": {"type": "enabled", "budget_tokens": 1024},
+            "context_management": None,
+        }
+    )
+    assert coerce_generation_parameters((anthropic,), budgeted_only) is None
+
+    # An adaptive-accepting reasoning route keeps the adaptive object verbatim.
+    reasoning = GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        model_id="claude-sonnet-4-6",
+        supports_reasoning=True,
+        reasoning_wire_format="anthropic_adaptive",
+    )
+    bare_adaptive = adaptive_only.model_copy(update={"context_management": None})
+    assert coerce_generation_parameters((reasoning,), bare_adaptive) is None
 
 
 def test_caller_budgeted_config_is_left_verbatim_on_a_budgeted_route() -> None:

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -512,6 +512,58 @@ def test_adaptive_thinking_translates_to_a_budget_on_a_budgeted_route() -> None:
     assert coercion.disclosures == ("thinking.type->enabled",)
 
 
+def test_adaptive_thinking_with_a_legal_caller_budget_keeps_that_budget() -> None:
+    """The model rejects ``adaptive`` by name, so a budget-carrying adaptive
+    config still translates to enabled — honoring the caller's own depth."""
+    request = _messages_request(
+        provider_thinking_config={"type": "adaptive", "budget_tokens": 2_048},
+        maximum_output_tokens=8_000,
+    )
+    coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), request)
+    assert coercion is not None
+    assert coercion.request.provider_thinking_config == {
+        "type": "enabled",
+        "budget_tokens": 2_048,
+    }
+    assert coercion.disclosures == ("thinking.type->enabled",)
+
+    # With no output ceiling the caller's legal budget is likewise honored.
+    unbounded = _messages_request(
+        provider_thinking_config={"type": "adaptive", "budget_tokens": 30_000},
+    )
+    coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), unbounded)
+    assert coercion is not None
+    assert coercion.request.provider_thinking_config == {
+        "type": "enabled",
+        "budget_tokens": 30_000,
+    }
+
+
+def test_adaptive_thinking_with_an_illegal_caller_budget_falls_back_to_derived() -> None:
+    """A caller budget below the floor or at/above max_tokens is replaced, never sent."""
+    too_small = _messages_request(
+        provider_thinking_config={"type": "adaptive", "budget_tokens": 512},
+        maximum_output_tokens=8_000,
+    )
+    coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), too_small)
+    assert coercion is not None
+    assert coercion.request.provider_thinking_config == {
+        "type": "enabled",
+        "budget_tokens": 4_000,
+    }
+
+    at_ceiling = _messages_request(
+        provider_thinking_config={"type": "adaptive", "budget_tokens": 8_000},
+        maximum_output_tokens=8_000,
+    )
+    coercion = coerce_generation_parameters((_budgeted_haiku_profile(),), at_ceiling)
+    assert coercion is not None
+    assert coercion.request.provider_thinking_config == {
+        "type": "enabled",
+        "budget_tokens": 4_000,
+    }
+
+
 def test_adaptive_thinking_drops_when_no_legal_budget_fits_max_tokens() -> None:
     """A ceiling too small for any legal budget drops thinking, disclosed.
 

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -551,6 +551,9 @@ def test_adaptive_thinking_with_an_illegal_caller_budget_falls_back_to_derived()
         "type": "enabled",
         "budget_tokens": 4_000,
     }
+    # The substitution changes the requested depth, so it is disclosed by
+    # itself beside the type translation.
+    assert coercion.disclosures == ("thinking.type->enabled", "thinking.budget_tokens")
 
     at_ceiling = _messages_request(
         provider_thinking_config={"type": "adaptive", "budget_tokens": 8_000},
@@ -562,6 +565,7 @@ def test_adaptive_thinking_with_an_illegal_caller_budget_falls_back_to_derived()
         "type": "enabled",
         "budget_tokens": 4_000,
     }
+    assert coercion.disclosures == ("thinking.type->enabled", "thinking.budget_tokens")
 
 
 def test_adaptive_thinking_drops_when_no_legal_budget_fits_max_tokens() -> None:

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -217,10 +217,13 @@ def anthropic_messages_stream_payload(
     # caller's depth intent, so it is realized as a derived budget — the same
     # wire realization the effort generation gets via the adaptive object.
     budgeted_only = supports_reasoning and anthropic_budgeted_enabled_only(model_id)
-    if budgeted_only and "effort" in output_config:
-        # A caller-seeded output_config.effort would be rejected by name; the
-        # same depth intent rides request.reasoning_effort (decode maps it)
-        # and is realized as the token budget below.
+    if budgeted_only and "effort" in output_config and request.reasoning_effort is not None:
+        # A recognized caller effort rides request.reasoning_effort too (decode
+        # maps it) and is realized as the token budget below, so the by-name-
+        # rejected output_config key comes off the wire. An UNRECOGNIZED effort
+        # never mapped, has no budget realization, and stays verbatim — the
+        # provider's own by-name rejection is the honest outcome, never a
+        # silent thinking-off answer.
         output_config.pop("effort")
     if request.provider_thinking_config is not None:
         # The caller's exact thinking configuration wins over the catalog's

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -19,7 +19,11 @@ from exp.runtime.models.providers.errors import (
     ProviderResponseError,
 )
 from exp.runtime.models.providers.gemini_requests import gemini_generate_request
-from exp.runtime.models.providers.reasoning_compat import anthropic_reasoning_effort
+from exp.runtime.models.providers.reasoning_compat import (
+    anthropic_budgeted_enabled_only,
+    anthropic_reasoning_effort,
+    anthropic_thinking_budget_tokens,
+)
 from exp.runtime.models.providers.wire_messages import anthropic_blocks
 from exp.runtime.openai_protocol.model_adapter import model_request as gateway_model_request
 
@@ -207,6 +211,17 @@ def anthropic_messages_stream_payload(
         payload["cache_control"] = request.provider_cache_control
     if request.inference_geo is not None:
         payload["inference_geo"] = request.inference_geo
+    # A budgeted-enabled-only model (haiku-4-5) rejects ``thinking.type:
+    # adaptive`` and ``output_config.effort`` by NAME: its reasoning dial is a
+    # token budget, not the effort ladder. An effort reaching this seam is the
+    # caller's depth intent, so it is realized as a derived budget — the same
+    # wire realization the effort generation gets via the adaptive object.
+    budgeted_only = supports_reasoning and anthropic_budgeted_enabled_only(model_id)
+    if budgeted_only and "effort" in output_config:
+        # A caller-seeded output_config.effort would be rejected by name; the
+        # same depth intent rides request.reasoning_effort (decode maps it)
+        # and is realized as the token budget below.
+        output_config.pop("effort")
     if request.provider_thinking_config is not None:
         # The caller's exact thinking configuration wins over the catalog's
         # adaptive default and travels verbatim, so budget semantics are
@@ -217,13 +232,21 @@ def anthropic_messages_stream_payload(
         if (
             request.provider_thinking_config.get("type") == "adaptive"
             and supports_reasoning
+            and not budgeted_only
             and effective_reasoning_effort is not None
             and "effort" not in output_config
         ):
             output_config["effort"] = anthropic_reasoning_effort(
                 model_id, effective_reasoning_effort
             )
-    elif supports_reasoning and effective_reasoning_effort is not None:
+    elif budgeted_only and effective_reasoning_effort not in (None, "none"):
+        # No legal budget under the output ceiling means thinking stays off;
+        # the model still answers, and route narrowing already disclosed any
+        # sampling interplay. output_config.effort is never emitted here.
+        budget = anthropic_thinking_budget_tokens(request.maximum_output_tokens)
+        if budget is not None:
+            payload["thinking"] = {"type": "enabled", "budget_tokens": budget}
+    elif supports_reasoning and not budgeted_only and effective_reasoning_effort is not None:
         payload["thinking"] = {"type": "adaptive"}
         if "effort" not in output_config:
             output_config["effort"] = anthropic_reasoning_effort(

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Collection
 from typing import cast
 
-from exp.common.models.known_models import canonical_model_id
+from exp.common.models.known_models import canonical_model_id, known_model_metadata
 from exp.common.models.model import ReasoningEffort
 from exp.runtime.models.providers.errors import (
     ProviderParameterError,
@@ -185,6 +185,64 @@ def anthropic_adaptive_only_thinking(model_id: str) -> bool:
     """
     normalized = _normalized_model(model_id)
     return any(family in normalized for family in _ANTHROPIC_ADAPTIVE_ONLY_FAMILIES)
+
+
+def anthropic_budgeted_enabled_only(model_id: str) -> bool:
+    """Whether an Anthropic model reasons via a token budget but rejects adaptive.
+
+    haiku-4-5 is marked ``supports_reasoning`` yet is NOT the effort/adaptive
+    generation (``supports_reasoning_effort`` is False), so it honors a
+    budgeted ``thinking: {type: enabled, budget_tokens}`` config while
+    rejecting ``thinking: {type: adaptive}`` and ``output_config.effort`` by
+    name. The effort generation (sonnet-4-6, opus-5, fable-5-1, ...) carries
+    ``supports_reasoning_effort`` and accepts the adaptive object verbatim,
+    so it is NOT one of these.
+
+    Args:
+        model_id: Exact Anthropic model identifier.
+
+    Returns:
+        ``True`` only for a reasoning model whose depth is a token budget and
+        which rejects an adaptive thinking config.
+    """
+    known = known_model_metadata("anthropic", model_id)
+    if known is None:
+        return False
+    return known.supports_reasoning is True and not known.supports_reasoning_effort
+
+
+MINIMUM_THINKING_BUDGET_TOKENS = 1024
+"""Smallest budget Anthropic accepts for an ``enabled`` thinking config."""
+
+MAXIMUM_THINKING_BUDGET_TOKENS = 16384
+"""Ceiling on a gateway-derived thinking budget when the caller supplied none."""
+
+
+def anthropic_thinking_budget_tokens(maximum_output_tokens: int | None) -> int | None:
+    """Return a legal ``budget_tokens`` for a translated enabled config, or None.
+
+    Anthropic requires ``1024 <= budget_tokens < max_tokens`` for an enabled
+    thinking config. With no effort→budget table to consult, the budget is
+    half the caller's output ceiling, clamped to a sane band. An unbounded
+    caller (no ceiling) takes the band ceiling. When the ceiling is too small
+    to admit any legal budget the translation is impossible and the caller
+    must fall through to the drop path.
+
+    Args:
+        maximum_output_tokens: The caller's output-token ceiling, if any.
+
+    Returns:
+        A legal budget, or ``None`` when no budget fits the ceiling.
+    """
+    if maximum_output_tokens is None:
+        return MAXIMUM_THINKING_BUDGET_TOKENS
+    budget = min(
+        max(maximum_output_tokens // 2, MINIMUM_THINKING_BUDGET_TOKENS),
+        MAXIMUM_THINKING_BUDGET_TOKENS,
+    )
+    if MINIMUM_THINKING_BUDGET_TOKENS <= budget < maximum_output_tokens:
+        return budget
+    return None
 
 
 def anthropic_reasoning_effort(model_id: str, effort: str) -> str:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -43,6 +43,7 @@ from exp.runtime.models.providers.openai_payloads import (
 from exp.runtime.models.providers.reasoning_compat import (
     REASONING_EFFORTS,
     anthropic_adaptive_only_thinking,
+    anthropic_budgeted_enabled_only,
 )
 
 if TYPE_CHECKING:
@@ -749,6 +750,25 @@ def route_generation_parameter_requests(
         adaptive_only = all(
             anthropic_adaptive_only_thinking(profile.model_id) for profile in profiles
         )
+        # A budgeted-enabled-only model (haiku-4-5) rejects an adaptive config
+        # by NAME; the named rejection here is what lets the admit loop offer
+        # the disclosed adaptive->enabled(budget) coercion instead of the
+        # provider's own opaque 400 (which never fails over).
+        budgeted_enabled_only = all(
+            profile.dialect == "anthropic_messages"
+            and anthropic_budgeted_enabled_only(profile.model_id)
+            for profile in profiles
+        )
+        if budgeted_enabled_only and config_type == "adaptive":
+            raise ProviderParameterError(
+                message=(
+                    "The parameter 'thinking.type' cannot be 'adaptive' on this model: "
+                    "it reasons via an explicit token budget. Send thinking "
+                    "{type: 'enabled', budget_tokens: N} or remove the field."
+                ),
+                param="thinking.type",
+                code="unsupported_parameter",
+            )
         if adaptive_only and config_type == "enabled":
             # Translate to the model's one supported mode, emitted explicitly
             # so the promise holds even on routes with no pinned effort. The

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -93,6 +93,23 @@ SERVICE_TIER_DIALECTS = frozenset({"openai_responses", "openai_compatible"})
 """Wire dialects with a request field that preserves the caller's service tier."""
 
 
+def _anthropic_reasoning_disengaged(request: GatewayRequest) -> bool:
+    """Whether an Anthropic dispatch will send no extended-thinking budget.
+
+    On the native Messages wire the model reasons only when the caller asks:
+    a ``thinking`` config of type ``enabled``/``adaptive`` or a reasoning
+    effort turns it on, and their absence leaves thinking OFF. This is the
+    inverse of the OpenAI effort-native models, whose default IS reasoning, so
+    it governs the srn sampling hatch ONLY for the anthropic_adaptive wire
+    (a budgeted-enabled route such as haiku-4-5): with thinking off, Anthropic
+    accepts an ordinary temperature, so srn must not drop it.
+    """
+    config = request.provider_thinking_config
+    thinking_on = config is not None and config.get("type") in {"enabled", "adaptive"}
+    effort_on = request.reasoning_effort is not None and request.reasoning_effort != "none"
+    return not thinking_on and not effort_on
+
+
 def dialect_stream_payload(
     profile: GatewayWireProfile,
     provider_request: GatewayRequest,
@@ -307,6 +324,13 @@ def route_generation_parameter_requests(
         return sampling_declared(profile, top_p=top_p) and (
             not profile.sampling_requires_reasoning_none
             or profile_reasoning_effort(profile) == "none"
+            # A budgeted-enabled Anthropic rung has no "none" effort on its
+            # ladder; its srn hatch opens when the dispatch sends no thinking
+            # budget at all, so ordinary thinking-off sampling is honored.
+            or (
+                profile.reasoning_wire_format == "anthropic_adaptive"
+                and _anthropic_reasoning_disengaged(request)
+            )
         )
 
     def srn_only_block(*, top_p: bool = False) -> bool:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -326,6 +326,97 @@ def test_haiku_thinking_off_temperature_is_honored_under_the_srn_hatch() -> None
     assert "temperature->dropped(set_reasoning_effort_none)" in public_on.ignored_parameters
 
 
+def test_haiku_bare_effort_realizes_as_a_token_budget_at_the_payload_seam() -> None:
+    """An effort on a budgeted-enabled-only model emits enabled+budget, never adaptive.
+
+    haiku rejects ``thinking.type: adaptive`` and ``output_config.effort`` by
+    name; an effort reaching the build is the caller's depth intent (or the
+    route's pinned default), realized as the derived token budget — the same
+    wire realization the effort generation gets via the adaptive object.
+    """
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        reasoning_effort="medium",
+        maximum_output_tokens=8_000,
+        stream=True,
+    )
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        request,
+        supports_reasoning=True,
+    )
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 4_000}
+    assert "output_config" not in payload
+
+    # The route's pinned catalog default (no caller effort) realizes the same way.
+    pinned = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        request.model_copy(update={"reasoning_effort": None}),
+        supports_reasoning=True,
+        reasoning_effort="medium",
+    )
+    assert pinned["thinking"] == {"type": "enabled", "budget_tokens": 4_000}
+    assert "output_config" not in pinned
+
+    # Effort "none" keeps thinking off entirely.
+    off = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        request.model_copy(update={"reasoning_effort": "none"}),
+        supports_reasoning=True,
+    )
+    assert "thinking" not in off
+
+    # A ceiling too small for any legal budget keeps thinking off rather than
+    # emitting an illegal budget the provider would reject.
+    tight = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        request.model_copy(update={"maximum_output_tokens": 1_024}),
+        supports_reasoning=True,
+    )
+    assert "thinking" not in tight
+
+
+def test_haiku_caller_output_config_effort_is_stripped_at_the_payload_seam() -> None:
+    """A caller-seeded output_config.effort never reaches a budgeted-only model."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        reasoning_effort="medium",
+        provider_output_config={"effort": "medium", "format": {"type": "text"}},
+        maximum_output_tokens=8_000,
+        stream=True,
+    )
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        request,
+        supports_reasoning=True,
+    )
+    # The depth intent rides the budget; the by-name-rejected key is gone and
+    # unrelated output_config keys survive verbatim.
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 4_000}
+    assert payload["output_config"] == {"format": {"type": "text"}}
+
+
+def test_haiku_adaptive_config_is_rejected_by_name_before_dispatch() -> None:
+    """An adaptive config on a budgeted-only route raises pre-dispatch.
+
+    The named rejection is what lets the admit loop offer the disclosed
+    adaptive->enabled(budget) coercion; forwarding verbatim would surface the
+    provider's own opaque 400 instead (which never fails over).
+    """
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        provider_thinking_config={"type": "adaptive"},
+        maximum_output_tokens=8_000,
+        stream=True,
+    )
+    with pytest.raises(ProviderParameterError) as excinfo:
+        route_generation_parameter_requests((_budgeted_haiku_profile(),), request)
+    assert excinfo.value.param == "thinking.type"
+
+
 def test_openai_compatible_stream_payload_omits_reasoning_without_route_capability() -> None:
     """A compatible route never receives a reasoning field without explicit capability proof."""
     request = _chat_request().model_copy(update={"reasoning_effort": "high"})

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -22,6 +22,7 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
     GatewayToolDefinition,
     StructuredTextFormat,
+    ThinkingBlock,
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.bedrock_requests import converse_body
@@ -239,6 +240,88 @@ def test_anthropic_stream_payload_omits_logprobs_even_when_flagged() -> None:
     )
     assert "logprobs" not in payload
     assert "top_logprobs" not in payload
+
+
+def _budgeted_haiku_profile() -> GatewayWireProfile:
+    """Return the Anthropic budgeted-enabled reasoning profile for haiku-4-5."""
+    return GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://api.anthropic.com/v1/messages",
+        model_id="claude-haiku-4-5",
+        supports_temperature=True,
+        supports_reasoning=True,
+        reasoning_wire_format="anthropic_adaptive",
+        sampling_requires_reasoning_none=True,
+        maximum_output_tokens=64_000,
+    )
+
+
+def test_haiku_multi_turn_budgeted_thinking_is_honored_end_to_end() -> None:
+    """A caller budget config plus replayed thinking blocks survive verbatim."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            GatewayMessage(
+                role="assistant",
+                content="prior answer",
+                provider_reasoning=(ThinkingBlock(text="prior reasoning", signature="sig-1"),),
+            ),
+            GatewayMessage(role="user", content="again"),
+        ),
+        provider_thinking_config={"type": "enabled", "budget_tokens": 2_048},
+        maximum_output_tokens=8_000,
+        stream=True,
+    )
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        request,
+        supports_temperature=True,
+        supports_reasoning=True,
+    )
+    assert payload["thinking"] == {"type": "enabled", "budget_tokens": 2_048}
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    content = assistant["content"]
+    assert isinstance(content, list)
+    # The signed thinking block re-emits byte-exact, leading the assistant turn.
+    assert content[0] == {"type": "thinking", "thinking": "prior reasoning", "signature": "sig-1"}
+
+
+def test_haiku_thinking_off_temperature_is_honored_under_the_srn_hatch() -> None:
+    """With thinking off (no config), haiku's srn hatch keeps temperature.
+
+    haiku has no "none" on its effort ladder, so the srn hatch opens on the
+    absence of any thinking budget instead — thinking-off traffic that sets
+    temperature keeps it rather than regressing to a silent drop.
+    """
+    profile = _budgeted_haiku_profile()
+    honored = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hello"),),
+        temperature=0.5,
+        maximum_output_tokens=1_000,
+        stream=True,
+    )
+    _public, provider = route_generation_parameter_requests((profile,), honored)
+    assert provider.temperature == 0.5
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        provider,
+        supports_temperature=True,
+        supports_reasoning=True,
+    )
+    assert payload["temperature"] == 0.5
+
+    # Contrast: with thinking ENABLED, Anthropic requires temperature 1, so the
+    # same control is a disclosed drop, not a rejection — srn is per request.
+    thinking_on = honored.model_copy(
+        update={"provider_thinking_config": {"type": "enabled", "budget_tokens": 2_048}}
+    )
+    public_on, provider_on = route_generation_parameter_requests((profile,), thinking_on)
+    assert provider_on.temperature is None
+    assert "temperature->dropped(set_reasoning_effort_none)" in public_on.ignored_parameters
 
 
 def test_openai_compatible_stream_payload_omits_reasoning_without_route_capability() -> None:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -397,6 +397,23 @@ def test_haiku_caller_output_config_effort_is_stripped_at_the_payload_seam() -> 
     assert payload["thinking"] == {"type": "enabled", "budget_tokens": 4_000}
     assert payload["output_config"] == {"format": {"type": "text"}}
 
+    # An UNRECOGNIZED effort never mapped to reasoning_effort, so it has no
+    # budget realization; it stays verbatim and the provider's own by-name
+    # rejection is the honest outcome, never a silent thinking-off answer.
+    future = request.model_copy(
+        update={
+            "reasoning_effort": None,
+            "provider_output_config": {"effort": "hyperdrive"},
+        }
+    )
+    payload = anthropic_messages_stream_payload(
+        "claude-haiku-4-5",
+        future,
+        supports_reasoning=True,
+    )
+    assert "thinking" not in payload
+    assert payload["output_config"] == {"effort": "hyperdrive"}
+
 
 def test_haiku_adaptive_config_is_rejected_by_name_before_dispatch() -> None:
     """An adaptive config on a budgeted-only route raises pre-dispatch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.29,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.30,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.31"
+version = "0.7.32"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.31"
+version = "0.7.32"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.29"
+version = "0.3.30"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
Fixes the Akhara 28%-of-haiku-4.5 multi-turn reject. Three stacked issues + two queued items. Engine stays 0.7.31 (version bump added at cut); native crate 0.3.29→0.3.30 (Fix 3).

## Fix 1 — haiku-4.5 mis-registered as non-reasoning
`discovery.py` derived `supports_reasoning` solely from `supports_reasoning_effort`, so there was no way to express "reasoning-capable but not effort-based." Added `KnownModel.supports_reasoning` (preferred; falls back to effort), and registered `claude-haiku-4-5` as **budgeted-enabled**: `supports_reasoning=True`, effort off, `sampling_requires_reasoning_none=True`, normal sampling (no temp[1,1] pin — thinking is optional). `capability_policy` now **translates** an adaptive config with no budget → `{type:enabled,budget_tokens:N}` (N = clamp(max_tokens//2, 1024, 16384), enforcing 1024 ≤ N < max_tokens); a caller-supplied budget passes through; when no legal budget fits, it drops + strips history (Fix 2), disclosed `thinking.type->enabled`.

## Fix 2 — dropped thinking left stale history blocks → provider 400
`wire_messages` re-emits thinking/redacted_thinking from `provider_reasoning` byte-exact (signature round-trip). When a coercion **drops** thinking, `capability_policy` now also strips thinking/redacted_thinking from prior assistant turns in the same request copy, disclosed `thinking_history->dropped(<reason>)`. Wired into all three drop paths; the honored path is untouched (byte-exact preserved). General fail-safe for genuinely non-reasoning Anthropic rungs.

## Fix 3 — failed-attempt attribution (native 0.3.30)
The Rust upstream collapsed provider 400s to a generic message and the ledger recorded no provider text. Now the settlement payload carries `provider_detail` (the **already-sanitized, already-caller-relayed** `param_attribution::rejected_detail` — `error.message` only, single-line, length-bounded, infra/credential-free), threaded to a new nullable `gateway_attempts.failure_message` column (schema v16). Same sanitized text the caller already gets — no widening of the ledger's content-free posture.

## Queued: RouteResolver Protocol + resolve_deployment_hint docstring
Exported a `RouteResolver` Protocol (`CatalogRouteResolver` satisfies it) so a platform wrapper's missing method is caught by ty statically (prevents the class of bug behind the check-5 prod 400). Tightened the docstring: the hint must be a canonical pool member; variant↔canonical mapping is the caller-resolver's job.

## Fixtures (all six)
haiku multi-turn honored (a); adaptive-no-budget → translated (b); tiny max_tokens → dropped + history stripped + disclosed (c); thinking-off + temperature honored via srn hatch (d); non-reasoning Anthropic route → history stripped (e); failed attempt → sanitized provider text on the ledger row (f).

## Validation
ruff/ty clean; pytest py3.13: exp/common/models 243, providers 528/1skip, gateway 782/3skip/1 known flake deselected; Rust 162 pass (fmt/clippy clean); uv.lock in sync.

## Reviewer notes (flagged)
1. Fix 1 needed a small `streaming_requests.sampling_supported` srn hatch: haiku has no `none` on its effort ladder, so thinking-OFF + temperature would have been silently dropped. Scoped to the `anthropic_adaptive` wire when reasoning is fully disengaged; cannot affect OpenAI srn models or always-reasoning adaptive-only families.
2. Out of scope (pre-existing, not the customer's traffic): a *bare* `reasoning_effort` with no thinking config sent to a budgeted-enabled Anthropic model (haiku/sonnet-4-6/opus-4-6) still makes `messages_payloads` emit `{type:adaptive}`, which the model rejects. Fixing needs a budgeted-vs-adaptive split in `messages_payloads`. Flagged for a follow-up.