### PR TITLE
gateway: replay plaintext reasoning_content on exposure-gated rungs (0.7.34)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -306,6 +306,19 @@ Anthropic message object. Completed streams stop with `end_turn` (`tool_use` whe
 present) and token-limited streams with `max_tokens`. The Anthropic protocol defines no
 idempotency header, so this surface never joins the keyed replay stores.
 
+Exposure-gated reasoning rungs (Tencent Hunyuan, DeepSeek — rows the catalog stamps
+`reasoning_output_exposed`) return the model's plaintext `reasoning_content` on every non-tool
+Chat turn, and the caller may echo that text back verbatim on later assistant turns: the
+decoder carries it as an `exposed_reasoning_content` block, route narrowing forwards it only to
+rungs that expose their reasoning (a route with no exposing rung rejects it by name as
+`messages.reasoning_content`; a mixed waterfall prefers the exposing rung and discloses the drop
+on the others), and the payload builder writes it back onto the wire unchanged. The provider's
+own API accepts and does not validate that text, so it is ordinary caller-owned history, exactly
+like a prior assistant `content`. A TOOL turn's reasoning still round-trips only as the sealed,
+rung-pinned carrier (`x-experiential-hunyuan-reasoning-v1:`), which the same decoder recognizes
+by prefix. This is what lets a Terminus-style loop (commands parsed from assistant text, output
+fed back as user messages) and Harbor's interleaved-thinking replay both preserve thinking.
+
 Route admission preserves caller capabilities in three verbatim-preference layers before any
 coercion: operationally dead rungs are skipped (`dispatchable_route_profiles`), generation
 controls narrow the waterfall to the rungs that preserve every exact value

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -28,6 +28,9 @@ from exp.runtime.gateway.reasoning_blocks import (
     EncryptedReasoningBlock as EncryptedReasoningBlock,
 )
 from exp.runtime.gateway.reasoning_blocks import (
+    ExposedReasoningContentBlock as ExposedReasoningContentBlock,
+)
+from exp.runtime.gateway.reasoning_blocks import (
     OpaqueReasoningContentBlock as OpaqueReasoningContentBlock,
 )
 from exp.runtime.gateway.reasoning_blocks import (

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -495,14 +495,15 @@ def test_fireworks_carrier_round_trip_rejects_tamper_and_credential_rotation(
     assert "reasoning_content" not in rotated_messages[1]
 
 
-def test_hunyuan_exposes_plaintext_reasoning_and_round_trips_only_as_carrier(
+def test_hunyuan_tool_turn_reasoning_round_trips_as_a_sealed_carrier(
     tmp_path: Path,
 ) -> None:
-    """Hunyuan returns plaintext reasoning for display yet round-trips it sealed.
+    """A Hunyuan TOOL turn round-trips its reasoning as the sealed carrier.
 
     The rung is marked as an exposed-plaintext reasoning route on the wire (so
-    the data plane returns ``reasoning_content`` to the caller), while the
-    tool-loop round-trip token stays the domain-separated opaque carrier: a
+    the data plane returns ``reasoning_content`` to the caller on plain turns,
+    which replay as plaintext — see the plain-turn test), while a tool turn's
+    round-trip token stays the domain-separated opaque carrier: a
     second replica unseals the exact turn and forwards the plaintext upstream,
     the Fireworks-only ``reasoning_history`` wire flag never appears, and a
     tampered turn fails closed.
@@ -602,6 +603,150 @@ def test_hunyuan_exposes_plaintext_reasoning_and_round_trips_only_as_carrier(
     with pytest.raises(NativeBridgeError) as modified:
         _admit(replica, raw_key, json.dumps(modified_turn))
     assert json.loads(modified.value.public_error_json)["param"] == "messages.reasoning_content"
+
+
+def test_hunyuan_plain_turn_plaintext_reasoning_replays_verbatim(tmp_path: Path) -> None:
+    """A Terminus-shaped loop round-trips the plaintext the rung itself returned.
+
+    Terminus-2 parses commands out of assistant TEXT and feeds the output back
+    as a user message, so every turn is a non-tool turn: the exposing rung
+    returns plaintext ``reasoning_content`` and the caller echoes it. The
+    provider's wire accepts that text verbatim and validates nothing about it,
+    so the gateway forwards it to the exposing rung — no carrier, no route
+    pin, no disclosure.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    thinking = "The user wants a directory listing; ls is the command."
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "List the files."},
+                {
+                    "role": "assistant",
+                    "content": '{"command": "ls"}',
+                    "reasoning_content": thinking,
+                },
+                {"role": "user", "content": "a.txt b.txt"},
+            ],
+        }
+    )
+    admitted = _admit(control, raw_key, body)
+    route = cast("list[JsonObject]", admitted["route"])
+    payload = cast("JsonObject", route[0]["upstream_payload"])
+    messages = cast("list[JsonObject]", payload["messages"])
+    assert messages[1]["reasoning_content"] == thinking
+    assert admitted["route_reason"] != "reasoning_continuation"
+    assert "reasoning_history" not in payload
+    assert admitted.get("ignored_parameters", []) == []
+
+
+def test_hunyuan_mixed_carrier_and_plaintext_history_round_trips(tmp_path: Path) -> None:
+    """Harbor with interleaved thinking echoes BOTH shapes and both replay.
+
+    A tool turn carries the sealed carrier (unsealed to its plaintext and
+    pinned to the issuing rung); a later plain turn carries the plaintext the
+    rung returned. One history, both forwarded verbatim.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    route_sha256 = initial["hunyuan_reasoning_route_sha256"]
+    hidden = "reason about the lookup privately"
+    sealed = json.loads(
+        control.seal_reasoning_content(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "route_depth": initial["route_depth"],
+                    "route_sha256": route_sha256,
+                    "content": hidden,
+                    "assistant_content": None,
+                    "tool_calls": [
+                        {"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}
+                    ],
+                }
+            )
+        )
+    )["carrier"]
+    control.settle(
+        json.dumps(
+            {
+                "request_id": initial["request_id"],
+                "attempt_id": initial["attempt_id"],
+                "outcome": "completed",
+                "usage": {"input_tokens": 3, "output_tokens": 2},
+                "tool_names": ["lookup"],
+                "failure": None,
+            }
+        )
+    )
+    plain = "now summarize what the tool said"
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": sealed,
+                    "tool_calls": [
+                        {
+                            "id": "call-one",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+                {"role": "assistant", "content": "It said done.", "reasoning_content": plain},
+                {"role": "user", "content": "thanks, and now?"},
+            ],
+        }
+    )
+    admitted = _admit(control, raw_key, body)
+    route = cast("list[JsonObject]", admitted["route"])
+    payload = cast("JsonObject", route[0]["upstream_payload"])
+    messages = cast("list[JsonObject]", payload["messages"])
+    # The carrier precedes the latest user turn, so it is stale history and
+    # is stripped exactly as before; the plaintext plain turn replays.
+    assert "reasoning_content" not in messages[1]
+    assert messages[3]["reasoning_content"] == plain
+
+
+def test_plaintext_reasoning_is_rejected_on_a_route_without_exposure(tmp_path: Path) -> None:
+    """A rung that never issued plaintext reasoning rejects it by name."""
+    _manager, raw_key = _configured_gateway(tmp_path, capabilities=ModelCapabilities())
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    body = json.dumps(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "x", "reasoning_content": "private"},
+                {"role": "user", "content": "again"},
+            ],
+        }
+    )
+    with pytest.raises(NativeBridgeError) as rejected:
+        _admit(control, raw_key, body)
+    assert json.loads(rejected.value.public_error_json)["param"] == "messages.reasoning_content"
 
 
 def test_hunyuan_endpoint_without_exposure_capability_strips_reasoning(

--- a/exp/runtime/gateway/reasoning_blocks.py
+++ b/exp/runtime/gateway/reasoning_blocks.py
@@ -76,11 +76,29 @@ class SealedReasoningContentBlock(ContractModel):
     deployment_hint: str = Field(min_length=1, max_length=256)
 
 
+class ExposedReasoningContentBlock(ContractModel):
+    """Caller-replayed plaintext reasoning for an exposure-gated rung.
+
+    A rung stamped ``reasoning_output_exposed`` (Tencent Hunyuan, DeepSeek)
+    returns the model's reasoning as plaintext ``reasoning_content`` on every
+    non-tool turn; the provider's own wire accepts that text back verbatim on
+    later assistant turns and validates nothing about it. The caller echoing
+    it is therefore ordinary conversation history — no different from prior
+    assistant ``content`` — so it is carried as this block and forwarded only
+    to rungs that expose their reasoning. Tool turns keep the sealed carrier
+    (``SealedReasoningContentBlock``), which additionally pins the issuing rung.
+    """
+
+    kind: Literal["exposed_reasoning_content"] = "exposed_reasoning_content"
+    content: str = Field(min_length=1, max_length=8 * 1024 * 1024)
+
+
 ProviderReasoningBlock = Annotated[
     ThinkingBlock
     | RedactedThinkingBlock
     | EncryptedReasoningBlock
     | OpaqueReasoningContentBlock
-    | SealedReasoningContentBlock,
+    | SealedReasoningContentBlock
+    | ExposedReasoningContentBlock,
     Field(discriminator="kind"),
 ]

--- a/exp/runtime/models/providers/generation_route_compat.py
+++ b/exp/runtime/models/providers/generation_route_compat.py
@@ -51,7 +51,9 @@ def compatible_generation_parameter_profile_indexes(
             rejections.append(exc)
             continue
         serviceable.append(index)
-        if _honors_requested_sampling(request, provider):
+        if _honors_requested_sampling(request, provider) and _carries_exposed_reasoning(
+            profile, request
+        ):
             exact.append(index)
     if exact:
         return tuple(exact)
@@ -75,3 +77,20 @@ def _honors_requested_sampling(request: GatewayRequest, provider_request: Gatewa
     if request.top_p is not None and provider_request.top_p is None:
         return False
     return not (request.top_k is not None and provider_request.top_k is None)
+
+
+def _carries_exposed_reasoning(profile: GatewayWireProfile, request: GatewayRequest) -> bool:
+    """Return whether a rung forwards the request's plaintext reasoning history.
+
+    Replayed plaintext ``reasoning_content`` reaches the provider only on an
+    exposure-gated rung; any other rung serves the turn by dropping it (a
+    disclosed drop), so it is only a fallback behind a rung that carries it —
+    the same preference rule sampling controls follow.
+    """
+    if profile.reasoning_output_exposed:
+        return True
+    return not any(
+        block.kind == "exposed_reasoning_content"
+        for message in request.messages
+        for block in message.provider_reasoning
+    )

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -169,6 +169,7 @@ def openai_compatible_stream_payload(
     sampling_requires_reasoning_none: bool = False,
     fireworks_reasoning_route_sha256: str | None = None,
     hunyuan_reasoning_route_sha256: str | None = None,
+    reasoning_output_exposed: bool = False,
     forwards_service_tier: bool = False,
 ) -> JsonObject:
     """Translate one canonical request to streaming Chat Completions JSON.
@@ -183,6 +184,8 @@ def openai_compatible_stream_payload(
         supports_reasoning: Whether this exact model accepts a reasoning control.
         reasoning_wire_format: Provider field used for normalized reasoning effort.
         reasoning_effort: Optional catalog-pinned reasoning effort.
+        reasoning_output_exposed: Whether this rung replays the caller's plaintext
+            ``reasoning_content`` history verbatim (exposure-gated Tencent/DeepSeek rung).
 
     Returns:
         Chat Completions request that always asks the provider for terminal usage.
@@ -201,6 +204,7 @@ def openai_compatible_stream_payload(
             openai_chat_message(
                 message,
                 reasoning_route_sha256=reasoning_route_sha256,
+                reasoning_output_exposed=reasoning_output_exposed,
             )
             for message in messages
         ],

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -264,6 +264,7 @@ def dialect_stream_payload(
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
             fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
             hunyuan_reasoning_route_sha256=profile.hunyuan_reasoning_route_sha256,
+            reasoning_output_exposed=profile.reasoning_output_exposed,
             forwards_service_tier=profile.billing_customer_managed,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")
@@ -726,6 +727,32 @@ def route_generation_parameter_requests(
 
     # Opaque provider-reasoning carriers replay only on the one wire that
     # issued them, so a mixed waterfall is rejected instead of dropping them.
+    # Plaintext reasoning an exposure-gated rung itself returned (Tencent/
+    # DeepSeek) replays only to rungs that expose their reasoning: the
+    # provider's wire accepts it verbatim there, and nowhere else was it ever
+    # issued. A route with no exposing rung rejects by name; a mixed waterfall
+    # keeps it on the exposing rungs and discloses the drop on the others.
+    exposed_reasoning_present = any(
+        block.kind == "exposed_reasoning_content"
+        for message in request.messages
+        for block in message.provider_reasoning
+    )
+    if exposed_reasoning_present:
+        if not any(profile.reasoning_output_exposed for profile in profiles):
+            raise ProviderParameterError(
+                message=(
+                    "The parameter 'messages.reasoning_content' carries plaintext reasoning, "
+                    "which only a model that exposes its reasoning can replay. Remove the "
+                    "field or choose a reasoning-exposed model alias."
+                ),
+                param="messages.reasoning_content",
+                code="unsupported_parameter",
+            )
+        if not all(profile.reasoning_output_exposed for profile in profiles):
+            ignore(
+                "messages.reasoning_content",
+                "messages.reasoning_content->dropped(unsupported_by_provider)",
+            )
     anthropic_reasoning_present = request.provider_thinking_config is not None or any(
         block.kind in {"thinking", "redacted_thinking"}
         for message in request.messages

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -15,6 +15,7 @@ from exp.common.models.content import (
 )
 from exp.common.models.model import ReasoningEffort, ToolCall
 from exp.runtime.gateway.contracts import (
+    ExposedReasoningContentBlock,
     GatewayApiSurface,
     GatewayMessage,
     GatewayNamedToolChoice,
@@ -3687,3 +3688,94 @@ def test_narrowing_surfaces_the_first_rung_rejection_not_the_route_shape() -> No
     with pytest.raises(ProviderParameterError) as reordered:
         compatible_generation_parameter_profile_indexes((fallback, anthropic), request)
     assert reordered.value.param == "thinking"
+
+
+def _exposed_reasoning_request(
+    surface: GatewayApiSurface = GatewayApiSurface.CHAT_COMPLETIONS,
+) -> GatewayRequest:
+    """A Terminus-shaped loop: plaintext reasoning on a prior non-tool assistant turn."""
+    return GatewayRequest(
+        surface=surface,
+        messages=(
+            GatewayMessage(role="user", content="run ls"),
+            GatewayMessage(
+                role="assistant",
+                content='{"command": "ls"}',
+                provider_reasoning=(
+                    ExposedReasoningContentBlock(content="The user wants a directory listing."),
+                ),
+            ),
+            GatewayMessage(role="user", content="a.txt b.txt"),
+        ),
+        stream=True,
+    )
+
+
+def _exposed_profile(
+    *, exposed: bool, url: str = "https://tokenhub-intl.tencentcloudmaas.com/v1"
+) -> GatewayWireProfile:
+    return GatewayWireProfile(
+        dialect="openai_compatible",
+        url=url,
+        model_id="hy4-preview",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_output_exposed=exposed,
+    )
+
+
+def test_plaintext_reasoning_replays_only_on_an_exposing_rung() -> None:
+    """The exposing rung forwards the caller's plaintext verbatim; others omit it."""
+    request = _exposed_reasoning_request()
+    forwarded = openai_compatible_stream_payload(
+        "hy4-preview", request, reasoning_output_exposed=True
+    )
+    messages = forwarded["messages"]
+    assert isinstance(messages, list)
+    assert messages[1]["reasoning_content"] == "The user wants a directory listing."
+    omitted = openai_compatible_stream_payload("hy4-preview", request)
+    omitted_messages = omitted["messages"]
+    assert isinstance(omitted_messages, list)
+    assert "reasoning_content" not in omitted_messages[1]
+    # Other wires drop the block instead of raising; narrowing disclosed it.
+    anthropic = anthropic_messages_stream_payload("claude-haiku-4-5", request)
+    anthropic_messages = anthropic["messages"]
+    assert isinstance(anthropic_messages, list)
+    assert anthropic_messages[1]["content"] == [{"type": "text", "text": '{"command": "ls"}'}]
+
+
+def test_plaintext_reasoning_route_gate_rejects_discloses_or_forwards() -> None:
+    """No exposing rung -> named 400; mixed -> disclosed drop; all exposing -> silent."""
+    request = _exposed_reasoning_request()
+    with pytest.raises(ProviderParameterError) as rejected:
+        route_generation_parameter_requests((_exposed_profile(exposed=False),), request)
+    assert rejected.value.param == "messages.reasoning_content"
+
+    public, _provider = route_generation_parameter_requests(
+        (
+            _exposed_profile(exposed=True),
+            _exposed_profile(exposed=False, url="https://openrouter.test/v1"),
+        ),
+        request,
+    )
+    assert (
+        "messages.reasoning_content->dropped(unsupported_by_provider)" in public.ignored_parameters
+    )
+
+    public, _provider = route_generation_parameter_requests(
+        (_exposed_profile(exposed=True),), request
+    )
+    assert public.ignored_parameters == ()
+
+
+def test_plaintext_reasoning_prefers_the_exposing_rung_on_a_mixed_waterfall() -> None:
+    """A rung that carries the reasoning is exact; a rung that would drop it is a fallback."""
+    request = _exposed_reasoning_request()
+    profiles = (
+        _exposed_profile(exposed=False, url="https://openrouter.test/v1"),
+        _exposed_profile(exposed=True),
+    )
+    assert compatible_generation_parameter_profile_indexes(profiles, request) == (1,)
+    # Without plaintext history both rungs are exact and the order is preserved.
+    plain = request.model_copy(update={"messages": (GatewayMessage(role="user", content="hi"),)})
+    assert compatible_generation_parameter_profile_indexes(profiles, plain) == (0, 1)

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -69,6 +69,10 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
     items: list[JsonObject] = []
     indexed_items: list[tuple[int, JsonObject]] = []
     for block in message.provider_reasoning:
+        if block.kind == "exposed_reasoning_content":
+            # Plaintext reasoning replays only on an exposure-gated Chat rung;
+            # route narrowing disclosed the drop for this wire.
+            continue
         if block.kind != "encrypted_reasoning":
             # Anthropic thinking cannot replay on the OpenAI wire; route
             # admission rejects the combination before dispatch.
@@ -234,6 +238,10 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         return "assistant", [message.provider_anthropic_block]
     blocks: list[JsonObject] = []
     for reasoning in message.provider_reasoning:
+        if reasoning.kind == "exposed_reasoning_content":
+            # Plaintext reasoning replays only on an exposure-gated Chat rung;
+            # route narrowing disclosed the drop for this wire.
+            continue
         # Thinking blocks lead the assistant turn (the Anthropic contract)
         # and re-emit verbatim: the signature must round-trip byte-exact.
         if reasoning.kind == "thinking":
@@ -337,12 +345,16 @@ def openai_chat_message(
     message: GatewayMessage,
     *,
     reasoning_route_sha256: str | None = None,
+    reasoning_output_exposed: bool = False,
 ) -> JsonObject:
     """Translate one gateway message to OpenAI Chat wire JSON.
 
     ``reasoning_route_sha256`` is the active preserved-thinking route identity
     for this rung (Fireworks or Hunyuan); an unsealed ``reasoning_content``
     block forwards to the provider only when it names that exact route.
+    ``reasoning_output_exposed`` marks a rung whose plaintext reasoning the
+    caller may replay verbatim (an ``exposed_reasoning_content`` block); any
+    other rung omits that block, which route narrowing already disclosed.
     """
     if message.role == "tool":
         return {
@@ -382,6 +394,10 @@ def openai_chat_message(
         if len(message.provider_reasoning) != 1:
             raise ProviderResponseError("Chat reasoning history requires exactly one carrier")
         block = message.provider_reasoning[0]
+        if block.kind == "exposed_reasoning_content":
+            if reasoning_output_exposed:
+                payload["reasoning_content"] = block.content
+            return payload
         if (
             block.kind != "reasoning_content"
             or reasoning_route_sha256 is None

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -660,6 +660,15 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
             # history and route admission decides which rungs may carry it.
             scheme = scheme_for_carrier(message.reasoning_content)
             if scheme is None:
+                if calls:
+                    # A tool turn's reasoning is only ever issued as the sealed
+                    # carrier that binds it to its calls and issuing rung;
+                    # plaintext here was never ours and would bypass that bond.
+                    raise invalid_field(
+                        param,
+                        f"'{param}' must be a gateway-issued carrier on an assistant "
+                        "tool-call turn.",
+                    )
                 try:
                     provider_reasoning = (
                         ExposedReasoningContentBlock(content=message.reasoning_content),

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -20,6 +20,7 @@ from exp.runtime.gateway.compatibility import (
 )
 from exp.runtime.gateway.contracts import (
     EncryptedReasoningBlock,
+    ExposedReasoningContentBlock,
     GatewayApiSurface,
     GatewayMessage,
     GatewayNamedToolChoice,
@@ -647,21 +648,37 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
             _tool_call(call, f"{prefix}.{message_index}.tool_calls.{call_index}.function.arguments")
             for call_index, call in enumerate(message.history_tool_calls)
         )
-        provider_reasoning: tuple[SealedReasoningContentBlock, ...] = ()
+        provider_reasoning: tuple[
+            SealedReasoningContentBlock | ExposedReasoningContentBlock, ...
+        ] = ()
         if message.reasoning_content is not None:
-            # The scheme is fixed by the carrier's own opaque prefix; raw client
-            # text (no known prefix) matches none and is rejected here. Each
-            # provider's carrier only parses under its own scheme.
+            param = f"{prefix}.{message_index}.reasoning_content"
+            # The scheme is fixed by the carrier's own opaque prefix. A known
+            # prefix MUST parse as that provider's carrier. Text under no known
+            # prefix is the plaintext an exposure-gated rung itself returned on
+            # a non-tool turn (Tencent/DeepSeek): it decodes as caller-owned
+            # history and route admission decides which rungs may carry it.
             scheme = scheme_for_carrier(message.reasoning_content)
-            try:
-                if scheme is None:
-                    raise ValueError("reasoning_content is not a gateway-issued carrier")
-                provider_reasoning = (
-                    parse_reasoning_content_carrier(message.reasoning_content, scheme=scheme),
-                )
-            except ValueError as exc:
-                param = f"{prefix}.{message_index}.reasoning_content"
-                raise invalid_field(param, f"'{param}' must be a gateway-issued carrier.") from exc
+            if scheme is None:
+                try:
+                    provider_reasoning = (
+                        ExposedReasoningContentBlock(content=message.reasoning_content),
+                    )
+                except ValidationError as exc:
+                    raise invalid_field(
+                        param,
+                        f"'{param}' must be non-empty plaintext reasoning within the size bound "
+                        "or a gateway-issued carrier.",
+                    ) from exc
+            else:
+                try:
+                    provider_reasoning = (
+                        parse_reasoning_content_carrier(message.reasoning_content, scheme=scheme),
+                    )
+                except ValueError as exc:
+                    raise invalid_field(
+                        param, f"'{param}' must be a gateway-issued carrier."
+                    ) from exc
         content, content_parts = message_content(
             message.content, f"{prefix}.{message_index}.content"
         )

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -413,10 +413,45 @@ def test_chat_decoder_rejects_duplicate_assistant_tool_call_ids() -> None:
     assert captured.value.detail.param == "messages.0"
 
 
+def test_chat_decoder_accepts_plaintext_reasoning_as_exposed_history() -> None:
+    """Plaintext ``reasoning_content`` decodes as caller-owned exposed history.
+
+    An exposure-gated rung (Tencent/DeepSeek) returns plaintext reasoning on
+    every non-tool turn; a Terminus/Harbor loop echoes it back verbatim. The
+    decoder carries it as an ``exposed_reasoning_content`` block — route
+    admission, not the decoder, decides which rungs may replay it.
+    """
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "run ls"},
+                {
+                    "role": "assistant",
+                    "content": '{"command": "ls"}',
+                    "reasoning_content": "The user wants a directory listing.",
+                },
+                {"role": "user", "content": "a.txt b.txt"},
+            ],
+        }
+    )
+    block = decoded.request.messages[1].provider_reasoning[0]
+    assert block.kind == "exposed_reasoning_content"
+    assert block.content == "The user wants a directory listing."
+    # An empty string is not reasoning; it names its field.
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "assistant", "content": "x", "reasoning_content": ""}],
+            }
+        )
+    assert raised.value.detail.param == "messages.0.reasoning_content"
+
+
 @pytest.mark.parametrize(
     "reasoning_content",
     (
-        "raw provider reasoning",
         FIREWORKS_REASONING_CONTENT_PREFIX,
         f"{FIREWORKS_REASONING_CONTENT_PREFIX}not-base64:payload",
     ),
@@ -424,7 +459,7 @@ def test_chat_decoder_rejects_duplicate_assistant_tool_call_ids() -> None:
 def test_chat_decoder_rejects_unbound_or_malformed_reasoning_content(
     reasoning_content: str,
 ) -> None:
-    """Public Chat input accepts only a bounded gateway-issued carrier."""
+    """A value under a known carrier prefix must parse as that carrier."""
     with pytest.raises(OpenAIProtocolError) as raised:
         decode_chat(
             {

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -438,6 +438,22 @@ def test_chat_decoder_accepts_plaintext_reasoning_as_exposed_history() -> None:
     block = decoded.request.messages[1].provider_reasoning[0]
     assert block.kind == "exposed_reasoning_content"
     assert block.content == "The user wants a directory listing."
+    # A reasoning-only assistant turn (content null — an exposed rung's
+    # length-cut thinking turn, echoed exactly as returned) decodes too.
+    reasoning_only = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "think"},
+                {"role": "assistant", "content": None, "reasoning_content": "ran out of room"},
+                {"role": "user", "content": "continue"},
+            ],
+        }
+    )
+    assert reasoning_only.request.messages[1].content is None
+    assert (
+        reasoning_only.request.messages[1].provider_reasoning[0].kind == "exposed_reasoning_content"
+    )
     # A tool-call turn's reasoning is only ever issued as the sealed carrier,
     # so plaintext there was never ours and is rejected by name.
     with pytest.raises(OpenAIProtocolError) as tool_turn:

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -438,6 +438,31 @@ def test_chat_decoder_accepts_plaintext_reasoning_as_exposed_history() -> None:
     block = decoded.request.messages[1].provider_reasoning[0]
     assert block.kind == "exposed_reasoning_content"
     assert block.content == "The user wants a directory listing."
+    # A tool-call turn's reasoning is only ever issued as the sealed carrier,
+    # so plaintext there was never ours and is rejected by name.
+    with pytest.raises(OpenAIProtocolError) as tool_turn:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {"role": "user", "content": "look it up"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "reasoning_content": "plaintext on a tool turn",
+                        "tool_calls": [
+                            {
+                                "id": "call-one",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+                ],
+            }
+        )
+    assert tool_turn.value.detail.param == "messages.1.reasoning_content"
     # An empty string is not reasoning; it names its field.
     with pytest.raises(OpenAIProtocolError) as raised:
         decode_chat(

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -269,8 +269,16 @@ class _Message(_WireModel):
     @model_validator(mode="after")
     def _require_role_fields(self) -> _Message:
         """Require tool linkage and assistant calls on their legal roles."""
-        if self.role == "assistant" and self.content is None and not self.history_tool_calls:
-            raise ValueError("assistant messages need content or tool calls")
+        if (
+            self.role == "assistant"
+            and self.content is None
+            and not self.history_tool_calls
+            and self.reasoning_content is None
+        ):
+            # A reasoning-only assistant turn is a shape the gateway itself
+            # returns (an exposed rung's length-cut thinking turn: content null,
+            # plaintext reasoning_content) and the provider accepts back.
+            raise ValueError("assistant messages need content, tool calls, or reasoning_content")
         if self.role == "tool" and self.tool_call_id is None:
             raise ValueError("tool messages require tool_call_id")
         if self.role != "tool" and self.tool_call_id is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.33"
+version = "0.7.34"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.33"
+version = "0.7.34"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Problem

An exposure-gated rung (Tencent hy4-preview, `reasoning_output_exposed`) returns plaintext `reasoning_content` on every non-tool Chat turn, but the decoder rejected that same text on the next turn (`'messages.N.reasoning_content' must be a gateway-issued carrier`). The carrier is structurally tool-turn-only at three seams (Rust emit: seals only when `has_tool_calls`; `seal_reasoning_content` requires tool calls; `_process_reasoning_history` binds a carrier to one assistant tool turn). A Terminus-2 loop — commands parsed from assistant text, output fed back as `user` messages — has no tool turns, so preserved thinking could not survive it; Harbor only worked by dropping the field (`interleaved_thinking=False`). Reported by Akhara (Spandana) with a live repro.

**Verified against Tencent TokenHub directly** (house key, 3-turn loop): the provider returns 200 with plaintext `reasoning_content` echoed on a prior plain turn, returns 200 with *forged* reasoning text identically, and validates nothing — so on exposed rungs the carrier's "CoT-injection" rationale does not hold (a caller can already put anything in prior assistant `content`), and the plaintext is ordinary caller-owned history.

## Change

- `ExposedReasoningContentBlock` (`exposed_reasoning_content`): the Chat decoder carries non-carrier text as this bounded block; a value under a known carrier prefix must still parse as that carrier.
- Route narrowing (`route_generation_parameter_requests`): no exposing rung → named 400 on `messages.reasoning_content`; mixed waterfall → exposing rungs are the *exact* rungs (`compatible_generation_parameter_profile_indexes`) and the drop is disclosed as `messages.reasoning_content->dropped(unsupported_by_provider)`; all exposing → forwarded silently.
- `openai_chat_message` writes the block back as `reasoning_content` only on an exposing rung (`reasoning_output_exposed` threaded from the wire profile); the Anthropic and Responses builders skip the kind instead of raising.
- Tool-turn carriers are unchanged: sealed, rung-pinned, stale-stripped before the latest user turn.
- Docs: `gateway-architecture.md` gains the plaintext-replay contract paragraph.

## Tests

Bridge round-trips: Terminus plain-turn loop (plaintext forwarded verbatim, no pin, no disclosure), Harbor interleaved carrier+plaintext history (stale carrier stripped, plaintext plain turn forwarded), non-exposed route rejection by name. Decoder acceptance + empty-string rejection; wire emit per dialect; route gate reject/disclose/forward; exact-rung preference on a mixed waterfall. Full suite green locally; `ty` clean.

Live matrix against real Tencent (Terminus loop, Harbor interleaved, forged plaintext, oversize, non-exposed alias, streaming, tool-turn carrier regression, disclosure body fields on both surfaces) will be pasted here before the cut.

Version 0.7.34; native unchanged (0.3.31).