### PR TITLE
gateway: classify history-reconstruction contract violations as named 400s

### DIFF
--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -341,7 +341,21 @@ def decode_messages(
             )
         )
     for index, message in enumerate(request.messages):
-        messages.extend(_gateway_messages(message, index))
+        try:
+            messages.extend(_gateway_messages(message, index))
+        except ValidationError as exc:
+            # Turn translation builds canonical messages, so a canonical-
+            # contract violation (such as duplicate tool_use ids in one
+            # assistant turn) first surfaces here, past the wire models. It
+            # is caller-shaped input all the same: name the offending turn
+            # instead of letting the exception escape as an unclassified 500.
+            detail = exc.errors(include_url=False)[0]
+            raise invalid_field(
+                f"messages.{index}",
+                f"Invalid value for 'messages.{index}': "
+                + detail["msg"].removeprefix("Value error, ")
+                + ".",
+            ) from exc
     parallel_tool_calls: bool | None = None
     if request.tool_choice is not None and request.tool_choice.disable_parallel_tool_use:
         parallel_tool_calls = False

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1544,3 +1544,40 @@ def test_a_screenshot_history_beyond_twenty_images_still_decodes() -> None:
 
     with pytest.raises(OpenAIProtocolError, match="at most 100 images"):
         decode_messages(_body(messages=[{"role": "user", "content": [image_block] * 101}]))
+
+
+def test_decode_names_a_duplicate_tool_use_id_instead_of_crashing() -> None:
+    """A canonical-contract violation in a replayed turn is a named 400.
+
+    Two ``tool_use`` blocks sharing one id in a single assistant turn violate
+    the canonical assistant-message contract during turn translation, after
+    the wire models have already passed. That exception must map to the
+    turn-specific protocol error every other invalid shape gets: before the
+    mapping it escaped decode as an unclassified 500 whose "retry the
+    request" guidance is wrong for caller-shaped input.
+    """
+    with pytest.raises(OpenAIProtocolError, match="messages.1.*unique") as rejected:
+        decode_messages(
+            _body(
+                messages=[
+                    {"role": "user", "content": "t"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "dup", "name": "a", "input": {}},
+                            {"type": "tool_use", "id": "dup", "name": "a", "input": {}},
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "tool_use_id": "dup", "content": "x"},
+                            {"type": "tool_result", "tool_use_id": "dup", "content": "y"},
+                        ],
+                    },
+                ],
+                tools=[{"name": "a", "description": "d", "input_schema": {"type": "object"}}],
+            )
+        )
+    assert rejected.value.status_code == 400
+    assert rejected.value.detail.param == "messages.1"

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -330,12 +330,20 @@ def decode_responses(
                     tool=cast("JsonObject", raw_tools[tool_index]),
                 )
             )
-    messages = list(
-        _response_input_messages(
-            request.input,
-            raw_items=cast("list[JsonObject]", raw_input) if isinstance(raw_input, list) else (),
-        )
-    )
+    replayed_items = cast("list[JsonObject]", raw_input) if isinstance(raw_input, list) else ()
+    try:
+        messages = list(_response_input_messages(request.input, raw_items=replayed_items))
+    except ValidationError as exc:
+        # History reconstruction folds echoed items into canonical messages,
+        # so a canonical-contract violation (such as duplicate call_ids in one
+        # assistant segment) first surfaces here, past the wire models. It is
+        # caller-shaped input all the same: name the rule instead of letting
+        # the exception escape as an unclassified 500.
+        detail = exc.errors(include_url=False)[0]
+        raise invalid_field(
+            "input",
+            "Invalid value for 'input': " + detail["msg"].removeprefix("Value error, ") + ".",
+        ) from exc
     if request.instructions is not None:
         messages.insert(0, GatewayMessage(role="developer", content=request.instructions))
     try:

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -3162,3 +3162,32 @@ def test_hosted_tool_echo_annotations_require_a_typed_object() -> None:
             }
         )
     assert rejected.value.status_code == 400
+
+
+def test_responses_decoder_names_a_duplicate_call_id_instead_of_crashing() -> None:
+    """A canonical-contract violation in replayed history is a named 400.
+
+    Two echoed ``function_call`` items sharing one ``call_id`` violate the
+    canonical assistant-message contract during history reconstruction,
+    after the wire models have already passed. That exception must map to
+    the field-specific protocol error every other invalid shape gets: before
+    the mapping it escaped decode as an unclassified 500 whose "retry the
+    request" guidance is wrong for caller-shaped input.
+    """
+    with pytest.raises(OpenAIProtocolError) as rejected:
+        decode_responses(
+            {
+                "model": "gpt-5.6-sol",
+                "tools": [{"type": "function", "name": "a", "parameters": {"type": "object"}}],
+                "input": [
+                    {"role": "user", "content": "t"},
+                    {"type": "function_call", "call_id": "dup", "name": "a", "arguments": "{}"},
+                    {"type": "function_call", "call_id": "dup", "name": "a", "arguments": "{}"},
+                    {"type": "function_call_output", "call_id": "dup", "output": "x"},
+                    {"type": "function_call_output", "call_id": "dup", "output": "y"},
+                ],
+            }
+        )
+    assert rejected.value.status_code == 400
+    assert rejected.value.detail.param == "input"
+    assert "tool call IDs must be unique" in rejected.value.detail.message


### PR DESCRIPTION
## Problem

Replayed history that clears the wire models but violates the canonical message contract raised a raw pydantic `ValidationError` during message assembly, escaping decode as an unclassified **500** ("Retry the request; if this persists, ask the gateway operator..."). Minimal repros through a real served engine:

- `POST /v1/responses` with two `function_call` items sharing one `call_id` → 500
- `POST /v1/messages` with two `tool_use` blocks sharing one `id` in a single assistant turn → 500

The identical shape through `/v1/chat/completions` already renders the named 400 (`Invalid value for 'messages.1': assistant tool call IDs must be unique.`) because the chat wire model owns the uniqueness check. The Responses and Messages decoders only hit the rule later, inside `responses_input_messages` / `_gateway_messages`, which run outside the `ValidationError → protocol error` mapping that wraps `GatewayRequest` construction.

Misclassification matters beyond aesthetics: providers occasionally emit duplicate call ids, so the shape can arrive baked into caller history; a 500 with retry guidance masks it as a gateway fault and inflates 5xx alerting.

## Fix

Wrap the two assembly seams in the same field-specific mapping the rest of decode uses:

- `decode_responses`: `_response_input_messages(...)` → 400 `Invalid value for 'input': <rule>.` (`param: input`)
- `decode_messages`: per-turn `_gateway_messages(message, index)` → 400 `Invalid value for 'messages.N': <rule>.` (`param: messages.N`)

Verified end to end against a locally served native engine: both repros now return the named 400 and the process never sees the exception.

## Tests

- `exp/runtime/openai_protocol/requests_test.py`: duplicate `call_id` replay decodes to a named 400.
- `exp/runtime/anthropic_protocol/requests_test.py`: duplicate `tool_use` id turn decodes to a named 400.
- `uv run pytest exp/runtime/openai_protocol/ exp/runtime/anthropic_protocol/ exp/runtime/gateway/native_responses_test.py` → 339 passed; `ruff check`/`format` and `ty check` clean on touched files.

Found by adversarial stress-testing of the #784/#786 wedge fixes (findings report to follow separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)