### PR TITLE
release: bump experiential to 0.7.33 (native 0.3.31)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.32"
+version = "0.7.33"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.32"
+version = "0.7.33"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only, for the owner-approved release of Experiential 0.7.33 with native 0.3.31: `pyproject.toml` version and the matching `uv.lock` entry. No other files change; main already carries native crate 0.3.31 and the `>=0.3.31,<0.4` floor (#784, #783). The release itself is cut as `v0.7.33` on main after this merges, which fires the python-package publish workflow for both `experiential==0.7.33` and the `exp-gateway-native==0.3.31` wheel matrix (0.3.31 is not yet on PyPI).