### PR TITLE
gateway: round-trip SDK 3.0 caller + list tool outputs; serve id-only reasoning replays (native 0.3.33)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -178,6 +178,18 @@ their native event names, including continuation retention. The item-level `name
 `custom_tool_call` namespace) round-trips verbatim through decode, the client stream, and
 continuation retention: the provider rejects a namespaced call replayed without it, so the
 field joins replay identity when present and absent items keep their exact pre-existing shape.
+The SDK 3.0 programmatic tool-calling `caller` object on `function_call`,
+`function_call_output`, and `custom_tool_call` gets the same verbatim round trip (validated only
+as an object; its internal shape is the provider's). `function_call_output.output` accepts the
+SDK list form: text and image parts map onto the canonical tool message and re-emit typed, an
+all-text list keeps the plain-string wire shape, and any other part kind is a named 400. A
+reasoning input item without `encrypted_content` (a `store: true` replay by item id) carries
+verbatim to homogeneous native Responses routes and the provider judges resolvability. Off the
+native Responses wire, tool-call and tool-result attribution (`namespace`/`caller`/output
+`name`) drops with per-field disclosure — the call itself always survives — and a
+Messages-surface effort the route cannot serve rejects as `output_config.effort` with
+"effort parameter … not supported" phrasing, the exact predicate Claude Code's built-in
+drop-and-retry recovery latches on.
 
 Provider client-errors stay sanitized: no provider error prose or body content ever reaches the
 caller. The one provider-derived fact a 4xx rejection may relay is the parameter path the provider

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -238,6 +238,18 @@ class ToolCall(ContractModel):
     from serialization like the other replay fields, and joins gateway replay
     identity explicitly.
     """
+    provider_caller: JsonObject | None = Field(default=None, exclude=True)
+    """Opaque SDK 3.0 ``caller`` attribution on a Responses tool-call item.
+
+    Programmatic tool calling attributes a ``function_call`` or
+    ``custom_tool_call`` to the program that invoked it (for example
+    ``{"type": "program", "id": ...}``). The object's internal shape is an
+    evolving provider surface, so it is validated only as an object and
+    round-trips verbatim like ``provider_namespace``: set when a Responses
+    caller replays an item carrying ``caller`` or when the provider emits
+    one. Excluded from serialization like the other replay fields, and joins
+    gateway replay identity explicitly.
+    """
 
     @model_validator(mode="after")
     def _require_matching_raw_arguments(self) -> ToolCall:

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -247,6 +247,17 @@ class GatewayMessage(ContractModel):
     excluded from serialization like the other replay carriers, joining
     replay identity explicitly through :func:`canonical_request_sha256`.
     """
+    provider_tool_caller: JsonObject | None = Field(default=None, exclude=True)
+    """Opaque SDK 3.0 ``caller`` attribution on a ``function_call_output``.
+
+    Programmatic tool calling attributes the result to the program that
+    invoked the call; the object's internal shape is an evolving provider
+    surface, so it is validated only as an object and re-emitted verbatim on
+    the rebuilt item (mirroring ``ToolCall.provider_caller`` on the call
+    side). Excluded from serialization like the other replay carriers,
+    joining replay identity explicitly through
+    :func:`canonical_request_sha256`.
+    """
     provider_native_item: JsonObject | None = Field(default=None, exclude=True)
     """One verbatim OpenAI Responses input item the gateway carries opaquely.
 
@@ -372,7 +383,9 @@ class GatewayMessage(ContractModel):
         if self.role != "tool" and self.tool_call_id is not None:
             raise ValueError("tool_call_id is valid only for tool messages")
         if self.role != "tool" and (
-            self.provider_tool_name is not None or self.provider_tool_namespace is not None
+            self.provider_tool_name is not None
+            or self.provider_tool_namespace is not None
+            or self.provider_tool_caller is not None
         ):
             raise ValueError("tool-result attribution is valid only for tool messages")
         if self.role != "tool" and self.tool_is_error:

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -1071,3 +1071,52 @@ def test_replay_identity_binds_tool_output_attribution() -> None:
     assert canonical_request_sha256(request(namespace="collaboration")) != canonical_request_sha256(
         plain
     )
+
+
+def test_replay_identity_binds_the_function_call_caller() -> None:
+    """A retained SDK 3.0 caller joins replay identity only when present."""
+    from exp.runtime.gateway.replay_identity import canonical_request_sha256
+
+    def request(*, caller: JsonObject | None) -> GatewayRequest:
+        return GatewayRequest(
+            surface=GatewayApiSurface.RESPONSES,
+            messages=(
+                GatewayMessage(
+                    role="assistant",
+                    tool_calls=(
+                        ToolCall(
+                            call_id="call-1",
+                            name="lookup",
+                            provider_output_index=0,
+                            provider_caller=caller,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    program: JsonObject = {"type": "program", "caller_id": "call_prog"}
+    direct: JsonObject = {"type": "direct"}
+    attributed = request(caller=program)
+    assert canonical_request_sha256(attributed) == canonical_request_sha256(request(caller=program))
+    assert canonical_request_sha256(attributed) != canonical_request_sha256(request(caller=direct))
+    assert canonical_request_sha256(attributed) != canonical_request_sha256(request(caller=None))
+
+
+def test_a_tool_result_caller_is_valid_only_on_tool_messages() -> None:
+    """The output-side attribution carrier keeps the tool-role contract."""
+    import pytest as _pytest
+
+    message = GatewayMessage(
+        role="tool",
+        content="ok",
+        tool_call_id="call-1",
+        provider_tool_caller={"type": "direct"},
+    )
+    assert message.provider_tool_caller == {"type": "direct"}
+    with _pytest.raises(ValueError, match="attribution"):
+        GatewayMessage(
+            role="assistant",
+            content="ok",
+            provider_tool_caller={"type": "direct"},
+        )

--- a/exp/runtime/gateway/guardrails/enforcement.py
+++ b/exp/runtime/gateway/guardrails/enforcement.py
@@ -47,6 +47,7 @@ def _restored_provider_authority(
             or message.provider_phase is not None
             or message.provider_tool_name is not None
             or message.provider_tool_namespace is not None
+            or message.provider_tool_caller is not None
             or message.tool_is_error
             or any(
                 call.raw_arguments is not None
@@ -54,6 +55,7 @@ def _restored_provider_authority(
                 or call.provider_output_index is not None
                 or call.provider_status is not None
                 or call.provider_namespace is not None
+                or call.provider_caller is not None
                 for call in message.tool_calls
             )
         )

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.32"
+version = "0.3.33"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.32"
+version = "0.3.33"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -82,6 +82,7 @@ impl Normalizer {
                             call_id,
                             name,
                             namespace: None,
+                            caller: None,
                         });
                     }
                     Some("server_tool_use") => {

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -104,6 +104,7 @@ impl Normalizer {
             call_id,
             name,
             namespace: None,
+            caller: None,
         }])
     }
 

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -164,6 +164,7 @@ impl Normalizer {
                 call_id,
                 name,
                 namespace: None,
+                caller: None,
             },
             Event::ToolArgumentsDelta {
                 index,

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -39,6 +39,17 @@ fn optional_openai_identity(
     }
 }
 
+fn optional_openai_caller(
+    object: &serde_json::Map<String, Value>,
+    label: &str,
+) -> Result<Option<Value>, Failure> {
+    match object.get("caller") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value @ Value::Object(_)) => Ok(Some(value.clone())),
+        Some(_) => Err(malformed(&format!("{label} must be an object"))),
+    }
+}
+
 fn openai_status(
     object: &serde_json::Map<String, Value>,
 ) -> Result<Option<ProviderOutputItemStatus>, Failure> {
@@ -297,6 +308,7 @@ impl Normalizer {
                         "namespace",
                         "OpenAI function call namespace",
                     )?;
+                    let caller = optional_openai_caller(item, "OpenAI function call caller")?;
                     let item_id =
                         optional_openai_identity(item, "id", "OpenAI function call item ID")?;
                     if !self.bind_openai_output_item(
@@ -309,6 +321,7 @@ impl Normalizer {
                     self.reserve_tool_entry(index)?;
                     let mut tool = ToolAccumulator::new(call_id.clone(), name.clone());
                     tool.namespace = namespace.clone();
+                    tool.caller = caller.clone();
                     tool.provider_item_id = item_id.clone();
                     tool.provider_status = status;
                     events.push(Event::ProviderOutputItemStarted {
@@ -323,6 +336,7 @@ impl Normalizer {
                         call_id,
                         name,
                         namespace,
+                        caller,
                     });
                     if let Some(Value::String(initial)) = item.get("arguments") {
                         if !initial.is_empty() {
@@ -358,6 +372,7 @@ impl Normalizer {
                         "namespace",
                         "OpenAI custom tool call namespace",
                     )?;
+                    let caller = optional_openai_caller(item, "OpenAI custom tool call caller")?;
                     let item_id =
                         optional_openai_identity(item, "id", "OpenAI custom tool call item ID")?;
                     if !self.bind_openai_output_item(
@@ -371,6 +386,7 @@ impl Normalizer {
                     let mut tool = ToolAccumulator::new(call_id.clone(), name.clone());
                     tool.custom = true;
                     tool.namespace = namespace.clone();
+                    tool.caller = caller.clone();
                     tool.provider_item_id = item_id.clone();
                     tool.provider_status = status;
                     events.push(Event::ProviderOutputItemStarted {
@@ -385,6 +401,7 @@ impl Normalizer {
                         call_id,
                         name,
                         namespace,
+                        caller,
                     });
                     if let Some(Value::String(initial)) = item.get("input") {
                         if !initial.is_empty() {
@@ -601,6 +618,7 @@ impl Normalizer {
                             "namespace",
                             "OpenAI function call namespace",
                         )?;
+                        let caller = optional_openai_caller(item, "OpenAI function call caller")?;
                         let arguments =
                             require_string(item, "arguments", "OpenAI function call arguments")
                                 .map_err(|message| malformed(&message))?;
@@ -611,6 +629,7 @@ impl Normalizer {
                             || tool.call_id != call_id
                             || tool.name != name
                             || tool.namespace != namespace
+                            || tool.caller != caller
                         {
                             return Err(malformed(
                                 "OpenAI function call changed identity at completion",
@@ -650,6 +669,8 @@ impl Normalizer {
                             "namespace",
                             "OpenAI custom tool call namespace",
                         )?;
+                        let caller =
+                            optional_openai_caller(item, "OpenAI custom tool call caller")?;
                         let input = require_string(item, "input", "OpenAI custom tool call input")
                             .map_err(|message| malformed(&message))?;
                         let tool = self.tools.get(&index).ok_or_else(|| {
@@ -660,6 +681,7 @@ impl Normalizer {
                             || tool.call_id != call_id
                             || tool.name != name
                             || tool.namespace != namespace
+                            || tool.caller != caller
                         {
                             return Err(malformed(
                                 "OpenAI custom tool call changed identity at completion",
@@ -924,6 +946,7 @@ impl Normalizer {
                             call_id,
                             name,
                             namespace: None,
+                            caller: None,
                         });
                     }
                     if let Some(fragment) = function.get("arguments") {

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -715,3 +715,121 @@ fn a_function_call_namespace_changed_at_completion_is_malformed() {
         .safe_message
         .contains("changed identity at completion"));
 }
+
+#[test]
+fn a_caller_attributed_function_call_round_trips_caller_through_the_stream() {
+    // SDK 3.0 programmatic tool calling attributes a function call to the
+    // program that invoked it via an opaque `caller` object; the item must
+    // replay exactly as emitted, so the object survives normalization
+    // verbatim.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+    let caller = serde_json::json!({"type": "program", "id": "prog_1"});
+    let added = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "status": "in_progress",
+                "call_id": "call_live", "name": "lookup",
+                "caller": caller, "arguments": "",
+            },
+        })
+        .to_string(),
+    };
+    let events = normalizer
+        .feed(&added)
+        .expect("caller-attributed start must normalize");
+    assert!(matches!(
+        events.as_slice(),
+        [
+            Event::ProviderOutputItemStarted { .. },
+            Event::ToolCallStarted { name, caller: Some(value), .. },
+        ] if name == "lookup" && *value == caller
+    ));
+    let item_done = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "status": "completed",
+                "call_id": "call_live", "name": "lookup",
+                "caller": caller, "arguments": "{}",
+            },
+        })
+        .to_string(),
+    };
+    let events = normalizer
+        .feed(&item_done)
+        .expect("caller-attributed completion must normalize");
+    assert!(matches!(
+        events.as_slice(),
+        [
+            Event::ToolArgumentsDelta { .. },
+            Event::ProviderOutputItemCompleted { .. },
+            Event::ToolCallCompleted { call, .. },
+        ] if call.caller.as_ref() == Some(&caller)
+    ));
+}
+
+#[test]
+fn a_function_call_caller_changed_at_completion_is_malformed() {
+    let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+    let added = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "call_id": "call_live", "name": "lookup",
+                "caller": {"type": "program", "id": "prog_1"}, "arguments": "",
+            },
+        })
+        .to_string(),
+    };
+    normalizer.feed(&added).expect("start must normalize");
+    let item_done = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "status": "completed",
+                "call_id": "call_live", "name": "lookup",
+                "caller": {"type": "program", "id": "prog_2"}, "arguments": "{}",
+            },
+        })
+        .to_string(),
+    };
+    let failure = normalizer
+        .feed(&item_done)
+        .expect_err("a caller changed at completion is malformed");
+    assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+}
+
+#[test]
+fn a_non_object_function_call_caller_is_malformed() {
+    let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+    let added = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "fc_live", "type": "function_call",
+                "call_id": "call_live", "name": "lookup",
+                "caller": "program", "arguments": "",
+            },
+        })
+        .to_string(),
+    };
+    let failure = normalizer
+        .feed(&added)
+        .expect_err("a non-object caller is malformed");
+    assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+}

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -712,6 +712,7 @@ mod tests {
             },
             Event::ToolCallStarted {
                 namespace: None,
+                caller: None,
                 index: 0,
                 call_id: "call-one".to_string(),
                 name: "lookup".to_string(),
@@ -724,6 +725,7 @@ mod tests {
                 index: 0,
                 call: crate::events::CompletedToolCall {
                     namespace: None,
+                    caller: None,
                     call_id: "call-one".to_string(),
                     name: "lookup".to_string(),
                     raw_arguments: "{}".to_string(),
@@ -803,12 +805,14 @@ mod tests {
             },
             Event::ToolCallStarted {
                 namespace: None,
+                caller: None,
                 index: 1,
                 call_id: "call-one".to_string(),
                 name: "first".to_string(),
             },
             Event::ToolCallStarted {
                 namespace: None,
+                caller: None,
                 index: 0,
                 call_id: "call-zero".to_string(),
                 name: "second".to_string(),
@@ -817,6 +821,7 @@ mod tests {
                 index: 0,
                 call: crate::events::CompletedToolCall {
                     namespace: None,
+                    caller: None,
                     call_id: "call-zero".to_string(),
                     name: "second".to_string(),
                     raw_arguments: "{\"order\":0}".to_string(),
@@ -829,6 +834,7 @@ mod tests {
                 index: 1,
                 call: crate::events::CompletedToolCall {
                     namespace: None,
+                    caller: None,
                     call_id: "call-one".to_string(),
                     name: "first".to_string(),
                     raw_arguments: "{\"order\":1}".to_string(),

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -73,6 +73,7 @@ fn completed_body_orders_text_before_tool_use_blocks() {
         Event::TextDelta("hi".to_string()),
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -85,6 +86,7 @@ fn completed_body_orders_text_before_tool_use_blocks() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -112,6 +114,7 @@ fn completed_body_preserves_interleaved_block_order() {
     let events = vec![
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -120,6 +123,7 @@ fn completed_body_preserves_interleaved_block_order() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -147,6 +151,7 @@ fn deferred_tool_completion_keeps_the_started_block_position() {
     let events = vec![
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -160,6 +165,7 @@ fn deferred_tool_completion_keeps_the_started_block_position() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -195,6 +201,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
     let events = vec![
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-a".to_string(),
             name: "alpha".to_string(),
@@ -205,6 +212,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 1,
             call_id: "call-b".to_string(),
             name: "beta".to_string(),
@@ -221,6 +229,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-a".to_string(),
                 name: "alpha".to_string(),
                 provider_item_id: None,
@@ -233,6 +242,7 @@ fn interleaved_parallel_tools_stream_strictly_sequential_blocks() {
             index: 1,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-b".to_string(),
                 name: "beta".to_string(),
                 provider_item_id: None,
@@ -402,6 +412,7 @@ fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-1".to_string(),
             name: "search".to_string(),
@@ -414,6 +425,7 @@ fn interleaved_thinking_between_tool_blocks_keeps_sequential_indices() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-1".to_string(),
                 name: "search".to_string(),
                 provider_item_id: None,
@@ -472,6 +484,7 @@ fn web_search_events() -> Vec<Event> {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "srvtoolu_1".to_string(),
                 name: "web_search".to_string(),
                 provider_item_id: None,
@@ -597,6 +610,7 @@ fn paused_turn_keeps_its_stop_reason_on_both_paths() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "srvtoolu_1".to_string(),
                 name: "web_search".to_string(),
                 provider_item_id: None,

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -197,7 +197,8 @@ impl ResponsesSseEncoder {
                 call_id,
                 name,
                 namespace,
-            } => self.tool_started(*index, call_id, name, namespace.as_deref()),
+                caller,
+            } => self.tool_started(*index, call_id, name, namespace.as_deref(), caller.as_ref()),
             Event::ToolArgumentsDelta { index, delta } => self.tool_arguments(*index, delta),
             Event::ToolCallCompleted { index, call } => self.tool_completed(*index, call),
             // Anthropic text-block boundaries and citation metadata have no
@@ -487,6 +488,7 @@ impl ResponsesSseEncoder {
         call_id: &str,
         name: &str,
         namespace: Option<&str>,
+        caller: Option<&Value>,
     ) -> Result<Vec<String>, PublicError> {
         if self.tools.contains_key(&index) {
             return Err(invalid_provider_stream(
@@ -531,6 +533,7 @@ impl ResponsesSseEncoder {
             call_id: call_id.to_string(),
             name: name.to_string(),
             namespace: namespace.map(str::to_string),
+            caller: caller.cloned(),
             arguments: String::new(),
             status,
             done: false,
@@ -587,6 +590,7 @@ impl ResponsesSseEncoder {
         if state.call_id != call.call_id
             || state.name != call.name
             || state.namespace != call.namespace
+            || state.caller != call.caller
             || state.arguments != call.raw_arguments
             || (provider_owned_identity && call.provider_item_id != state.item_id)
         {

--- a/exp/runtime/gateway/native/src/encode_responses/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/tests.rs
@@ -66,6 +66,7 @@ fn fireworks_tool_events() -> Vec<Event> {
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-one".to_string(),
             name: "lookup".to_string(),
@@ -78,6 +79,7 @@ fn fireworks_tool_events() -> Vec<Event> {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-one".to_string(),
                 name: "lookup".to_string(),
                 raw_arguments: "{}".to_string(),
@@ -151,12 +153,14 @@ fn fireworks_parallel_tools_share_public_and_carrier_order() {
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 1,
             call_id: "call-one".to_string(),
             name: "first".to_string(),
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 0,
             call_id: "call-zero".to_string(),
             name: "second".to_string(),
@@ -173,6 +177,7 @@ fn fireworks_parallel_tools_share_public_and_carrier_order() {
             index: 0,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-zero".to_string(),
                 name: "second".to_string(),
                 raw_arguments: "{\"order\":0}".to_string(),
@@ -185,6 +190,7 @@ fn fireworks_parallel_tools_share_public_and_carrier_order() {
             index: 1,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-one".to_string(),
                 name: "first".to_string(),
                 raw_arguments: "{\"order\":1}".to_string(),
@@ -363,6 +369,7 @@ fn provider_item_starts_preserve_reasoning_tool_order_and_identity() {
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 1,
             call_id: "call-1".to_string(),
             name: "lookup".to_string(),
@@ -380,6 +387,7 @@ fn provider_item_starts_preserve_reasoning_tool_order_and_identity() {
             index: 1,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-1".to_string(),
                 name: "lookup".to_string(),
                 provider_item_id: Some("fc-provider-1".to_string()),
@@ -477,6 +485,7 @@ fn provider_items_preserve_multiple_messages_status_phase_and_idless_call() {
         },
         Event::ToolCallStarted {
             namespace: None,
+            caller: None,
             index: 2,
             call_id: "call-required".to_string(),
             name: "lookup".to_string(),
@@ -496,6 +505,7 @@ fn provider_items_preserve_multiple_messages_status_phase_and_idless_call() {
             index: 2,
             call: CompletedToolCall {
                 namespace: None,
+                caller: None,
                 call_id: "call-required".to_string(),
                 name: "lookup".to_string(),
                 provider_item_id: None,
@@ -573,6 +583,7 @@ fn namespaced_tool_call_items_re_emit_namespace_to_the_caller() {
             call_id: "call-ns".to_string(),
             name: "spawn_agent".to_string(),
             namespace: Some("collaboration".to_string()),
+            caller: None,
         },
         Event::ToolArgumentsDelta {
             index: 0,
@@ -584,6 +595,7 @@ fn namespaced_tool_call_items_re_emit_namespace_to_the_caller() {
                 call_id: "call-ns".to_string(),
                 name: "spawn_agent".to_string(),
                 namespace: Some("collaboration".to_string()),
+                caller: None,
                 provider_item_id: None,
                 provider_status: None,
                 raw_arguments: "{}".to_string(),
@@ -639,6 +651,7 @@ fn namespaced_tool_call_items_re_emit_namespace_to_the_caller() {
                 call_id: "call-plain".to_string(),
                 name: "lookup".to_string(),
                 namespace: None,
+                caller: None,
             },
             Event::ToolArgumentsDelta {
                 index: 0,
@@ -650,6 +663,7 @@ fn namespaced_tool_call_items_re_emit_namespace_to_the_caller() {
                     call_id: "call-plain".to_string(),
                     name: "lookup".to_string(),
                     namespace: None,
+                    caller: None,
                     provider_item_id: None,
                     provider_status: None,
                     raw_arguments: "{}".to_string(),
@@ -868,4 +882,70 @@ fn hosted_non_call_items_never_join_the_ledger_tool_names() {
         crate::relay::track_event(event, &mut usage, &mut tool_names);
     }
     assert_eq!(tool_names, vec!["web_search_call".to_string()]);
+}
+
+#[test]
+fn caller_attributed_tool_call_items_re_emit_caller_to_the_caller() {
+    // The caller replays the completed function_call item verbatim, so the
+    // synthesized output items must carry the SDK 3.0 `caller` attribution
+    // exactly as the provider emitted it.
+    let caller = json!({"type": "program", "id": "prog_1"});
+    let events = vec![
+        Event::ToolCallStarted {
+            index: 0,
+            call_id: "call-caller".to_string(),
+            name: "lookup".to_string(),
+            namespace: None,
+            caller: Some(caller.clone()),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: crate::events::CompletedToolCall {
+                call_id: "call-caller".to_string(),
+                name: "lookup".to_string(),
+                namespace: None,
+                caller: Some(caller.clone()),
+                provider_item_id: None,
+                provider_status: None,
+                raw_arguments: "{}".to_string(),
+                custom: false,
+            },
+        },
+        Event::Completed,
+    ];
+    let mut encoder = ResponsesSseEncoder::new(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+    );
+    encoder.start().expect("stream start must encode");
+    let mut frames = Vec::new();
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("events must encode"));
+    }
+    let added = frames
+        .iter()
+        .find(|frame| frame.contains("response.output_item.added"))
+        .expect("tool item start frame");
+    assert!(added.contains("\"caller\"") && added.contains("\"prog_1\""));
+    let done = frames
+        .iter()
+        .find(|frame| frame.contains("response.output_item.done"))
+        .expect("tool item done frame");
+    assert!(done.contains("\"caller\"") && done.contains("\"prog_1\""));
+
+    let completed = completed_responses_body(
+        "request-1",
+        "coding",
+        1_700_000_000.0,
+        ResponsesEnvelope::default(),
+        &events,
+    )
+    .expect("completed body must encode");
+    assert_eq!(completed.body["output"][0]["caller"], caller);
 }

--- a/exp/runtime/gateway/native/src/encode_responses/tool_state.rs
+++ b/exp/runtime/gateway/native/src/encode_responses/tool_state.rs
@@ -14,6 +14,9 @@ pub(super) struct ToolState {
     /// re-emitted verbatim so the caller can round-trip the item (the
     /// provider rejects a namespaced call replayed without it).
     pub(super) namespace: Option<String>,
+    /// Opaque SDK 3.0 `caller` attribution re-emitted verbatim like
+    /// `namespace` so the item round-trips exactly as emitted.
+    pub(super) caller: Option<Value>,
     pub(super) arguments: String,
     pub(super) status: Option<ProviderOutputItemStatus>,
     pub(super) done: bool,
@@ -41,6 +44,9 @@ impl ToolState {
         item.insert("name".to_string(), json!(self.name));
         if let Some(namespace) = &self.namespace {
             item.insert("namespace".to_string(), json!(namespace));
+        }
+        if let Some(caller) = &self.caller {
+            item.insert("caller".to_string(), caller.clone());
         }
         item.insert(payload_key.to_string(), json!(self.arguments));
         item.insert(

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -64,6 +64,11 @@ pub struct CompletedToolCall {
     /// preserved verbatim through retention and the client stream because
     /// the provider rejects a namespaced call replayed without it.
     pub namespace: Option<String>,
+    /// Opaque SDK 3.0 `caller` attribution (for example
+    /// `{"type": "program", "id": ...}`) naming the program that invoked
+    /// this call; carried verbatim like `namespace` so the item
+    /// round-trips exactly as the provider emitted it.
+    pub caller: Option<Value>,
     pub provider_item_id: Option<String>,
     pub provider_status: Option<ProviderOutputItemStatus>,
     /// Raw provider-order argument text: a validated JSON object for
@@ -208,6 +213,9 @@ pub enum Event {
         /// present only on native Responses streams and preserved verbatim
         /// because the provider rejects a namespaced call replayed without it.
         namespace: Option<String>,
+        /// Opaque SDK 3.0 `caller` attribution carried verbatim like
+        /// `namespace`.
+        caller: Option<Value>,
     },
     ToolArgumentsDelta {
         index: u32,
@@ -463,6 +471,7 @@ pub fn simplified_event(event: &Event) -> Value {
             call_id,
             name,
             namespace,
+            caller,
         } => {
             let mut payload = serde_json::json!({
                 "kind": "tool_call_started",
@@ -472,6 +481,9 @@ pub fn simplified_event(event: &Event) -> Value {
             });
             if let Some(namespace) = namespace {
                 payload["namespace"] = Value::String(namespace.clone());
+            }
+            if let Some(caller) = caller {
+                payload["caller"] = caller.clone();
             }
             payload
         }
@@ -490,6 +502,9 @@ pub fn simplified_event(event: &Event) -> Value {
             });
             if let Some(namespace) = &call.namespace {
                 payload["namespace"] = Value::String(namespace.clone());
+            }
+            if let Some(caller) = &call.caller {
+                payload["caller"] = caller.clone();
             }
             if let Some(item_id) = &call.provider_item_id {
                 payload["item_id"] = Value::String(item_id.clone());
@@ -648,6 +663,8 @@ pub struct ToolAccumulator {
     pub name: String,
     /// Nested tool tree (Responses `namespace`) that declared this call.
     pub namespace: Option<String>,
+    /// Opaque SDK 3.0 `caller` attribution carried verbatim.
+    pub caller: Option<Value>,
     pub provider_item_id: Option<String>,
     pub provider_status: Option<ProviderOutputItemStatus>,
     pub raw_arguments: String,
@@ -665,6 +682,7 @@ impl ToolAccumulator {
             call_id,
             name,
             namespace: None,
+            caller: None,
             provider_item_id: None,
             provider_status: None,
             raw_arguments: String::new(),
@@ -699,6 +717,7 @@ impl ToolAccumulator {
             call_id: self.call_id.clone(),
             name: self.name.clone(),
             namespace: self.namespace.clone(),
+            caller: self.caller.clone(),
             provider_item_id: self.provider_item_id.clone(),
             provider_status: self.provider_status,
             raw_arguments: self.raw_arguments.clone(),

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -22,6 +22,7 @@ fn output_tokens_lead_a_turn_but_control_frames_do_not() {
     // A tool-only turn's first token is the tool call itself.
     assert!(Event::ToolCallStarted {
         namespace: None,
+        caller: None,
         index: 0,
         call_id: "call_1".to_string(),
         name: "get".to_string(),

--- a/exp/runtime/gateway/native/src/guardrails.rs
+++ b/exp/runtime/gateway/native/src/guardrails.rs
@@ -168,6 +168,7 @@ mod tests {
                 index: 0,
                 call: CompletedToolCall {
                     namespace: None,
+                    caller: None,
                     call_id: "call-1".to_string(),
                     name: "lookup".to_string(),
                     provider_item_id: None,
@@ -227,6 +228,7 @@ mod tests {
                 index: 0,
                 call: CompletedToolCall {
                     namespace: None,
+                    caller: None,
                     call_id: "call-1".to_string(),
                     name: "lookup".to_string(),
                     provider_item_id: None,

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -452,6 +452,10 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                     .get("namespace")
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_string),
+                caller: object
+                    .get("caller")
+                    .filter(|value| value.is_object())
+                    .cloned(),
             },
             "tool_arguments_delta" => events::Event::ToolArgumentsDelta { index, delta: text },
             "tool_call_completed" => events::Event::ToolCallCompleted {
@@ -471,6 +475,10 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                         .get("namespace")
                         .and_then(serde_json::Value::as_str)
                         .map(str::to_string),
+                    caller: object
+                        .get("caller")
+                        .filter(|value| value.is_object())
+                        .cloned(),
                     provider_item_id: object
                         .get("item_id")
                         .and_then(serde_json::Value::as_str)
@@ -526,6 +534,7 @@ fn parse_fixture_events(events_json: &str) -> Result<Vec<events::Event>, String>
                         .unwrap_or("")
                         .to_string(),
                     namespace: None,
+                    caller: None,
                     name: object
                         .get("name")
                         .and_then(serde_json::Value::as_str)

--- a/exp/runtime/gateway/native/src/responses_retention.rs
+++ b/exp/runtime/gateway/native/src/responses_retention.rs
@@ -282,6 +282,7 @@ pub(crate) fn remember_argument(
                 "call_id": call.call_id,
                 "name": call.name,
                 "namespace": call.namespace,
+                "caller": call.caller,
                 "arguments": call.raw_arguments,
                 "status": call.provider_status.map(ProviderOutputItemStatus::as_str),
                 "custom": call.custom,
@@ -379,6 +380,7 @@ mod tests {
                 index: 2,
                 call: CompletedToolCall {
                     namespace: None,
+                    caller: None,
                     call_id: "call-required".to_string(),
                     name: "lookup".to_string(),
                     provider_item_id: None,
@@ -431,6 +433,7 @@ mod tests {
                 index: 0,
                 call: CompletedToolCall {
                     namespace: Some("collaboration".to_string()),
+                    caller: None,
                     call_id: "call-ns".to_string(),
                     name: "spawn_agent".to_string(),
                     provider_item_id: None,
@@ -495,6 +498,35 @@ mod tests {
         // The done-frame item (not the added one) is what a continuation replays.
         assert_eq!(payload["hosted_items"][0]["item"]["action"]["query"], "pi");
         assert_eq!(payload["message_outputs"][0]["item_id"], "msg_1");
+    }
+
+    #[test]
+    fn retention_carries_a_tool_call_caller_to_the_remember_payload() {
+        let events = [
+            Event::ToolCallCompleted {
+                index: 0,
+                call: CompletedToolCall {
+                    namespace: None,
+                    caller: Some(serde_json::json!({"type": "program", "id": "prog_1"})),
+                    call_id: "call-caller".to_string(),
+                    name: "lookup".to_string(),
+                    provider_item_id: None,
+                    provider_status: None,
+                    raw_arguments: "{}".to_string(),
+                    custom: false,
+                },
+            },
+            Event::Completed,
+        ];
+        let mut retention = ResponsesRetention::default();
+        for event in &events {
+            retention.track(event);
+        }
+        let payload: Value =
+            serde_json::from_str(&remember_argument("request-caller", &retention, None))
+                .expect("retention payload is JSON");
+        assert_eq!(payload["tool_calls"][0]["caller"]["id"], "prog_1");
+        assert_eq!(payload["tool_calls"][0]["caller"]["type"], "program");
     }
 
     #[test]

--- a/exp/runtime/gateway/native_responses.py
+++ b/exp/runtime/gateway/native_responses.py
@@ -297,6 +297,7 @@ def remember_turn(
         name = call["name"]
         raw_arguments = call["arguments"]
         namespace = call.get("namespace")
+        caller = call.get("caller")
         if (
             not isinstance(call_id, str)
             or not call_id
@@ -304,6 +305,7 @@ def remember_turn(
             or not name
             or not isinstance(raw_arguments, str)
             or not (namespace is None or (isinstance(namespace, str) and namespace))
+            or not (caller is None or isinstance(caller, dict))
         ):
             raise ValueError("Responses retained tool call fields are invalid")
         if call.get("custom") is True:
@@ -318,6 +320,8 @@ def remember_turn(
             }
             if namespace is not None:
                 native_item["namespace"] = namespace
+            if caller is not None:
+                native_item["caller"] = caller
             if provider_item_id is not None:
                 native_item["id"] = provider_item_id
             status_value = call.get("status")
@@ -342,6 +346,7 @@ def remember_turn(
                 else None
             ),
             provider_namespace=namespace,
+            provider_caller=caller,
         )
         if provider_output_index is None:
             unindexed_calls.append(parsed_call)

--- a/exp/runtime/gateway/native_responses_test.py
+++ b/exp/runtime/gateway/native_responses_test.py
@@ -595,3 +595,68 @@ def test_remember_turn_rejects_malformed_hosted_items(item: JsonObject) -> None:
             context=_context(),
             data={"text": "", "refusal": False, "hosted_items": [item], "tool_calls": []},
         )
+
+
+def test_remember_turn_retains_and_replays_a_tool_call_caller() -> None:
+    """A caller-attributed call retained for continuation re-emits it verbatim.
+
+    SDK 3.0 programmatic tool calling attributes a call to the program that
+    invoked it; the item must replay exactly as emitted, so the boundary
+    payload's caller must survive retention into the rebuilt input item (a
+    custom call keeps it on the verbatim native item).
+    """
+    store = BoundedContinuationStore()
+    context = _context()
+    caller = {"type": "program", "caller_id": "call_prog"}
+    remember_turn(
+        store,
+        context=context,
+        route_binding=_binding(),
+        data={
+            "text": "",
+            "refusal": False,
+            "tool_calls": [
+                {
+                    "output_index": 0,
+                    "item_id": "fc-caller",
+                    "call_id": "call-caller",
+                    "name": "lookup",
+                    "caller": caller,
+                    "arguments": "{}",
+                    "status": "completed",
+                },
+                {
+                    "output_index": 1,
+                    "item_id": "ctc-caller",
+                    "call_id": "call-custom",
+                    "name": "exec",
+                    "caller": caller,
+                    "arguments": "const r = 1;",
+                    "status": "completed",
+                    "custom": True,
+                },
+            ],
+        },
+    )
+
+    state = store.resolve_now(
+        namespace=context.namespace,
+        previous_response_id=context.response_id,
+    )
+    call = state.messages[0].tool_calls[0]
+    assert call.provider_caller == caller
+    native = state.messages[1].provider_native_item
+    assert native is not None and native["caller"] == caller
+
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=state.messages,
+    )
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-sol",
+        request,
+        supports_temperature=False,
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[0]["caller"] == caller
+    assert payload_input[1]["caller"] == caller

--- a/exp/runtime/gateway/replay_identity.py
+++ b/exp/runtime/gateway/replay_identity.py
@@ -57,6 +57,7 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
                 and call.provider_output_index is None
                 and call.provider_status is None
                 and call.provider_namespace is None
+                and call.provider_caller is None
             ):
                 continue
             retained_call: JsonObject = {
@@ -72,6 +73,8 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
             # its exact pre-existing digest.
             if call.provider_namespace is not None:
                 retained_call["provider_namespace"] = call.provider_namespace
+            if call.provider_caller is not None:
+                retained_call["provider_caller"] = call.provider_caller
             retained_calls.append(retained_call)
         if retained_calls:
             authority["tool_calls"] = retained_calls
@@ -81,6 +84,8 @@ def provider_replay_authority(request: GatewayRequest) -> JsonObject | None:
             authority["provider_tool_name"] = message.provider_tool_name
         if message.provider_tool_namespace is not None:
             authority["provider_tool_namespace"] = message.provider_tool_namespace
+        if message.provider_tool_caller is not None:
+            authority["provider_tool_caller"] = message.provider_tool_caller
         if len(authority) > 1:
             replay.append(authority)
     retained_tools: list[JsonObject] = []

--- a/exp/runtime/models/providers/errors.py
+++ b/exp/runtime/models/providers/errors.py
@@ -95,15 +95,20 @@ class UnsupportedReasoningEffortError(ProviderParameterError):
             supported_efforts: Ordered effort values accepted by every route deployment.
             param: Public request path carrying the unsupported value.
         """
+        # "effort parameter" + "not supported" is deliberate phrasing: Claude
+        # Code's built-in recovery latch drops output_config.effort and
+        # retries only when the 400 message matches that predicate; any other
+        # wording turns a gracefully degradable condition into a wedged
+        # session (issue #795).
         if supported_efforts:
             choices = ", ".join(repr(value) for value in supported_efforts)
             message = (
-                f"Reasoning effort {effort!r} is not supported by this model route. "
-                f"Supported values: {choices}."
+                f"The effort parameter value {effort!r} is not supported by this model "
+                f"route. Supported values: {choices}."
             )
         else:
             message = (
-                f"The parameter {param!r} is not supported by this model route. "
+                f"The effort parameter ({param!r}) is not supported by this model route. "
                 "Remove the field or choose a different model."
             )
         super().__init__(message=message, param=param, code="unsupported_parameter")

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -240,7 +240,16 @@ def route_generation_parameter_requests(
         provider_updates["maximum_output_tokens"] = min(
             (_ANTHROPIC_REQUIRED_MAX_TOKENS_DEFAULT, *route_limits)
         )
-    effort_path = "reasoning.effort" if request.surface.value == "responses" else "reasoning_effort"
+    # The rejection names the field the CALLER sent: Claude Code carries its
+    # effort as Messages output_config.effort and auto-recovers (drops the
+    # field and retries) only when the 400 names that channel, so naming the
+    # translated internal field wedges every turn instead (issue #795).
+    if request.surface == GatewayApiSurface.RESPONSES:
+        effort_path = "reasoning.effort"
+    elif request.surface == GatewayApiSurface.MESSAGES:
+        effort_path = "output_config.effort"
+    else:
+        effort_path = "reasoning_effort"
 
     def profile_reasoning_effort(profile: GatewayWireProfile) -> str | None:
         """Return the caller effort or this wire's required provider default."""
@@ -456,15 +465,19 @@ def route_generation_parameter_requests(
             code="unsupported_parameter",
         )
 
-    # Only the Anthropic wire defines an image carrier inside a tool result.
-    # A route with any other dialect degrades tool-result images to positional
-    # placeholder text with disclosure instead of rejecting: the block is baked
-    # into the caller's history, so a rejection wedges the whole session, and a
-    # silent drop at encoding would misstate what the model saw. All-Anthropic
-    # routes keep the images; a non-vision rung then rejects at preflight and
-    # the route-wide coercion applies the same disclosed degrade.
-    if any(message.role == "tool" and message.images for message in request.messages) and not all(
-        profile.dialect == "anthropic_messages" for profile in profiles
+    # Two wires define an image carrier inside a tool result: Anthropic
+    # (tool_result image blocks) and native Responses (the SDK
+    # function_call_output part list). A homogeneous route on either keeps
+    # the images; a route with any rung that has no carrier degrades them to
+    # positional placeholder text with disclosure instead of rejecting: the
+    # block is baked into the caller's history, so a rejection wedges the
+    # whole session, and a silent drop at encoding would misstate what the
+    # model saw. A non-vision rung on a keeping route still rejects at
+    # preflight and the route-wide coercion applies the same disclosed
+    # degrade.
+    if any(message.role == "tool" and message.images for message in request.messages) and not (
+        all(profile.dialect == "anthropic_messages" for profile in profiles)
+        or all(profile.dialect == "openai_responses" for profile in profiles)
     ):
         stripped = strip_tool_result_images(request.messages)
         if stripped is not None:
@@ -610,6 +623,45 @@ def route_generation_parameter_requests(
             ),
         )
         for path, present in tool_annotation_paths:
+            if present and path not in ignored:
+                ignored.append(path)
+
+    # Responses tool-call attribution (the nested-tool `namespace` and the
+    # SDK 3.0 programmatic `caller`, on calls and on their results) exists
+    # only on the native Responses wire; every other rung rebuilds the call
+    # or result without it. The call still executes with its exact name and
+    # arguments, so the omission is disclosed per field rather than
+    # rejected — but only the caller's attribution is dropped, never the
+    # call itself.
+    if not all(profile.dialect == "openai_responses" for profile in profiles):
+        attribution_paths = (
+            (
+                "messages.tool_calls.namespace->dropped(unsupported_by_provider)",
+                any(
+                    call.provider_namespace is not None
+                    for message in request.messages
+                    for call in message.tool_calls
+                ),
+            ),
+            (
+                "messages.tool_calls.caller->dropped(unsupported_by_provider)",
+                any(
+                    call.provider_caller is not None
+                    for message in request.messages
+                    for call in message.tool_calls
+                ),
+            ),
+            (
+                "messages.tool_results.attribution->dropped(unsupported_by_provider)",
+                any(
+                    message.provider_tool_name is not None
+                    or message.provider_tool_namespace is not None
+                    or message.provider_tool_caller is not None
+                    for message in request.messages
+                ),
+            ),
+        )
+        for path, present in attribution_paths:
             if present and path not in ignored:
                 ignored.append(path)
 

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -878,7 +878,8 @@ def test_route_rejects_effort_not_preserved_by_the_whole_waterfall() -> None:
 
     assert raised.value.param == "reasoning.effort"
     assert str(raised.value) == (
-        "Reasoning effort 'minimal' is not supported by this model route. Supported values: 'high'."
+        "The effort parameter value 'minimal' is not supported by this model route. "
+        "Supported values: 'high'."
     )
 
 
@@ -4066,3 +4067,136 @@ def test_route_rejects_max_output_tokens_below_the_responses_minimum() -> None:
     anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://a.test")
     public, _provider = route_generation_parameter_requests((responses, anthropic), request)
     assert public.ignored_parameters == ()
+
+
+def test_an_all_responses_route_keeps_tool_result_images() -> None:
+    """The native Responses wire carries tool-result images itself (the SDK
+    function_call_output part list), so a homogeneous Responses route keeps
+    the screenshot verbatim like an all-Anthropic route does."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"), _tool_image_message()),
+    )
+    profiles = (GatewayWireProfile(dialect="openai_responses", url="https://r.test"),)
+
+    public_request, provider_request = route_generation_parameter_requests(profiles, request)
+
+    assert provider_request.messages[-1].images
+    assert TOOL_RESULT_IMAGE_DROP_DISCLOSURE not in public_request.ignored_parameters
+
+
+def test_a_responses_and_chat_route_still_degrades_tool_result_images() -> None:
+    """A chat fallback rung has no tool-image carrier, so the mixed route
+    keeps the disclosed placeholder degrade."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(GatewayMessage(role="user", content="go"), _tool_image_message()),
+    )
+    profiles = (
+        GatewayWireProfile(dialect="openai_responses", url="https://r.test"),
+        GatewayWireProfile(dialect="openai_compatible", url="https://c.test"),
+    )
+
+    public_request, provider_request = route_generation_parameter_requests(profiles, request)
+
+    assert provider_request.messages[-1].content_parts == ()
+    assert TOOL_RESULT_IMAGE_DROP_DISCLOSURE in public_request.ignored_parameters
+
+
+def _attributed_history_request() -> GatewayRequest:
+    """One replayed turn whose call, and result, carry Responses attribution."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="user", content="go"),
+            GatewayMessage(
+                role="assistant",
+                tool_calls=(
+                    ToolCall(
+                        call_id="call-1",
+                        name="spawn_agent",
+                        arguments={},
+                        provider_namespace="collaboration",
+                        provider_caller={"type": "program", "caller_id": "call_prog"},
+                    ),
+                ),
+            ),
+            GatewayMessage(
+                role="tool",
+                tool_call_id="call-1",
+                content="done",
+                provider_tool_name="spawn_agent",
+                provider_tool_namespace="collaboration",
+            ),
+        ),
+    )
+
+
+def test_tool_call_attribution_drops_with_disclosure_off_the_responses_wire() -> None:
+    """A chat rung rebuilds the call without its namespace/caller attribution;
+    the call still executes with its exact name and arguments, so the route
+    discloses the per-field drop instead of rejecting a history the caller
+    cannot rewrite."""
+    profiles = (GatewayWireProfile(dialect="openai_compatible", url="https://c.test"),)
+
+    public_request, _provider = route_generation_parameter_requests(
+        profiles, _attributed_history_request()
+    )
+
+    assert (
+        "messages.tool_calls.namespace->dropped(unsupported_by_provider)"
+        in public_request.ignored_parameters
+    )
+    assert (
+        "messages.tool_calls.caller->dropped(unsupported_by_provider)"
+        in public_request.ignored_parameters
+    )
+    assert (
+        "messages.tool_results.attribution->dropped(unsupported_by_provider)"
+        in public_request.ignored_parameters
+    )
+
+
+def test_tool_call_attribution_is_undisclosed_on_a_homogeneous_responses_route() -> None:
+    """The native wire re-emits the attribution verbatim: nothing is dropped."""
+    profiles = (GatewayWireProfile(dialect="openai_responses", url="https://r.test"),)
+
+    public_request, _provider = route_generation_parameter_requests(
+        profiles, _attributed_history_request()
+    )
+
+    assert not any("attribution" in path for path in public_request.ignored_parameters)
+    assert not any("tool_calls.namespace" in path for path in public_request.ignored_parameters)
+    assert not any("tool_calls.caller" in path for path in public_request.ignored_parameters)
+
+
+def test_a_messages_surface_effort_rejection_matches_the_client_recovery_latch() -> None:
+    """The 400 names output_config.effort and phrases the miss recoverably.
+
+    Claude Code sends output_config.effort on every request and auto-recovers
+    (drops the field and retries) only when the message contains "effort
+    parameter" and "not support" or the param names output_config.effort; any
+    other phrasing wedges every turn on an effort-constrained route (#795).
+    """
+    profiles = (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://c.test",
+            model_id="hermes-4-405b",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning_effort",
+            supported_reasoning_efforts=("medium",),
+        ),
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        reasoning_effort="high",
+    )
+
+    with pytest.raises(UnsupportedReasoningEffortError) as raised:
+        route_generation_parameter_requests(profiles, request)
+
+    assert raised.value.param == "output_config.effort"
+    assert "effort parameter" in str(raised.value)
+    assert "not supported" in str(raised.value)

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import (
+    TOOL_ERROR_TEXT_PREFIX,
     GatewayMessage,
     GatewayNamedToolChoice,
     GatewayRequest,
@@ -32,10 +33,31 @@ from exp.runtime.models.providers.videos import openai_chat_video_part, reject_v
 def responses_items(message: GatewayMessage) -> list[JsonObject]:
     """Translate one non-instruction gateway message to Responses input items."""
     if message.role == "tool":
+        output_value: str | list[JsonObject]
+        if message.content_parts:
+            # The SDK list form round-trips: text and image parts re-emit as
+            # typed output parts (the image encoder is the same one user
+            # messages use). A failed invocation folds its error prefix in as
+            # a leading text part, derived from the canonical flag each time
+            # so replays never accumulate prefixes.
+            output_value = []
+            for part in message.content_parts:
+                if part.kind == "text":
+                    output_value.append({"type": "input_text", "text": part.text})
+                elif part.kind == "image":
+                    output_value.append(responses_image_part(part))
+                else:
+                    # The canonical contract restricts tool messages to text
+                    # and image parts; anything else here is a gateway bug.
+                    raise ProviderResponseError("tool results carry only text and image parts")
+            if message.tool_is_error:
+                output_value.insert(0, {"type": "input_text", "text": TOOL_ERROR_TEXT_PREFIX})
+        else:
+            output_value = message.folded_tool_error_content()
         output_item: JsonObject = {
             "type": "function_call_output",
             "call_id": message.tool_call_id or "",
-            "output": message.folded_tool_error_content(),
+            "output": output_value,
         }
         # Tool attribution round-trips verbatim: present stays present and
         # absent stays absent, so pre-namespace histories are unchanged.
@@ -43,6 +65,8 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
             output_item["name"] = message.provider_tool_name
         if message.provider_tool_namespace is not None:
             output_item["namespace"] = message.provider_tool_namespace
+        if message.provider_tool_caller is not None:
+            output_item["caller"] = message.provider_tool_caller
         return [output_item]
     if message.role == "user":
         if message.content_parts:
@@ -135,6 +159,10 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
         # retained value re-emits verbatim; absent stays absent.
         if call.provider_namespace is not None:
             item["namespace"] = call.provider_namespace
+        # SDK 3.0 programmatic tool-calling attribution round-trips verbatim
+        # like the namespace; absent stays absent.
+        if call.provider_caller is not None:
+            item["caller"] = call.provider_caller
         if call.provider_item_id is not None:
             item["id"] = call.provider_item_id
         if call.provider_status is not None:

--- a/exp/runtime/openai_protocol/manifest.py
+++ b/exp/runtime/openai_protocol/manifest.py
@@ -231,10 +231,10 @@ honoring the selector is impossible and accepting it would be silent."""
 RESPONSES_INPUT_ITEM_FIELDS_ACCEPTED: dict[str, frozenset[str]] = {
     "message": frozenset({"type", "role", "content", "id", "status", "phase"}),
     "function_call": frozenset(
-        {"type", "call_id", "name", "namespace", "arguments", "id", "status"}
+        {"type", "call_id", "name", "namespace", "caller", "arguments", "id", "status"}
     ),
     "function_call_output": frozenset(
-        {"type", "call_id", "output", "name", "namespace", "id", "status"}
+        {"type", "call_id", "output", "name", "namespace", "caller", "id", "status"}
     ),
     "reasoning": frozenset({"type", "id", "encrypted_content", "summary", "content", "status"}),
 }
@@ -250,19 +250,19 @@ is validated and dropped like its populated form. ``namespace`` on a
 ``function_call_output``) attributes the call to its declaring nested tool
 tree and round-trips verbatim: the provider rejects a namespaced call
 replayed without it ("Missing namespace for function_call ..."), which
-wedges every later turn of the session.
+wedges every later turn of the session. ``caller`` is SDK 3.0's opaque
+programmatic tool-calling attribution (``{"type": "program", "id": ...}``);
+its internal shape is an evolving provider surface, so it is validated only
+as an object and round-trips verbatim like ``namespace``.
 """
 
 RESPONSES_INPUT_ITEM_FIELDS_REJECTED: dict[str, frozenset[str]] = {
     "message": frozenset(),
-    "function_call": frozenset({"caller"}),
-    "function_call_output": frozenset({"caller"}),
+    "function_call": frozenset(),
+    "function_call_output": frozenset(),
     "reasoning": frozenset(),
 }
-"""Echoable input-item fields consciously rejected with a named 400.
-
-``caller`` attributes server-tool invocations this gateway does not serve.
-"""
+"""Echoable input-item fields consciously rejected with a named 400."""
 
 
 CHAT_CACHE_CONTROL_PLACEMENTS: dict[str, str] = {

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -847,6 +847,17 @@ def _response_input_messages(
                 ReplayedNativeItem(index=index, role=native_role, item=raw_items[index])
             )
         elif isinstance(item, _ResponseReasoningItem):
+            if item.encrypted_content is None:
+                # A store=true flow replays reasoning by item id alone (the
+                # SDK marks encrypted_content optional); only the issuing
+                # native Responses wire can resolve the id, so the item is
+                # carried verbatim like a hosted-tool item and the provider
+                # judges resolvability, rather than rejecting SDK-legal
+                # input the provider itself may serve.
+                replayed.append(
+                    ReplayedNativeItem(index=index, role="assistant", item=raw_items[index])
+                )
+                continue
             if item.encrypted_content.startswith(FIREWORKS_REASONING_CONTENT_PREFIX):
                 try:
                     block: EncryptedReasoningBlock | SealedReasoningContentBlock = (
@@ -894,18 +905,43 @@ def _response_input_messages(
                             "provider_output_index": index,
                             "provider_status": item.status,
                             "provider_namespace": item.namespace,
+                            "provider_caller": item.caller,
                         }
                     ),
                 )
             )
         else:
+            if isinstance(item.output, str):
+                output_text, output_parts = item.output, ()
+            else:
+                # The SDK list form: text and image parts map onto the
+                # canonical tool message (the tool-message contract carries
+                # exactly those two kinds); any other kind is a named 400
+                # because a tool result has no canonical carrier for it and
+                # dropping it would misstate what the tool returned.
+                output_text, output_parts = message_content(item.output, f"input.{index}.output")
+                unsupported = next(
+                    (part for part in output_parts if part.kind not in ("text", "image")),
+                    None,
+                )
+                if unsupported is not None:
+                    raise unsupported_field(
+                        f"input.{index}.output",
+                        message=(
+                            "function_call_output.output supports text and image parts "
+                            f"only; this list carries a {unsupported.kind!r} part."
+                        ),
+                    )
+                output_text = output_text or ""
             replayed.append(
                 ReplayedFunctionOutput(
                     index=index,
                     call_id=item.call_id,
-                    output=item.output,
+                    output=output_text,
                     name=item.name,
                     namespace=item.namespace,
+                    caller=item.caller,
+                    content_parts=output_parts,
                 )
             )
     return responses_input_messages(tuple(replayed))

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -1171,7 +1171,7 @@ def test_responses_decoder_preserves_multiple_official_output_message_phases() -
     ("item", "param"),
     (
         (
-            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": ""},
             "input.0.encrypted_content",
         ),
         (
@@ -1361,13 +1361,17 @@ def test_responses_decoder_rejects_unknown_include_paths() -> None:
         )
     assert raised.value.detail.param == "include"
 
-    with pytest.raises(OpenAIProtocolError):
-        decode_responses(
-            {
-                "model": "coding",
-                "input": [{"type": "reasoning", "id": "rs_1", "summary": []}],
-            }
-        )
+    # An id-only reasoning item (store=true replay, encrypted_content is
+    # SDK-optional) is no longer a 400: it carries verbatim to the native
+    # Responses wire and the provider judges resolvability.
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [{"type": "reasoning", "id": "rs_1", "summary": []}],
+        }
+    )
+    native = decoded.request.messages[-1].provider_native_item
+    assert native == {"type": "reasoning", "id": "rs_1", "summary": []}
 
 
 def test_chat_decoder_accepts_the_ultra_reasoning_effort() -> None:
@@ -1508,7 +1512,7 @@ def test_responses_union_errors_name_the_item_field_not_the_branch() -> None:
                         "call_id": "call-1",
                         "name": "get_weather",
                         "arguments": "{}",
-                        "caller": {"type": "direct"},
+                        "caller": "direct",
                     },
                 ],
             }
@@ -3191,3 +3195,206 @@ def test_responses_decoder_names_a_duplicate_call_id_instead_of_crashing() -> No
     assert rejected.value.status_code == 400
     assert rejected.value.detail.param == "input"
     assert "tool call IDs must be unique" in rejected.value.detail.message
+
+
+def test_a_caller_attributed_function_call_round_trips_its_caller_verbatim() -> None:
+    """The SDK 3.0 programmatic tool-calling attribution reaches the provider unchanged.
+
+    ``caller`` (for example ``{"type": "program", "id": ...}``) arrives on
+    function_call, function_call_output, and custom_tool_call items; each is
+    baked into the caller's history, so dropping or rejecting the field would
+    wedge every later turn of a session the provider itself serves.
+    """
+    caller = {"type": "program", "caller_id": "call_prog"}
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "message", "role": "user", "content": "run the program"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_c",
+                    "name": "lookup",
+                    "caller": caller,
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_c",
+                    "caller": caller,
+                    "output": "found",
+                },
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_free",
+                    "name": "freeform",
+                    "caller": caller,
+                    "input": "raw text",
+                },
+            ],
+        }
+    )
+    call = decoded.request.messages[1].tool_calls[0]
+    assert call.provider_caller == caller
+    tool_message = decoded.request.messages[2]
+    assert tool_message.provider_tool_caller == caller
+    native = decoded.request.messages[3].provider_native_item
+    assert native is not None and native["caller"] == caller
+
+    payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[-3] == {
+        "type": "function_call",
+        "call_id": "call_c",
+        "name": "lookup",
+        "arguments": "{}",
+        "caller": caller,
+    }
+    assert payload_input[-2] == {
+        "type": "function_call_output",
+        "call_id": "call_c",
+        "output": "found",
+        "caller": caller,
+    }
+    assert payload_input[-1] == {
+        "type": "custom_tool_call",
+        "call_id": "call_free",
+        "name": "freeform",
+        "caller": caller,
+        "input": "raw text",
+    }
+
+
+def test_a_caller_free_function_call_keeps_its_exact_wire_shape() -> None:
+    """Histories from before programmatic tool calling re-emit byte-identically."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "function_call", "call_id": "call_p", "name": "f", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "call_p", "output": "ok"},
+            ],
+        }
+    )
+    assert decoded.request.messages[0].tool_calls[0].provider_caller is None
+    assert decoded.request.messages[1].provider_tool_caller is None
+    payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert "caller" not in payload_input[-2]
+    assert "caller" not in payload_input[-1]
+
+
+def test_a_list_valued_function_output_maps_onto_canonical_tool_parts() -> None:
+    """A tool that returns an image beside text serves instead of a 400.
+
+    The SDK types ``function_call_output.output`` as a union of plain text
+    and a content-part list; the list form decodes onto the canonical tool
+    message (text and image parts) and re-emits as the typed list, so the
+    history round-trips on the native Responses wire.
+    """
+    image_url = "data:image/png;base64,aGk="
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "function_call", "call_id": "call_s", "name": "shot", "arguments": "{}"},
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_s",
+                    "output": [
+                        {"type": "input_text", "text": "screenshot:"},
+                        {"type": "input_image", "image_url": image_url},
+                    ],
+                },
+            ],
+        }
+    )
+    tool_message = decoded.request.messages[-1]
+    assert tool_message.content == "screenshot:"
+    assert [part.kind for part in tool_message.content_parts] == ["text", "image"]
+
+    payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[-1]["type"] == "function_call_output"
+    output_value = cast(list[JsonObject], payload_input[-1]["output"])
+    assert output_value[0] == {"type": "input_text", "text": "screenshot:"}
+    assert output_value[1]["type"] == "input_image"
+    assert output_value[1]["image_url"] == image_url
+
+
+def test_an_all_text_list_function_output_flattens_to_the_plain_string_form() -> None:
+    """A text-only part list keeps the exact pre-list message and wire shape."""
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {"type": "function_call", "call_id": "call_t", "name": "f", "arguments": "{}"},
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_t",
+                    "output": [
+                        {"type": "input_text", "text": "part one "},
+                        {"type": "input_text", "text": "part two"},
+                    ],
+                },
+            ],
+        }
+    )
+    tool_message = decoded.request.messages[-1]
+    assert tool_message.content == "part one part two"
+    assert tool_message.content_parts == ()
+    payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    payload_input = cast(list[JsonObject], payload["input"])
+    assert payload_input[-1]["output"] == "part one part two"
+
+
+def test_a_file_part_inside_a_function_output_is_rejected_by_name() -> None:
+    """The canonical tool message carries text and image parts only."""
+    with pytest.raises(OpenAIProtocolError) as error:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": [
+                    {"type": "function_call", "call_id": "call_f", "name": "f", "arguments": "{}"},
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_f",
+                        "output": [
+                            {
+                                "type": "input_file",
+                                "file_data": "data:application/pdf;base64,aGk=",
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+    assert error.value.status_code == 400
+    assert error.value.detail.param == "input.1.output"
+
+
+def test_a_custom_tool_call_output_list_carries_verbatim() -> None:
+    """The freeform result item is opaque: a list output rides the raw item."""
+    output_value = [{"type": "input_text", "text": "raw"}]
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_free",
+                    "output": output_value,
+                }
+            ],
+        }
+    )
+    native = decoded.request.messages[-1].provider_native_item
+    assert native is not None and native["output"] == output_value

--- a/exp/runtime/openai_protocol/responses_input.py
+++ b/exp/runtime/openai_protocol/responses_input.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ToolCall
+from exp.common.models.content import MessageContentPart
 from exp.runtime.gateway.contracts import (
     EncryptedReasoningBlock,
     GatewayMessage,
@@ -54,7 +55,9 @@ class ReplayedFunctionOutput:
     """One validated function result.
 
     ``name`` and ``namespace`` are the optional tool attribution Codex
-    serializes on outputs of namespaced calls, re-emitted verbatim.
+    serializes on outputs of namespaced calls, re-emitted verbatim; ``caller``
+    is SDK 3.0's opaque programmatic tool-calling attribution, re-emitted the
+    same way.
     """
 
     index: int
@@ -62,6 +65,11 @@ class ReplayedFunctionOutput:
     output: str
     name: str | None = None
     namespace: str | None = None
+    caller: JsonObject | None = None
+    content_parts: tuple[MessageContentPart, ...] = ()
+    """Ordered canonical parts when the SDK list form carried an image
+    beside text; empty for the plain-text form, whose message shape is
+    unchanged."""
 
 
 ReplayedInput = (
@@ -160,9 +168,11 @@ def responses_input_messages(value: str | tuple[ReplayedInput, ...]) -> tuple[Ga
                 GatewayMessage(
                     role="tool",
                     content=item.output,
+                    content_parts=item.content_parts,
                     tool_call_id=item.call_id,
                     provider_tool_name=item.name,
                     provider_tool_namespace=item.namespace,
+                    provider_tool_caller=item.caller,
                 )
             )
         else:

--- a/exp/runtime/openai_protocol/state.py
+++ b/exp/runtime/openai_protocol/state.py
@@ -398,6 +398,7 @@ class ContinuationState(ContractModel):
                     and call.provider_output_index is None
                     and call.provider_status is None
                     and call.provider_namespace is None
+                    and call.provider_caller is None
                 ):
                     continue
                 retained_call: dict[str, object] = {
@@ -409,6 +410,8 @@ class ContinuationState(ContractModel):
                 }
                 if call.provider_namespace is not None:
                     retained_call["provider_namespace"] = call.provider_namespace
+                if call.provider_caller is not None:
+                    retained_call["provider_caller"] = call.provider_caller
                 retained_calls.append(retained_call)
             if retained_calls:
                 authority["tool_calls"] = retained_calls
@@ -418,6 +421,8 @@ class ContinuationState(ContractModel):
                 authority["provider_tool_name"] = message.provider_tool_name
             if message.provider_tool_namespace is not None:
                 authority["provider_tool_namespace"] = message.provider_tool_namespace
+            if message.provider_tool_caller is not None:
+                authority["provider_tool_caller"] = message.provider_tool_caller
             if len(authority) > 1:
                 replay_authority.append(authority)
         if replay_authority:

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -612,6 +612,11 @@ class _ResponseFunctionCall(_WireModel):
     call_id: str = Field(min_length=1, max_length=256)
     name: str = Field(min_length=1, max_length=256)
     namespace: str | None = Field(default=None, min_length=1, max_length=256)
+    caller: JsonObject | None = None
+    """Opaque SDK 3.0 programmatic tool-calling attribution (for example
+    ``{"type": "program", "id": ...}``); an evolving provider surface, so it
+    is validated only as an object and round-trips verbatim like
+    ``namespace``."""
     arguments: str = Field(max_length=4_000_000)
     status: _EchoedItemStatus | None = None
 
@@ -624,13 +629,23 @@ class _ResponseFunctionOutput(_WireModel):
     ``name`` and ``namespace`` attribute the result to a namespaced tool
     (Codex serializes both on outputs of namespaced calls) and round-trip
     verbatim like the sibling ``function_call`` namespace.
+
+    ``output`` is the SDK union: plain text, or an ordered list of content
+    parts for tools that return images beside text. The decoder maps a part
+    list onto the canonical tool message's content parts (text and image
+    only, the tool-message contract); any other part kind is rejected by
+    name rather than dropped.
     """
 
     type: Literal["function_call_output"]
     call_id: str = Field(min_length=1, max_length=256)
     name: str | None = Field(default=None, min_length=1, max_length=256)
     namespace: str | None = Field(default=None, min_length=1, max_length=256)
-    output: str
+    caller: JsonObject | None = None
+    """Opaque SDK 3.0 attribution of this result to the program that invoked
+    the call; validated only as an object and round-tripped verbatim like the
+    sibling ``function_call`` caller."""
+    output: str | tuple[_ContentPart, ...]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     status: _EchoedItemStatus | None = None
 
@@ -659,11 +674,20 @@ class _ResponseReasoningItem(_WireModel):
     reasoning output items with an explicit ``content: null`` (captured
     live 2026-08-29); the provider accepts that null while rejecting a
     null ``summary``, so exactly ``content`` is nullable here.
+
+    ``encrypted_content`` itself is OPTIONAL, as the SDK marks it: a
+    ``store: true`` flow replays reasoning by item id alone and the
+    provider resolves it from stored state. An id-only item is carried
+    verbatim to homogeneous native Responses routes (the only wire that
+    can resolve the id) and the provider judges resolvability with its own
+    error — the hosted-item posture. That provider behavior is documented
+    from the SDK contract, not verified live (no key in the development
+    environment, 2026-09-05).
     """
 
     type: Literal["reasoning"]
     id: str = Field(min_length=1, max_length=256)
-    encrypted_content: str = Field(min_length=1)
+    encrypted_content: str | None = Field(default=None, min_length=1)
     summary: tuple[_ReasoningSummaryPart, ...] = ()
     content: tuple[_ReasoningTextPart, ...] | None = None
     status: _EchoedItemStatus | None = None
@@ -749,6 +773,9 @@ class _CustomToolCall(_WireModel):
     call_id: str = Field(min_length=1, max_length=256)
     name: str = Field(min_length=1, max_length=256)
     namespace: str | None = Field(default=None, min_length=1, max_length=256)
+    caller: JsonObject | None = None
+    """Opaque SDK 3.0 programmatic tool-calling attribution, forwarded
+    verbatim with the rest of the raw item like ``namespace``."""
     input: str = Field(max_length=4_000_000)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.32,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.33,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.32"
+version = "0.3.33"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What this is

The follow-up wedge-fix train from the Sep 2026 adversarial stress test (the round-3 open findings), plus #795. Each item is a field or shape that is VALID to the upstream provider but that this gateway 400-killed on input or mangled on output; every one is baked into the caller's conversation history, so the rejection wedged whole sessions. All five now serve, following the drift-tolerance philosophy and the #784/#774/#787 precedents they extend.

### 1. SDK 3.0 `caller` round-trip (HIGH — the full #784 treatment)

`caller` is the SDK 3.0 programmatic tool-calling attribution (`{"type": "direct"}` / `{"type": "program", "caller_id": ...}`) on `function_call`, `function_call_output`, and `custom_tool_call` items. Before: rejected on input by the manifest's conscious-reject list AND stripped from provider output by the Rust encoder. Now it survives the whole loop, exactly like the #784 namespace: wire models + manifest accept-list on decode (validated only as an object — its internal shape is the provider's evolving surface), canonical carriers (`ToolCall.provider_caller`, `GatewayMessage.provider_tool_caller` with the tool-role validator), the outbound Responses payload rebuild, continuation retention (Rust + `remember_turn`), the Rust dialect parser (with completion identity checks and a malformed non-object 400), the client SSE encoder and non-streamed body, and replay identity — joining only when present so caller-free digests are byte-identical. Native crate 0.3.32 → **0.3.33** (Cargo.toml + crate pyproject + root pin + locks).

### 2. `function_call_output.output` list form (HIGH — the #774 tool_result treatment)

The SDK types `output` as `str | list of content parts` (tools that return images beside text). The list form now decodes onto the canonical tool message — text parts concatenate into `content`, image parts become `content_parts` (role=tool carries text+image since #774) — and re-emits as the typed part list on the native Responses wire (same image encoder as user messages; a failed invocation folds its `[tool error]` prefix in as a leading text part, derived from the canonical flag so replays never accumulate). An all-text list flattens back to the exact plain-string wire shape, so pre-list histories and digests are unchanged. An `input_file` part is a named 400: the canonical tool-message contract is text+image only (deliberate scope; widening to documents is a separate contract change). `custom_tool_call_output.output` was already opaque `JsonValue` carried verbatim — now pinned by fixture. Route shaping: the tool-result image keep-rule extends from all-Anthropic to all-Anthropic OR all-native-Responses routes (the Responses wire has its own carrier now); mixed/chat routes keep the #774 disclosed placeholder degrade, and non-vision rungs keep the preflight + coerce path.

### 3. Reasoning items without `encrypted_content` (MEDIUM — the hosted-item posture)

The SDK marks `encrypted_content` optional: a `store: true` flow replays reasoning by item id alone and the provider resolves it from stored state. An id-only reasoning item now carries VERBATIM as a native item to homogeneous native Responses routes — admission already restricts native items to exactly the one wire that can resolve the id — and the provider judges resolvability with its own named error, instead of this gateway 400ing SDK-legal input. An EMPTY `encrypted_content` stays a named 400 (malformed, not merely absent). **LIVE-VERIFIED post-review (session lead, house key, 2026-09-05), results verbatim:** created a stored gpt-5.1 response with reasoning effort low → output carried a reasoning item `rs_0ae4b217...`; replayed that reasoning item BY ID with NO `encrypted_content` in the input array alongside a new user message — (A) `store: true`: 200, status completed (`resp_...5b476...`); (B) `store: false`: ALSO 200, completed (`resp_...5c6f5c...`). OpenAI accepts encrypted-content-less reasoning items by id in BOTH store modes, so the verbatim-native-item posture is provider-confirmed, not just SDK-justified — and the fail-closed 400 shipped before this PR rejected a shape the provider demonstrably serves. (The wire-model docstring's "not verified live" caveat predates this probe; it gets corrected on the release-train PR.) The posture fails open to the provider's own verdict, mirroring the #792 hosted-item philosophy.

### 4. Attribution drop disclosure off the Responses wire (LOW)

A namespaced or caller-attributed call replayed through a chat/Anthropic/Gemini/Bedrock rung is rebuilt without its attribution; previously a silent drop. Route shaping now discloses each drop (`messages.tool_calls.namespace->dropped(unsupported_by_provider)`, `.caller->...`, `messages.tool_results.attribution->...`) — the call itself always survives with its exact name and arguments, so this is disclosure, never rejection.

### 5. #795: effort 400s match Claude Code's recovery latch

Claude Code sends `output_config.effort` on every request and auto-recovers from an effort rejection (drops the field, retries, `tengu_effort_unsupported_retry`) only when the 400 matches its predicates. The gateway named the translated internal param (`reasoning_effort`) with unmatched phrasing, so every turn on an effort-constrained route (e.g. hermes-4-405b, `medium`-only) hard-failed. Now: the Messages surface names `output_config.effort` and `UnsupportedReasoningEffortError` phrases the miss as "The effort parameter value 'high' is not supported by this model route. Supported values: 'medium'." — containing the exact "effort parameter" + "not supported" predicate. Closes #795.

## Fixtures

- Repo: caller round-trip (decode → carriers → payload rebuild, caller-free byte-identity, malformed named 400s, retention replay, replay identity binding, tool-role validator), list outputs (text+image mapping + typed re-emission, all-text flattening, input_file named 400, custom verbatim), id-only reasoning (native-item decode; empty-payload 400 repinned), keep-rule (all-Responses keeps, Responses+chat degrades), attribution disclosures (chat rung discloses, homogeneous Responses does not), effort latch (param + both phrasing predicates). Rust: normalizer caller round-trip + changed-at-completion + non-object 400, SSE/body re-emission, retention payload.
- Wedge-stress harness (`exp-wedge-stress/stress/run_attacks4.py`, out of repo): 14/14 ok against the real served engine, including the provider-EMITS-caller round trip over two generations, streamed and non-streamed.
- Three pre-existing tests pinned the old rejections and were updated to pin the new contract (id-only reasoning decodes; empty `encrypted_content` still 400s; an object `caller` accepted, a non-object one still names `input.N.caller`; the effort phrasing pin).

## Gates

- `uv run ruff format/check`, `ty check` clean; full `uv run pytest -q` green (3702 passed; the two w16 evidence tests require the clean committed checkout and pass on it).
- native/ touched: `cargo fmt --check`, `cargo clippy --no-default-features -D warnings`, `cargo test --no-default-features` (191) all green; crate version moved 0.3.32 → 0.3.33 as the gate requires; native parity tests green against the rebuilt wheel.

## Release train

Rides the next `exp-gateway-native` release with the #784/#786/#787 train: publish `experiential` + `exp-gateway-native` 0.3.33 wheels, then bump the platform's exact `==X.Y.Z` pins. Until then these fixes serve from-source checkouts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
