### PR TITLE
gateway: raise the per-request image ceiling to the Anthropic API's documented 100

### DIFF
--- a/exp/common/models/content.py
+++ b/exp/common/models/content.py
@@ -35,8 +35,16 @@ IMAGE_MEDIA_TYPES: dict[str, ImageMediaType] = {
 MAXIMUM_IMAGE_BASE64_BYTES = 5 * 1024 * 1024
 """Largest encoded image this gateway forwards (the narrowest provider cap)."""
 
-MAXIMUM_IMAGES_PER_REQUEST = 20
-"""Largest number of images one request may carry across all its messages."""
+MAXIMUM_IMAGES_PER_REQUEST = 100
+"""Largest number of images one request may carry across all its messages.
+
+The Anthropic Messages API accepts 100 images per request on 200k-context
+models (20 is claude.ai's UI limit, not the API's), and OpenAI documents no
+per-request image count. Screenshots accumulate in an agent session's
+history, so a ceiling below the provider's own cap wedges the session: the
+images are baked into the transcript and every replay re-trips the ceiling.
+Bedrock Converse's narrower 20-image cap surfaces as a provider error on
+Bedrock rungs, like the narrower Bedrock Nova video limit."""
 
 VideoMediaType = Literal[
     "video/mp4",

--- a/exp/common/models/content_test.py
+++ b/exp/common/models/content_test.py
@@ -10,6 +10,7 @@ from exp.common.models.content import (
     MAXIMUM_AUDIOS_PER_REQUEST,
     MAXIMUM_DOCUMENT_BASE64_BYTES,
     MAXIMUM_IMAGE_BASE64_BYTES,
+    MAXIMUM_IMAGES_PER_REQUEST,
     MAXIMUM_VIDEO_BASE64_BYTES,
     AudioContentPart,
     DocumentContentPart,
@@ -427,6 +428,20 @@ def test_attachment_ceilings_count_each_kind_separately() -> None:
         require_attachment_ceilings(
             [DocumentContentPart(url="https://example.com/a.pdf") for _ in range(6)]
         )
+
+
+def test_the_image_ceiling_matches_the_provider_api_not_a_ui_limit() -> None:
+    """A long agent session's screenshot history stays under the ceiling.
+
+    The Anthropic API accepts 100 images per request (20 is claude.ai's UI
+    limit); screenshots are baked into the transcript, so a lower gateway
+    ceiling wedges the session because every replay re-trips it.
+    """
+    image = ImageContentPart(media_type="image/png", data=_PNG_BASE64)
+    require_attachment_ceilings([image] * 21)
+    require_attachment_ceilings([image] * MAXIMUM_IMAGES_PER_REQUEST)
+    with pytest.raises(ValueError, match="at most 100 images"):
+        require_attachment_ceilings([image] * (MAXIMUM_IMAGES_PER_REQUEST + 1))
 
 
 def test_audio_clips_share_one_request_wide_encoded_budget() -> None:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1523,3 +1523,24 @@ def test_audio_block_is_rejected_with_a_surface_hint() -> None:
         assert "audio blocks are not supported" in excinfo.value.detail.message
         assert "input_audio" not in excinfo.value.detail.message
         assert "Chat Completions" in excinfo.value.detail.message
+
+
+def test_a_screenshot_history_beyond_twenty_images_still_decodes() -> None:
+    """A long agent session's image history clears validation and route shaping.
+
+    Screenshots are baked into the transcript, so a per-request image ceiling
+    the history can grow into wedges the session: the live incident hit
+    "a request carries at most 20 images" once its screenshot history passed
+    20, and every replay failed forever. The Anthropic API itself accepts 100
+    images per request, so 21 must decode; beyond the API ceiling the named
+    rejection stays (the provider would refuse anyway, less clearly).
+    """
+    image_block: dict[str, object] = {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": _PNG_BASE64},
+    }
+    decoded = decode_messages(_body(messages=[{"role": "user", "content": [image_block] * 21}]))
+    assert len(decoded.request.images) == 21
+
+    with pytest.raises(OpenAIProtocolError, match="at most 100 images"):
+        decode_messages(_body(messages=[{"role": "user", "content": [image_block] * 101}]))


### PR DESCRIPTION
## Live bug

A long Claude Code design session through the gateway wedged on:

> 400 a request carries at most 20 images. (param: body)

once its screenshot HISTORY exceeded 20 images. The images are baked into the transcript, so every replay re-trips the ceiling and the session is dead forever: the same wedged-session class as the tool_result-image fix (#774) and the function_call namespace fix (#784).

## Fix

`MAXIMUM_IMAGES_PER_REQUEST` raised 20 -> 100 in `exp/common/models/content.py`. 20 was claude.ai's UI limit, not the API's. Anthropic's vision documentation (platform.claude.com/docs/en/build-with-claude/vision, "Request limits") states:

> The maximum number of images per message or request is: 20 per message on claude.ai. 100 per request on the API, for models with a 200k-token context window. 600 per request on the API, for all other models.

100 (the 200k-context API cap, i.e. the binding one for the wedged sessions) is the new gateway ceiling; the reject beyond it stays because the provider would refuse anyway and the gateway's named error is clearer.

Bedrock Converse documents a narrower 20-image-per-request cap (AWS Converse API reference: "You can include up to 20 images. Each image's size, height, and width must be no more than 3.75 MB, 8,000 px, and 8,000 px"). That narrower wire cap now surfaces as a provider error on Bedrock rungs, exactly the precedent the video ceiling already records (Gemini's 10 is the gateway ceiling; Bedrock Nova's 1-video limit surfaces as a provider error).

## The other ceilings, checked against provider docs

- `MAXIMUM_VIDEOS_PER_REQUEST = 10`: Gemini's documented per-request video cap; already cited in the docstring. Unchanged.
- `MAXIMUM_DOCUMENTS_PER_REQUEST = 5`: Bedrock Converse's documented cap ("up to five documents... no more than 4.5 MB"), already cited. Unchanged; note it shares the history-wedge hazard in principle (a 6-document history on a non-Bedrock route), but there is no owner incident and no wider documented cap that is clearly safe across wires, so it stays a recorded decision rather than a silent change.
- `MAXIMUM_AUDIOS_PER_REQUEST = 10`: explicitly a gateway-invented bound (no audio wire documents a count), already documented as such. Unchanged.

## Design observation (follow-up, not this PR)

Any per-request ceiling that HISTORY can grow into is a session-wedge machine by construction: the caller cannot remove what is baked into the transcript. The durable pattern is degrade-oldest-with-disclosure for history-borne attachments (the #774 placeholder-with-disclosure precedent) and reject only what a caller can re-send. Two owner incidents motivate it: the #774 tool_result-image class and this image cap. That is a route-shaping change (per-kind degrade policy over history position), deliberately not folded into this constant fix.

## Regression coverage

- `content_test.py`: 21 images pass `require_attachment_ceilings` (the old wedge), 100 passes, 101 rejects with the named ceiling message.
- `anthropic_protocol/requests_test.py`: driven through the real `/v1/messages` decode surface, a 21-image history decodes and reaches the canonical request (route shaping consumes it from there); 101 still rejects with "at most 100 images".

## Gates

- `uv run ruff format`, `uv run ruff check`, `uv run ty check` all clean
- full `uv run pytest -q` green
- Python-only; no native crate change.
