### PR TITLE
gateway: sanitize caller-minted tool ids for the provider wires that reject them

### DIFF
--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -8,6 +8,9 @@ engines cannot drift at the message boundary.
 
 from __future__ import annotations
 
+import hashlib
+import re
+
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import (
     TOOL_ERROR_TEXT_PREFIX,
@@ -28,6 +31,51 @@ from exp.runtime.models.providers.images import (
     responses_image_part,
 )
 from exp.runtime.models.providers.videos import openai_chat_video_part, reject_video_part
+
+_ANTHROPIC_TOOL_ID_UNSAFE = re.compile(r"[^a-zA-Z0-9_-]")
+"""Characters outside the wire's documented tool-id pattern ``^[a-zA-Z0-9_-]+$``."""
+
+_OPENAI_MAXIMUM_CALL_ID_CHARS = 64
+"""Longest ``call_id`` the Responses API accepts (probed live 2026-09-05:
+65 characters answers "Invalid 'input[N].call_id': string too long")."""
+
+
+def _collision_suffix(call_id: str) -> str:
+    """One short deterministic suffix distinguishing rewritten originals."""
+    return hashlib.sha256(call_id.encode()).hexdigest()[:8]
+
+
+def anthropic_tool_use_id(call_id: str) -> str:
+    """Deterministically rewrite one caller-minted tool id for this wire.
+
+    The public OpenAI surfaces accept arbitrary id bytes while this wire
+    rejects anything outside ``^[a-zA-Z0-9_-]+$`` post-dispatch (probed live
+    2026-09-05: "tool_use.id: String should match pattern"). A conforming id
+    passes through byte-identical; a non-conforming one maps to its cleaned
+    form plus an 8-hex suffix of the original, so distinct originals that
+    clean to the same bytes stay distinct, and the same mapping applied to
+    the paired ``tool_result.tool_use_id`` keeps history linked. The rewrite
+    never reaches the caller: responses only carry provider-minted ids.
+    """
+    if call_id and not _ANTHROPIC_TOOL_ID_UNSAFE.search(call_id):
+        return call_id
+    cleaned = _ANTHROPIC_TOOL_ID_UNSAFE.sub("_", call_id) or "call"
+    return f"{cleaned}-{_collision_suffix(call_id)}"
+
+
+def responses_call_id(call_id: str) -> str:
+    """Deterministically bound one caller-minted call id for the Responses wire.
+
+    The wire accepts arbitrary bytes but caps ``call_id`` at 64 characters
+    (probed live 2026-09-05); a longer caller-minted id maps to its prefix
+    plus an 8-hex suffix of the original so distinct originals stay distinct
+    and call/output pairs stay linked. The rewrite never reaches the caller:
+    responses only carry provider-minted ids.
+    """
+    if len(call_id) <= _OPENAI_MAXIMUM_CALL_ID_CHARS:
+        return call_id
+    prefix = call_id[: _OPENAI_MAXIMUM_CALL_ID_CHARS - 9]
+    return f"{prefix}-{_collision_suffix(call_id)}"
 
 
 def responses_items(message: GatewayMessage) -> list[JsonObject]:
@@ -56,7 +104,7 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
             output_value = message.folded_tool_error_content()
         output_item: JsonObject = {
             "type": "function_call_output",
-            "call_id": message.tool_call_id or "",
+            "call_id": responses_call_id(message.tool_call_id or ""),
             "output": output_value,
         }
         # Tool attribution round-trips verbatim: present stays present and
@@ -150,7 +198,7 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
     for call in message.tool_calls:
         item: JsonObject = {
             "type": "function_call",
-            "call_id": call.call_id,
+            "call_id": responses_call_id(call.call_id),
             "name": call.name,
             "arguments": call.arguments_json(),
         }
@@ -261,7 +309,7 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
     if message.role == "tool":
         result: JsonObject = {
             "type": "tool_result",
-            "tool_use_id": message.tool_call_id or "",
+            "tool_use_id": anthropic_tool_use_id(message.tool_call_id or ""),
             "content": message.content or "",
         }
         if message.content_parts:
@@ -342,7 +390,7 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
     for call in message.tool_calls:
         tool_use: JsonObject = {
             "type": "tool_use",
-            "id": call.call_id,
+            "id": anthropic_tool_use_id(call.call_id),
             "name": call.name,
             "input": call.arguments,
         }

--- a/exp/runtime/models/providers/wire_messages_test.py
+++ b/exp/runtime/models/providers/wire_messages_test.py
@@ -110,3 +110,71 @@ def test_empty_text_blocks_drop_loss_free_on_the_anthropic_wire() -> None:
     run = blocks[0]["content"]
     assert isinstance(run, list)
     assert [block["type"] for block in run if isinstance(block, dict)] == ["image"]
+
+
+def test_caller_minted_tool_ids_sanitize_deterministically_for_the_anthropic_wire() -> None:
+    """Anthropic rejects tool ids outside ``^[a-zA-Z0-9_-]+$`` post-dispatch
+    (probed live 2026-09-05, prod rows 2026-09-05 09:48); a caller-minted id
+    rewrites deterministically with the SAME mapping on the paired
+    tool_result so history stays linked, and conforming ids pass through
+    byte-identical."""
+    from exp.common.models.model import ToolCall
+    from exp.runtime.models.providers.wire_messages import anthropic_tool_use_id
+
+    assert anthropic_tool_use_id("toolu_01AbC-xyz") == "toolu_01AbC-xyz"
+
+    rewritten = anthropic_tool_use_id("call:with:colons")
+    assert rewritten.startswith("call_with_colons-")
+    assert anthropic_tool_use_id("call:with:colons") == rewritten
+
+    # Distinct originals that clean to the same bytes stay distinct.
+    sibling = anthropic_tool_use_id("call.with.colons")
+    assert sibling != rewritten
+
+    call = ToolCall(
+        call_id="call:with:colons",
+        name="get_weather",
+        arguments={"city": "Paris"},
+        raw_arguments='{"city": "Paris"}',
+    )
+    _role, blocks = anthropic_blocks(
+        GatewayMessage(role="assistant", content=None, tool_calls=(call,))
+    )
+    tool_use = blocks[-1]
+    assert tool_use["id"] == rewritten
+
+    _role, result_blocks = anthropic_blocks(
+        GatewayMessage(role="tool", content="sunny", tool_call_id="call:with:colons")
+    )
+    assert result_blocks[0]["tool_use_id"] == rewritten
+
+
+def test_overlong_call_ids_bound_deterministically_for_the_responses_wire() -> None:
+    """The Responses wire caps call_id at 64 characters (probed live
+    2026-09-05: "Invalid 'input[N].call_id': string too long"; one prod
+    gpt-6-astra row). A longer caller-minted id maps to a bounded
+    prefix+digest with the same mapping on the paired output."""
+    from exp.common.models.model import ToolCall
+    from exp.runtime.models.providers.wire_messages import responses_call_id, responses_items
+
+    assert responses_call_id("c" * 64) == "c" * 64
+
+    long_id = "x" * 100
+    bounded = responses_call_id(long_id)
+    assert len(bounded) == 64
+    assert bounded.startswith("x" * 55)
+    assert responses_call_id(long_id) == bounded
+    assert responses_call_id("y" + "x" * 99) != bounded
+
+    call = ToolCall(
+        call_id=long_id,
+        name="get_weather",
+        arguments={"city": "Paris"},
+        raw_arguments='{"city": "Paris"}',
+    )
+    call_items = responses_items(GatewayMessage(role="assistant", content=None, tool_calls=(call,)))
+    assert call_items[-1]["call_id"] == bounded
+    output_items = responses_items(
+        GatewayMessage(role="tool", content="sunny", tool_call_id=long_id)
+    )
+    assert output_items[0]["call_id"] == bounded


### PR DESCRIPTION
## Why (prod, 2026-09-05)

Caller-minted tool call ids flow through the wires unchanged, and two providers reject shapes the public OpenAI surfaces accept: Anthropic 400s ids outside `^[a-zA-Z0-9_-]+$` (3 prod rows at 09:48; exact error probed live: `messages.N.content.M.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'`), and the OpenAI Responses wire caps `call_id` at 64 characters (1 gpt-6-astra prod row; probed live: `Invalid 'input[N].call_id': string too long. Expected a string with maximum length 64`). Both are post-dispatch invalid_request 400s with no failover.

## Fix (deterministic, compat-preserving, at the wire seam)

- `anthropic_tool_use_id`: a conforming id passes through byte-identical; a non-conforming one maps to its cleaned bytes plus an 8-hex sha256 suffix of the original (collision-safe: distinct originals that clean identically stay distinct). Applied to `tool_use.id` and the paired `tool_result.tool_use_id`, so pairs stay linked across turns — deterministic, so resent histories map identically every turn. Anthropic has no practical length cap (128-char ids accepted live), so no truncation there.
- `responses_call_id`: ids within 64 chars pass through byte-identical; longer ones map to a 55-char prefix plus the 8-hex suffix (total 64). Applied to `function_call.call_id` and the paired `function_call_output.call_id`.
- The rewrite never reaches the caller: responses only carry provider-minted ids for NEW calls, and history is request-side only, so no reverse mapping exists or is needed. (Provider-minted ids — `toolu_`, `call_`, `srvtoolu_` — are always conforming and pass through untouched; the verbatim echo contracts for provider-owned blocks/items are unaffected.)

Scope notes: the OpenAI-compatible Chat wire's `tool_calls[].id` and the Bedrock `toolUseId` are left as-is (no prod evidence; Bedrock's pattern matches Anthropic's, so the same helper can extend there if rows appear).

Pinned with the exact probed/prod shapes: charset rewrite + pair linkage + collision distinctness, and the 64-cap bound + pairing.

Python-only, no crate bump, no catalog identity impact. **Sequencing: post-release follow-up — do not merge before the 0.7.36 train (#796) clears.** Draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)