### PR TITLE
gateway: round-trip the Responses function_call namespace (native 0.3.31)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -173,7 +173,11 @@ declarations (`custom` freeform-grammar tools, `namespace` tool trees, `web_sear
 `tool_search`) carry byte-for-byte at their caller positions and require a homogeneous native
 Responses route; echoed message items accept `id`/`phase` with `status`
 optional (non-assistant identity drops); and freeform custom tool calls stream end to end with
-their native event names, including continuation retention.
+their native event names, including continuation retention. The item-level `namespace` on
+`function_call` (plus the `name`/`namespace` pair on `function_call_output` and the
+`custom_tool_call` namespace) round-trips verbatim through decode, the client stream, and
+continuation retention: the provider rejects a namespaced call replayed without it, so the
+field joins replay identity when present and absent items keep their exact pre-existing shape.
 
 Provider client-errors stay sanitized: no provider error prose or body content ever reaches the
 caller. The one provider-derived fact a 4xx rejection may relay is the parameter path the provider

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -222,6 +222,22 @@ class ToolCall(ContractModel):
         default=None,
         exclude=True,
     )
+    provider_namespace: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        exclude=True,
+    )
+    """Nested tool tree (OpenAI Responses ``namespace``) that declared this call.
+
+    Set when a Responses caller replays a ``function_call`` item carrying
+    ``namespace``, or when the provider emits one; the field must round-trip
+    verbatim because the provider rejects a namespaced call replayed without
+    it. The tree itself is declared through ``GatewayProviderNativeTool``
+    ``namespace`` entries; this is the per-item linkage back to it. Excluded
+    from serialization like the other replay fields, and joins gateway replay
+    identity explicitly.
+    """
 
     @model_validator(mode="after")
     def _require_matching_raw_arguments(self) -> ToolCall:

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -209,6 +209,26 @@ class GatewayMessage(ContractModel):
         exclude=True,
     )
     """OpenAI Responses assistant-message phase retained for exact replay."""
+    provider_tool_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        exclude=True,
+    )
+    provider_tool_namespace: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+        exclude=True,
+    )
+    """Tool-result attribution replayed on a Responses ``function_call_output``.
+
+    Codex serializes an optional ``name`` and ``namespace`` on the outputs of
+    namespaced tool calls; both re-emit verbatim on the rebuilt item
+    (mirroring ``ToolCall.provider_namespace`` on the call side) and are
+    excluded from serialization like the other replay carriers, joining
+    replay identity explicitly through :func:`canonical_request_sha256`.
+    """
     provider_native_item: JsonObject | None = Field(default=None, exclude=True)
     """One verbatim OpenAI Responses input item the gateway carries opaquely.
 
@@ -331,6 +351,10 @@ class GatewayMessage(ContractModel):
             raise ValueError("tool messages require tool_call_id")
         if self.role != "tool" and self.tool_call_id is not None:
             raise ValueError("tool_call_id is valid only for tool messages")
+        if self.role != "tool" and (
+            self.provider_tool_name is not None or self.provider_tool_namespace is not None
+        ):
+            raise ValueError("tool-result attribution is valid only for tool messages")
         if self.role != "tool" and self.tool_is_error:
             raise ValueError("tool_is_error is valid only for tool messages")
         if self.cache_control is not None and self.role != "tool":

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -1009,3 +1009,65 @@ def test_tool_messages_carry_text_and_image_parts_only() -> None:
                 ImageContentPart(media_type="image/png", data="aGk="),
             ),
         )
+
+
+def test_replay_identity_binds_the_function_call_namespace() -> None:
+    """A replayed item differing only by namespace is a different request.
+
+    Namespace-free requests keep their exact pre-existing digest because the
+    field joins the replay envelope only when present.
+    """
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
+
+    def request(*, namespace: str | None) -> GatewayRequest:
+        return GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(
+                GatewayMessage(
+                    role="assistant",
+                    tool_calls=(
+                        ToolCall(
+                            call_id="call-1",
+                            name="spawn_agent",
+                            provider_output_index=0,
+                            provider_namespace=namespace,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    namespaced = request(namespace="collaboration")
+    assert canonical_request_sha256(namespaced) == canonical_request_sha256(
+        request(namespace="collaboration")
+    )
+    assert canonical_request_sha256(namespaced) != canonical_request_sha256(
+        request(namespace="agents")
+    )
+    assert canonical_request_sha256(namespaced) != canonical_request_sha256(request(namespace=None))
+
+
+def test_replay_identity_binds_tool_output_attribution() -> None:
+    """A function_call_output name/namespace pair joins replay identity."""
+    from exp.common.core.artifacts import sha256_json
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
+
+    def request(*, namespace: str | None) -> GatewayRequest:
+        return GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(
+                GatewayMessage(
+                    role="tool",
+                    content="spawned",
+                    tool_call_id="call-1",
+                    provider_tool_name="spawn_agent" if namespace is not None else None,
+                    provider_tool_namespace=namespace,
+                ),
+            ),
+        )
+
+    plain = request(namespace=None)
+    assert canonical_request_sha256(plain) == sha256_json(plain)
+    assert canonical_request_sha256(request(namespace="collaboration")) != canonical_request_sha256(
+        plain
+    )

--- a/exp/runtime/gateway/guardrails/enforcement.py
+++ b/exp/runtime/gateway/guardrails/enforcement.py
@@ -45,12 +45,15 @@ def _restored_provider_authority(
             or message.provider_output_index is not None
             or message.provider_status is not None
             or message.provider_phase is not None
+            or message.provider_tool_name is not None
+            or message.provider_tool_namespace is not None
             or message.tool_is_error
             or any(
                 call.raw_arguments is not None
                 or call.provider_item_id is not None
                 or call.provider_output_index is not None
                 or call.provider_status is not None
+                or call.provider_namespace is not None
                 for call in message.tool_calls
             )
         )

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.30"
+version = "0.3.31"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.30"
+version = "0.3.31"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -81,6 +81,7 @@ impl Normalizer {
                             index,
                             call_id,
                             name,
+                            namespace: None,
                         });
                     }
                     Some("server_tool_use") => {

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -97,6 +97,7 @@ impl Normalizer {
             index,
             call_id,
             name,
+            namespace: None,
         }])
     }
 

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -137,6 +137,7 @@ impl Normalizer {
                 index,
                 call_id,
                 name,
+                namespace: None,
             },
             Event::ToolArgumentsDelta {
                 index,

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -282,6 +282,11 @@ impl Normalizer {
                     }
                     let call_id = call_id.to_string();
                     let name = openai_identity(item, "name", "OpenAI function call name")?;
+                    let namespace = optional_openai_identity(
+                        item,
+                        "namespace",
+                        "OpenAI function call namespace",
+                    )?;
                     let item_id =
                         optional_openai_identity(item, "id", "OpenAI function call item ID")?;
                     if !self.bind_openai_output_item(
@@ -293,6 +298,7 @@ impl Normalizer {
                     }
                     self.reserve_tool_entry(index)?;
                     let mut tool = ToolAccumulator::new(call_id.clone(), name.clone());
+                    tool.namespace = namespace.clone();
                     tool.provider_item_id = item_id.clone();
                     tool.provider_status = status;
                     events.push(Event::ProviderOutputItemStarted {
@@ -306,6 +312,7 @@ impl Normalizer {
                         index,
                         call_id,
                         name,
+                        namespace,
                     });
                     if let Some(Value::String(initial)) = item.get("arguments") {
                         if !initial.is_empty() {
@@ -336,6 +343,11 @@ impl Normalizer {
                     }
                     let call_id = call_id.to_string();
                     let name = openai_identity(item, "name", "OpenAI custom tool call name")?;
+                    let namespace = optional_openai_identity(
+                        item,
+                        "namespace",
+                        "OpenAI custom tool call namespace",
+                    )?;
                     let item_id =
                         optional_openai_identity(item, "id", "OpenAI custom tool call item ID")?;
                     if !self.bind_openai_output_item(
@@ -348,6 +360,7 @@ impl Normalizer {
                     self.reserve_tool_entry(index)?;
                     let mut tool = ToolAccumulator::new(call_id.clone(), name.clone());
                     tool.custom = true;
+                    tool.namespace = namespace.clone();
                     tool.provider_item_id = item_id.clone();
                     tool.provider_status = status;
                     events.push(Event::ProviderOutputItemStarted {
@@ -361,6 +374,7 @@ impl Normalizer {
                         index,
                         call_id,
                         name,
+                        namespace,
                     });
                     if let Some(Value::String(initial)) = item.get("input") {
                         if !initial.is_empty() {
@@ -566,6 +580,11 @@ impl Normalizer {
                         )?;
                         let call_id = openai_identity(item, "call_id", "OpenAI function call ID")?;
                         let name = openai_identity(item, "name", "OpenAI function call name")?;
+                        let namespace = optional_openai_identity(
+                            item,
+                            "namespace",
+                            "OpenAI function call namespace",
+                        )?;
                         let arguments =
                             require_string(item, "arguments", "OpenAI function call arguments")
                                 .map_err(|message| malformed(&message))?;
@@ -575,6 +594,7 @@ impl Normalizer {
                         if tool.provider_item_id != item_id
                             || tool.call_id != call_id
                             || tool.name != name
+                            || tool.namespace != namespace
                         {
                             return Err(malformed(
                                 "OpenAI function call changed identity at completion",
@@ -609,6 +629,11 @@ impl Normalizer {
                         let call_id =
                             openai_identity(item, "call_id", "OpenAI custom tool call ID")?;
                         let name = openai_identity(item, "name", "OpenAI custom tool call name")?;
+                        let namespace = optional_openai_identity(
+                            item,
+                            "namespace",
+                            "OpenAI custom tool call namespace",
+                        )?;
                         let input = require_string(item, "input", "OpenAI custom tool call input")
                             .map_err(|message| malformed(&message))?;
                         let tool = self.tools.get(&index).ok_or_else(|| {
@@ -618,6 +643,7 @@ impl Normalizer {
                             || tool.provider_item_id != item_id
                             || tool.call_id != call_id
                             || tool.name != name
+                            || tool.namespace != namespace
                         {
                             return Err(malformed(
                                 "OpenAI custom tool call changed identity at completion",
@@ -859,6 +885,7 @@ impl Normalizer {
                             index,
                             call_id,
                             name,
+                            namespace: None,
                         });
                     }
                     if let Some(fragment) = function.get("arguments") {

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -620,3 +620,98 @@ fn unparsable_tool_arguments_stay_malformed_on_a_normal_finish() {
         .expect_err("a dangling fragment on a normal finish is malformed");
     assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
 }
+
+#[test]
+fn namespaced_function_call_round_trips_namespace_through_the_stream() {
+    // Codex agent tools (e.g. spawn_agent) arrive as namespaced function
+    // calls; the provider rejects a replay of the item without its
+    // namespace, so the field must survive normalization verbatim.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+    let added = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "status": "in_progress",
+                "call_id": "call_live", "name": "spawn_agent",
+                "namespace": "collaboration", "arguments": "",
+            },
+        })
+        .to_string(),
+    };
+    let events = normalizer
+        .feed(&added)
+        .expect("namespaced start must normalize");
+    assert!(matches!(
+        events.as_slice(),
+        [
+            Event::ProviderOutputItemStarted { .. },
+            Event::ToolCallStarted { name, namespace: Some(namespace), .. },
+        ] if name == "spawn_agent" && namespace == "collaboration"
+    ));
+    let item_done = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "status": "completed",
+                "call_id": "call_live", "name": "spawn_agent",
+                "namespace": "collaboration", "arguments": "{}",
+            },
+        })
+        .to_string(),
+    };
+    let events = normalizer
+        .feed(&item_done)
+        .expect("namespaced completion must normalize");
+    assert!(matches!(
+        events.as_slice(),
+        [
+            Event::ToolArgumentsDelta { .. },
+            Event::ProviderOutputItemCompleted { .. },
+            Event::ToolCallCompleted { call, .. },
+        ] if call.namespace.as_deref() == Some("collaboration") && !call.custom
+    ));
+}
+
+#[test]
+fn a_function_call_namespace_changed_at_completion_is_malformed() {
+    let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+    let added = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "call_id": "call_live", "name": "spawn_agent",
+                "namespace": "collaboration", "arguments": "",
+            },
+        })
+        .to_string(),
+    };
+    normalizer.feed(&added).expect("start must normalize");
+    let item_done = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "call_id": "call_live", "name": "spawn_agent",
+                "namespace": "other", "arguments": "{}",
+            },
+        })
+        .to_string(),
+    };
+    let failure = normalizer
+        .feed(&item_done)
+        .expect_err("a changed namespace must fail closed");
+    assert!(failure
+        .safe_message
+        .contains("changed identity at completion"));
+}

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -77,6 +77,7 @@ impl ReasoningCarrierState {
                 index,
                 call_id,
                 name,
+                ..
             } => {
                 if self.tool_ids.contains_key(index)
                     || self
@@ -299,6 +300,7 @@ impl ChatSseEncoder {
                 index,
                 call_id,
                 name,
+                ..
             } => {
                 if self.tool_indices.contains_key(index) {
                     return Err(invalid_provider_stream(
@@ -699,6 +701,7 @@ mod tests {
                 delta: "hidden provider reasoning".to_string(),
             },
             Event::ToolCallStarted {
+                namespace: None,
                 index: 0,
                 call_id: "call-one".to_string(),
                 name: "lookup".to_string(),
@@ -710,6 +713,7 @@ mod tests {
             Event::ToolCallCompleted {
                 index: 0,
                 call: crate::events::CompletedToolCall {
+                    namespace: None,
                     call_id: "call-one".to_string(),
                     name: "lookup".to_string(),
                     raw_arguments: "{}".to_string(),
@@ -788,11 +792,13 @@ mod tests {
                 delta: "hidden".to_string(),
             },
             Event::ToolCallStarted {
+                namespace: None,
                 index: 1,
                 call_id: "call-one".to_string(),
                 name: "first".to_string(),
             },
             Event::ToolCallStarted {
+                namespace: None,
                 index: 0,
                 call_id: "call-zero".to_string(),
                 name: "second".to_string(),
@@ -800,6 +806,7 @@ mod tests {
             Event::ToolCallCompleted {
                 index: 0,
                 call: crate::events::CompletedToolCall {
+                    namespace: None,
                     call_id: "call-zero".to_string(),
                     name: "second".to_string(),
                     raw_arguments: "{\"order\":0}".to_string(),
@@ -811,6 +818,7 @@ mod tests {
             Event::ToolCallCompleted {
                 index: 1,
                 call: crate::events::CompletedToolCall {
+                    namespace: None,
                     call_id: "call-one".to_string(),
                     name: "first".to_string(),
                     raw_arguments: "{\"order\":1}".to_string(),

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -303,6 +303,7 @@ impl MessagesSseEncoder {
                 index,
                 call_id,
                 name,
+                ..
             } => self.tool_started(*index, call_id, name),
             Event::ToolArgumentsDelta { index, delta } => self.tool_arguments_delta(*index, delta),
             Event::ToolCallCompleted { index, call } => {

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -72,6 +72,7 @@ fn completed_body_orders_text_before_tool_use_blocks() {
     let events = vec![
         Event::TextDelta("hi".to_string()),
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -83,6 +84,7 @@ fn completed_body_orders_text_before_tool_use_blocks() {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -109,6 +111,7 @@ fn completed_body_orders_text_before_tool_use_blocks() {
 fn completed_body_preserves_interleaved_block_order() {
     let events = vec![
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -116,6 +119,7 @@ fn completed_body_preserves_interleaved_block_order() {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -142,6 +146,7 @@ fn deferred_tool_completion_keeps_the_started_block_position() {
     // text may arrive between the tool's arguments and its completion.
     let events = vec![
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -154,6 +159,7 @@ fn deferred_tool_completion_keeps_the_started_block_position() {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -188,6 +194,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
     // buffers and flushes as one delta after A's block closes.
     let events = vec![
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-a".to_string(),
             name: "alpha".to_string(),
@@ -197,6 +204,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
             delta: "{\"a\": ".to_string(),
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 1,
             call_id: "call-b".to_string(),
             name: "beta".to_string(),
@@ -212,6 +220,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-a".to_string(),
                 name: "alpha".to_string(),
                 provider_item_id: None,
@@ -223,6 +232,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
         Event::ToolCallCompleted {
             index: 1,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-b".to_string(),
                 name: "beta".to_string(),
                 provider_item_id: None,
@@ -391,6 +401,7 @@ fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
             signature: "sig-a".to_string(),
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -402,6 +413,7 @@ fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -459,6 +471,7 @@ fn web_search_events() -> Vec<Event> {
         Event::ServerToolUseCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "srvtoolu_1".to_string(),
                 name: "web_search".to_string(),
                 provider_item_id: None,
@@ -583,6 +596,7 @@ fn paused_turn_keeps_its_stop_reason_on_both_paths() {
         Event::ServerToolUseCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "srvtoolu_1".to_string(),
                 name: "web_search".to_string(),
                 provider_item_id: None,

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -296,7 +296,8 @@ impl ResponsesSseEncoder {
                 index,
                 call_id,
                 name,
-            } => self.tool_started(*index, call_id, name),
+                namespace,
+            } => self.tool_started(*index, call_id, name, namespace.as_deref()),
             Event::ToolArgumentsDelta { index, delta } => self.tool_arguments(*index, delta),
             Event::ToolCallCompleted { index, call } => self.tool_completed(*index, call),
             // Anthropic text-block boundaries and citation metadata have no
@@ -567,6 +568,7 @@ impl ResponsesSseEncoder {
         index: u32,
         call_id: &str,
         name: &str,
+        namespace: Option<&str>,
     ) -> Result<Vec<String>, PublicError> {
         if self.tools.contains_key(&index) {
             return Err(invalid_provider_stream(
@@ -610,6 +612,7 @@ impl ResponsesSseEncoder {
             output_index,
             call_id: call_id.to_string(),
             name: name.to_string(),
+            namespace: namespace.map(str::to_string),
             arguments: String::new(),
             status,
             done: false,
@@ -665,6 +668,7 @@ impl ResponsesSseEncoder {
         let state = self.open_tool(index)?;
         if state.call_id != call.call_id
             || state.name != call.name
+            || state.namespace != call.namespace
             || state.arguments != call.raw_arguments
             || (provider_owned_identity && call.provider_item_id != state.item_id)
         {

--- a/exp/runtime/gateway/native/src/encode_responses/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/tests.rs
@@ -65,6 +65,7 @@ fn fireworks_tool_events() -> Vec<Event> {
             delta: "hidden provider reasoning".to_string(),
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-one".to_string(),
             name: "lookup".to_string(),
@@ -76,6 +77,7 @@ fn fireworks_tool_events() -> Vec<Event> {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-one".to_string(),
                 name: "lookup".to_string(),
                 raw_arguments: "{}".to_string(),
@@ -148,11 +150,13 @@ fn fireworks_parallel_tools_share_public_and_carrier_order() {
             delta: "hidden".to_string(),
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 1,
             call_id: "call-one".to_string(),
             name: "first".to_string(),
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 0,
             call_id: "call-zero".to_string(),
             name: "second".to_string(),
@@ -168,6 +172,7 @@ fn fireworks_parallel_tools_share_public_and_carrier_order() {
         Event::ToolCallCompleted {
             index: 0,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-zero".to_string(),
                 name: "second".to_string(),
                 raw_arguments: "{\"order\":0}".to_string(),
@@ -179,6 +184,7 @@ fn fireworks_parallel_tools_share_public_and_carrier_order() {
         Event::ToolCallCompleted {
             index: 1,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-one".to_string(),
                 name: "first".to_string(),
                 raw_arguments: "{\"order\":1}".to_string(),
@@ -356,6 +362,7 @@ fn provider_item_starts_preserve_reasoning_tool_order_and_identity() {
             phase: None,
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 1,
             call_id: "call-1".to_string(),
             name: "lookup".to_string(),
@@ -372,6 +379,7 @@ fn provider_item_starts_preserve_reasoning_tool_order_and_identity() {
         Event::ToolCallCompleted {
             index: 1,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-1".to_string(),
                 name: "lookup".to_string(),
                 provider_item_id: Some("fc-provider-1".to_string()),
@@ -468,6 +476,7 @@ fn provider_items_preserve_multiple_messages_status_phase_and_idless_call() {
             phase: None,
         },
         Event::ToolCallStarted {
+            namespace: None,
             index: 2,
             call_id: "call-required".to_string(),
             name: "lookup".to_string(),
@@ -486,6 +495,7 @@ fn provider_items_preserve_multiple_messages_status_phase_and_idless_call() {
         Event::ToolCallCompleted {
             index: 2,
             call: CompletedToolCall {
+                namespace: None,
                 call_id: "call-required".to_string(),
                 name: "lookup".to_string(),
                 provider_item_id: None,
@@ -550,4 +560,109 @@ fn provider_items_preserve_multiple_messages_status_phase_and_idless_call() {
     assert!(!frames
         .iter()
         .any(|frame| frame.contains("response.function_call_arguments")));
+}
+
+#[test]
+fn namespaced_tool_call_items_re_emit_namespace_to_the_caller() {
+    // The caller replays the completed function_call item verbatim, so the
+    // synthesized output items must carry the namespace or the provider
+    // rejects the next turn ("Missing namespace for function_call ...").
+    let events = vec![
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-ns".to_string(),
+            name: "spawn_agent".to_string(),
+            namespace: Some("collaboration".to_string()),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: crate::events::CompletedToolCall {
+                call_id: "call-ns".to_string(),
+                name: "spawn_agent".to_string(),
+                namespace: Some("collaboration".to_string()),
+                provider_item_id: None,
+                provider_status: None,
+                raw_arguments: "{}".to_string(),
+                custom: false,
+            },
+        },
+        Event::Completed,
+    ];
+    let mut encoder = ResponsesSseEncoder::new(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+    );
+    encoder.start().expect("stream start must encode");
+    let mut frames = Vec::new();
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("events must encode"));
+    }
+    let added = frames
+        .iter()
+        .find(|frame| frame.contains("response.output_item.added"))
+        .expect("tool item start frame");
+    assert!(added.contains("\"namespace\":\"collaboration\""));
+    let done = frames
+        .iter()
+        .find(|frame| frame.contains("response.output_item.done"))
+        .expect("tool item done frame");
+    assert!(done.contains("\"namespace\":\"collaboration\""));
+
+    let completed = completed_responses_body(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &events,
+    )
+    .expect("completed body must encode");
+    assert_eq!(
+        completed.body["output"][0]["namespace"],
+        json!("collaboration")
+    );
+
+    // A namespace-free call keeps the exact pre-existing item shape.
+    let plain = completed_responses_body(
+        "request-2",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &[
+            Event::ToolCallStarted {
+                index: 0,
+                call_id: "call-plain".to_string(),
+                name: "lookup".to_string(),
+                namespace: None,
+            },
+            Event::ToolArgumentsDelta {
+                index: 0,
+                delta: "{}".to_string(),
+            },
+            Event::ToolCallCompleted {
+                index: 0,
+                call: crate::events::CompletedToolCall {
+                    call_id: "call-plain".to_string(),
+                    name: "lookup".to_string(),
+                    namespace: None,
+                    provider_item_id: None,
+                    provider_status: None,
+                    raw_arguments: "{}".to_string(),
+                    custom: false,
+                },
+            },
+            Event::Completed,
+        ],
+    )
+    .expect("completed body must encode");
+    assert!(plain.body["output"][0]
+        .as_object()
+        .expect("tool item object")
+        .get("namespace")
+        .is_none());
 }

--- a/exp/runtime/gateway/native/src/encode_responses/tool_state.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/tool_state.rs
@@ -10,6 +10,10 @@ pub(super) struct ToolState {
     pub(super) output_index: usize,
     pub(super) call_id: String,
     pub(super) name: String,
+    /// Nested tool tree (Responses `namespace`) that declared this call;
+    /// re-emitted verbatim so the caller can round-trip the item (the
+    /// provider rejects a namespaced call replayed without it).
+    pub(super) namespace: Option<String>,
     pub(super) arguments: String,
     pub(super) status: Option<ProviderOutputItemStatus>,
     pub(super) done: bool,
@@ -35,6 +39,9 @@ impl ToolState {
         item.insert("type".to_string(), json!(item_type));
         item.insert("call_id".to_string(), json!(self.call_id));
         item.insert("name".to_string(), json!(self.name));
+        if let Some(namespace) = &self.namespace {
+            item.insert("namespace".to_string(), json!(namespace));
+        }
         item.insert(payload_key.to_string(), json!(self.arguments));
         item.insert(
             "status".to_string(),

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -60,6 +60,10 @@ impl Usage {
 pub struct CompletedToolCall {
     pub call_id: String,
     pub name: String,
+    /// Nested tool tree (Responses `namespace`) that declared this call,
+    /// preserved verbatim through retention and the client stream because
+    /// the provider rejects a namespaced call replayed without it.
+    pub namespace: Option<String>,
     pub provider_item_id: Option<String>,
     pub provider_status: Option<ProviderOutputItemStatus>,
     /// Raw provider-order argument text: a validated JSON object for
@@ -200,6 +204,10 @@ pub enum Event {
         index: u32,
         call_id: String,
         name: String,
+        /// Nested tool tree (Responses `namespace`) that declared this call;
+        /// present only on native Responses streams and preserved verbatim
+        /// because the provider rejects a namespaced call replayed without it.
+        namespace: Option<String>,
     },
     ToolArgumentsDelta {
         index: u32,
@@ -410,12 +418,19 @@ pub fn simplified_event(event: &Event) -> Value {
             index,
             call_id,
             name,
-        } => serde_json::json!({
-            "kind": "tool_call_started",
-            "index": index,
-            "call_id": call_id,
-            "name": name,
-        }),
+            namespace,
+        } => {
+            let mut payload = serde_json::json!({
+                "kind": "tool_call_started",
+                "index": index,
+                "call_id": call_id,
+                "name": name,
+            });
+            if let Some(namespace) = namespace {
+                payload["namespace"] = Value::String(namespace.clone());
+            }
+            payload
+        }
         Event::ToolArgumentsDelta { index, delta } => serde_json::json!({
             "kind": "tool_arguments_delta",
             "index": index,
@@ -429,6 +444,9 @@ pub fn simplified_event(event: &Event) -> Value {
                 "name": call.name,
                 "raw_arguments": call.raw_arguments,
             });
+            if let Some(namespace) = &call.namespace {
+                payload["namespace"] = Value::String(namespace.clone());
+            }
             if let Some(item_id) = &call.provider_item_id {
                 payload["item_id"] = Value::String(item_id.clone());
             }
@@ -528,6 +546,8 @@ pub fn require_json_object_text(raw: &str) -> Result<(), String> {
 pub struct ToolAccumulator {
     pub call_id: String,
     pub name: String,
+    /// Nested tool tree (Responses `namespace`) that declared this call.
+    pub namespace: Option<String>,
     pub provider_item_id: Option<String>,
     pub provider_status: Option<ProviderOutputItemStatus>,
     pub raw_arguments: String,
@@ -544,6 +564,7 @@ impl ToolAccumulator {
         Self {
             call_id,
             name,
+            namespace: None,
             provider_item_id: None,
             provider_status: None,
             raw_arguments: String::new(),
@@ -566,6 +587,10 @@ impl ToolAccumulator {
             || self.call_id.chars().count() > 256
             || self.name.is_empty()
             || self.name.chars().count() > 256
+            || self
+                .namespace
+                .as_ref()
+                .is_some_and(|namespace| namespace.is_empty() || namespace.chars().count() > 256)
             || self.raw_arguments.chars().count() > 4_000_000
         {
             return Err("streamed tool call is incomplete".to_string());
@@ -573,6 +598,7 @@ impl ToolAccumulator {
         Ok(CompletedToolCall {
             call_id: self.call_id.clone(),
             name: self.name.clone(),
+            namespace: self.namespace.clone(),
             provider_item_id: self.provider_item_id.clone(),
             provider_status: self.provider_status,
             raw_arguments: self.raw_arguments.clone(),

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -21,6 +21,7 @@ fn output_tokens_lead_a_turn_but_control_frames_do_not() {
     .is_output_token());
     // A tool-only turn's first token is the tool call itself.
     assert!(Event::ToolCallStarted {
+        namespace: None,
         index: 0,
         call_id: "call_1".to_string(),
         name: "get".to_string(),

--- a/exp/runtime/gateway/native/src/guardrails.rs
+++ b/exp/runtime/gateway/native/src/guardrails.rs
@@ -162,6 +162,7 @@ mod tests {
             Event::ToolCallCompleted {
                 index: 0,
                 call: CompletedToolCall {
+                    namespace: None,
                     call_id: "call-1".to_string(),
                     name: "lookup".to_string(),
                     provider_item_id: None,
@@ -220,6 +221,7 @@ mod tests {
             Event::ToolCallCompleted {
                 index: 0,
                 call: CompletedToolCall {
+                    namespace: None,
                     call_id: "call-1".to_string(),
                     name: "lookup".to_string(),
                     provider_item_id: None,

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -448,6 +448,10 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or("")
                     .to_string(),
+                namespace: object
+                    .get("namespace")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
             },
             "tool_arguments_delta" => events::Event::ToolArgumentsDelta { index, delta: text },
             "tool_call_completed" => events::Event::ToolCallCompleted {
@@ -463,6 +467,10 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("")
                         .to_string(),
+                    namespace: object
+                        .get("namespace")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string),
                     provider_item_id: object
                         .get("item_id")
                         .and_then(serde_json::Value::as_str)
@@ -517,6 +525,7 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("")
                         .to_string(),
+                    namespace: None,
                     name: object
                         .get("name")
                         .and_then(serde_json::Value::as_str)

--- a/exp/runtime/gateway/native/src/responses_retention.rs
+++ b/exp/runtime/gateway/native/src/responses_retention.rs
@@ -258,6 +258,7 @@ pub(crate) fn remember_argument(
                 "item_id": call.provider_item_id,
                 "call_id": call.call_id,
                 "name": call.name,
+                "namespace": call.namespace,
                 "arguments": call.raw_arguments,
                 "status": call.provider_status.map(ProviderOutputItemStatus::as_str),
                 "custom": call.custom,
@@ -354,6 +355,7 @@ mod tests {
             Event::ToolCallCompleted {
                 index: 2,
                 call: CompletedToolCall {
+                    namespace: None,
                     call_id: "call-required".to_string(),
                     name: "lookup".to_string(),
                     provider_item_id: None,
@@ -397,6 +399,34 @@ mod tests {
         assert_eq!(payload["tool_calls"][0]["output_index"], 2);
         assert!(payload["tool_calls"][0]["item_id"].is_null());
         assert_eq!(payload["tool_calls"][0]["status"], "incomplete");
+    }
+
+    #[test]
+    fn retention_carries_a_tool_call_namespace_to_the_remember_payload() {
+        let events = [
+            Event::ToolCallCompleted {
+                index: 0,
+                call: CompletedToolCall {
+                    namespace: Some("collaboration".to_string()),
+                    call_id: "call-ns".to_string(),
+                    name: "spawn_agent".to_string(),
+                    provider_item_id: None,
+                    provider_status: None,
+                    raw_arguments: "{}".to_string(),
+                    custom: false,
+                },
+            },
+            Event::Completed,
+        ];
+        let mut retention = ResponsesRetention::default();
+        for event in &events {
+            retention.track(event);
+        }
+        let payload: Value =
+            serde_json::from_str(&remember_argument("request-ns", &retention, None))
+                .expect("retention payload is JSON");
+        assert_eq!(payload["tool_calls"][0]["namespace"], "collaboration");
+        assert_eq!(payload["tool_calls"][0]["name"], "spawn_agent");
     }
 
     #[test]

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -296,12 +296,14 @@ def remember_turn(
         call_id = call["call_id"]
         name = call["name"]
         raw_arguments = call["arguments"]
+        namespace = call.get("namespace")
         if (
             not isinstance(call_id, str)
             or not call_id
             or not isinstance(name, str)
             or not name
             or not isinstance(raw_arguments, str)
+            or not (namespace is None or (isinstance(namespace, str) and namespace))
         ):
             raise ValueError("Responses retained tool call fields are invalid")
         if call.get("custom") is True:
@@ -314,6 +316,8 @@ def remember_turn(
                 "name": name,
                 "input": raw_arguments,
             }
+            if namespace is not None:
+                native_item["namespace"] = namespace
             if provider_item_id is not None:
                 native_item["id"] = provider_item_id
             status_value = call.get("status")
@@ -337,6 +341,7 @@ def remember_turn(
                 if provider_output_index is not None
                 else None
             ),
+            provider_namespace=namespace,
         )
         if provider_output_index is None:
             unindexed_calls.append(parsed_call)

--- a/exp/runtime/gateway/native_responses_test.py
+++ b/exp/runtime/gateway/native_responses_test.py
@@ -424,3 +424,101 @@ def test_remember_turn_retains_an_output_less_turn_as_the_conversation_so_far() 
     )
     assert state.messages == context.messages
     assert state.episode_key == context.episode_key
+
+
+def test_remember_turn_retains_and_replays_a_tool_call_namespace() -> None:
+    """A namespaced call retained for continuation re-emits its namespace.
+
+    The provider rejects a namespaced function_call replayed without the
+    field, so the boundary payload's namespace must survive retention into
+    the rebuilt input item verbatim (a custom call keeps it on the verbatim
+    native item).
+    """
+    store = BoundedContinuationStore()
+    context = _context()
+    remember_turn(
+        store,
+        context=context,
+        route_binding=_binding(),
+        data={
+            "text": "",
+            "refusal": False,
+            "tool_calls": [
+                {
+                    "output_index": 0,
+                    "item_id": "fc-ns",
+                    "call_id": "call-ns",
+                    "name": "spawn_agent",
+                    "namespace": "collaboration",
+                    "arguments": "{}",
+                    "status": "completed",
+                },
+                {
+                    "output_index": 1,
+                    "item_id": "ctc-ns",
+                    "call_id": "call-custom",
+                    "name": "exec",
+                    "namespace": "code",
+                    "arguments": "const r = 1;",
+                    "status": "completed",
+                    "custom": True,
+                },
+            ],
+        },
+    )
+
+    state = store.resolve_now(
+        namespace=context.namespace,
+        previous_response_id=context.response_id,
+    )
+    call = state.messages[0].tool_calls[0]
+    assert call.provider_namespace == "collaboration"
+    native = state.messages[1].provider_native_item
+    assert native is not None and native["namespace"] == "code"
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=state.messages,
+    )
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-sol",
+        request,
+        supports_temperature=False,
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[0] == {
+        "id": "fc-ns",
+        "type": "function_call",
+        "call_id": "call-ns",
+        "name": "spawn_agent",
+        "arguments": "{}",
+        "namespace": "collaboration",
+        "status": "completed",
+    }
+    assert payload_input[1]["namespace"] == "code"
+
+
+def test_remember_turn_rejects_a_coerced_tool_call_namespace() -> None:
+    """A non-text or empty namespace is a boundary contract violation."""
+    for value in (7, ""):
+        with pytest.raises(ValueError, match="tool call fields"):
+            remember_turn(
+                BoundedContinuationStore(),
+                context=_context(),
+                route_binding=_binding(),
+                data={
+                    "text": "",
+                    "refusal": False,
+                    "tool_calls": [
+                        {
+                            "output_index": 0,
+                            "item_id": "fc-ns",
+                            "call_id": "call-ns",
+                            "name": "spawn_agent",
+                            "namespace": cast(JsonValue, value),
+                            "arguments": "{}",
+                            "status": "completed",
+                        }
+                    ],
+                },
+            )

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -56,23 +56,31 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
                 and call.provider_item_id is None
                 and call.provider_output_index is None
                 and call.provider_status is None
+                and call.provider_namespace is None
             ):
                 continue
-            retained_calls.append(
-                {
-                    "tool_call_index": tool_call_index,
-                    "call_id": call.call_id,
-                    "name": call.name,
-                    "raw_arguments": call.raw_arguments,
-                    "provider_item_id": call.provider_item_id,
-                    "provider_output_index": call.provider_output_index,
-                    "provider_status": call.provider_status,
-                }
-            )
+            retained_call: JsonObject = {
+                "tool_call_index": tool_call_index,
+                "call_id": call.call_id,
+                "name": call.name,
+                "raw_arguments": call.raw_arguments,
+                "provider_item_id": call.provider_item_id,
+                "provider_output_index": call.provider_output_index,
+                "provider_status": call.provider_status,
+            }
+            # Joins only when present so every namespace-free request keeps
+            # its exact pre-existing digest.
+            if call.provider_namespace is not None:
+                retained_call["provider_namespace"] = call.provider_namespace
+            retained_calls.append(retained_call)
         if retained_calls:
             authority["tool_calls"] = retained_calls
         if message.tool_is_error:
             authority["tool_is_error"] = True
+        if message.provider_tool_name is not None:
+            authority["provider_tool_name"] = message.provider_tool_name
+        if message.provider_tool_namespace is not None:
+            authority["provider_tool_namespace"] = message.provider_tool_namespace
         if len(authority) > 1:
             replay.append(authority)
     retained_tools: list[JsonObject] = []

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -32,13 +32,18 @@ from exp.runtime.models.providers.videos import openai_chat_video_part, reject_v
 def responses_items(message: GatewayMessage) -> list[JsonObject]:
     """Translate one non-instruction gateway message to Responses input items."""
     if message.role == "tool":
-        return [
-            {
-                "type": "function_call_output",
-                "call_id": message.tool_call_id or "",
-                "output": message.content or "",
-            }
-        ]
+        output_item: JsonObject = {
+            "type": "function_call_output",
+            "call_id": message.tool_call_id or "",
+            "output": message.content or "",
+        }
+        # Tool attribution round-trips verbatim: present stays present and
+        # absent stays absent, so pre-namespace histories are unchanged.
+        if message.provider_tool_name is not None:
+            output_item["name"] = message.provider_tool_name
+        if message.provider_tool_namespace is not None:
+            output_item["namespace"] = message.provider_tool_namespace
+        return [output_item]
     if message.role == "user":
         if message.content_parts:
             return [
@@ -121,6 +126,11 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
             "name": call.name,
             "arguments": call.arguments_json(),
         }
+        # The provider rejects a namespaced call replayed without its
+        # namespace ("Missing namespace for function_call ..."), so the
+        # retained value re-emits verbatim; absent stays absent.
+        if call.provider_namespace is not None:
+            item["namespace"] = call.provider_namespace
         if call.provider_item_id is not None:
             item["id"] = call.provider_item_id
         if call.provider_status is not None:

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -230,8 +230,12 @@ honoring the selector is impossible and accepting it would be silent."""
 
 RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED: dict[str, frozenset[str]] = {
     "message": frozenset({"type", "role", "content", "id", "status", "phase"}),
-    "function_call": frozenset({"type", "call_id", "name", "arguments", "id", "status"}),
-    "function_call_output": frozenset({"type", "call_id", "output", "id", "status"}),
+    "function_call": frozenset(
+        {"type", "call_id", "name", "namespace", "arguments", "id", "status"}
+    ),
+    "function_call_output": frozenset(
+        {"type", "call_id", "output", "name", "namespace", "id", "status"}
+    ),
     "reasoning": frozenset({"type", "id", "encrypted_content", "summary", "content", "status"}),
 }
 """Echoable input-item fields the Responses decoder models per item type.
@@ -241,20 +245,23 @@ INPUT, so every field this gateway's own output items carry must decode.
 Codex echoes assistant messages with ``phase`` and reasoning items with an
 explicit ``content: null`` (both captured live 2026-08-29); the message
 ``phase`` is retained for replay identity and the null reasoning content
-is validated and dropped like its populated form.
+is validated and dropped like its populated form. ``namespace`` on a
+``function_call`` (and the ``name``/``namespace`` pair on a
+``function_call_output``) attributes the call to its declaring nested tool
+tree and round-trips verbatim: the provider rejects a namespaced call
+replayed without it ("Missing namespace for function_call ..."), which
+wedges every later turn of the session.
 """
 
 RESPONSES_INPUT_ITEM_FIELDS_REJECTED: dict[str, frozenset[str]] = {
     "message": frozenset(),
-    "function_call": frozenset({"caller", "namespace"}),
-    "function_call_output": frozenset({"caller", "namespace", "name"}),
+    "function_call": frozenset({"caller"}),
+    "function_call_output": frozenset({"caller"}),
     "reasoning": frozenset(),
 }
 """Echoable input-item fields consciously rejected with a named 400.
 
-``caller``/``namespace`` attribute server-tool invocations this gateway does
-not serve, and a ``name`` on a function output duplicates the call linkage
-already carried by ``call_id``.
+``caller`` attributes server-tool invocations this gateway does not serve.
 """
 
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -848,12 +848,19 @@ def _response_input_messages(
                             "provider_item_id": item.id,
                             "provider_output_index": index,
                             "provider_status": item.status,
+                            "provider_namespace": item.namespace,
                         }
                     ),
                 )
             )
         else:
             replayed.append(
-                ReplayedFunctionOutput(index=index, call_id=item.call_id, output=item.output)
+                ReplayedFunctionOutput(
+                    index=index,
+                    call_id=item.call_id,
+                    output=item.output,
+                    name=item.name,
+                    namespace=item.namespace,
+                )
             )
     return responses_input_messages(tuple(replayed))

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -2840,3 +2840,111 @@ def test_service_tier_decodes_on_both_openai_surfaces_and_rejects_unknown_values
         with pytest.raises(OpenAIProtocolError) as captured:
             decoder(payload)
         assert captured.value.detail.param == "service_tier"
+
+
+def test_a_namespaced_function_call_round_trips_its_namespace_verbatim() -> None:
+    """The exact Codex namespaced wire shape reaches the provider unchanged.
+
+    OpenAI rejects a namespaced call replayed without its namespace ("Missing
+    namespace for function_call 'spawn_agent'. It does not exist in the
+    default namespace. Round-trip the model's function_call item with its
+    namespace field included."), and the item is baked into the caller's
+    history, so dropping or rejecting the field wedges every later turn.
+    """
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "message", "role": "user", "content": "spawn a worker"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_x",
+                    "name": "spawn_agent",
+                    "namespace": "collaboration",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_x",
+                    "name": "spawn_agent",
+                    "namespace": "collaboration",
+                    "output": "spawned",
+                },
+            ],
+        }
+    )
+    call = decoded.request.messages[1].tool_calls[0]
+    assert call.provider_namespace == "collaboration"
+    tool_message = decoded.request.messages[2]
+    assert tool_message.provider_tool_name == "spawn_agent"
+    assert tool_message.provider_tool_namespace == "collaboration"
+
+    payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[-2] == {
+        "type": "function_call",
+        "call_id": "call_x",
+        "name": "spawn_agent",
+        "arguments": "{}",
+        "namespace": "collaboration",
+    }
+    assert payload_input[-1] == {
+        "type": "function_call_output",
+        "call_id": "call_x",
+        "output": "spawned",
+        "name": "spawn_agent",
+        "namespace": "collaboration",
+    }
+
+
+def test_a_namespace_free_function_call_keeps_its_exact_wire_shape() -> None:
+    """Histories from before namespaced tools re-emit byte-identically."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "function_call", "call_id": "call_p", "name": "f", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "call_p", "output": "ok"},
+            ],
+        }
+    )
+    assert decoded.request.messages[0].tool_calls[0].provider_namespace is None
+    assert decoded.request.messages[1].provider_tool_name is None
+    assert decoded.request.messages[1].provider_tool_namespace is None
+    payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[-2] == {
+        "type": "function_call",
+        "call_id": "call_p",
+        "name": "f",
+        "arguments": "{}",
+    }
+    assert payload_input[-1] == {
+        "type": "function_call_output",
+        "call_id": "call_p",
+        "output": "ok",
+    }
+
+
+def test_a_malformed_function_call_namespace_names_its_field() -> None:
+    """An unusable namespace value reports its own input location."""
+    with pytest.raises(OpenAIProtocolError) as error:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_x",
+                        "name": "spawn_agent",
+                        "namespace": "",
+                        "arguments": "{}",
+                    }
+                ],
+            }
+        )
+    assert error.value.detail.param == "input.0.namespace"

--- a/exp/runtime/openai_protocol/responses_input.py
+++ b/exp/runtime/openai_protocol/responses_input.py
@@ -51,11 +51,17 @@ class ReplayedNativeItem:
 
 @dataclass(frozen=True)
 class ReplayedFunctionOutput:
-    """One validated function result."""
+    """One validated function result.
+
+    ``name`` and ``namespace`` are the optional tool attribution Codex
+    serializes on outputs of namespaced calls, re-emitted verbatim.
+    """
 
     index: int
     call_id: str
     output: str
+    name: str | None = None
+    namespace: str | None = None
 
 
 ReplayedInput = (
@@ -151,7 +157,13 @@ def responses_input_messages(value: str | tuple[ReplayedInput, ...]) -> tuple[Ga
         elif isinstance(item, ReplayedFunctionOutput):
             flush_segment()
             messages.append(
-                GatewayMessage(role="tool", content=item.output, tool_call_id=item.call_id)
+                GatewayMessage(
+                    role="tool",
+                    content=item.output,
+                    tool_call_id=item.call_id,
+                    provider_tool_name=item.name,
+                    provider_tool_namespace=item.namespace,
+                )
             )
         else:
             segment.append(item)

--- a/exp/runtime/openai_protocol/state.py
+++ b/exp/runtime/openai_protocol/state.py
@@ -397,21 +397,27 @@ class ContinuationState(ContractModel):
                     and call.provider_item_id is None
                     and call.provider_output_index is None
                     and call.provider_status is None
+                    and call.provider_namespace is None
                 ):
                     continue
-                retained_calls.append(
-                    {
-                        "call_id": call.call_id,
-                        "raw_arguments": call.raw_arguments,
-                        "provider_item_id": call.provider_item_id,
-                        "provider_output_index": call.provider_output_index,
-                        "provider_status": call.provider_status,
-                    }
-                )
+                retained_call: dict[str, object] = {
+                    "call_id": call.call_id,
+                    "raw_arguments": call.raw_arguments,
+                    "provider_item_id": call.provider_item_id,
+                    "provider_output_index": call.provider_output_index,
+                    "provider_status": call.provider_status,
+                }
+                if call.provider_namespace is not None:
+                    retained_call["provider_namespace"] = call.provider_namespace
+                retained_calls.append(retained_call)
             if retained_calls:
                 authority["tool_calls"] = retained_calls
             if message.tool_is_error:
                 authority["tool_is_error"] = True
+            if message.provider_tool_name is not None:
+                authority["provider_tool_name"] = message.provider_tool_name
+            if message.provider_tool_namespace is not None:
+                authority["provider_tool_namespace"] = message.provider_tool_namespace
             if len(authority) > 1:
                 replay_authority.append(authority)
         if replay_authority:

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -574,15 +574,22 @@ class _ResponseFunctionCall(_WireModel):
     """Completed Responses function call included as assistant history.
 
     ``id`` and ``status`` arrive on verbatim echoes of prior output items
-    and are accepted and dropped; ``call_id`` is the linkage that matters.
+    and are retained for exact replay; ``call_id`` is the linkage that
+    matters. ``namespace`` attributes the call to the nested tool tree that
+    declared it (the ``namespace`` declarations carried by
+    ``GatewayProviderNativeTool``) and must round-trip verbatim: the
+    provider rejects a namespaced call replayed without it ("Missing
+    namespace for function_call .... Round-trip the model's function_call
+    item with its namespace field included."), which wedges every later
+    turn of the session because the item is baked into history.
     """
 
     type: Literal["function_call"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     call_id: str = Field(min_length=1, max_length=256)
     name: str = Field(min_length=1, max_length=256)
+    namespace: str | None = Field(default=None, min_length=1, max_length=256)
     arguments: str = Field(max_length=4_000_000)
-    id: str | None = Field(default=None, min_length=1, max_length=256)
     status: _EchoedItemStatus | None = None
 
 
@@ -591,10 +598,15 @@ class _ResponseFunctionOutput(_WireModel):
 
     ``id`` and ``status`` arrive when a stored turn's input items are
     re-listed and echoed; accepted and dropped like the other echo markers.
+    ``name`` and ``namespace`` attribute the result to a namespaced tool
+    (Codex serializes both on outputs of namespaced calls) and round-trip
+    verbatim like the sibling ``function_call`` namespace.
     """
 
     type: Literal["function_call_output"]
     call_id: str = Field(min_length=1, max_length=256)
+    name: str | None = Field(default=None, min_length=1, max_length=256)
+    namespace: str | None = Field(default=None, min_length=1, max_length=256)
     output: str
     id: str | None = Field(default=None, min_length=1, max_length=256)
     status: _EchoedItemStatus | None = None
@@ -700,13 +712,20 @@ class _AdditionalToolsItem(_WireModel):
 
 
 class _CustomToolCall(_WireModel):
-    """One freeform (custom) tool call echoed as assistant history."""
+    """One freeform (custom) tool call echoed as assistant history.
+
+    ``namespace`` attributes the call to its declaring nested tool tree and
+    forwards verbatim with the rest of the raw item (the whole item replays
+    byte-for-byte on native Responses rungs), mirroring the typed
+    ``function_call`` namespace round trip.
+    """
 
     type: Literal["custom_tool_call"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     status: _EchoedItemStatus | None = None
     call_id: str = Field(min_length=1, max_length=256)
     name: str = Field(min_length=1, max_length=256)
+    namespace: str | None = Field(default=None, min_length=1, max_length=256)
     input: str = Field(max_length=4_000_000)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.30,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.31,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.30"
+version = "0.3.31"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Live bug

OpenAI's Responses API now emits NAMESPACED function calls (Codex's agent tools, e.g. `spawn_agent` in the `collaboration` namespace, declared through the `namespace` tool tree from #710). The gateway dropped the item-level `namespace` at two independent seams, and OpenAI then rejects the next turn with exactly:

> Missing namespace for function_call 'spawn_agent'. It does not exist in the default namespace. Round-trip the model's function_call item with its namespace field included.

The item is baked into the caller's history, so every subsequent turn of the session fails: the same wedged-session class as the tool_result-image fix (#774).

Two seams, both fixed here:

1. **Response side (Rust, the live wedge).** The client-bound stream is synthesized from parsed events, not passed through: `dialects/openai.rs` did not capture `namespace` from the provider's `function_call` / `custom_tool_call` output items, so the caller never received it, echoed the item without it, and the provider rejected the replay. The namespace now rides `ToolCallStarted` / `CompletedToolCall`, re-emits on the synthesized `response.output_item.added` / `.done` items and the non-streamed body, is identity-checked at item completion (a changed namespace is a malformed stream), and joins the continuation retention payload.
2. **Request/replay side (Python).** `_ResponseFunctionCall` had no `namespace` field and `_WireModel` is `extra="forbid"`, so a caller that DID replay the namespace got a 400 (`Invalid value for 'input.N.namespace'`) - the same wedge from the other direction (`namespace` on `function_call`/`function_call_output` was in `RESPONSES_INPUT_ITEM_FIELDS_REJECTED`, a decision that predates namespaced agent tools). The decoder now accepts it, and the outbound Responses payload rebuilds it verbatim.

## Canonical carrier design

- The call-side namespace lands on **`ToolCall.provider_namespace`** (`exp/common/models/model.py`), an excluded replay field exactly like `provider_item_id` / `provider_status`: absent from serialization so immutable artifacts and pre-existing request digests are byte-identical, re-emitted verbatim by `responses_items`, and folded into replay identity **only when present** (`replay_identity.py`, `state.py` size fold, guardrail `has_authority`). Two replays differing only by namespace hash differently; namespace-free requests keep their exact digests (pinned by tests).
- The output-side attribution lands on **`GatewayMessage.provider_tool_name` / `provider_tool_namespace`** (tool-role-only, excluded, same replay-identity treatment). Codex's protocol serializes optional `name` + `namespace` on `function_call_output` items of namespaced calls (openai/codex `codex-rs/protocol/src/models.rs`, `ResponseItem::FunctionCallOutput`), so **yes, `function_call_output` needed the field** and both round-trip verbatim.
- `custom_tool_call` also carries `namespace` on Codex's wire; the typed wire model accepts it and the raw item already forwards byte-for-byte (native-item path), with the Rust parser/encoder/retention now preserving it on that item type too. `custom_tool_call_output` has no namespace on Codex's wire (only optional `name`) and is unchanged.
- Item-level namespace vs #710's declaration-level `namespace` tool type: the declarations (`GatewayProviderNativeTool`) define the tree; this PR adds the per-item linkage back to it. Cross-referenced in the docstrings.
- Verbatim round-trip contract throughout: present stays present (identical bytes), absent stays absent, so pre-namespace histories re-emit byte-identically (pinned).

## Continuation path

The `previous_response_id` path does NOT preserve output items verbatim: it re-models tool calls through the Rust retention boundary (`responses_retention.rs::remember_argument`) into canonical `ToolCall`s (`native_responses.py`). That boundary now carries `namespace` end to end (crate emits it, `remember_turn` validates and retains it, the rebuilt input item re-emits it), covered by a remember-and-replay test.

## Manifest

`namespace` (both items) and `name` (`function_call_output`) moved from `RESPONSES_INPUT_ITEM_FIELDS_REJECTED` to ACCEPTED with the rationale recorded; `caller` stays rejected (server-tool attribution this gateway does not serve).

## Not python-only: crate 0.3.31

The task brief expected the Rust relay to pass output through; verification showed the opposite (the client stream is synthesized by `ResponsesSseEncoder` from parsed events even on native Responses rungs), so the crate change is required for the fix to reach the caller at all. Native bumped 0.3.30 -> 0.3.31 (Cargo.toml, crate pyproject, Cargo.lock, parent pin floor, uv.lock).

## Regression coverage

- Python, driven through the real decode surface (`decode_responses` -> `openai_responses_stream_payload`): the exact wire shape `{"type":"function_call","call_id":"call_x","name":"spawn_agent","namespace":"collaboration","arguments":"{}"}` round-trips verbatim; the `function_call_output` name/namespace pair round-trips; absent-namespace histories re-emit byte-identically; a malformed namespace names its field (`input.0.namespace`).
- Replay identity: namespace-only difference changes `canonical_request_sha256`; namespace-free digest equals the plain serialization (contracts_test.py).
- Continuation: `remember_turn` retains and replays the namespace (typed call + custom native item); coerced namespace fails closed.
- Rust: namespaced stream normalizes with namespace on started/completed events; changed-at-completion is malformed; encoder re-emits on `.added`/`.done` and the non-streamed body; namespace-free item shape unchanged; retention payload carries it.
- End-to-end through the compiled module: a synthetic namespaced provider stream driven through `normalize_stream_fixture` -> `encode_responses_fixture` / `completed_responses_fixture` carries the namespace on every client-visible item.

## Overlap with open PR #780

#780 (image inside `function_call_output`) touches the same regions: `_ResponseFunctionOutput`, `ReplayedFunctionOutput`, the `function_call_output` branch of `responses_items`, and the decode else-branch in `_response_input_messages`. The changes are semantically independent (output shape/content_parts vs name/namespace attribution) but will conflict textually; whichever lands second rebases (mechanical: keep both field additions and both item-emission blocks). This PR also bumps the native crate, so on a crate-version race with other engine PRs, re-pick the next free patch before merge.

## Release train

This PR bumps the native crate (0.3.31), so it rides the next `exp-gateway-native` release train: publish the abi3 wheels via the release workflow, then bump the platform's exact pins (`experiential==X.Y.Z`, `exp-gateway-native`) per the usual checklist. Until that release, the fix serves only from-source checkouts.

## Gates

- `cargo fmt --check`, `cargo clippy --no-default-features --all-targets -- -D warnings`, `cargo test --no-default-features` (166 passed)
- `uv run ruff format`, `uv run ruff check`, `uv run ty check` all clean
- full `uv run pytest -q` green
