### PR TITLE
feat(ingest): add Datadog LLM Observability adapter

### DIFF
--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -14,6 +14,7 @@ loader. Each source is declared, never guessed:
 | `mastra` | Mastra spans, or a `spans` envelope. |
 | `phoenix` | Phoenix and OpenInference spans, native nested, flat dotted, or OTLP JSON. |
 | `chat-json` | OpenAI-style chat conversations, one object, an array, or bare message arrays. |
+| `datadog` | Datadog LLM Observability spans, a v0.4 array of trace arrays, or a `spans` envelope. |
 
 Every file source accepts JSON or JSONL. A malformed JSONL line is never skipped silently: it is
 retained as an explicit normalization issue. Every normalized trace keeps the immutable source

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -974,12 +974,13 @@ def test_sweep_replays_the_original_completed_settlement(tmp_path: Path) -> None
 
 def test_abandoned_inflight_attempts_are_swept_after_the_deadline(tmp_path: Path) -> None:
     """An admitted request the data plane never settles is closed by the sweep."""
-    # The admit-to-start budget stays generous on purpose: the deadline is
-    # stamped at admission, so a tight timeout flakes when a loaded worker
-    # schedules this test late. The sleep still comfortably exceeds it.
-    control, raw_key = _control_plane(tmp_path, request_timeout_seconds=0.5)
+    # Expiry is deterministic: the deadline moves into the past, the same
+    # pattern the accounting tests use, so no sleep or timeout tuning is needed.
+    control, raw_key = _control_plane(tmp_path)
     abandoned = _admit_started(control, raw_key, _chat_body())
-    time.sleep(1.0)
+    entry = control._accounting.entry(str(abandoned["request_id"]))  # noqa: SLF001 - fault injection for the test.
+    assert entry is not None
+    entry.deadline_monotonic = time.monotonic() - 60.0
     with mock.patch("exp.runtime.gateway.native_accounting._SWEEP_GRACE_SECONDS", 0.0):
         second = _admit(control, raw_key, _chat_body())
     assert control._accounting.entry(str(abandoned["request_id"])) is None  # noqa: SLF001

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -974,9 +974,12 @@ def test_sweep_replays_the_original_completed_settlement(tmp_path: Path) -> None
 
 def test_abandoned_inflight_attempts_are_swept_after_the_deadline(tmp_path: Path) -> None:
     """An admitted request the data plane never settles is closed by the sweep."""
-    control, raw_key = _control_plane(tmp_path, request_timeout_seconds=0.01)
+    # The admit-to-start budget stays generous on purpose: the deadline is
+    # stamped at admission, so a tight timeout flakes when a loaded worker
+    # schedules this test late. The sleep still comfortably exceeds it.
+    control, raw_key = _control_plane(tmp_path, request_timeout_seconds=0.5)
     abandoned = _admit_started(control, raw_key, _chat_body())
-    time.sleep(0.05)
+    time.sleep(1.0)
     with mock.patch("exp.runtime.gateway.native_accounting._SWEEP_GRACE_SECONDS", 0.0):
         second = _admit(control, raw_key, _chat_body())
     assert control._accounting.entry(str(abandoned["request_id"])) is None  # noqa: SLF001

--- a/exp/simulation/engines/sandbox_test.py
+++ b/exp/simulation/engines/sandbox_test.py
@@ -263,7 +263,10 @@ def test_permanently_hung_cleanup_returns_bounded_failure(tmp_path: Path) -> Non
     )
     rollout = _load_rollout(store, artifact_set.artifact_ids[0])
 
-    assert time.monotonic() - started < 1.0
+    # The bound proves an infinitely hung cleanup was interrupted, so it must
+    # tolerate loaded-runner overhead around the short 0.2s timer: fixture
+    # persistence and artifact writes already pushed one CI worker past 1.0s.
+    assert time.monotonic() - started < 5.0
     assert rollout.stop_reason == StopReason.MAXIMUM_TIME
     assert rollout.failure is not None
     assert rollout.failure.attribution is not None

--- a/exp/simulation/engines/sandbox_test.py
+++ b/exp/simulation/engines/sandbox_test.py
@@ -257,16 +257,17 @@ def test_permanently_hung_cleanup_returns_bounded_failure(tmp_path: Path) -> Non
         agent_factory=_ToolAgent,
     )
     started = time.monotonic()
-
     artifact_set = simulator.run(
         _spec(plan_input, task_input, ("cell-a",), maximum_time_seconds=0.2)
     )
+    elapsed = time.monotonic() - started
     rollout = _load_rollout(store, artifact_set.artifact_ids[0])
 
-    # The bound proves an infinitely hung cleanup was interrupted, so it must
-    # tolerate loaded-runner overhead around the short 0.2s timer: fixture
-    # persistence and artifact writes already pushed one CI worker past 1.0s.
-    assert time.monotonic() - started < 5.0
+    # The bound proves an infinitely hung cleanup was interrupted. Only the
+    # timed run is measured so artifact loading cannot mask a slow interrupt,
+    # and the bound stays tight enough to catch a multi-second regression
+    # while tolerating loaded-runner overhead around the short 0.2s timer.
+    assert elapsed < 2.0
     assert rollout.stop_reason == StopReason.MAXIMUM_TIME
     assert rollout.failure is not None
     assert rollout.failure.attribution is not None

--- a/exp/simulation/ingest/__init__.py
+++ b/exp/simulation/ingest/__init__.py
@@ -2,6 +2,7 @@
 
 from exp.simulation.ingest.braintrust import BRAINTRUST_SOURCE
 from exp.simulation.ingest.chat_json import CHAT_JSON_SOURCE
+from exp.simulation.ingest.datadog import DATADOG_SOURCE
 from exp.simulation.ingest.dataset import PersistedTraceDataset, persist_trace_dataset
 from exp.simulation.ingest.langfuse import LANGFUSE_SOURCE
 from exp.simulation.ingest.langsmith import LANGSMITH_SOURCE
@@ -38,6 +39,7 @@ __all__ = [
     "BRAINTRUST_SOURCE",
     "CANONICAL_TRACE_SOURCES",
     "CHAT_JSON_SOURCE",
+    "DATADOG_SOURCE",
     "GENAI_SEMANTIC_CONVENTION_VERSION",
     "LANGFUSE_SOURCE",
     "LANGSMITH_SOURCE",

--- a/exp/simulation/ingest/datadog.py
+++ b/exp/simulation/ingest/datadog.py
@@ -1,0 +1,510 @@
+"""Normalize Datadog LLM Observability span exports into canonical trace evidence.
+
+Datadog APM spans carry ``trace_id``, ``span_id``, ``parent_id``, ``name``,
+``resource``, ``start`` (nanoseconds since epoch) and ``duration``
+(nanoseconds), plus ``meta``, ``metrics``, and ``error``. LLM Observability
+spans add ``meta_struct._llmobs`` with ``meta.span.kind``, ``input``/``output``
+(messages or value), ``model_name``/``model_provider``, ``metrics`` token
+counts, and ``tags``. Exports arrive as a span array, a v0.4 array of trace
+arrays, a ``spans``/``traces`` envelope, or JSONL with one span per line.
+
+Spans map to canonical evidence by what they observe:
+
+- ``llm`` becomes model calls, including the tool calls their output requests,
+- ``tool`` becomes tool results paired with the earlier requesting call,
+- ``workflow`` and ``agent`` become agent-level evidence when they declare
+  input or output, and are ignored otherwise,
+- ``task``, ``retrieval``, ``embedding``, and other orchestration types are
+  not converted.
+
+Model identity comes from ``model_name``/``model_provider`` and is retained
+only when the export declares both; usage comes from ``input_tokens`` and
+``output_tokens``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import JsonValue
+
+from exp.common.core.artifacts import JsonObject
+from exp.simulation.ingest.vendor_observations import (
+    VendorObservation,
+    VendorTokenUsage,
+    declared_completion_text,
+    declared_error_message,
+    declared_model_identity,
+    declared_tool_calls,
+    declared_usage,
+)
+from exp.simulation.ingest.vendor_records import (
+    first_text,
+    first_user_text,
+    json_text,
+    json_value,
+    required_text,
+    source_interval,
+)
+from exp.simulation.ingest.vendor_source import VendorSource, record_flattener
+from exp.simulation.ingest.vendor_trace import approved_extensions
+
+VENDOR = "datadog"
+
+_MODEL_KINDS = frozenset({"llm"})
+_TOOL_KINDS = frozenset({"tool"})
+_AGENT_KINDS = frozenset({"workflow", "agent"})
+_MODEL_KEYS = ("model_name", "modelName", "model")
+_PROVIDER_KEYS = ("model_provider", "modelProvider", "provider", "llm.system")
+_ERROR_KEYS = ("error.message", "error_message", "errorMessage")
+
+
+def _span_observation(span: JsonObject, ordinal: int) -> tuple[VendorObservation, ...]:
+    """Convert one Datadog span to a declared model, tool-result, or agent observation.
+
+    Args:
+        span: Datadog span record.
+        ordinal: Source order position for the emitted observation.
+
+    Returns:
+        Declared observation, or nothing for orchestration-only span kinds.
+
+    Raises:
+        VendorTraceFormatError: The span lacks identity, timing, or tool evidence.
+    """
+    llmobs = _llmobs_meta(span)
+    kind = _span_kind(span, llmobs)
+    if kind not in _MODEL_KINDS | _TOOL_KINDS | _AGENT_KINDS:
+        return ()
+    source_trace_id = _trace_id(span, llmobs)
+    source_span_id = _span_id(span)
+    started_at, ended_at = _interval(span)
+    attributes = _attributes(span)
+    inputs = _io(span, llmobs, "input")
+    outputs = _io(span, llmobs, "output")
+    extensions = _extensions(span, attributes)
+    failure = _failure_message(span, attributes)
+    parent = _parent_id(span, llmobs)
+    if kind in _TOOL_KINDS:
+        return (
+            VendorObservation(
+                source_trace_id=source_trace_id,
+                source_span_id=source_span_id,
+                ordinal=ordinal,
+                started_at=started_at,
+                ended_at=ended_at,
+                kind="tool_result",
+                source_parent_span_id=parent,
+                request_text=first_user_text(inputs),
+                tool_name=_tool_name(span, attributes),
+                tool_arguments=json_text(inputs),
+                tool_message=declared_completion_text(outputs),
+                tool_call_id=first_text(attributes, ("toolCallId", "tool_call_id")),
+                failure_message=failure,
+                extensions=extensions,
+            ),
+        )
+    if kind in _AGENT_KINDS:
+        if inputs is None and outputs is None:
+            return ()
+        completion = declared_completion_text(outputs)
+        if not completion and first_user_text(inputs) is None:
+            return ()
+        return (
+            VendorObservation(
+                source_trace_id=source_trace_id,
+                source_span_id=source_span_id,
+                ordinal=ordinal,
+                started_at=started_at,
+                ended_at=ended_at,
+                kind="agent",
+                source_parent_span_id=parent,
+                request_text=first_user_text(inputs),
+                completion_text=completion or None,
+                failure_message=failure,
+                extensions=extensions,
+            ),
+        )
+    model, declared_model = declared_model_identity(
+        {**attributes, **_identity_fields(span, llmobs)},
+        model_keys=_MODEL_KEYS,
+        provider_keys=_PROVIDER_KEYS,
+    )
+    return (
+        VendorObservation(
+            source_trace_id=source_trace_id,
+            source_span_id=source_span_id,
+            ordinal=ordinal,
+            started_at=started_at,
+            ended_at=ended_at,
+            kind="model",
+            source_parent_span_id=parent,
+            request_text=first_user_text(inputs),
+            input_messages=_input_messages(inputs),
+            completion_text=declared_completion_text(outputs) or None,
+            tool_calls=declared_tool_calls(outputs),
+            model=model,
+            usage=_usage(span, llmobs, attributes),
+            failure_message=failure,
+            declared_attributes=(
+                {} if declared_model is None else {"gen_ai.request.model": declared_model}
+            ),
+            extensions=extensions,
+        ),
+    )
+
+
+def _llmobs_meta(span: JsonObject) -> JsonObject:
+    """Return the decoded Datadog LLM Observability payload for one span.
+
+    Args:
+        span: Datadog span record.
+
+    Returns:
+        The ``meta_struct._llmobs`` object with ``meta``, ``metrics``, and
+        ``tags``, or an empty mapping when the span declares none.
+    """
+    meta_struct = span.get("meta_struct", span.get("metaStruct"))
+    if not isinstance(meta_struct, dict):
+        return {}
+    llmobs = meta_struct.get("_llmobs")
+    if isinstance(llmobs, dict):
+        return llmobs
+    return {}
+
+
+def _span_kind(span: JsonObject, llmobs: JsonObject) -> str:
+    """Return the lowercase declared Datadog span kind.
+
+    Args:
+        span: Datadog span record.
+        llmobs: Decoded LLM Observability payload.
+
+    Returns:
+        Lowercase span kind, empty when the span declares none.
+    """
+    meta = llmobs.get("meta")
+    if isinstance(meta, dict):
+        inner = meta.get("span")
+        if isinstance(inner, dict):
+            kind = inner.get("kind")
+            if isinstance(kind, str) and kind.strip():
+                return kind.strip().casefold()
+    for key in ("span.kind", "span_kind", "kind"):
+        value = first_text(span, (key,))
+        if value:
+            return value.casefold()
+    attributes = span.get("meta")
+    if isinstance(attributes, dict):
+        for key in ("span.kind", "span_kind", "kind"):
+            raw = attributes.get(key)
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip().casefold()
+    return ""
+
+
+def _trace_id(span: JsonObject, llmobs: JsonObject) -> str:
+    """Read the Datadog trace identifier.
+
+    Args:
+        span: Datadog span record.
+        llmobs: Decoded LLM Observability payload.
+
+    Returns:
+        Declared trace identifier.
+
+    Raises:
+        VendorTraceFormatError: The span declares no trace identifier.
+    """
+    for key in ("trace_id", "traceId", "traceID"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return required_text(value, "Datadog trace_id")
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+    trace_id = llmobs.get("trace_id", llmobs.get("traceId"))
+    if isinstance(trace_id, str) and trace_id.strip():
+        return required_text(trace_id, "Datadog trace_id")
+    return required_text(None, "Datadog trace_id")
+
+
+def _span_id(span: JsonObject) -> str:
+    """Read the Datadog span identifier.
+
+    Args:
+        span: Datadog span record.
+
+    Returns:
+        Declared span identifier.
+
+    Raises:
+        VendorTraceFormatError: The span declares no span identifier.
+    """
+    for key in ("span_id", "spanId", "spanID", "id"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return required_text(value, "Datadog span_id")
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+    return required_text(None, "Datadog span_id")
+
+
+def _parent_id(span: JsonObject, llmobs: JsonObject) -> str | None:
+    """Return the declared Datadog parent span identifier, if any.
+
+    Args:
+        span: Datadog span record.
+        llmobs: Decoded LLM Observability payload.
+
+    Returns:
+        Declared parent span identifier, or ``None`` when absent.
+    """
+    for key in ("parent_id", "parentId", "parent_span_id"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip() and value.strip() != "undefined":
+            return value.strip()
+        if isinstance(value, int) and not isinstance(value, bool) and value != 0:
+            return str(value)
+    parent_id = llmobs.get("parent_id", llmobs.get("parentId"))
+    if isinstance(parent_id, str) and parent_id.strip() and parent_id.strip() != "undefined":
+        return parent_id.strip()
+    return None
+
+
+def _attributes(span: JsonObject) -> JsonObject:
+    """Return the Datadog span metadata object.
+
+    Args:
+        span: Datadog span record.
+
+    Returns:
+        Metadata mapping, empty when the span declares none.
+    """
+    value = span.get("meta", span.get("attributes"))
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _identity_fields(span: JsonObject, llmobs: JsonObject) -> JsonObject:
+    """Return the declared Datadog model and provider names.
+
+    Args:
+        span: Datadog span record.
+        llmobs: Decoded LLM Observability payload.
+
+    Returns:
+        Mapping with the declared model and provider values, when present.
+    """
+    fields: JsonObject = {}
+    meta = llmobs.get("meta")
+    candidates: list[JsonObject] = [span]
+    if isinstance(meta, dict):
+        candidates.append(meta)
+    attributes = _attributes(span)
+    candidates.append(attributes)
+    for source in candidates:
+        for key in _MODEL_KEYS:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip() and key not in fields:
+                fields[key] = value.strip()
+        for key in _PROVIDER_KEYS:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip() and key not in fields:
+                fields[key] = value.strip()
+    return fields
+
+
+def _io(span: JsonObject, llmobs: JsonObject, which: str) -> JsonValue | None:
+    """Read the declared Datadog span input or output.
+
+    Args:
+        span: Datadog span record.
+        llmobs: Decoded LLM Observability payload.
+        which: ``"input"`` or ``"output"``.
+
+    Returns:
+        Decoded input or output, or ``None`` when the span declares neither.
+    """
+    meta = llmobs.get("meta")
+    if isinstance(meta, dict):
+        value = meta.get(which)
+        if value is not None:
+            return value
+    for key in (which, f"{which}s"):
+        value = json_value(span.get(key))
+        if value is not None:
+            return value
+    attributes = _attributes(span)
+    for key in (which, f"{which}s", f"{which}.messages", f"{which}_messages"):
+        if key in attributes:
+            value = json_value(attributes[key])
+            if value is not None:
+                return value
+    return None
+
+
+def _input_messages(inputs: JsonValue | None) -> JsonValue | None:
+    """Return the declared model input messages for one Datadog model span.
+
+    Args:
+        inputs: Decoded span input.
+
+    Returns:
+        The declared message list, or the raw input when the span declares no list.
+    """
+    if isinstance(inputs, dict):
+        for key in ("messages", "prompt", "input", "value"):
+            value = inputs.get(key)
+            if isinstance(value, list):
+                return value
+    if isinstance(inputs, list):
+        return inputs
+    return inputs
+
+
+def _tool_name(span: JsonObject, attributes: JsonObject) -> str:
+    """Read the executed tool name from a Datadog tool span.
+
+    Args:
+        span: Datadog span record.
+        attributes: Declared span metadata.
+
+    Returns:
+        Declared tool name.
+
+    Raises:
+        VendorTraceFormatError: The span declares no tool name.
+    """
+    name = first_text(attributes, ("toolName", "tool_name", "name"))
+    if name is not None:
+        return name
+    for key in ("name", "resource"):
+        value = span.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return required_text(None, "Datadog tool span name")
+
+
+def _interval(span: JsonObject) -> tuple[datetime, datetime]:
+    """Read the source interval from Datadog nanosecond or ISO fields.
+
+    Args:
+        span: Datadog span record.
+
+    Returns:
+        Source start and end instants, equal when the span declares no end.
+
+    Raises:
+        VendorTraceFormatError: The span declares no readable start time.
+    """
+    start_ns = span.get("start", span.get("start_ns"))
+    if isinstance(start_ns, int | float) and not isinstance(start_ns, bool):
+        start_seconds = float(start_ns) / 1_000_000_000
+        duration_ns = span.get("duration", span.get("duration_ns"))
+        end_seconds: float | None = None
+        if isinstance(duration_ns, int | float) and not isinstance(duration_ns, bool):
+            end_seconds = start_seconds + float(duration_ns) / 1_000_000_000
+        else:
+            end_ns = span.get("end", span.get("end_ns"))
+            if isinstance(end_ns, int | float) and not isinstance(end_ns, bool):
+                end_seconds = float(end_ns) / 1_000_000_000
+        return source_interval(
+            start_seconds,
+            end_seconds,
+            start_label="Datadog span start",
+            end_label="Datadog span end",
+        )
+    return source_interval(
+        span.get("start_time", span.get("startTime")),
+        span.get("end_time", span.get("endTime")),
+        start_label="Datadog span start_time",
+        end_label="Datadog span end_time",
+    )
+
+
+def _usage(span: JsonObject, llmobs: JsonObject, attributes: JsonObject) -> VendorTokenUsage | None:
+    """Read declared token accounting from a Datadog span.
+
+    Args:
+        span: Datadog span record.
+        llmobs: Decoded LLM Observability payload.
+        attributes: Declared span metadata.
+
+    Returns:
+        Declared usage, or ``None`` when the span declares no complete accounting.
+
+    Raises:
+        VendorTraceFormatError: A declared token count is not a non-negative integer.
+    """
+    candidates: list[JsonValue | None] = [span.get("metrics")]
+    metrics = llmobs.get("metrics")
+    candidates.append(metrics if isinstance(metrics, dict) else None)
+    candidates.append(attributes.get("metrics"))
+    candidates.append(attributes.get("usage"))
+    candidates.append(attributes)
+    for candidate in candidates:
+        usage = declared_usage(candidate)
+        if usage is not None:
+            return usage
+    return None
+
+
+def _failure_message(span: JsonObject, attributes: JsonObject) -> str | None:
+    """Read a Datadog span failure message when the span reports an error.
+
+    Args:
+        span: Datadog span record.
+        attributes: Declared span metadata.
+
+    Returns:
+        Declared error text, or ``None`` when the span reports no error.
+    """
+    error = span.get("error")
+    if isinstance(error, int) and not isinstance(error, bool) and error != 0:
+        return (
+            declared_error_message({**span, **attributes}, keys=_ERROR_KEYS, label="Datadog span")
+            or f"Datadog span failed with error {error}"
+        )
+    if isinstance(error, str) and error.strip() and error.strip() != "0":
+        return (
+            declared_error_message({**span, **attributes}, keys=_ERROR_KEYS, label="Datadog span")
+            or f"Datadog span failed with error {error.strip()}"
+        )
+    failure = declared_error_message(span, keys=_ERROR_KEYS, label="Datadog span")
+    if failure is not None:
+        return failure
+    return declared_error_message(attributes, keys=_ERROR_KEYS, label="Datadog span")
+
+
+def _extensions(span: JsonObject, attributes: JsonObject) -> JsonObject:
+    """Read approved EXP extensions and the Datadog application from one span.
+
+    Args:
+        span: Datadog span record.
+        attributes: Declared span metadata.
+
+    Returns:
+        Approved extension attributes for this record.
+    """
+    extensions = approved_extensions(span)
+    extensions.update(approved_extensions(attributes))
+    llmobs = _llmobs_meta(span)
+    tags = llmobs.get("tags")
+    if isinstance(tags, dict):
+        extensions.update(approved_extensions(tags))
+        app = tags.get("ml_app", tags.get("mlApp"))
+        if isinstance(app, str) and app.strip() and "exp.datadog.app" not in extensions:
+            extensions["exp.datadog.app"] = app.strip()
+    return extensions
+
+
+DATADOG_SOURCE: VendorSource[JsonObject] = VendorSource(
+    vendor=VENDOR,
+    records=record_flattener(
+        vendor=VENDOR,
+        wrapper_keys=("spans", "traces", "data", "results", "items", "events"),
+        record_keys=("trace_id", "traceId", "span_id", "spanId"),
+    ),
+    convert=_span_observation,
+)

--- a/exp/simulation/ingest/datadog.py
+++ b/exp/simulation/ingest/datadog.py
@@ -318,6 +318,9 @@ def _identity_fields(span: JsonObject, llmobs: JsonObject) -> JsonObject:
 def _io(span: JsonObject, llmobs: JsonObject, which: str) -> JsonValue | None:
     """Read the declared Datadog span input or output.
 
+    Datadog wraps scalar payloads as ``{"value": ...}``; the wrapper is removed
+    so tool arguments, results, and completion text keep their declared shape.
+
     Args:
         span: Datadog span record.
         llmobs: Decoded LLM Observability payload.
@@ -330,18 +333,32 @@ def _io(span: JsonObject, llmobs: JsonObject, which: str) -> JsonValue | None:
     if isinstance(meta, dict):
         value = meta.get(which)
         if value is not None:
-            return value
+            return _unwrap(value)
     for key in (which, f"{which}s"):
         value = json_value(span.get(key))
         if value is not None:
-            return value
+            return _unwrap(value)
     attributes = _attributes(span)
     for key in (which, f"{which}s", f"{which}.messages", f"{which}_messages"):
         if key in attributes:
             value = json_value(attributes[key])
             if value is not None:
-                return value
+                return _unwrap(value)
     return None
+
+
+def _unwrap(value: JsonValue | None) -> JsonValue | None:
+    """Remove the Datadog scalar ``{"value": ...}`` wrapper, when present.
+
+    Args:
+        value: Decoded span input or output.
+
+    Returns:
+        The wrapped payload, or the value unchanged when it is not a wrapper.
+    """
+    if isinstance(value, dict) and set(value) == {"value"}:
+        return json_value(value["value"])
+    return value
 
 
 def _input_messages(inputs: JsonValue | None) -> JsonValue | None:

--- a/exp/simulation/ingest/datadog_test.py
+++ b/exp/simulation/ingest/datadog_test.py
@@ -148,6 +148,13 @@ def test_load_datadog_file_tool_result_is_paired_with_requesting_call(tmp_path: 
     tool_names = [span.attributes.get("gen_ai.tool.name") for span in result.traces[0].spans]
     assert "lookup_order" in tool_names
     assert len(result.traces[0].spans) == 2
+    tool_span = next(
+        span
+        for span in result.traces[0].spans
+        if span.attributes.get("gen_ai.tool.name") == "lookup_order"
+    )
+    assert json.loads(str(tool_span.attributes["gen_ai.tool.call.arguments"])) == {"order": "A1"}
+    assert tool_span.attributes["gen_ai.tool.message"] == "ships tomorrow"
 
 
 def test_load_datadog_file_ignores_orchestration_spans(tmp_path: Path) -> None:

--- a/exp/simulation/ingest/datadog_test.py
+++ b/exp/simulation/ingest/datadog_test.py
@@ -1,0 +1,304 @@
+"""Tests for Datadog LLM Observability span export normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from exp.simulation.ingest.datadog import DATADOG_SOURCE
+from exp.simulation.ingest.sources import CANONICAL_TRACE_SOURCES, load_trace_source
+
+_START_NS = 1_788_516_258_420_588_000
+
+
+def _llm_span(
+    *,
+    trace_id: JsonValue = "trace-1",
+    span_id: JsonValue = "span-1",
+    parent_id: JsonValue | None = None,
+    name: str = "answer",
+    model: str = "gpt-4o-mini",
+    provider: str = "openai",
+    inputs: JsonValue | None = None,
+    outputs: JsonValue | None = None,
+) -> dict[str, JsonValue]:
+    """Return one Datadog LLM span with nanosecond timing and model identity.
+
+    Args:
+        trace_id: Declared trace identifier.
+        span_id: Declared span identifier.
+        parent_id: Declared parent span identifier, when any.
+        name: Declared span name.
+        model: Declared model name.
+        provider: Declared provider name.
+        inputs: Declared span input, defaulting to a user message list.
+        outputs: Declared span output, defaulting to an assistant completion.
+
+    Returns:
+        One Datadog span object.
+    """
+    span: dict[str, JsonValue] = {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "name": name,
+        "resource": name,
+        "service": "agent",
+        "type": "llm",
+        "start": _START_NS,
+        "duration": 130_000,
+        "meta": {
+            "span.kind": "llm",
+            "model_name": model,
+            "model_provider": provider,
+            "ml_app": "experiential-check",
+        },
+        "metrics": {"input_tokens": 12, "output_tokens": 8, "total_tokens": 20},
+        "error": 0,
+    }
+    span["meta_struct"] = {
+        "_llmobs": {
+            "meta": {
+                "input": inputs
+                if inputs is not None
+                else {"messages": [{"role": "user", "content": "Where is my order?"}]},
+                "output": outputs
+                if outputs is not None
+                else {"messages": [{"role": "assistant", "content": "It ships tomorrow."}]},
+                "span": {"kind": "llm"},
+                "model_name": model,
+                "model_provider": provider,
+            },
+            "metrics": {"input_tokens": 12, "output_tokens": 8, "total_tokens": 20},
+            "tags": {"ml_app": "experiential-check"},
+        }
+    }
+    if parent_id is not None:
+        span["parent_id"] = parent_id
+    return span
+
+
+def _tool_span(
+    *,
+    trace_id: JsonValue = "trace-1",
+    span_id: JsonValue = "span-2",
+    parent_id: JsonValue = "span-1",
+    name: str = "lookup_order",
+) -> dict[str, JsonValue]:
+    """Return one Datadog tool span that reports its arguments and result."""
+    span = _llm_span(trace_id=trace_id, span_id=span_id, parent_id=parent_id, name=name)
+    assert isinstance(span["meta"], dict)
+    assert isinstance(span["meta_struct"], dict)
+    span["meta"]["span.kind"] = "tool"
+    llmobs = span["meta_struct"]["_llmobs"]
+    assert isinstance(llmobs, dict)
+    meta = llmobs["meta"]
+    assert isinstance(meta, dict)
+    meta["span"] = {"kind": "tool"}
+    meta["input"] = {"value": '{"order": "A1"}'}
+    meta["output"] = {"value": "ships tomorrow"}
+    del meta["model_name"]
+    del meta["model_provider"]
+    return span
+
+
+def test_load_datadog_file_keeps_completion_and_model_identity(tmp_path: Path) -> None:
+    """The model span keeps its completion text and declared provider model."""
+    path = tmp_path / "datadog.json"
+    path.write_text(
+        json.dumps([_llm_span(), _tool_span(), _llm_span(span_id="span-3")]),
+        encoding="utf-8",
+    )
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert len(result.traces) == 1
+    assert result.traces[0].task == "Where is my order?"
+    completions = [
+        str(span.attributes.get("gen_ai.completion") or "") for span in result.traces[0].spans
+    ]
+    assert any("It ships tomorrow." in completion for completion in completions)
+    assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_load_datadog_file_preserves_usage_when_declared(tmp_path: Path) -> None:
+    """Token accounting declared on LLM spans is retained on the model span."""
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps([_llm_span()]), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    usage = result.traces[0].spans[0].usage
+    assert usage is not None
+    assert (usage.input_tokens, usage.output_tokens) == (12, 8)
+
+
+def test_load_datadog_file_tool_result_is_paired_with_requesting_call(tmp_path: Path) -> None:
+    """A tool span is normalized as a tool_result paired with the earlier model call."""
+    path = tmp_path / "datadog.json"
+    path.write_text(
+        json.dumps([_llm_span(span_id="span-1"), _tool_span(span_id="span-2", parent_id="span-1")]),
+        encoding="utf-8",
+    )
+
+    result = DATADOG_SOURCE.load(path)
+
+    tool_names = [span.attributes.get("gen_ai.tool.name") for span in result.traces[0].spans]
+    assert "lookup_order" in tool_names
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_datadog_file_ignores_orchestration_spans(tmp_path: Path) -> None:
+    """Task and retrieval spans carry no direct evidence and are ignored."""
+    ignored = _llm_span(span_id="span-99", name="retrieve")
+    assert isinstance(ignored["meta"], dict)
+    ignored["meta"]["span.kind"] = "retrieval"
+    assert isinstance(ignored["meta_struct"], dict)
+    llmobs = ignored["meta_struct"]["_llmobs"]
+    assert isinstance(llmobs, dict)
+    meta = llmobs["meta"]
+    assert isinstance(meta, dict)
+    meta["span"] = {"kind": "retrieval"}
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps([_llm_span(span_id="span-1"), ignored]), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert len(result.traces[0].spans) == 1
+
+
+def test_load_datadog_file_keeps_workflow_agent_evidence(tmp_path: Path) -> None:
+    """A workflow span with input and output is kept as agent-level evidence."""
+    workflow = {
+        "trace_id": "trace-1",
+        "span_id": "span-root",
+        "name": "chat",
+        "type": "llm",
+        "start": _START_NS,
+        "duration": 264_000,
+        "meta_struct": {
+            "_llmobs": {
+                "meta": {
+                    "input": {"value": "Where is my order?"},
+                    "output": {"value": "It ships tomorrow."},
+                    "span": {"kind": "workflow"},
+                },
+                "tags": {"ml_app": "experiential-check"},
+            }
+        },
+    }
+    path = tmp_path / "datadog.json"
+    path.write_text(
+        json.dumps([workflow, _llm_span(span_id="span-1", parent_id="span-root")]),
+        encoding="utf-8",
+    )
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert result.traces[0].task == "Where is my order?"
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_datadog_file_accepts_v04_trace_arrays(tmp_path: Path) -> None:
+    """A v0.4 array of trace arrays is flattened into one trace."""
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps([[_llm_span(span_id="span-7")]]), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert result.traces[0].spans[0].attributes["gen_ai.request.model"] == "gpt-4o-mini"
+
+
+def test_load_datadog_file_accepts_jsonl(tmp_path: Path) -> None:
+    """JSONL with one span per line is supported."""
+    path = tmp_path / "datadog.jsonl"
+    spans = [
+        _llm_span(trace_id="trace-2", span_id="span-a"),
+        _tool_span(trace_id="trace-2", span_id="span-b", parent_id="span-a"),
+    ]
+    path.write_text("\n".join(json.dumps(span) for span in spans), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert len(result.traces) == 1
+    assert len(result.traces[0].spans) == 2
+
+
+def test_load_datadog_file_marks_failed_span(tmp_path: Path) -> None:
+    """A span with a nonzero error flag retains the declared failure message."""
+    span = _tool_span(span_id="span-err")
+    span["error"] = 1
+    assert isinstance(span["meta"], dict)
+    span["meta"]["error.message"] = "not refundable"
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps([_llm_span(span_id="span-1"), span]), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert result.issues == ()
+    failed = [span for span in result.traces[0].spans if span.failure is not None]
+    assert len(failed) == 1
+    assert failed[0].failure is not None
+    assert failed[0].failure.message == "not refundable"
+
+
+def test_load_datadog_file_accepts_flat_meta_shape(tmp_path: Path) -> None:
+    """Spans without meta_struct read kind, model, and messages from flat meta."""
+    span: dict[str, JsonValue] = {
+        "trace_id": 12345,
+        "span_id": 67890,
+        "name": "answer",
+        "resource": "answer",
+        "start": _START_NS,
+        "duration": 130_000,
+        "meta": {
+            "span.kind": "llm",
+            "model_name": "gpt-4o-mini",
+            "model_provider": "openai",
+            "input.messages": json.dumps([{"role": "user", "content": "Where is my order?"}]),
+            "output.messages": json.dumps([{"role": "assistant", "content": "It ships tomorrow."}]),
+        },
+        "metrics": {"input_tokens": 12, "output_tokens": 8},
+        "error": 0,
+    }
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps([span]), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert result.issues == ()
+    assert result.traces[0].task == "Where is my order?"
+    usage = result.traces[0].spans[0].usage
+    assert usage is not None
+    assert (usage.input_tokens, usage.output_tokens) == (12, 8)
+
+
+def test_datadog_is_registered_as_canonical_source() -> None:
+    """The Datadog source is discoverable through the canonical source table."""
+    assert "datadog" in CANONICAL_TRACE_SOURCES
+    assert "datadog" in sorted(CANONICAL_TRACE_SOURCES)
+
+
+def test_load_trace_source_dispatches_to_datadog(tmp_path: Path) -> None:
+    """The generic loader routes ``datadog`` to the Datadog adapter."""
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps([_llm_span()]), encoding="utf-8")
+
+    result = load_trace_source("datadog", path)
+
+    assert len(result.traces) == 1
+
+
+def test_load_datadog_file_rejects_unsupported_shape(tmp_path: Path) -> None:
+    """A payload without any Datadog record keys is reported as an exclusion."""
+    path = tmp_path / "datadog.json"
+    path.write_text(json.dumps({"unknown": 1}), encoding="utf-8")
+
+    result = DATADOG_SOURCE.load(path)
+
+    assert result.traces == ()
+    assert len(result.issues) == 1

--- a/exp/simulation/ingest/sources.py
+++ b/exp/simulation/ingest/sources.py
@@ -19,6 +19,7 @@ from typing import Protocol
 
 from exp.simulation.ingest.braintrust import BRAINTRUST_SOURCE
 from exp.simulation.ingest.chat_json import CHAT_JSON_SOURCE
+from exp.simulation.ingest.datadog import DATADOG_SOURCE
 from exp.simulation.ingest.langfuse import LANGFUSE_SOURCE
 from exp.simulation.ingest.langsmith import LANGSMITH_SOURCE
 from exp.simulation.ingest.mastra import MASTRA_SOURCE
@@ -53,6 +54,7 @@ class _TraceFileLoader(Protocol):
 _LOADERS: dict[str, _TraceFileLoader] = {
     "braintrust": BRAINTRUST_SOURCE.load,
     "chat-json": CHAT_JSON_SOURCE.load,
+    "datadog": DATADOG_SOURCE.load,
     "langfuse": LANGFUSE_SOURCE.load,
     "langsmith": LANGSMITH_SOURCE.load,
     "mastra": MASTRA_SOURCE.load,

--- a/exp/simulation/ingest/sources_test.py
+++ b/exp/simulation/ingest/sources_test.py
@@ -32,6 +32,30 @@ _MINIMAL_VENDOR_EXPORTS: dict[str, JsonValue] = {
             }
         ]
     },
+    "datadog": [
+        {
+            "trace_id": "trace-1",
+            "span_id": "span-0",
+            "name": "answer",
+            "start": 1_788_516_258_420_588_000,
+            "duration": 130_000,
+            "meta": {
+                "span.kind": "llm",
+                "model_name": "gpt-test",
+                "model_provider": "openai",
+            },
+            "metrics": {"input_tokens": 10, "output_tokens": 20},
+            "meta_struct": {
+                "_llmobs": {
+                    "meta": {
+                        "input": {"messages": [_USER]},
+                        "output": {"content": "here is the plan"},
+                        "span": {"kind": "llm"},
+                    }
+                }
+            },
+        }
+    ],
     "langfuse": {
         "id": "trace-1",
         "timestamp": "2026-02-01T00:00:00Z",
@@ -147,6 +171,7 @@ def test_declared_sources_are_the_supported_set() -> None:
     assert CANONICAL_TRACE_SOURCES == (
         "braintrust",
         "chat-json",
+        "datadog",
         "langfuse",
         "langsmith",
         "mastra",


### PR DESCRIPTION
### Summary

Datadog LLM Observability is the dominant enterprise LLM monitoring surface and exports spans with `trace_id`/`span_id`/`parent_id`, nanosecond `start`/`duration`, `meta`, `metrics`, and `meta_struct._llmobs` carrying `span.kind`, `input`/`output`, `model_name`/`model_provider`, and token counts. Users previously had to convert via the generic OTLP path and lost model identity, tool pairing, and failure fidelity. This adds an explicit canonical loader `datadog` alongside `braintrust`, `langfuse`, `mastra`, `phoenix`, `posthog` etc.

### Design

Datadog spans map to canonical evidence by what they observe:

- `llm` becomes model calls, including tool calls their output requests,
- `tool` becomes tool results paired with the earlier requesting call,
- `workflow` and `agent` become agent-level evidence when they declare input or output,
- `task`, `retrieval`, `embedding`, and other orchestration types are ignored.

Exports arrive as a span array, a v0.4 array of trace arrays, a `spans`/`traces` envelope, or JSONL with one span per line. Model identity comes from `model_name`/`model_provider`; usage from `input_tokens`/`output_tokens`; failures from the nonzero `error` flag plus `error.message`. Flat-meta exports (no `meta_struct`) are accepted with the same keys.

### Changes

- `exp/simulation/ingest/datadog.py` (new, 510 lines, under the 999-line ceiling) with nanosecond start/duration handling, integer or string identifiers, and nested `_llmobs` plus flat-meta readers.
- `exp/simulation/ingest/datadog_test.py` (new, 12 tests): completion and model identity, usage, tool pairing, orchestration ignore, workflow agent evidence, v0.4 arrays, JSONL, failure propagation, flat-meta shape, registration, generic dispatch, and unsupported-shape rejection.
- `exp/simulation/ingest/sources.py` and `__init__.py`: register `datadog`.
- `exp/simulation/ingest/sources_test.py`: canonical set plus a minimal datadog fixture.
- `docs/reference/ingest.md`: source table row.

### Verification

Shapes were verified against a real local capture: ddtrace 4.x LLMObs spans (workflow plus llm plus tool, with annotations and token metrics) submitted to a stub agent and decoded from the v0.4 msgpack payload. That capture loads as 1 trace / 3 spans with the task, model identity, usage (12/8), and tool pairing intact.

- `uv run ruff check .` (pass), `uv run ruff format --check .` (pass), `uv run ty check` (pass)
- `uv run pytest exp/simulation/ingest/ -q`: 163 passed
- `uv run pytest exp/tests/repo_layout_test.py exp/tests/repo_import_boundaries_test.py -q`: 22 passed

### Not a duplicate

No existing adapter, open issue, or open PR covers Datadog (checked the full PR list; only the Weave adapter in #121 and the MLflow adapter in #727 exist in this lane).