### PR TITLE
release: bump experiential to 0.7.36 (native 0.3.35)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.35"
+version = "0.7.36"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.35"
+version = "0.7.36"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the combined release: #796 (astra truncation tolerance: max_output_tokens mid-arguments truncation surfaces incomplete per OpenAI's own wire instead of a malformed 502; content_filter truncation surfaces the refusal), #798 (provider-declared failure forensics into ledger + alerts across all dialects), #799 (Anthropic empty-text-block drops + chat-surface max_tokens floor on Responses-rung routes). Mirrors #788/#793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)