### PR TITLE
release: bump experiential to 0.7.35 (native 0.3.32)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.34"
+version = "0.7.35"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.34"
+version = "0.7.35"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the release carrying #792 (OpenAI Responses hosted-tool items end to end, throttle-window reclass, admission minimum for max_output_tokens, provider-detail passthrough). Native crate is already 0.3.32 in-tree (unreleased; PyPI latest is 0.3.31). Mirrors #788's release-bump pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)