### PR TITLE
gateway: record the provider's own stream-failure reason for the ledger

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.33"
+version = "0.3.34"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.33"
+version = "0.3.34"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -129,11 +129,88 @@ fn provider_stream_failed() -> Failure {
     Failure::new(FailureClass::ProviderInternal, "provider stream failed").with_retry(true, true)
 }
 
+/// Longest provider-declared error detail retained for the ledger, matching
+/// the python `GatewayFailure.provider_detail` bound.
+const MAXIMUM_STREAM_ERROR_DETAIL_CHARS: usize = 240;
+
+/// Reduce one provider-declared stream error to a bounded single-line detail.
+///
+/// A provider that opens the stream and then declares its own failure names
+/// the mechanism only inside that frame; dropping it left every such kill an
+/// undiagnosable "provider stream failed" (2026-09-05: gpt-6-astra streams
+/// dying ~120ms post-dispatch with the reason discarded). The code reduces
+/// to an identifier-shaped token and the message to one bounded line (cut at
+/// the first control character, whitespace collapsed). This detail is
+/// attached only to failure classes that never relay `provider_detail` to
+/// callers (the stream-failure family), so it reaches the ledger and alert
+/// samples without widening the caller-facing sanitization boundary.
+fn provider_error_detail(code: Option<&str>, message: Option<&str>) -> Option<String> {
+    let code = code
+        .filter(|value| !value.is_empty())
+        .map(bounded_wire_token);
+    let line = message.and_then(|message| {
+        let cut: String = message
+            .chars()
+            .take_while(|character| !character.is_control())
+            .collect();
+        let collapsed = cut.split_whitespace().collect::<Vec<_>>().join(" ");
+        (!collapsed.is_empty()).then_some(collapsed)
+    });
+    let detail = match (code, line) {
+        (None, None) => return None,
+        (Some(code), None) => code,
+        (None, Some(line)) => line,
+        (Some(code), Some(line)) => format!("{code}: {line}"),
+    };
+    Some(
+        detail
+            .chars()
+            .take(MAXIMUM_STREAM_ERROR_DETAIL_CHARS)
+            .collect(),
+    )
+}
+
+/// Build the provider-declared stream failure carrying its bounded detail,
+/// and emit the structured operator line naming it.
+fn provider_stream_failed_with_detail(
+    dialect: &str,
+    code: Option<&str>,
+    message: Option<&str>,
+) -> Failure {
+    let detail = provider_error_detail(code, message);
+    if let Some(detail) = &detail {
+        let line = serde_json::json!({
+            "event": "provider_declared_failure",
+            "dialect": dialect,
+            "detail": detail,
+        });
+        eprintln!("exp-gateway-native: {line}");
+    }
+    provider_stream_failed().with_provider_detail(detail)
+}
+
 fn parse_object(data: &str) -> Result<Map<String, Value>, Failure> {
     match serde_json::from_str::<Value>(data) {
         Ok(Value::Object(object)) => Ok(object),
         Ok(_) => Err(malformed("provider stream event must be a JSON object")),
-        Err(_) => Err(malformed("provider stream event is not valid JSON")),
+        Err(error) => {
+            // The frame bytes are never logged, hashed, or otherwise derived
+            // from (a frame is provider payload, and even an unkeyed digest
+            // of low-entropy content invites dictionary guessing): the size
+            // and serde's positional description (token category and
+            // line/column, never input bytes) name the parse failure and
+            // correlate identical malformed frames across requests.
+            let line = serde_json::json!({
+                "event": "malformed_stream_frame",
+                "bytes": data.len(),
+                "reason": error.to_string(),
+            });
+            eprintln!("exp-gateway-native: {line}");
+            Err(malformed(&format!(
+                "provider stream event is not valid JSON: {error} ({} bytes)",
+                data.len()
+            )))
+        }
     }
 }
 
@@ -654,5 +731,154 @@ mod recover_abnormal_end_tests {
             .recover_abnormal_end(incoming())
             .expect_err("a terminated stream does not re-recover");
         assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+    }
+}
+
+#[cfg(test)]
+mod stream_error_detail_tests {
+    use super::*;
+
+    fn frame(payload: serde_json::Value) -> SseEvent {
+        SseEvent {
+            event: None,
+            data: payload.to_string(),
+        }
+    }
+
+    fn failed_detail(events: &[Event]) -> Option<String> {
+        match events.last() {
+            Some(Event::Failed(failure)) => failure.provider_detail.clone(),
+            other => panic!("expected a failed terminal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn provider_error_detail_is_one_bounded_line() {
+        assert_eq!(provider_error_detail(None, None), None);
+        assert_eq!(
+            provider_error_detail(Some("server_error"), None).as_deref(),
+            Some("server_error")
+        );
+        assert_eq!(
+            provider_error_detail(Some("server_error"), Some("The model failed  to respond."))
+                .as_deref(),
+            Some("server_error: The model failed to respond.")
+        );
+        // The line cuts at the first control character: a payload dump never
+        // rides past its first row.
+        assert_eq!(
+            provider_error_detail(None, Some("first line\nsecond line")).as_deref(),
+            Some("first line")
+        );
+        // A hostile code reduces to the shared identifier token.
+        assert_eq!(
+            provider_error_detail(Some("weird code!{}"), None).as_deref(),
+            Some("non-identifier")
+        );
+        // The composed detail never exceeds the python provider_detail bound.
+        let long = "x".repeat(400);
+        let bounded = provider_error_detail(Some("code"), Some(&long)).expect("bounded");
+        assert_eq!(bounded.chars().count(), 240);
+    }
+
+    /// Every dialect's provider-declared stream failure carries its bounded
+    /// mechanism into `provider_detail` (ledger-only for these classes), so
+    /// the next post-open kill is diagnosable from the ledger instead of an
+    /// opaque "provider stream failed" (2026-09-05: gpt-6-astra kills ~120ms
+    /// post-dispatch across 20 orgs with the reason discarded on the wire).
+    #[test]
+    fn responses_failed_terminal_carries_its_error_detail() {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+        let events = normalizer
+            .feed(&frame(serde_json::json!({
+                "type": "response.failed",
+                "response": {
+                    "status": "failed",
+                    "error": {"code": "server_error", "message": "The model failed."},
+                },
+            })))
+            .expect("failed terminal normalizes");
+        assert_eq!(
+            failed_detail(&events).as_deref(),
+            Some("server_error: The model failed.")
+        );
+    }
+
+    #[test]
+    fn responses_error_frame_carries_its_error_detail() {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+        let events = normalizer
+            .feed(&frame(serde_json::json!({
+                "type": "error",
+                "code": "rate_limit_exceeded",
+                "message": "Rate limit reached for gpt-6-astra.",
+                "param": null,
+                "sequence_number": 1,
+            })))
+            .expect("error frame normalizes");
+        assert_eq!(
+            failed_detail(&events).as_deref(),
+            Some("rate_limit_exceeded: Rate limit reached for gpt-6-astra.")
+        );
+    }
+
+    #[test]
+    fn compatible_error_frame_carries_its_error_detail() {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+        let events = normalizer
+            .feed(&frame(serde_json::json!({
+                "error": {"code": 502, "message": "upstream connect error"},
+            })))
+            .expect("error frame normalizes");
+        assert_eq!(
+            failed_detail(&events).as_deref(),
+            Some("502: upstream connect error")
+        );
+    }
+
+    #[test]
+    fn anthropic_error_frame_carries_its_error_detail() {
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let events = normalizer
+            .feed(&frame(serde_json::json!({
+                "type": "error",
+                "error": {"type": "overloaded_error", "message": "Overloaded"},
+            })))
+            .expect("error frame normalizes");
+        assert_eq!(
+            failed_detail(&events).as_deref(),
+            Some("overloaded_error: Overloaded")
+        );
+    }
+
+    #[test]
+    fn gemini_error_envelope_carries_its_error_detail() {
+        let mut normalizer = Normalizer::new(Dialect::GeminiGenerateContent);
+        let events = normalizer
+            .feed(&frame(serde_json::json!({
+                "error": {"code": 503, "status": "UNAVAILABLE", "message": "Overloaded."},
+            })))
+            .expect("error envelope normalizes");
+        assert_eq!(
+            failed_detail(&events).as_deref(),
+            Some("UNAVAILABLE: Overloaded.")
+        );
+    }
+
+    #[test]
+    fn unparsable_stream_frames_name_size_and_parse_position() {
+        let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+        let failure = normalizer
+            .feed(&SseEvent {
+                event: None,
+                data: "<html>502 Bad Gateway</html>".to_string(),
+            })
+            .expect_err("a non-JSON frame is malformed");
+        assert!(
+            failure.safe_message.contains("not valid JSON")
+                && failure.safe_message.contains("(28 bytes)"),
+            "reason must carry the parse diagnosis: {}",
+            failure.safe_message
+        );
     }
 }

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -139,11 +139,14 @@ const MAXIMUM_STREAM_ERROR_DETAIL_CHARS: usize = 240;
 /// the mechanism only inside that frame; dropping it left every such kill an
 /// undiagnosable "provider stream failed" (2026-09-05: gpt-6-astra streams
 /// dying ~120ms post-dispatch with the reason discarded). The code reduces
-/// to an identifier-shaped token and the message to one bounded line (cut at
-/// the first control character, whitespace collapsed). This detail is
-/// attached only to failure classes that never relay `provider_detail` to
-/// callers (the stream-failure family), so it reaches the ledger and alert
-/// samples without widening the caller-facing sanitization boundary.
+/// to an identifier-shaped token; the message reduces to one bounded line
+/// (cut at the first control character, whitespace collapsed) and is then
+/// held to the same identifier screen the caller-facing attribution path
+/// uses, so a sentence naming request-specific or infrastructure handles
+/// drops while its code token survives. The detail is attached only to
+/// failure classes that never relay `provider_detail` to callers (the
+/// stream-failure family), so it reaches the ledger and alert samples
+/// without widening the caller-facing sanitization boundary.
 fn provider_error_detail(code: Option<&str>, message: Option<&str>) -> Option<String> {
     let code = code
         .filter(|value| !value.is_empty())
@@ -154,7 +157,11 @@ fn provider_error_detail(code: Option<&str>, message: Option<&str>) -> Option<St
             .take_while(|character| !character.is_control())
             .collect();
         let collapsed = cut.split_whitespace().collect::<Vec<_>>().join(" ");
-        (!collapsed.is_empty()).then_some(collapsed)
+        (!collapsed.is_empty()
+            && !collapsed
+                .split(' ')
+                .any(|word| crate::param_attribution::carries_provider_identifier(word, &[])))
+        .then_some(collapsed)
     });
     let detail = match (code, line) {
         (None, None) => return None,
@@ -821,9 +828,12 @@ mod stream_error_detail_tests {
                 "sequence_number": 1,
             })))
             .expect("error frame normalizes");
+        // The model id trips the identifier screen (letters+digits label), so
+        // the sentence drops while the code token survives: the mechanism
+        // stays named without relaying a label-shaped word to the ledger.
         assert_eq!(
             failed_detail(&events).as_deref(),
-            Some("rate_limit_exceeded: Rate limit reached for gpt-6-astra.")
+            Some("rate_limit_exceeded")
         );
     }
 

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -170,6 +170,16 @@ fn provider_error_detail(code: Option<&str>, message: Option<&str>) -> Option<St
     )
 }
 
+/// Emit the structured operator line naming one provider-declared failure.
+fn log_provider_declared_failure(dialect: &str, detail: &str) {
+    let line = serde_json::json!({
+        "event": "provider_declared_failure",
+        "dialect": dialect,
+        "detail": detail,
+    });
+    eprintln!("exp-gateway-native: {line}");
+}
+
 /// Build the provider-declared stream failure carrying its bounded detail,
 /// and emit the structured operator line naming it.
 fn provider_stream_failed_with_detail(
@@ -179,12 +189,7 @@ fn provider_stream_failed_with_detail(
 ) -> Failure {
     let detail = provider_error_detail(code, message);
     if let Some(detail) = &detail {
-        let line = serde_json::json!({
-            "event": "provider_declared_failure",
-            "dialect": dialect,
-            "detail": detail,
-        });
-        eprintln!("exp-gateway-native: {line}");
+        log_provider_declared_failure(dialect, detail);
     }
     provider_stream_failed().with_provider_detail(detail)
 }

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -765,6 +765,30 @@ mod stream_error_detail_tests {
     }
 
     #[test]
+    fn secret_shaped_words_drop_the_whole_detail_line() {
+        // The identifier screen treats any letter+digit label as a handle,
+        // which covers key and token shapes: a sentence carrying one drops
+        // entirely (never partially redacted), for every dialect that feeds
+        // the shared detail path, Bedrock exception messages included.
+        for message in [
+            "Invalid key sk-abc123def provided.",
+            "The access key AKIA9X7EXAMPLE is not authorized for this model.",
+            "Bearer eyJhbGciOi9 was rejected.",
+        ] {
+            assert_eq!(
+                provider_error_detail(None, Some(message)),
+                None,
+                "a credential-shaped word must drop the sentence: {message}"
+            );
+            assert_eq!(
+                provider_error_detail(Some("validation_error"), Some(message)).as_deref(),
+                Some("validation_error"),
+                "the safe code token alone survives: {message}"
+            );
+        }
+    }
+
+    #[test]
     fn provider_error_detail_is_one_bounded_line() {
         assert_eq!(provider_error_detail(None, None), None);
         assert_eq!(

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use super::{
     complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
-    provider_stream_failed, refusal_failure, Normalizer,
+    refusal_failure, Normalizer,
 };
 use crate::encode::compact_json;
 use crate::errors::Failure;
@@ -304,7 +304,20 @@ impl Normalizer {
                 }
             }
             "error" => {
-                events.push(Event::Failed(provider_stream_failed()));
+                // The provider names its failure mechanism only inside this
+                // frame; the bounded detail rides the failure into the ledger.
+                let (code, message) = match payload.get("error").and_then(Value::as_object) {
+                    Some(error) => (
+                        error.get("type").and_then(Value::as_str),
+                        error.get("message").and_then(Value::as_str),
+                    ),
+                    None => (None, None),
+                };
+                events.push(Event::Failed(super::provider_stream_failed_with_detail(
+                    "anthropic_messages",
+                    code,
+                    message,
+                )));
             }
             "ping" => {}
             _ => {

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -7,6 +7,25 @@ use super::{complete_streamed_tool, malformed, parse_object, refusal_failure, No
 use crate::errors::{Failure, FailureClass};
 use crate::events::{bedrock_usage, require_string, require_u64, Event, ToolAccumulator};
 
+/// The bounded single-line detail of one Bedrock exception frame.
+///
+/// Exception messages name the mechanism (model stream errors, service
+/// unavailability) that the typed class alone cannot; the detail is attached
+/// only to stream-failure classes that never relay `provider_detail` to
+/// callers, so it reaches the ledger without widening the caller-facing
+/// sanitization boundary.
+fn bedrock_exception_detail(frame: &crate::sse::SseEvent) -> Option<String> {
+    let message = serde_json::from_str::<Value>(&frame.data)
+        .ok()
+        .and_then(|payload| {
+            payload
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+    super::provider_error_detail(None, message.as_deref())
+}
+
 impl Normalizer {
     /// Normalize one Bedrock ConverseStream frame, mirroring the python
     /// `BedrockProviderStream._decode` mapper: tool calls stream as indexed
@@ -32,20 +51,20 @@ impl Normalizer {
                 Ok(Vec::new())
             }
             "metadata" => self.bedrock_metadata(frame),
-            "throttlingException" => Ok(vec![Event::Failed(Failure::new(
-                FailureClass::Throttled,
-                "provider throttled the request",
-            ))]),
-            "modelTimeoutException" => Ok(vec![Event::Failed(Failure::new(
-                FailureClass::Timeout,
-                "provider request timed out",
-            ))]),
+            "throttlingException" => Ok(vec![Event::Failed(
+                Failure::new(FailureClass::Throttled, "provider throttled the request")
+                    .with_provider_detail(bedrock_exception_detail(frame)),
+            )]),
+            "modelTimeoutException" => Ok(vec![Event::Failed(
+                Failure::new(FailureClass::Timeout, "provider request timed out")
+                    .with_provider_detail(bedrock_exception_detail(frame)),
+            )]),
             "internalServerException"
             | "modelStreamErrorException"
-            | "serviceUnavailableException" => Ok(vec![Event::Failed(Failure::new(
-                FailureClass::ProviderInternal,
-                "provider stream failed",
-            ))]),
+            | "serviceUnavailableException" => Ok(vec![Event::Failed(
+                Failure::new(FailureClass::ProviderInternal, "provider stream failed")
+                    .with_provider_detail(bedrock_exception_detail(frame)),
+            )]),
             "validationException" => Ok(vec![Event::Failed(Failure::new(
                 FailureClass::InvalidRequest,
                 "provider rejected the request",

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -23,7 +23,14 @@ fn bedrock_exception_detail(frame: &crate::sse::SseEvent) -> Option<String> {
                 .and_then(Value::as_str)
                 .map(str::to_string)
         });
-    super::provider_error_detail(None, message.as_deref())
+    let detail = super::provider_error_detail(None, message.as_deref());
+    if let Some(detail) = &detail {
+        // The same structured operator line the other dialects emit, so a
+        // Bedrock-declared failure is equally visible in the immediate
+        // diagnostic stream.
+        super::log_provider_declared_failure("bedrock_converse_stream", detail);
+    }
+    detail
 }
 
 impl Normalizer {

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -2,7 +2,7 @@
 
 use serde_json::Value;
 
-use super::{malformed, parse_object, provider_stream_failed, refusal_failure, Normalizer};
+use super::{malformed, parse_object, refusal_failure, Normalizer};
 use crate::errors::{Failure, FailureClass};
 use crate::events::{gemini_usage, require_string, Event, ToolAccumulator};
 

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -19,14 +19,24 @@ impl Normalizer {
         frame: &crate::sse::SseEvent,
     ) -> Result<Vec<Event>, Failure> {
         let payload = parse_object(&frame.data)?;
-        if payload.get("error").is_some_and(|value| !value.is_null()) {
+        if let Some(error) = payload.get("error").filter(|value| !value.is_null()) {
             // Google's error envelope ({"error":{"code":503,"status":"UNAVAILABLE"}})
             // arrives as a candidate-less frame; without this branch it reads
             // as a usage-only trailer and the stream ends malformed (or, after
             // prior output, as a synthesized completion of a failed answer).
             // It is the provider declaring failure, so it takes the shared
-            // retry-then-failover classification the other dialects give it.
-            return Ok(vec![Event::Failed(provider_stream_failed())]);
+            // retry-then-failover classification the other dialects give it,
+            // with its status and message riding as the bounded ledger detail.
+            let (code, message) = match error.as_object() {
+                Some(error) => (
+                    error.get("status").and_then(Value::as_str),
+                    error.get("message").and_then(Value::as_str),
+                ),
+                None => (None, None),
+            };
+            return Ok(vec![Event::Failed(
+                super::provider_stream_failed_with_detail("gemini_generate_content", code, message),
+            )]);
         }
         if let Some(raw_usage) = payload.get("usageMetadata") {
             if !raw_usage.is_null() {

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -537,7 +537,7 @@ mod gemini_tests {
             events,
             vec![json!({"kind": "text_delta", "text": "partial"}), failed]
         );
-        let classified = provider_stream_failed();
+        let classified = crate::dialects::provider_stream_failed();
         assert_eq!(classified.failure_class, FailureClass::ProviderInternal);
         assert!(classified.retryable_same_deployment);
         assert!(classified.failover_eligible);

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -4,14 +4,14 @@
 use serde_json::Value;
 
 use super::{
-    bounded_wire_token, complete_streamed_tool, finish_open_tools, finish_open_tools_truncated,
-    malformed, optional_text, parse_object, provider_error_detail,
-    provider_stream_failed_with_detail, refusal_failure, Normalizer,
+    bounded_wire_token, complete_streamed_tool, finish_open_tools, malformed, optional_text,
+    parse_object, provider_error_detail, provider_stream_failed_with_detail, refusal_failure,
+    Normalizer,
 };
 use crate::errors::{Failure, FailureClass};
 use crate::events::{
-    openai_compatible_usage, openai_usage, require_bounded_string, require_string, require_u64,
-    Event, ProviderAssistantMessagePhase, ProviderOutputItemKind, ProviderOutputItemStatus,
+    openai_usage, require_bounded_string, require_string, require_u64, Event,
+    ProviderAssistantMessagePhase, ProviderOutputItemKind, ProviderOutputItemStatus,
     ToolAccumulator,
 };
 
@@ -829,202 +829,9 @@ impl Normalizer {
         }
         Ok(events)
     }
-
-    pub(super) fn feed_openai_compatible(
-        &mut self,
-        frame: &crate::sse::SseEvent,
-    ) -> Result<Vec<Event>, Failure> {
-        if frame.data == "[DONE]" {
-            let finish = self.finish_reason.as_deref();
-            // A tool call cut off by the output budget (finish_reason=length,
-            // arguments still an open JSON fragment) is the provider's honest
-            // truncation, not a malformed stream: it surfaces as Incomplete
-            // with the truncated call dropped, exactly what the caller must
-            // act on (raise max_tokens), never as a 502. Live shape: Tencent
-            // TokenHub glm-5.3 at max_tokens=32 streamed `{"` + `city` then
-            // finished with length (staging, 2026-09-03). Any other finish
-            // keeps the strict contract: unparsable arguments are malformed.
-            let mut events = if finish == Some("length") {
-                finish_open_tools_truncated(&mut self.tools)?
-            } else {
-                finish_open_tools(&mut self.tools)?
-            };
-            if let Some(usage) = self.usage.take() {
-                events.push(Event::Usage(usage));
-            }
-            if self.refusal_seen || matches!(finish, Some("content_filter" | "safety")) {
-                events.push(Event::Failed(refusal_failure()));
-            } else if finish == Some("length") {
-                events.push(Event::Incomplete);
-            } else {
-                events.push(Event::Completed);
-            }
-            return Ok(events);
-        }
-        let payload = parse_object(&frame.data)?;
-        if let Some(error) = payload.get("error").filter(|value| !value.is_null()) {
-            // An OpenAI-compatible relay declaring failure inside the stream
-            // names the mechanism only here; the bounded detail rides the
-            // failure into the ledger.
-            let (code, message) = match error.as_object() {
-                Some(error) => (
-                    error.get("code").and_then(|value| {
-                        value
-                            .as_str()
-                            .map(str::to_string)
-                            .or_else(|| value.as_i64().map(|numeric| numeric.to_string()))
-                    }),
-                    error
-                        .get("message")
-                        .and_then(Value::as_str)
-                        .map(str::to_string),
-                ),
-                None => (None, None),
-            };
-            return Ok(vec![Event::Failed(provider_stream_failed_with_detail(
-                "openai_compatible",
-                code.as_deref(),
-                message.as_deref(),
-            ))]);
-        }
-        let mut events = Vec::new();
-        if let Some(raw_usage) = payload.get("usage") {
-            if !raw_usage.is_null() {
-                self.usage = Some(
-                    openai_compatible_usage(raw_usage).map_err(|message| malformed(&message))?,
-                );
-            }
-        }
-        let choices = payload
-            .get("choices")
-            .and_then(Value::as_array)
-            .ok_or_else(|| malformed("OpenAI-compatible choices must be an array"))?;
-        if choices.is_empty() {
-            return Ok(events);
-        }
-        if choices.len() != 1 {
-            return Err(malformed(
-                "OpenAI-compatible stream must contain one choice",
-            ));
-        }
-        let choice = choices[0]
-            .as_object()
-            .ok_or_else(|| malformed("OpenAI-compatible choice must be an object"))?;
-        let delta = choice
-            .get("delta")
-            .and_then(Value::as_object)
-            .ok_or_else(|| malformed("OpenAI-compatible delta must be an object"))?;
-        if let Some(Value::String(content)) = delta.get("content") {
-            if !content.is_empty() {
-                events.push(Event::TextDelta(content.clone()));
-            }
-        }
-        if let Some(Value::String(refusal)) = delta.get("refusal") {
-            self.refusal_seen = true;
-            events.push(Event::RefusalDelta(refusal.clone()));
-        }
-        if let Some(route_sha256) = self.reasoning_content_route_sha256.clone() {
-            if let Some(value) = delta.get("reasoning_content") {
-                let reasoning = match value {
-                    Value::Null => None,
-                    Value::String(text) => Some(text),
-                    _ => return Err(malformed("Fireworks reasoning_content delta must be text")),
-                };
-                if let Some(reasoning) = reasoning.filter(|text| !text.is_empty()) {
-                    self.reserve_summary_bytes(reasoning.len())?;
-                    events.push(Event::ReasoningContentDelta {
-                        route_sha256,
-                        delta: reasoning.clone(),
-                    });
-                }
-            }
-        }
-        if let Some(raw_tools) = delta.get("tool_calls") {
-            if !raw_tools.is_null() {
-                let items = raw_tools
-                    .as_array()
-                    .ok_or_else(|| malformed("OpenAI-compatible tool_calls must be an array"))?;
-                for value in items {
-                    let item = value.as_object().ok_or_else(|| {
-                        malformed("OpenAI-compatible tool call must be an object")
-                    })?;
-                    let index = require_u64(item, "index", "OpenAI-compatible tool index")
-                        .map_err(|message| malformed(&message))?
-                        as u32;
-                    let function =
-                        item.get("function")
-                            .and_then(Value::as_object)
-                            .ok_or_else(|| {
-                                malformed("OpenAI-compatible tool function must be an object")
-                            })?;
-                    if let Some(tool) = self.tools.get(&index) {
-                        // An identity is only restated when it is non-empty:
-                        // DashScope (Qwen) argument deltas carry `"id": ""`
-                        // (documented shape, live 2026-09-03), and an empty
-                        // placeholder names nothing, so only a different
-                        // NON-EMPTY id or name is a stream that changed identity.
-                        if let Some(Value::String(repeated_id)) = item.get("id") {
-                            if !repeated_id.is_empty() && repeated_id != &tool.call_id {
-                                return Err(malformed(
-                                    "OpenAI-compatible stream changed a tool-call ID",
-                                ));
-                            }
-                        }
-                        if let Some(Value::String(repeated_name)) = function.get("name") {
-                            if !repeated_name.is_empty() && repeated_name != &tool.name {
-                                return Err(malformed(
-                                    "OpenAI-compatible stream changed a tool-call name",
-                                ));
-                            }
-                        }
-                    } else {
-                        let call_id = require_string(item, "id", "OpenAI-compatible tool ID")
-                            .map_err(|message| malformed(&message))?;
-                        let name = require_string(function, "name", "OpenAI-compatible tool name")
-                            .map_err(|message| malformed(&message))?;
-                        self.reserve_tool_entry(index)?;
-                        self.tools
-                            .insert(index, ToolAccumulator::new(call_id.clone(), name.clone()));
-                        events.push(Event::ToolCallStarted {
-                            index,
-                            call_id,
-                            name,
-                            namespace: None,
-                            caller: None,
-                        });
-                    }
-                    if let Some(fragment) = function.get("arguments") {
-                        if !fragment.is_null() {
-                            let raw_fragment = match fragment {
-                                Value::String(text) => text.clone(),
-                                _ => {
-                                    return Err(malformed(
-                                        "OpenAI-compatible argument delta must be text",
-                                    ))
-                                }
-                            };
-                            self.reserve_tool_bytes(raw_fragment.len())?;
-                            let tool = self.tools.get_mut(&index).expect("tool just ensured");
-                            tool.raw_arguments.push_str(&raw_fragment);
-                            events.push(Event::ToolArgumentsDelta {
-                                index,
-                                delta: raw_fragment,
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        if let Some(Value::String(finish)) = choice.get("finish_reason") {
-            self.finish_reason = Some(finish.clone());
-            if matches!(finish.as_str(), "content_filter" | "safety") && !self.refusal_seen {
-                self.refusal_seen = true;
-                events.push(Event::RefusalDelta(String::new()));
-            }
-        }
-        Ok(events)
-    }
 }
+
+mod compatible;
 
 #[cfg(test)]
 #[path = "openai/normalizer_tests.rs"]

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -5,7 +5,8 @@ use serde_json::Value;
 
 use super::{
     bounded_wire_token, complete_streamed_tool, finish_open_tools, finish_open_tools_truncated,
-    malformed, optional_text, parse_object, provider_stream_failed, refusal_failure, Normalizer,
+    malformed, optional_text, parse_object, provider_error_detail,
+    provider_stream_failed_with_detail, refusal_failure, Normalizer,
 };
 use crate::errors::{Failure, FailureClass};
 use crate::events::{
@@ -770,12 +771,15 @@ impl Normalizer {
                     } else if reason == "content_filter" || reason == "safety" {
                         events.push(Event::Failed(refusal_failure()));
                     } else {
+                        // The undocumented reason is the only diagnostic this
+                        // terminal carries; it rides as the bounded detail.
                         events.push(Event::Failed(
                             Failure::new(
                                 FailureClass::ProviderInternal,
                                 "provider ended the stream incompletely",
                             )
-                            .with_retry(true, true),
+                            .with_retry(true, true)
+                            .with_provider_detail(provider_error_detail(Some(reason), None)),
                         ));
                     }
                 }
@@ -783,22 +787,40 @@ impl Normalizer {
             "response.failed" => {
                 // A failed terminal still reports the usage the provider
                 // billed for the processed legs; fold it so settlement
-                // accounts the charged tokens instead of zero.
+                // accounts the charged tokens instead of zero. Its error
+                // object names the mechanism, so a bounded detail rides the
+                // failure into the ledger (2026-09-05: gpt-6-astra kills
+                // ~120ms post-dispatch were undiagnosable without it).
+                let mut code = None;
+                let mut message = None;
                 if let Some(response) = payload.get("response").and_then(Value::as_object) {
                     if let Some(usage) = openai_usage(response.get("usage"))
                         .map_err(|message| malformed(&message))?
                     {
                         events.push(Event::Usage(usage));
                     }
+                    if let Some(error) = response.get("error").and_then(Value::as_object) {
+                        code = error.get("code").and_then(Value::as_str);
+                        message = error.get("message").and_then(Value::as_str);
+                    }
                 }
-                events.push(Event::Failed(provider_stream_failed()));
+                events.push(Event::Failed(provider_stream_failed_with_detail(
+                    "openai_responses",
+                    code,
+                    message,
+                )));
             }
             "error" => {
                 // The in-stream error frame is the provider declaring its own
                 // failure mid-stream, mirroring the Anthropic dialect's error
                 // event: provider_internal (retry, then fail over), never a
-                // stream that "ended without a terminal event".
-                events.push(Event::Failed(provider_stream_failed()));
+                // stream that "ended without a terminal event". Its code and
+                // message ride the failure as the bounded ledger detail.
+                events.push(Event::Failed(provider_stream_failed_with_detail(
+                    "openai_responses",
+                    payload.get("code").and_then(Value::as_str),
+                    payload.get("message").and_then(Value::as_str),
+                )));
             }
             other if is_openai_hosted_progress_event(other) => {
                 events.extend(self.openai_hosted_progress(other, &payload)?);
@@ -840,8 +862,30 @@ impl Normalizer {
             return Ok(events);
         }
         let payload = parse_object(&frame.data)?;
-        if payload.get("error").is_some_and(|value| !value.is_null()) {
-            return Ok(vec![Event::Failed(provider_stream_failed())]);
+        if let Some(error) = payload.get("error").filter(|value| !value.is_null()) {
+            // An OpenAI-compatible relay declaring failure inside the stream
+            // names the mechanism only here; the bounded detail rides the
+            // failure into the ledger.
+            let (code, message) = match error.as_object() {
+                Some(error) => (
+                    error.get("code").and_then(|value| {
+                        value
+                            .as_str()
+                            .map(str::to_string)
+                            .or_else(|| value.as_i64().map(|numeric| numeric.to_string()))
+                    }),
+                    error
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                ),
+                None => (None, None),
+            };
+            return Ok(vec![Event::Failed(provider_stream_failed_with_detail(
+                "openai_compatible",
+                code.as_deref(),
+                message.as_deref(),
+            ))]);
         }
         let mut events = Vec::new();
         if let Some(raw_usage) = payload.get("usage") {

--- a/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
@@ -1,0 +1,209 @@
+//! The OpenAI-compatible Chat Completions frame mapping (split from
+//! `openai.rs` for the module line budget): incremental deltas, tool-call
+//! fragments, exposure-gated reasoning content, and the `[DONE]` terminal.
+
+use serde_json::Value;
+
+use super::super::{
+    finish_open_tools, finish_open_tools_truncated, malformed, parse_object,
+    provider_stream_failed_with_detail, refusal_failure, Normalizer,
+};
+use crate::errors::Failure;
+use crate::events::{openai_compatible_usage, require_string, require_u64, Event, ToolAccumulator};
+
+impl Normalizer {
+    pub(in crate::dialects) fn feed_openai_compatible(
+        &mut self,
+        frame: &crate::sse::SseEvent,
+    ) -> Result<Vec<Event>, Failure> {
+        if frame.data == "[DONE]" {
+            let finish = self.finish_reason.as_deref();
+            // A tool call cut off by the output budget (finish_reason=length,
+            // arguments still an open JSON fragment) is the provider's honest
+            // truncation, not a malformed stream: it surfaces as Incomplete
+            // with the truncated call dropped, exactly what the caller must
+            // act on (raise max_tokens), never as a 502. Live shape: Tencent
+            // TokenHub glm-5.3 at max_tokens=32 streamed `{"` + `city` then
+            // finished with length (staging, 2026-09-03). Any other finish
+            // keeps the strict contract: unparsable arguments are malformed.
+            let mut events = if finish == Some("length") {
+                finish_open_tools_truncated(&mut self.tools)?
+            } else {
+                finish_open_tools(&mut self.tools)?
+            };
+            if let Some(usage) = self.usage.take() {
+                events.push(Event::Usage(usage));
+            }
+            if self.refusal_seen || matches!(finish, Some("content_filter" | "safety")) {
+                events.push(Event::Failed(refusal_failure()));
+            } else if finish == Some("length") {
+                events.push(Event::Incomplete);
+            } else {
+                events.push(Event::Completed);
+            }
+            return Ok(events);
+        }
+        let payload = parse_object(&frame.data)?;
+        if let Some(error) = payload.get("error").filter(|value| !value.is_null()) {
+            // An OpenAI-compatible relay declaring failure inside the stream
+            // names the mechanism only here; the bounded detail rides the
+            // failure into the ledger.
+            let (code, message) = match error.as_object() {
+                Some(error) => (
+                    error.get("code").and_then(|value| {
+                        value
+                            .as_str()
+                            .map(str::to_string)
+                            .or_else(|| value.as_i64().map(|numeric| numeric.to_string()))
+                    }),
+                    error
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                ),
+                None => (None, None),
+            };
+            return Ok(vec![Event::Failed(provider_stream_failed_with_detail(
+                "openai_compatible",
+                code.as_deref(),
+                message.as_deref(),
+            ))]);
+        }
+        let mut events = Vec::new();
+        if let Some(raw_usage) = payload.get("usage") {
+            if !raw_usage.is_null() {
+                self.usage = Some(
+                    openai_compatible_usage(raw_usage).map_err(|message| malformed(&message))?,
+                );
+            }
+        }
+        let choices = payload
+            .get("choices")
+            .and_then(Value::as_array)
+            .ok_or_else(|| malformed("OpenAI-compatible choices must be an array"))?;
+        if choices.is_empty() {
+            return Ok(events);
+        }
+        if choices.len() != 1 {
+            return Err(malformed(
+                "OpenAI-compatible stream must contain one choice",
+            ));
+        }
+        let choice = choices[0]
+            .as_object()
+            .ok_or_else(|| malformed("OpenAI-compatible choice must be an object"))?;
+        let delta = choice
+            .get("delta")
+            .and_then(Value::as_object)
+            .ok_or_else(|| malformed("OpenAI-compatible delta must be an object"))?;
+        if let Some(Value::String(content)) = delta.get("content") {
+            if !content.is_empty() {
+                events.push(Event::TextDelta(content.clone()));
+            }
+        }
+        if let Some(Value::String(refusal)) = delta.get("refusal") {
+            self.refusal_seen = true;
+            events.push(Event::RefusalDelta(refusal.clone()));
+        }
+        if let Some(route_sha256) = self.reasoning_content_route_sha256.clone() {
+            if let Some(value) = delta.get("reasoning_content") {
+                let reasoning = match value {
+                    Value::Null => None,
+                    Value::String(text) => Some(text),
+                    _ => return Err(malformed("Fireworks reasoning_content delta must be text")),
+                };
+                if let Some(reasoning) = reasoning.filter(|text| !text.is_empty()) {
+                    self.reserve_summary_bytes(reasoning.len())?;
+                    events.push(Event::ReasoningContentDelta {
+                        route_sha256,
+                        delta: reasoning.clone(),
+                    });
+                }
+            }
+        }
+        if let Some(raw_tools) = delta.get("tool_calls") {
+            if !raw_tools.is_null() {
+                let items = raw_tools
+                    .as_array()
+                    .ok_or_else(|| malformed("OpenAI-compatible tool_calls must be an array"))?;
+                for value in items {
+                    let item = value.as_object().ok_or_else(|| {
+                        malformed("OpenAI-compatible tool call must be an object")
+                    })?;
+                    let index = require_u64(item, "index", "OpenAI-compatible tool index")
+                        .map_err(|message| malformed(&message))?
+                        as u32;
+                    let function =
+                        item.get("function")
+                            .and_then(Value::as_object)
+                            .ok_or_else(|| {
+                                malformed("OpenAI-compatible tool function must be an object")
+                            })?;
+                    if let Some(tool) = self.tools.get(&index) {
+                        // An identity is only restated when it is non-empty:
+                        // DashScope (Qwen) argument deltas carry `"id": ""`
+                        // (documented shape, live 2026-09-03), and an empty
+                        // placeholder names nothing, so only a different
+                        // NON-EMPTY id or name is a stream that changed identity.
+                        if let Some(Value::String(repeated_id)) = item.get("id") {
+                            if !repeated_id.is_empty() && repeated_id != &tool.call_id {
+                                return Err(malformed(
+                                    "OpenAI-compatible stream changed a tool-call ID",
+                                ));
+                            }
+                        }
+                        if let Some(Value::String(repeated_name)) = function.get("name") {
+                            if !repeated_name.is_empty() && repeated_name != &tool.name {
+                                return Err(malformed(
+                                    "OpenAI-compatible stream changed a tool-call name",
+                                ));
+                            }
+                        }
+                    } else {
+                        let call_id = require_string(item, "id", "OpenAI-compatible tool ID")
+                            .map_err(|message| malformed(&message))?;
+                        let name = require_string(function, "name", "OpenAI-compatible tool name")
+                            .map_err(|message| malformed(&message))?;
+                        self.reserve_tool_entry(index)?;
+                        self.tools
+                            .insert(index, ToolAccumulator::new(call_id.clone(), name.clone()));
+                        events.push(Event::ToolCallStarted {
+                            index,
+                            call_id,
+                            name,
+                            namespace: None,
+                            caller: None,
+                        });
+                    }
+                    if let Some(fragment) = function.get("arguments") {
+                        if !fragment.is_null() {
+                            let raw_fragment = match fragment {
+                                Value::String(text) => text.clone(),
+                                _ => {
+                                    return Err(malformed(
+                                        "OpenAI-compatible argument delta must be text",
+                                    ))
+                                }
+                            };
+                            self.reserve_tool_bytes(raw_fragment.len())?;
+                            let tool = self.tools.get_mut(&index).expect("tool just ensured");
+                            tool.raw_arguments.push_str(&raw_fragment);
+                            events.push(Event::ToolArgumentsDelta {
+                                index,
+                                delta: raw_fragment,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(Value::String(finish)) = choice.get("finish_reason") {
+            self.finish_reason = Some(finish.clone());
+            if matches!(finish.as_str(), "content_filter" | "safety") && !self.refusal_seen {
+                self.refusal_seen = true;
+                events.push(Event::RefusalDelta(String::new()));
+            }
+        }
+        Ok(events)
+    }
+}

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -174,7 +174,7 @@ fn sanitized_detail(message: &str, request_words: &[&str]) -> Option<String> {
 /// (label-shaped values the dispatched payload itself carried, such as its
 /// `model`) is the same caller-known exception without the quotes, though
 /// the unambiguous network and resource shapes still disqualify it.
-fn carries_provider_identifier(word: &str, request_words: &[&str]) -> bool {
+pub(crate) fn carries_provider_identifier(word: &str, request_words: &[&str]) -> bool {
     let bare = word.trim_matches(|c: char| !c.is_alphanumeric());
     if word.contains("://") || word.contains('@') || bare.to_ascii_lowercase().starts_with("arn:") {
         return true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.33,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.34,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.33"
+version = "0.3.34"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why now

The dominant gpt-6-astra stream killer (~263 chat-surface attempts in the last hour, 20 orgs, dying ~120ms post-dispatch since ~04:30 UTC under 0.7.34) settles as an opaque `provider stream failed`: the provider opens the stream, then declares its own failure in an error frame whose code and message the gateway discards. Live probes through prod and against api.openai.com with byte-faithful translated payloads (plain, tools, reasoning-effort shapes) all succeed, so the trigger is caller-specific and cannot be identified without the provider's own reason. This PR makes exactly that reason land in the ledger, which is where the 04:30 mechanism becomes diagnosable.

## What changes

Every dialect's provider-declared stream failure now carries a bounded single-line `provider_detail` (code reduced to an identifier-shaped token, message cut at the first control character, whitespace collapsed, capped at the 240-char ledger bound):

- OpenAI Responses: the `response.failed` terminal's `response.error.{code,message}` and the in-stream `error` frame's `{code,message}`; the unknown-reason `response.incomplete` terminal carries its reason token.
- OpenAI-compatible Chat: the in-stream `error` object (string or numeric `code` + `message`).
- Anthropic Messages: the `error` frame's `{type,message}` (e.g. `overloaded_error: Overloaded`).
- Gemini: the error envelope's `{status,message}`.
- Bedrock: exception-frame `message` on the throttle/timeout/internal classes.

The detail is attached **only to failure classes that never relay `provider_detail` to callers** (the stream-failure family), so it reaches `gateway_attempts.error_message` and the #1268 alert samples through the existing settlement seam with zero platform work, without widening the caller-facing sanitization boundary. A structured stderr operator line (`provider_declared_failure`) mirrors it.

Unparsable stream frames (an HTML error page mid-stream, a truncated JSON line) now fail with their size and serde's positional parse description (token category and line/column). The frame bytes themselves are never logged, hashed, or otherwise derived from — no digests, per the payload-guessing concern raised on #796.

No dispatch, failover, settlement-outcome, or caller-facing message changes: the classes, retry flags, and public errors are byte-identical; only the ledger detail and operator lines are new.

## Release

Crate 0.3.33 (note: #796 also stakes 0.3.33 off the same base — whichever merges second gets mechanically re-bumped by the version gate). Touches neither catalog identity nor `SNAPSHOT_SCHEMA_VERSION`. This is release-worthy alone as 0.7.36 so prod starts naming the 04:30 mechanism immediately; the astra truncation fix (#796), the empty-text-block fix, and the sub-16 Chat-surface path follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)