### PR TITLE
feat(ingest): add Opik tracing adapter

### DIFF
--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -12,6 +12,7 @@ loader. Each source is declared, never guessed:
 | `langfuse` | Langfuse traces with observations, or bare observations carrying `traceId`. |
 | `langsmith` | LangSmith runs, or a `runs` envelope. |
 | `mastra` | Mastra spans, or a `spans` envelope. |
+| `opik` | Opik spans, or a `spans` envelope. |
 | `phoenix` | Phoenix and OpenInference spans, native nested, flat dotted, or OTLP JSON. |
 | `chat-json` | OpenAI-style chat conversations, one object, an array, or bare message arrays. |
 

--- a/exp/simulation/ingest/__init__.py
+++ b/exp/simulation/ingest/__init__.py
@@ -6,6 +6,7 @@ from exp.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_d
 from exp.simulation.ingest.langfuse import LANGFUSE_SOURCE
 from exp.simulation.ingest.langsmith import LANGSMITH_SOURCE
 from exp.simulation.ingest.mastra import MASTRA_SOURCE
+from exp.simulation.ingest.opik import OPIK_SOURCE
 from exp.simulation.ingest.otel_genai import (
     load_otel_genai_file,
     normalize_otel_genai_payloads,
@@ -42,6 +43,7 @@ __all__ = [
     "LANGFUSE_SOURCE",
     "LANGSMITH_SOURCE",
     "MASTRA_SOURCE",
+    "OPIK_SOURCE",
     "OtlpTraceFormatError",
     "PHOENIX_SOURCE",
     "PersistedTraceDataset",

--- a/exp/simulation/ingest/opik.py
+++ b/exp/simulation/ingest/opik.py
@@ -1,0 +1,274 @@
+"""Normalize Opik tracing exports into canonical trace evidence.
+
+Opik exports one record per span with ``trace_id``, ``id``, ``parent_span_id``,
+``name``, ``type``, ``input``, ``output``, ``metadata``, ``start_time``,
+``end_time``, and any ``error_info``. Exports arrive as a span array, a ``spans``
+or ``traces`` envelope, or JSONL with one span per line.
+
+Span types map to canonical evidence by what they observe:
+
+- ``llm`` becomes model calls, including the tool calls their output requests,
+- ``tool`` becomes tool results paired with the earlier requesting call,
+- ``general``, ``guardrail``, and other orchestration types are not converted.
+
+Model identity comes from the span ``model`` and ``provider`` fields and is
+retained only when Opik declares both; usage comes from the flat ``usage``
+mapping with ``prompt_tokens`` and ``completion_tokens``.
+"""
+
+from __future__ import annotations
+
+from pydantic import JsonValue
+
+from exp.common.core.artifacts import JsonObject
+from exp.simulation.ingest.vendor_observations import (
+    VendorObservation,
+    VendorTokenUsage,
+    declared_completion_text,
+    declared_error_message,
+    declared_model_identity,
+    declared_tool_calls,
+    declared_usage,
+)
+from exp.simulation.ingest.vendor_records import (
+    first_text,
+    first_user_text,
+    json_text,
+    json_value,
+    required_text,
+    source_interval,
+)
+from exp.simulation.ingest.vendor_source import VendorSource, record_flattener
+from exp.simulation.ingest.vendor_trace import approved_extensions
+
+VENDOR = "opik"
+
+_MODEL_TYPES = frozenset({"llm"})
+_TOOL_TYPES = frozenset({"tool"})
+_MODEL_KEYS = ("model", "model_name", "modelName")
+_PROVIDER_KEYS = ("provider", "model_provider", "modelProvider", "llm.system")
+_ERROR_KEYS = ("error", "errorInfo", "error_info")
+
+
+def _span_observation(span: JsonObject, ordinal: int) -> tuple[VendorObservation, ...]:
+    """Convert one Opik span to a declared model or tool-result observation.
+
+    Args:
+        span: Opik span record.
+        ordinal: Source order position for the emitted observation.
+
+    Returns:
+        Declared observation, or nothing for orchestration-only span types.
+
+    Raises:
+        VendorTraceFormatError: The span lacks identity, timing, or tool evidence.
+    """
+    span_type = (first_text(span, ("type", "spanType")) or "").casefold()
+    if span_type not in _MODEL_TYPES | _TOOL_TYPES:
+        return ()
+    source_trace_id = required_text(span.get("trace_id", span.get("traceId")), "Opik trace_id")
+    source_span_id = required_text(
+        span.get("id", span.get("span_id", span.get("spanId"))), "Opik span id"
+    )
+    started_at, ended_at = source_interval(
+        span.get("start_time", span.get("startTime")),
+        span.get("end_time", span.get("endTime")),
+        start_label="Opik span start_time",
+        end_label="Opik span end_time",
+    )
+    attributes = _attributes(span)
+    inputs = json_value(span.get("input", span.get("inputs")))
+    outputs = json_value(span.get("output", span.get("outputs")))
+    extensions = _extensions(span, attributes)
+    failure = _failure_message(span)
+    parent = first_text(span, ("parent_span_id", "parentSpanId", "parent_id"))
+    if span_type in _TOOL_TYPES:
+        return (
+            VendorObservation(
+                source_trace_id=source_trace_id,
+                source_span_id=source_span_id,
+                ordinal=ordinal,
+                started_at=started_at,
+                ended_at=ended_at,
+                kind="tool_result",
+                source_parent_span_id=parent,
+                request_text=first_user_text(inputs),
+                tool_name=_tool_name(span, attributes),
+                tool_arguments=json_text(inputs),
+                tool_message=declared_completion_text(outputs),
+                tool_call_id=first_text(attributes, ("toolCallId", "tool_call_id")),
+                failure_message=failure,
+                extensions=extensions,
+            ),
+        )
+    model, declared_model = declared_model_identity(
+        {**attributes, **_identity_fields(span)},
+        model_keys=_MODEL_KEYS,
+        provider_keys=_PROVIDER_KEYS,
+    )
+    return (
+        VendorObservation(
+            source_trace_id=source_trace_id,
+            source_span_id=source_span_id,
+            ordinal=ordinal,
+            started_at=started_at,
+            ended_at=ended_at,
+            kind="model",
+            source_parent_span_id=parent,
+            request_text=first_user_text(inputs),
+            input_messages=_input_messages(inputs),
+            completion_text=declared_completion_text(outputs) or None,
+            tool_calls=declared_tool_calls(outputs),
+            model=model,
+            usage=_usage(attributes, span),
+            failure_message=failure,
+            declared_attributes=(
+                {} if declared_model is None else {"gen_ai.request.model": declared_model}
+            ),
+            extensions=extensions,
+        ),
+    )
+
+
+def _attributes(span: JsonObject) -> JsonObject:
+    """Return the Opik span metadata object.
+
+    Args:
+        span: Opik span record.
+
+    Returns:
+        Metadata mapping, empty when the span declares none.
+    """
+    value = span.get("metadata", span.get("attributes"))
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _identity_fields(span: JsonObject) -> JsonObject:
+    """Return the top-level Opik model and provider declarations.
+
+    Args:
+        span: Opik span record.
+
+    Returns:
+        Mapping with the span-level model and provider values, when declared.
+    """
+    fields: JsonObject = {}
+    for key in _MODEL_KEYS:
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            fields[key] = value.strip()
+    for key in _PROVIDER_KEYS:
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            fields[key] = value.strip()
+    return fields
+
+
+def _input_messages(inputs: JsonValue | None) -> JsonValue | None:
+    """Return the declared model input messages for one Opik model span.
+
+    Args:
+        inputs: Decoded span input.
+
+    Returns:
+        The declared message list, or the raw input when the span declares no list.
+    """
+    if isinstance(inputs, dict):
+        for key in ("messages", "prompt", "input"):
+            value = inputs.get(key)
+            if isinstance(value, list):
+                return value
+    return inputs
+
+
+def _tool_name(span: JsonObject, attributes: JsonObject) -> str:
+    """Read the executed tool name from an Opik tool span.
+
+    Args:
+        span: Opik span record.
+        attributes: Declared span metadata.
+
+    Returns:
+        Declared tool name.
+
+    Raises:
+        VendorTraceFormatError: The span declares no tool name.
+    """
+    name = first_text(attributes, ("toolName", "tool_name", "name"))
+    if name is not None:
+        return name
+    return required_text(span.get("name"), "Opik tool span name")
+
+
+def _failure_message(span: JsonObject) -> str | None:
+    """Read an Opik span failure message from its error info, when present.
+
+    Args:
+        span: Opik span record.
+
+    Returns:
+        Declared error text, or ``None`` when the span declares no error.
+    """
+    error = span.get("error_info", span.get("errorInfo"))
+    if isinstance(error, dict) and error:
+        message = first_text(error, ("message", "error", "exception_type"))
+        if message is not None:
+            return message
+        return json_text(error)
+    return declared_error_message(span, keys=_ERROR_KEYS, label="Opik span")
+
+
+def _usage(attributes: JsonObject, span: JsonObject) -> VendorTokenUsage | None:
+    """Read declared token accounting from an Opik span or its metadata.
+
+    Args:
+        attributes: Declared span metadata.
+        span: Opik span record.
+
+    Returns:
+        Declared usage, or ``None`` when the span declares no complete accounting.
+
+    Raises:
+        VendorTraceFormatError: A declared token count is not a non-negative integer.
+    """
+    for candidate in (span.get("usage"), attributes.get("usage"), attributes):
+        usage = declared_usage(candidate)
+        if usage is not None:
+            return usage
+    return None
+
+
+def _extensions(span: JsonObject, attributes: JsonObject) -> JsonObject:
+    """Read approved EXP extensions and the Opik project from one span.
+
+    Args:
+        span: Opik span record.
+        attributes: Declared span metadata.
+
+    Returns:
+        Approved extension attributes for this record.
+    """
+    extensions = approved_extensions(span)
+    extensions.update(approved_extensions(attributes))
+    metadata = span.get("metadata")
+    if isinstance(metadata, dict):
+        extensions.update(approved_extensions(metadata))
+        if "exp.trace.metadata" not in extensions:
+            extensions["exp.trace.metadata"] = metadata
+    project = first_text(span, ("project_name", "projectName"))
+    if project is not None and "exp.opik.project" not in extensions:
+        extensions["exp.opik.project"] = project
+    return extensions
+
+
+OPIK_SOURCE: VendorSource[JsonObject] = VendorSource(
+    vendor=VENDOR,
+    records=record_flattener(
+        vendor=VENDOR,
+        wrapper_keys=("spans", "traces", "data", "results", "items"),
+        record_keys=("trace_id", "traceId"),
+    ),
+    convert=_span_observation,
+)

--- a/exp/simulation/ingest/opik.py
+++ b/exp/simulation/ingest/opik.py
@@ -31,6 +31,7 @@ from exp.simulation.ingest.vendor_observations import (
     declared_usage,
 )
 from exp.simulation.ingest.vendor_records import (
+    VendorTraceFormatError,
     first_text,
     first_user_text,
     json_text,
@@ -61,9 +62,13 @@ def _span_observation(span: JsonObject, ordinal: int) -> tuple[VendorObservation
         Declared observation, or nothing for orchestration-only span types.
 
     Raises:
-        VendorTraceFormatError: The span lacks identity, timing, or tool evidence.
+        VendorTraceFormatError: The span lacks a type, identity, timing, or tool
+            evidence.
     """
-    span_type = (first_text(span, ("type", "spanType")) or "").casefold()
+    raw_type = first_text(span, ("type", "spanType"))
+    if raw_type is None:
+        raise VendorTraceFormatError("Opik span declares no type")
+    span_type = raw_type.casefold()
     if span_type not in _MODEL_TYPES | _TOOL_TYPES:
         return ()
     source_trace_id = required_text(span.get("trace_id", span.get("traceId")), "Opik trace_id")

--- a/exp/simulation/ingest/opik_test.py
+++ b/exp/simulation/ingest/opik_test.py
@@ -1,0 +1,263 @@
+"""Tests for Opik trace export normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exp.simulation.ingest.opik import OPIK_SOURCE
+from exp.simulation.ingest.sources import CANONICAL_TRACE_SOURCES, load_trace_source
+
+
+def _llm_span(
+    *,
+    trace_id: str = "trace-1",
+    span_id: str = "span-1",
+    parent_id: str | None = None,
+    name: str = "answer",
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    inputs: object | None = None,
+    outputs: object | None = None,
+) -> dict[str, object]:
+    """Return one Opik LLM span with explicit timing and model identity.
+
+    Args:
+        trace_id: Declared trace identifier.
+        span_id: Declared span identifier.
+        parent_id: Declared parent span identifier, when any.
+        name: Declared span name.
+        model: Declared model name.
+        provider: Declared provider name.
+        inputs: Declared span input, defaulting to a user message list.
+        outputs: Declared span output, defaulting to an assistant completion.
+
+    Returns:
+        One Opik span object.
+    """
+    span: dict[str, object] = {
+        "trace_id": trace_id,
+        "id": span_id,
+        "name": name,
+        "type": "llm",
+        "start_time": "2026-09-04T12:00:00+00:00",
+        "end_time": "2026-09-04T12:00:01+00:00",
+        "input": inputs
+        if inputs is not None
+        else {"messages": [{"role": "user", "content": "Where is my order?"}]},
+        "output": outputs
+        if outputs is not None
+        else {"role": "assistant", "content": "It ships tomorrow."},
+        "model": model,
+        "provider": provider,
+        "usage": {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20},
+    }
+    if parent_id is not None:
+        span["parent_span_id"] = parent_id
+    return span
+
+
+def _tool_span(
+    *,
+    trace_id: str = "trace-1",
+    span_id: str = "span-2",
+    parent_id: str = "span-1",
+    name: str = "lookup_order",
+) -> dict[str, object]:
+    """Return one Opik TOOL span that reports its arguments and result."""
+    return {
+        "trace_id": trace_id,
+        "id": span_id,
+        "parent_span_id": parent_id,
+        "name": name,
+        "type": "tool",
+        "start_time": "2026-09-04T12:00:01+00:00",
+        "end_time": "2026-09-04T12:00:02+00:00",
+        "input": {"order": "A1"},
+        "output": "ships tomorrow",
+    }
+
+
+def test_load_opik_file_keeps_completion_and_model_identity(tmp_path: Path) -> None:
+    """The model span keeps its completion text and declared provider model."""
+    path = tmp_path / "opik.json"
+    path.write_text(
+        json.dumps([_llm_span(), _tool_span(), _llm_span(span_id="span-3", outputs="Done.")]),
+        encoding="utf-8",
+    )
+
+    result = OPIK_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert len(result.traces) == 1
+    assert result.traces[0].task == "Where is my order?"
+    completions = [span.attributes.get("gen_ai.completion") for span in result.traces[0].spans]
+    assert "It ships tomorrow." in completions
+    assert "Done." in completions
+    assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_load_opik_file_preserves_usage_when_declared(tmp_path: Path) -> None:
+    """Token accounting declared on LLM spans is retained on the model span."""
+    path = tmp_path / "opik.json"
+    path.write_text(json.dumps([_llm_span()]), encoding="utf-8")
+
+    result = OPIK_SOURCE.load(path)
+
+    usage = result.traces[0].spans[0].usage
+    assert usage is not None
+    assert usage.input_tokens == 12
+    assert usage.output_tokens == 8
+
+
+def test_load_opik_file_tool_result_is_paired_with_requesting_call(tmp_path: Path) -> None:
+    """A tool span is normalized as a tool_result paired with the earlier model call."""
+    tool_call_outputs = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "function": {"name": "lookup_order", "arguments": '{"order": "A1"}'},
+            }
+        ],
+    }
+    path = tmp_path / "opik.json"
+    path.write_text(
+        json.dumps(
+            [
+                _llm_span(span_id="span-1", outputs=tool_call_outputs),
+                _tool_span(span_id="span-2", parent_id="span-1"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = OPIK_SOURCE.load(path)
+
+    tool_names = [span.attributes.get("gen_ai.tool.name") for span in result.traces[0].spans]
+    assert "lookup_order" in tool_names
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_opik_file_ignores_orchestration_spans(tmp_path: Path) -> None:
+    """General and guardrail spans carry no direct evidence and are ignored."""
+    general_span = {
+        "trace_id": "trace-1",
+        "id": "span-99",
+        "name": "chat",
+        "type": "general",
+        "start_time": "2026-09-04T12:00:02+00:00",
+        "end_time": "2026-09-04T12:00:03+00:00",
+        "input": {"question": "Where is my order?"},
+        "output": "It ships tomorrow.",
+    }
+    guardrail_span = dict(general_span, id="span-98", type="guardrail")
+    path = tmp_path / "opik.json"
+    path.write_text(
+        json.dumps([_llm_span(span_id="span-1"), general_span, guardrail_span]),
+        encoding="utf-8",
+    )
+
+    result = OPIK_SOURCE.load(path)
+
+    assert len(result.traces[0].spans) == 1
+
+
+def test_load_opik_file_accepts_spans_envelope_wrapper(tmp_path: Path) -> None:
+    """A ``spans`` envelope is flattened into one trace."""
+    path = tmp_path / "opik.json"
+    path.write_text(json.dumps({"spans": [_llm_span(span_id="span-7")]}), encoding="utf-8")
+
+    result = OPIK_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_load_opik_file_accepts_jsonl(tmp_path: Path) -> None:
+    """JSONL with one span per line is supported."""
+    path = tmp_path / "opik.jsonl"
+    spans = [
+        _llm_span(trace_id="trace-2", span_id="span-a"),
+        _tool_span(trace_id="trace-2", span_id="span-b", parent_id="span-a"),
+    ]
+    path.write_text("\n".join(json.dumps(span) for span in spans), encoding="utf-8")
+
+    result = OPIK_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_opik_file_marks_failed_span(tmp_path: Path) -> None:
+    """A span with error_info retains the declared failure message."""
+    span = _tool_span(span_id="span-err")
+    assert isinstance(span, dict)
+    span["error_info"] = {"exception_type": "ValueError", "message": "not refundable"}
+    path = tmp_path / "opik.json"
+    path.write_text(json.dumps([_llm_span(span_id="span-1"), span]), encoding="utf-8")
+
+    result = OPIK_SOURCE.load(path)
+
+    assert result.issues == ()
+    failed = [span for span in result.traces[0].spans if span.failure is not None]
+    assert len(failed) == 1
+    assert failed[0].failure is not None
+    assert failed[0].failure.message == "not refundable"
+
+
+def test_load_opik_file_accepts_sdk_serialized_shapes(tmp_path: Path) -> None:
+    """Payloads serialized by the Opik SDK keep identity, usage, and failures."""
+    llm_span = {
+        "trace_id": "0196a3b4-9c8f-7e2d-a1b0-c5d4e3f2a190",
+        "id": "span-llm",
+        "parent_span_id": "span-root",
+        "name": "answer",
+        "type": "llm",
+        "start_time": "2026-09-04 12:00:00+00:00",
+        "end_time": "2026-09-04 12:00:01+00:00",
+        "input": {"messages": [{"role": "user", "content": "Where is my order?"}]},
+        "output": {"role": "assistant", "content": "It ships tomorrow."},
+        "usage": {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20},
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "project_name": "experiential-check",
+    }
+    path = tmp_path / "opik.json"
+    path.write_text(json.dumps([llm_span]), encoding="utf-8")
+
+    result = OPIK_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert result.traces[0].task == "Where is my order?"
+    usage = result.traces[0].spans[0].usage
+    assert usage is not None
+    assert (usage.input_tokens, usage.output_tokens) == (12, 8)
+
+
+def test_opik_is_registered_as_canonical_source() -> None:
+    """The Opik source is discoverable through the canonical source table."""
+    assert "opik" in CANONICAL_TRACE_SOURCES
+    assert "opik" in sorted(CANONICAL_TRACE_SOURCES)
+
+
+def test_load_trace_source_dispatches_to_opik(tmp_path: Path) -> None:
+    """The generic loader routes ``opik`` to the Opik adapter."""
+    path = tmp_path / "opik.json"
+    path.write_text(json.dumps([_llm_span()]), encoding="utf-8")
+
+    result = load_trace_source("opik", path)
+
+    assert len(result.traces) == 1
+
+
+def test_load_opik_file_rejects_unsupported_shape(tmp_path: Path) -> None:
+    """A payload without any Opik record keys is reported as an exclusion."""
+    path = tmp_path / "opik.json"
+    path.write_text(json.dumps({"unknown": 1}), encoding="utf-8")
+
+    result = OPIK_SOURCE.load(path)
+
+    assert result.traces == ()
+    assert len(result.issues) == 1

--- a/exp/simulation/ingest/opik_test.py
+++ b/exp/simulation/ingest/opik_test.py
@@ -236,6 +236,30 @@ def test_load_opik_file_accepts_sdk_serialized_shapes(tmp_path: Path) -> None:
     assert (usage.input_tokens, usage.output_tokens) == (12, 8)
 
 
+def test_load_opik_file_reports_typeless_record_as_exclusion(tmp_path: Path) -> None:
+    """A record with identity but no declared type is reported, not silently dropped."""
+    path = tmp_path / "opik.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "trace_id": "trace-1",
+                    "id": "span-typeless",
+                    "name": "chat",
+                    "start_time": "2026-09-04T12:00:00+00:00",
+                    "end_time": "2026-09-04T12:00:01+00:00",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = OPIK_SOURCE.load(path)
+
+    assert result.traces == ()
+    assert len(result.issues) == 1
+
+
 def test_opik_is_registered_as_canonical_source() -> None:
     """The Opik source is discoverable through the canonical source table."""
     assert "opik" in CANONICAL_TRACE_SOURCES

--- a/exp/simulation/ingest/sources.py
+++ b/exp/simulation/ingest/sources.py
@@ -22,6 +22,7 @@ from exp.simulation.ingest.chat_json import CHAT_JSON_SOURCE
 from exp.simulation.ingest.langfuse import LANGFUSE_SOURCE
 from exp.simulation.ingest.langsmith import LANGSMITH_SOURCE
 from exp.simulation.ingest.mastra import MASTRA_SOURCE
+from exp.simulation.ingest.opik import OPIK_SOURCE
 from exp.simulation.ingest.otel_genai import load_otel_genai_file
 from exp.simulation.ingest.otlp import (
     OtlpTraceFormatError,
@@ -56,6 +57,7 @@ _LOADERS: dict[str, _TraceFileLoader] = {
     "langfuse": LANGFUSE_SOURCE.load,
     "langsmith": LANGSMITH_SOURCE.load,
     "mastra": MASTRA_SOURCE.load,
+    "opik": OPIK_SOURCE.load,
     "otel-genai": load_otel_genai_file,
     "otlp": load_otlp_file,
     "phoenix": PHOENIX_SOURCE.load,

--- a/exp/simulation/ingest/sources_test.py
+++ b/exp/simulation/ingest/sources_test.py
@@ -81,6 +81,20 @@ _MINIMAL_VENDOR_EXPORTS: dict[str, JsonValue] = {
             }
         ]
     },
+    "opik": [
+        {
+            "trace_id": "trace-1",
+            "id": "span-0",
+            "name": "answer",
+            "type": "llm",
+            "start_time": "2026-09-04T12:00:00+00:00",
+            "end_time": "2026-09-04T12:00:01+00:00",
+            "input": {"messages": [_USER]},
+            "output": {"content": "here is the plan"},
+            "model": "gpt-test",
+            "provider": "openai",
+        }
+    ],
     "otel-genai": [
         {
             "trace_id": "9" * 32,
@@ -150,6 +164,7 @@ def test_declared_sources_are_the_supported_set() -> None:
         "langfuse",
         "langsmith",
         "mastra",
+        "opik",
         "otel-genai",
         "otlp",
         "phoenix",


### PR DESCRIPTION
### Summary

Opik (Comet) is a leading OSS LLM observability platform and exports traces as spans with `trace_id`, `id`, `type`, `input`/`output`, `model`, `provider`, `usage`, and `error_info`. Users previously had to convert via the generic OTLP path and lost model identity, tool pairing, and failure fidelity. This adds an explicit canonical loader `opik` alongside `braintrust`, `langfuse`, `mastra`, `phoenix`, `posthog` etc.

### Design

Opik spans map to canonical evidence by what they observe:

- `llm` becomes model calls, including tool calls their output requests,
- `tool` becomes tool results paired with the earlier requesting call,
- `general`, `guardrail`, and other orchestration types are ignored.

Exports arrive as a span array, a `spans`/`traces`/`data` envelope, or JSONL with one span per line. Model identity comes from the span-level `model`/`provider` fields; usage from the flat `usage` mapping (`prompt_tokens`/`completion_tokens`); failures from `error_info.message`.

### Changes

- `exp/simulation/ingest/opik.py` (new, 274 lines, under the 999-line ceiling) with ISO timestamp handling and SDK field names (`id`, `parent_span_id`, `start_time`/`end_time`).
- `exp/simulation/ingest/opik_test.py` (new, 11 tests): completion and model identity, usage, tool pairing, orchestration ignore, envelope, JSONL, failure propagation, SDK-serialized shapes, registration, generic dispatch, and unsupported-shape rejection.
- `exp/simulation/ingest/sources.py` and `__init__.py`: register `opik`.
- `exp/simulation/ingest/sources_test.py`: canonical set plus a minimal opik fixture.
- `docs/reference/ingest.md`: source table row.

### Verification

Shapes were verified against real objects built with the official Opik 2.x SDK (`SpanData.as_parameters` serialization): an `llm` span with usage, a `tool` span, and an `error_info` failure load as 1 trace / 3 spans with model identity, tool pairing, and failure message intact.

- `uv run ruff check .` (pass), `uv run ruff format --check .` (pass), `uv run ty check` (pass)
- `uv run pytest exp/simulation/ingest/ -q`: 162 passed
- `uv run pytest exp/tests/repo_layout_test.py exp/tests/repo_import_boundaries_test.py -q`: 22 passed

### Not a duplicate

No existing adapter, open issue, or open PR covers Opik (checked the full PR list; only the Weave adapter in #121 and the MLflow adapter in #727 exist in this lane).