### PR TITLE
gateway: never dispatch empty text blocks to the Anthropic wire; floor translated Chat output ceilings

### DIFF
--- a/exp/runtime/models/providers/generation_parameter_validation.py
+++ b/exp/runtime/models/providers/generation_parameter_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 
+from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderParameterError
 from exp.runtime.models.providers.reasoning_compat import supported_reasoning_efforts
@@ -68,3 +69,52 @@ def require_route_numeric_parameter(
         param=param,
         code="invalid_parameter",
     )
+
+
+REASONING_SUMMARY_DIALECTS = frozenset({"openai_responses", "anthropic_messages"})
+
+
+def serves_reasoning_summary(profile: GatewayWireProfile) -> bool:
+    """Return whether one rung's reasoning reaches Responses summary parts.
+
+    Native Responses deployments carry summary parts on the wire, and
+    Anthropic thinking text is projected onto the same parts by the
+    Responses encoder. Every other dialect either has no reasoning text or
+    surfaces a reasoning item the summary channel cannot carry.
+
+    Args:
+        profile: One certified deployment wire profile from the route.
+
+    Returns:
+        Whether this deployment can serve a requested reasoning summary.
+    """
+    return profile.supports_reasoning and profile.dialect in REASONING_SUMMARY_DIALECTS
+
+
+def anthropic_reasoning_disengaged(request: GatewayRequest) -> bool:
+    """Whether an Anthropic dispatch will send no extended-thinking budget.
+
+    On the native Messages wire the model reasons only when the caller asks:
+    a ``thinking`` config of type ``enabled``/``adaptive`` or a reasoning
+    effort turns it on, and their absence leaves thinking OFF. This is the
+    inverse of the OpenAI effort-native models, whose default IS reasoning, so
+    it governs the srn sampling hatch ONLY for the anthropic_adaptive wire
+    (a budgeted-enabled route such as haiku-4-5): with thinking off, Anthropic
+    accepts an ordinary temperature, so srn must not drop it.
+    """
+    config = request.provider_thinking_config
+    thinking_on = config is not None and config.get("type") in {"enabled", "adaptive"}
+    effort_on = request.reasoning_effort is not None and request.reasoning_effort != "none"
+    return not thinking_on and not effort_on
+
+
+def mid_conversation_system_present(request: GatewayRequest) -> bool:
+    """Whether a system turn appears after the conversation has begun."""
+    conversation_started = False
+    for message in request.messages:
+        if message.role in {"system", "developer"} and message.provider_native_item is None:
+            if conversation_started:
+                return True
+        else:
+            conversation_started = True
+    return False

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -37,6 +37,11 @@ from exp.runtime.models.providers.fireworks import (
     require_responses_continuation_channel,
 )
 from exp.runtime.models.providers.generation_parameter_validation import (
+    anthropic_reasoning_disengaged,
+    mid_conversation_system_present,
+    serves_reasoning_summary,
+)
+from exp.runtime.models.providers.generation_parameter_validation import (
     effective_profile_reasoning_effort as _effective_profile_reasoning_effort,
 )
 from exp.runtime.models.providers.generation_parameter_validation import (
@@ -100,53 +105,6 @@ _STRICT_STRUCTURED_OUTPUT_DIALECTS = frozenset(
 _NO_PARALLEL_TOOL_CONTROL_DIALECTS = frozenset(
     {"gemini_generate_content", "bedrock_converse_stream"}
 )
-_REASONING_SUMMARY_DIALECTS = frozenset({"openai_responses", "anthropic_messages"})
-
-
-def _serves_reasoning_summary(profile: GatewayWireProfile) -> bool:
-    """Return whether one rung's reasoning reaches Responses summary parts.
-
-    Native Responses deployments carry summary parts on the wire, and
-    Anthropic thinking text is projected onto the same parts by the
-    Responses encoder. Every other dialect either has no reasoning text or
-    surfaces a reasoning item the summary channel cannot carry.
-
-    Args:
-        profile: One certified deployment wire profile from the route.
-
-    Returns:
-        Whether this deployment can serve a requested reasoning summary.
-    """
-    return profile.supports_reasoning and profile.dialect in _REASONING_SUMMARY_DIALECTS
-
-
-def _anthropic_reasoning_disengaged(request: GatewayRequest) -> bool:
-    """Whether an Anthropic dispatch will send no extended-thinking budget.
-
-    On the native Messages wire the model reasons only when the caller asks:
-    a ``thinking`` config of type ``enabled``/``adaptive`` or a reasoning
-    effort turns it on, and their absence leaves thinking OFF. This is the
-    inverse of the OpenAI effort-native models, whose default IS reasoning, so
-    it governs the srn sampling hatch ONLY for the anthropic_adaptive wire
-    (a budgeted-enabled route such as haiku-4-5): with thinking off, Anthropic
-    accepts an ordinary temperature, so srn must not drop it.
-    """
-    config = request.provider_thinking_config
-    thinking_on = config is not None and config.get("type") in {"enabled", "adaptive"}
-    effort_on = request.reasoning_effort is not None and request.reasoning_effort != "none"
-    return not thinking_on and not effort_on
-
-
-def _mid_conversation_system_present(request: GatewayRequest) -> bool:
-    """Whether a system turn appears after the conversation has begun."""
-    conversation_started = False
-    for message in request.messages:
-        if message.role in {"system", "developer"} and message.provider_native_item is None:
-            if conversation_started:
-                return True
-        else:
-            conversation_started = True
-    return False
 
 
 def route_generation_parameter_requests(
@@ -282,7 +240,7 @@ def route_generation_parameter_requests(
             # budget at all, so ordinary thinking-off sampling is honored.
             or (
                 profile.reasoning_wire_format == "anthropic_adaptive"
-                and _anthropic_reasoning_disengaged(request)
+                and anthropic_reasoning_disengaged(request)
             )
         )
 
@@ -432,7 +390,7 @@ def route_generation_parameter_requests(
             code="unsupported_parameter",
         )
     if request.reasoning_summary is not None and not all(
-        _serves_reasoning_summary(profile) for profile in profiles
+        serves_reasoning_summary(profile) for profile in profiles
     ):
         path = next(
             iter(request.reasoning_summary_parameters),
@@ -884,7 +842,7 @@ def route_generation_parameter_requests(
 
     # A system turn after conversation began has positional semantics that
     # instruction-hoisting wires cannot preserve; those rungs narrow out.
-    if _mid_conversation_system_present(request) and any(
+    if mid_conversation_system_present(request) and any(
         profile.dialect in {"gemini_generate_content", "bedrock_converse_stream"}
         for profile in profiles
     ):

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -209,23 +209,36 @@ def route_generation_parameter_requests(
                 code="invalid_parameter",
             )
         if (
-            request.surface == GatewayApiSurface.MESSAGES
-            and request.maximum_output_tokens < OPENAI_MINIMUM_OUTPUT_TOKENS
-            and any(
-                profile.dialect in {"openai_responses", "openai_compatible"} for profile in profiles
+            request.maximum_output_tokens < OPENAI_MINIMUM_OUTPUT_TOKENS
+            and (
+                request.surface == GatewayApiSurface.MESSAGES
+                and any(
+                    profile.dialect in {"openai_responses", "openai_compatible"}
+                    for profile in profiles
+                )
+                # A Chat value keeps native semantics on a chat wire (some
+                # compatible providers accept an output ceiling of 1); only
+                # the TRANSLATED Responses wire imposes OpenAI's minimum, so
+                # the floor covers exactly the routes that translate.
+                or request.surface == GatewayApiSurface.CHAT_COMPLETIONS
+                and any(profile.dialect == "openai_responses" for profile in profiles)
             )
             # The floored value must stay within every rung's declared output
             # ceiling; a route capped below the floor keeps the caller value
             # and the provider's own rejection.
             and (not route_limits or min(route_limits) >= OPENAI_MINIMUM_OUTPUT_TOKENS)
         ):
-            # Anthropic accepts max_tokens down to 1 (Claude Code probes with
-            # exactly that after a /model switch) while OpenAI rejects
-            # max_output_tokens below 16, so the translated value rides the
-            # provider floor with disclosure instead of surfacing a provider
-            # 400 the caller cannot act on.
+            # Anthropic and Chat Completions accept output ceilings down to
+            # 1 (Claude Code probes with exactly that after a /model switch)
+            # while OpenAI rejects max_output_tokens below 16, so a Messages
+            # or Chat value translated onto an OpenAI Responses rung rides
+            # the provider floor with disclosure instead of surfacing a
+            # provider 400 the caller cannot act on (2026-09-05 stragglers).
+            # A native Responses caller keeps the named admission rejection
+            # below: sub-16 is invalid on its own surface.
             provider_updates["maximum_output_tokens"] = OPENAI_MINIMUM_OUTPUT_TOKENS
-            path = f"max_tokens->{OPENAI_MINIMUM_OUTPUT_TOKENS}"
+            parameter = request.maximum_output_tokens_parameter or "max_tokens"
+            path = f"{parameter}->{OPENAI_MINIMUM_OUTPUT_TOKENS}"
             if path not in ignored:
                 ignored.append(path)
     elif any(profile.dialect == "anthropic_messages" for profile in profiles):
@@ -843,6 +856,30 @@ def route_generation_parameter_requests(
             ),
             param="tools",
             code="unsupported_parameter",
+        )
+
+    if any(profile.dialect == "anthropic_messages" for profile in profiles) and any(
+        message.role == "user"
+        and not message.content
+        and not message.content_parts
+        and message.provider_anthropic_block is None
+        and message.provider_native_item is None
+        for message in request.messages
+    ):
+        # The Anthropic wire rejects empty text content blocks post-dispatch
+        # ("text content blocks must be non-empty"; 2026-09-05, six orgs on
+        # claude-fable routes). Empty blocks inside a richer turn drop
+        # loss-free at conversion, but a user turn that is entirely empty
+        # has nothing to send and dropping the whole message would change
+        # conversation structure, so it is refused by name pre-dispatch.
+        raise ProviderParameterError(
+            message=(
+                "A user message with empty content cannot be served by this "
+                "model route: the provider rejects empty text content blocks. "
+                "Add content to the message or remove it."
+            ),
+            param="messages",
+            code="invalid_parameter",
         )
 
     # A system turn after conversation began has positional semantics that

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4225,6 +4225,26 @@ def test_route_refuses_a_whole_empty_user_turn_before_an_anthropic_dispatch() ->
     assert rejected.value.param == "messages"
     assert "empty content" in str(rejected.value)
 
+    # An all-empty cache-marked block run is the same empty turn (the blocks
+    # must flatten to the content, so all-empty blocks imply empty content)
+    # and takes the same refusal instead of falling through to the builder.
+    marked = request.model_copy(
+        update={
+            "messages": (
+                GatewayMessage(role="user", content="hello"),
+                GatewayMessage(role="assistant", content="hi"),
+                GatewayMessage(
+                    role="user",
+                    content="",
+                    provider_text_blocks=({"type": "text", "text": ""},),
+                ),
+            )
+        }
+    )
+    with pytest.raises(ProviderParameterError) as rejected:
+        route_generation_parameter_requests((anthropic,), marked)
+    assert rejected.value.param == "messages"
+
     # A non-Anthropic route keeps serving the shape it can carry.
     chat = GatewayWireProfile(dialect="openai_compatible", url="https://chat.test")
     public, _provider = route_generation_parameter_requests((chat,), request)

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4200,3 +4200,63 @@ def test_a_messages_surface_effort_rejection_matches_the_client_recovery_latch()
     assert raised.value.param == "output_config.effort"
     assert "effort parameter" in str(raised.value)
     assert "not supported" in str(raised.value)
+
+
+def test_route_refuses_a_whole_empty_user_turn_before_an_anthropic_dispatch() -> None:
+    """The Anthropic wire rejects empty text content blocks post-dispatch
+    ("text content blocks must be non-empty"; 2026-09-05, six orgs on
+    claude-fable routes); a user turn that is entirely empty has nothing to
+    send and dropping the whole message would change conversation structure,
+    so it is refused by name pre-dispatch."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="hello"),
+            GatewayMessage(role="assistant", content="hi"),
+            GatewayMessage(role="user", content=""),
+        ),
+        maximum_output_tokens=256,
+        stream=True,
+        include_usage=True,
+    )
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://a.test")
+    with pytest.raises(ProviderParameterError) as rejected:
+        route_generation_parameter_requests((anthropic,), request)
+    assert rejected.value.param == "messages"
+    assert "empty content" in str(rejected.value)
+
+    # A non-Anthropic route keeps serving the shape it can carry.
+    chat = GatewayWireProfile(dialect="openai_compatible", url="https://chat.test")
+    public, _provider = route_generation_parameter_requests((chat,), request)
+    assert public.ignored_parameters == ()
+
+
+def test_chat_surface_sub_16_output_ceiling_rides_the_openai_floor() -> None:
+    """A Chat-surface max_tokens below OpenAI's minimum translated onto an
+    OpenAI rung rides the disclosed 16-token floor (the Messages-surface
+    contract), instead of dispatching a value the provider 400s opaquely
+    post-commit (2026-09-05 stragglers)."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        maximum_output_tokens=1,
+        maximum_output_tokens_parameter="max_tokens",
+        stream=True,
+        include_usage=True,
+    )
+    responses = GatewayWireProfile(dialect="openai_responses", url="https://openai.test")
+    chat_rung = GatewayWireProfile(dialect="openai_compatible", url="https://chat.test")
+    # The floor applies on all-OpenAI routes AND mixed OpenAI routes, so no
+    # rung dispatches the sub-minimum value.
+    for route in ((responses,), (responses, chat_rung)):
+        public, provider = route_generation_parameter_requests(route, request)
+        assert provider.maximum_output_tokens == 16
+        assert "max_tokens->16" in public.ignored_parameters
+
+    # The disclosure names the caller's own parameter.
+    completion_request = request.model_copy(
+        update={"maximum_output_tokens_parameter": "max_completion_tokens"}
+    )
+    public, provider = route_generation_parameter_requests((responses,), completion_request)
+    assert provider.maximum_output_tokens == 16
+    assert "max_completion_tokens->16" in public.ignored_parameters

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -210,6 +210,12 @@ def _anthropic_multimodal_blocks(message: GatewayMessage) -> list[JsonObject]:
         if part.kind == "document":
             blocks.append(anthropic_document_block(part))
             continue
+        if not part.text:
+            # This wire rejects empty text content blocks post-dispatch
+            # ("text content blocks must be non-empty"), and an empty part
+            # carries nothing, so it drops loss-free; the turn's attachment
+            # guarantees the content array stays non-empty.
+            continue
         blocks.append(
             marked[text_index] if text_index < len(marked) else {"type": "text", "text": part.text}
         )
@@ -229,16 +235,19 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             # A tool screenshot re-emits as the caller's exact block run:
             # image parts become image blocks in their original positions.
             # The canonical model restricts tool messages to these two kinds.
+            # Empty text parts drop loss-free (the wire rejects empty text
+            # blocks); an all-empty run keeps the flattened string content.
             run: list[JsonObject] = []
             for part in message.content_parts:
                 if part.kind == "image":
                     run.append(anthropic_image_block(part))
-                elif part.kind == "text":
+                elif part.kind == "text" and part.text:
                     block: JsonObject = {"type": "text", "text": part.text}
                     if part.cache_control is not None:
                         block["cache_control"] = part.cache_control
                     run.append(block)
-            result["content"] = run
+            if run:
+                result["content"] = run
         # Only the Anthropic wire can express a failed tool invocation; the
         # marker is emitted solely when set so existing payloads are unchanged.
         if message.tool_is_error:
@@ -253,10 +262,12 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             # The caller's exact interleaving is preserved: an image before
             # its question reads differently from one after it.
             return "user", _anthropic_multimodal_blocks(message)
-        if message.provider_text_blocks:
-            # The cache-marked run re-emits the caller's exact blocks; the
-            # flattened content stays canonical for every other wire.
-            return "user", list(message.provider_text_blocks)
+        marked_run = [block for block in message.provider_text_blocks if block.get("text")]
+        if marked_run:
+            # The cache-marked run re-emits the caller's exact blocks (empty
+            # blocks drop loss-free: the wire rejects them and they carry
+            # nothing); the flattened content stays canonical elsewhere.
+            return "user", marked_run
         return "user", [{"type": "text", "text": message.content or ""}]
     if message.role != "assistant":
         raise ProviderResponseError("unsupported Anthropic message role")

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -179,6 +179,39 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
     return items
 
 
+def _retained_cache_marked_blocks(
+    blocks: tuple[JsonObject, ...] | list[JsonObject],
+) -> list[JsonObject]:
+    """Drop empty text blocks while keeping their cache breakpoints.
+
+    The wire rejects empty text blocks, but Claude Code lands its
+    prompt-cache marker on the LAST block of a turn, which can be empty;
+    dropping the block must not drop the breakpoint or the whole prefix
+    bills uncached (the block-cache incident class). A displaced marker
+    lands on the closest retained block before it (an empty block adds no
+    bytes, so that boundary is byte-identical), or on the first retained
+    block after it when nothing precedes (a slightly wider, still valid
+    breakpoint). Adjacent duplicate markers collapse: one marker per
+    boundary suffices.
+    """
+    retained: list[JsonObject] = []
+    displaced: object | None = None
+    for block in blocks:
+        if block.get("text"):
+            kept = dict(block)
+            if displaced is not None and "cache_control" not in kept:
+                kept["cache_control"] = displaced
+            displaced = None
+            retained.append(kept)
+        elif "cache_control" in block:
+            if retained:
+                if "cache_control" not in retained[-1]:
+                    retained[-1] = {**retained[-1], "cache_control": block["cache_control"]}
+            else:
+                displaced = block["cache_control"]
+    return retained
+
+
 def _anthropic_multimodal_blocks(message: GatewayMessage) -> list[JsonObject]:
     """Emit one multimodal user turn in caller order, markers intact.
 
@@ -194,7 +227,7 @@ def _anthropic_multimodal_blocks(message: GatewayMessage) -> list[JsonObject]:
     Returns:
         The ordered Anthropic content blocks for the turn.
     """
-    marked = [block for block in message.provider_text_blocks if block.get("text")]
+    marked = _retained_cache_marked_blocks(message.provider_text_blocks)
     blocks: list[JsonObject] = []
     text_index = 0
     for part in message.content_parts:
@@ -262,11 +295,12 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             # The caller's exact interleaving is preserved: an image before
             # its question reads differently from one after it.
             return "user", _anthropic_multimodal_blocks(message)
-        marked_run = [block for block in message.provider_text_blocks if block.get("text")]
+        marked_run = _retained_cache_marked_blocks(message.provider_text_blocks)
         if marked_run:
-            # The cache-marked run re-emits the caller's exact blocks (empty
-            # blocks drop loss-free: the wire rejects them and they carry
-            # nothing); the flattened content stays canonical elsewhere.
+            # The cache-marked run re-emits the caller's blocks with empty
+            # ones dropped loss-free (the wire rejects them and they carry
+            # nothing) and their breakpoints migrated to a retained
+            # neighbor; the flattened content stays canonical elsewhere.
             return "user", marked_run
         return "user", [{"type": "text", "text": message.content or ""}]
     if message.role != "assistant":

--- a/exp/runtime/models/providers/wire_messages_test.py
+++ b/exp/runtime/models/providers/wire_messages_test.py
@@ -37,6 +37,54 @@ def test_empty_text_blocks_drop_loss_free_on_the_anthropic_wire() -> None:
     _role, blocks = anthropic_blocks(marked)
     assert blocks == [{"type": "text", "text": "real", "cache_control": {"type": "ephemeral"}}]
 
+    # A breakpoint on a dropped TRAILING empty block migrates to the retained
+    # neighbor: an empty block adds no bytes, so the cache boundary is
+    # byte-identical and the prefix keeps billing cached (the block-cache
+    # incident class).
+    trailing_marker = GatewayMessage(
+        role="user",
+        content="real",
+        provider_text_blocks=(
+            {"type": "text", "text": "real"},
+            {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+        ),
+    )
+    _role, blocks = anthropic_blocks(trailing_marker)
+    assert blocks == [{"type": "text", "text": "real", "cache_control": {"type": "ephemeral"}}]
+
+    # A marker on a dropped LEADING empty block lands on the first retained
+    # block (a wider, still valid breakpoint), and never overwrites one the
+    # retained block already carries.
+    leading_marker = GatewayMessage(
+        role="user",
+        content="real",
+        provider_text_blocks=(
+            {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "real"},
+        ),
+    )
+    _role, blocks = anthropic_blocks(leading_marker)
+    assert blocks == [{"type": "text", "text": "real", "cache_control": {"type": "ephemeral"}}]
+
+    # The same migration applies on the multimodal path, where Claude Code's
+    # turn-final marker can land on an empty trailing block.
+    multimodal_marker = GatewayMessage(
+        role="user",
+        content="look",
+        content_parts=(
+            TextContentPart(text="look"),
+            ImageContentPart(media_type="image/png", data="aGk="),
+            TextContentPart(text=""),
+        ),
+        provider_text_blocks=(
+            {"type": "text", "text": "look"},
+            {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+        ),
+    )
+    _role, blocks = anthropic_blocks(multimodal_marker)
+    assert blocks[0] == {"type": "text", "text": "look", "cache_control": {"type": "ephemeral"}}
+    assert [block["type"] for block in blocks] == ["text", "image"]
+
     # An all-empty marked run can only exist on an all-empty turn (the model
     # requires the blocks to flatten to the content); it falls back to the
     # flattened string, and route admission refuses the whole-empty user turn

--- a/exp/runtime/models/providers/wire_messages_test.py
+++ b/exp/runtime/models/providers/wire_messages_test.py
@@ -1,2 +1,64 @@
 """Wire-message translation is covered through the payload builders in
-:mod:`exp.runtime.models.providers.streaming_requests_test`."""
+:mod:`exp.runtime.models.providers.streaming_requests_test`; the Anthropic
+empty-block conversion contract is pinned here beside its module."""
+
+from exp.common.models.content import ImageContentPart, TextContentPart
+from exp.runtime.gateway.contracts import GatewayMessage
+from exp.runtime.models.providers.wire_messages import anthropic_blocks
+
+
+def test_empty_text_blocks_drop_loss_free_on_the_anthropic_wire() -> None:
+    """The wire rejects empty text content blocks post-dispatch ("text content
+    blocks must be non-empty"; 2026-09-05, six orgs on claude-fable routes), and
+    an empty block carries nothing, so conversion drops it wherever other
+    content keeps the array non-empty."""
+
+    multimodal = GatewayMessage(
+        role="user",
+        content="look",
+        content_parts=(
+            TextContentPart(text=""),
+            ImageContentPart(media_type="image/png", data="aGk="),
+            TextContentPart(text="look"),
+        ),
+    )
+    _role, blocks = anthropic_blocks(multimodal)
+    assert [block["type"] for block in blocks] == ["image", "text"]
+    assert blocks[1]["text"] == "look"
+
+    marked = GatewayMessage(
+        role="user",
+        content="real",
+        provider_text_blocks=(
+            {"type": "text", "text": ""},
+            {"type": "text", "text": "real", "cache_control": {"type": "ephemeral"}},
+        ),
+    )
+    _role, blocks = anthropic_blocks(marked)
+    assert blocks == [{"type": "text", "text": "real", "cache_control": {"type": "ephemeral"}}]
+
+    # An all-empty marked run can only exist on an all-empty turn (the model
+    # requires the blocks to flatten to the content); it falls back to the
+    # flattened string, and route admission refuses the whole-empty user turn
+    # by name before an Anthropic dispatch.
+    hollow = GatewayMessage(
+        role="user",
+        content="",
+        provider_text_blocks=({"type": "text", "text": ""},),
+    )
+    _role, blocks = anthropic_blocks(hollow)
+    assert blocks == [{"type": "text", "text": ""}]
+
+    tool = GatewayMessage(
+        role="tool",
+        content="",
+        tool_call_id="call-1",
+        content_parts=(
+            TextContentPart(text=""),
+            ImageContentPart(media_type="image/png", data="aGk="),
+        ),
+    )
+    _role, blocks = anthropic_blocks(tool)
+    run = blocks[0]["content"]
+    assert isinstance(run, list)
+    assert [block["type"] for block in run if isinstance(block, dict)] == ["image"]


### PR DESCRIPTION
## Empty text blocks (live: 6+ orgs on claude-fable-5.1/-5, 2026-09-05)

Anthropic rejects empty text content blocks post-dispatch ("messages: text content blocks must be non-empty") — a 400 with no failover. The conversion seam now mirrors Anthropic's actual constraint:

- **Loss-free drops** wherever other content keeps the array non-empty: empty text parts in multimodal user turns, empty caller blocks in cache-marked runs (the non-empty run still re-emits verbatim with its markers), and empty text parts in tool-result block runs (an all-empty run keeps the flattened string).
- **Named pre-dispatch refusal** for the one case dropping would change conversation structure: a user turn that is entirely empty (`invalid_parameter` on `messages`, "the provider rejects empty text content blocks"), scoped to routes with an Anthropic rung — other wires keep serving the shape they can carry. The canonical model itself forbids the remaining hollow shapes (blocks must flatten to content, parts require an attachment), so the builder guards plus this admission check cover the space.

The existing assistant-side behavior (an empty assistant text block re-emits only when it is the entire turn, the OpenCode tool-call-only shape) is deliberately unchanged.

## Sub-16 stragglers (Chat surface onto Responses rungs)

The 2026-09-05 stragglers of the sub-16 rejection were Chat-surface `max_tokens` values translated onto OpenAI Responses rungs: they bypassed both the Messages-surface floor (#787) and the all-Responses admission rejection (#792) on mixed routes. The floor now also covers the Chat surface **when the route carries an `openai_responses` rung** (the translated wire imposes OpenAI's minimum); a Chat value on a native chat wire keeps provider semantics per the pinned #787 contract (`test_the_openai_floor_leaves_anthropic_routes_and_other_surfaces_alone` unchanged). The disclosure names the caller's own parameter (`max_tokens->16` / `max_completion_tokens->16`).

Also includes a mechanical line-budget split (the three route-shaping predicates join their sibling helpers in `generation_parameter_validation`, public there) after main's growth landed in `streaming_requests.py`.

Python-only: no crate change, no version bump, no catalog identity or `SNAPSHOT_SCHEMA_VERSION` impact. Sequencing: independent of #796/#798; can ride whichever release train is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)