### PR TITLE
gateway: accept the legacy name on Chat tool messages and round-trip it on OpenAI wires

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -246,6 +246,11 @@ class GatewayMessage(ContractModel):
     (mirroring ``ToolCall.provider_namespace`` on the call side) and are
     excluded from serialization like the other replay carriers, joining
     replay identity explicitly through :func:`canonical_request_sha256`.
+    ``provider_tool_name`` also carries the Chat surface's legacy
+    ``role: "tool"`` ``name`` (the old ``role: "function"`` attribution many
+    agent frameworks still send; the provider serves it, probed live
+    2026-09-05), re-emitted on both OpenAI wires and dropped with disclosure
+    elsewhere.
     """
     provider_tool_caller: JsonObject | None = Field(default=None, exclude=True)
     """Opaque SDK 3.0 ``caller`` attribution on a ``function_call_output``.

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -625,8 +625,7 @@ def route_generation_parameter_requests(
             (
                 "messages.tool_results.attribution->dropped(unsupported_by_provider)",
                 any(
-                    message.provider_tool_name is not None
-                    or message.provider_tool_namespace is not None
+                    message.provider_tool_namespace is not None
                     or message.provider_tool_caller is not None
                     for message in request.messages
                 ),
@@ -635,6 +634,16 @@ def route_generation_parameter_requests(
         for path, present in attribution_paths:
             if present and path not in ignored:
                 ignored.append(path)
+
+    # The legacy tool-result name has a slot on BOTH OpenAI wires (Chat tool
+    # messages and Responses function_call_output), so it drops with
+    # disclosure only when some rung is on neither.
+    if any(message.provider_tool_name is not None for message in request.messages) and not all(
+        profile.dialect in {"openai_responses", "openai_compatible"} for profile in profiles
+    ):
+        name_path = "messages.tool_results.name->dropped(unsupported_by_provider)"
+        if name_path not in ignored:
+            ignored.append(name_path)
 
     # Opaque provider-reasoning carriers replay only on the one wire that
     # issued them, so a mixed waterfall is rejected instead of dropping them.

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4289,3 +4289,56 @@ def test_chat_surface_sub_16_output_ceiling_rides_the_openai_floor() -> None:
     public, provider = route_generation_parameter_requests((responses,), completion_request)
     assert provider.maximum_output_tokens == 16
     assert "max_completion_tokens->16" in public.ignored_parameters
+
+
+def test_a_tool_result_name_is_undisclosed_on_openai_wire_routes() -> None:
+    """Both OpenAI wires carry the legacy tool-result name; nothing drops."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="go"),
+            GatewayMessage(
+                role="tool",
+                tool_call_id="call-1",
+                content="ok",
+                provider_tool_name="read_file",
+            ),
+        ),
+    )
+    profiles = (
+        GatewayWireProfile(dialect="openai_compatible", url="https://c.test"),
+        GatewayWireProfile(dialect="openai_responses", url="https://r.test"),
+    )
+
+    public_request, _provider = route_generation_parameter_requests(profiles, request)
+
+    assert not any("tool_results" in path for path in public_request.ignored_parameters)
+
+
+def test_a_tool_result_name_drops_with_disclosure_off_the_openai_wires() -> None:
+    """A rung with no name slot (Anthropic tool_result) discloses the drop."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="go"),
+            GatewayMessage(
+                role="tool",
+                tool_call_id="call-1",
+                content="ok",
+                provider_tool_name="read_file",
+            ),
+        ),
+    )
+    profiles = (
+        GatewayWireProfile(dialect="openai_compatible", url="https://c.test"),
+        GatewayWireProfile(dialect="anthropic_messages", url="https://a.test"),
+    )
+
+    public_request, _provider = route_generation_parameter_requests(profiles, request)
+
+    assert (
+        "messages.tool_results.name->dropped(unsupported_by_provider)"
+        in public_request.ignored_parameters
+    )
+    # Namespace/caller attribution stays a Responses-only concern.
+    assert not any("attribution" in path for path in public_request.ignored_parameters)

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -430,11 +430,17 @@ def openai_chat_message(
     other rung omits that block, which route narrowing already disclosed.
     """
     if message.role == "tool":
-        return {
+        tool_payload: JsonObject = {
             "role": "tool",
             "content": message.folded_tool_error_content(),
             "tool_call_id": message.tool_call_id or "",
         }
+        # Legacy tool-result name attribution round-trips on the OpenAI
+        # wires: present stays present (the provider serves it) and absent
+        # stays absent, so name-free histories keep their exact wire bytes.
+        if message.provider_tool_name is not None:
+            tool_payload["name"] = message.provider_tool_name
+        return tool_payload
     payload: JsonObject = {
         "role": message.role,
         "content": (

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -712,6 +712,7 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
                 content_parts=content_parts,
                 tool_call_id=message.tool_call_id,
                 tool_calls=calls,
+                provider_tool_name=message.name,
                 provider_reasoning=provider_reasoning,
             )
         )

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -3398,3 +3398,103 @@ def test_a_custom_tool_call_output_list_carries_verbatim() -> None:
     )
     native = decoded.request.messages[-1].provider_native_item
     assert native is not None and native["output"] == output_value
+
+
+def test_a_tool_message_name_round_trips_on_both_openai_wires() -> None:
+    """The legacy role:"function" name on a tool result serves instead of a 400.
+
+    hermes-agent (and other agent frameworks) sends name:"<function>" on
+    every tool-result message; the provider serves the shape (probed live
+    2026-09-05), and the field is baked into history, so the previous
+    "Invalid value for 'messages.N.name'" rejection wedged every session on
+    its first tool call.
+    """
+    from exp.runtime.models.providers.streaming_requests import (
+        openai_compatible_stream_payload,
+        openai_responses_stream_payload,
+    )
+
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "read it"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_probe1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_probe1",
+                    "name": "read_file",
+                    "content": "contents",
+                },
+            ],
+        }
+    )
+    tool_message = decoded.request.messages[-1]
+    assert tool_message.provider_tool_name == "read_file"
+
+    chat_payload = openai_compatible_stream_payload("chat-fixture", decoded.request)
+    chat_messages = cast(list[JsonObject], chat_payload["messages"])
+    assert chat_messages[-1] == {
+        "role": "tool",
+        "content": "contents",
+        "tool_call_id": "call_probe1",
+        "name": "read_file",
+    }
+
+    responses_payload = openai_responses_stream_payload(
+        "gpt-fixture", decoded.request, supports_temperature=False
+    )
+    responses_input = cast(list[JsonObject], responses_payload["input"])
+    assert responses_input[-1]["name"] == "read_file"
+
+
+def test_a_name_free_tool_message_keeps_its_exact_chat_wire_shape() -> None:
+    """Histories without the legacy attribution re-emit byte-identically."""
+    from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
+
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            ],
+        }
+    )
+    assert decoded.request.messages[-1].provider_tool_name is None
+    chat_payload = openai_compatible_stream_payload("chat-fixture", decoded.request)
+    chat_messages = cast(list[JsonObject], chat_payload["messages"])
+    assert chat_messages[-1] == {"role": "tool", "content": "ok", "tool_call_id": "call_1"}
+
+
+def test_a_name_on_a_non_tool_message_stays_a_named_400() -> None:
+    """The participant-name field on other roles keeps the explicit rejection."""
+    with pytest.raises(OpenAIProtocolError) as error:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi", "name": "alice"}],
+            }
+        )
+    assert error.value.status_code == 400
+    assert error.value.detail.param == "messages.0"
+    assert "name is valid only for tool messages" in str(error.value.detail.message)

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -262,6 +262,16 @@ class _Message(_WireModel):
     content: str | tuple[_ContentPart, ...] | None = None
     tool_calls: tuple[_AssistantToolCall, ...] | None = None
     tool_call_id: str | None = Field(default=None, min_length=1, max_length=256)
+    name: str | None = Field(default=None, min_length=1, max_length=256)
+    """Tool function name on a ``role: "tool"`` message.
+
+    The legacy ``role: "function"`` attribution many agent frameworks
+    (hermes-agent among them) still send on every tool result; the provider
+    serves it (probed live 2026-09-05, api.openai.com), and the field is
+    baked into caller history, so rejecting it wedges whole sessions. It
+    round-trips verbatim on OpenAI-family wires and drops with disclosure
+    elsewhere. Other roles keep the named rejection.
+    """
     refusal: None = None
     annotations: tuple[()] | None = None
     audio: None = None
@@ -298,6 +308,8 @@ class _Message(_WireModel):
             raise ValueError("tool messages require tool_call_id")
         if self.role != "tool" and self.tool_call_id is not None:
             raise ValueError("tool_call_id is valid only for tool messages")
+        if self.role != "tool" and self.name is not None:
+            raise ValueError("name is valid only for tool messages")
         if self.role != "assistant" and self.history_tool_calls:
             raise ValueError("tool_calls are valid only for assistant messages")
         if self.role != "assistant" and self.reasoning_content is not None:


### PR DESCRIPTION
## What this is

The next wedge-class finding from verifying Nous Research's hermes-agent coding harness against the gateway: the chat-completions surface 400d `name` on `role:"tool"` messages ("Invalid value for 'messages.N.name'.", param `messages.N.name`). hermes-agent sends `name:"<tool function name>"` on every tool-result message — the legacy `role:"function"` attribution many agent frameworks still send — so every session died on its FIRST tool call, and the field is baked into history: the full wedge signature.

**Provider truth (probed live 2026-09-05, api.openai.com, gpt-5.1):** a chat completion whose history carries `{"role":"tool","tool_call_id":"call_probe1","name":"read_file","content":"..."}` returns HTTP 200 with a correct answer. The provider serves the shape we rejected. A captured verbatim hermes request (`/tmp/hermes-probe/req-006.json`, message index 3) 400s before this fix; with the field carried, the same session completes end-to-end.

## The fix (the #784 pattern on the chat dialect)

- The Chat wire model accepts `name` on tool messages (1-256 chars); any other role keeps a named rejection ("name is valid only for tool messages") so nothing is silently dropped.
- It decodes into the EXISTING `GatewayMessage.provider_tool_name` carrier — the #784 `function_call_output` attribution is the same semantic (the tool function name attributed to a result), so continuation retention, replay identity (joins only when present), and the guardrail authority checks all apply unchanged, zero new plumbing.
- Re-emission: verbatim on both OpenAI wires — Chat tool messages get `"name"` back, and a chat-decoded session served over the Responses wire carries it as `function_call_output.name` (already wired since #784). Absent stays absent, so name-free histories keep their exact wire bytes and digests.
- Off the OpenAI wires (Anthropic/Gemini/Bedrock have no slot): degrade-with-disclosure, `messages.tool_results.name->dropped(unsupported_by_provider)` — never a 400, since callers cannot rewrite history. The #797 `messages.tool_results.attribution` disclosure narrows to `namespace`/`caller`, which remain Responses-only.
- Python-only: the caller-request decode path never touches the native crate (verified: no request-side chat parsing in `native/src`), so no crate version bump — the gate's version-move check does not apply.

## Fixtures

- Repo: the exact hermes shape decodes → carrier → both OpenAI payload rebuilds (`name` present verbatim); name-free tool messages keep the byte-exact chat wire shape; `name` on a user message stays a named 400; route shaping — OpenAI-wire routes disclose nothing, an Anthropic-bearing route discloses the name drop while namespace/caller attribution stays Responses-scoped.
- Wedge-stress harness round 4 extended (W11/W12): the hermes shape serves end-to-end on the real chat engine with `name` reaching the upstream verbatim, and the name-free shape stays unchanged — 16/16 attacks ok on this build.

## Informational, not in scope

hermes' session-title side-call sends `temperature`, which correctly fails closed on sampling-pinned routes — non-fatal and caller-fixable; no change.

## Gates

`uv run ruff format/check`, `ty check` clean; full `uv run pytest -q` green (3711 passed on the committed tree — the two w16 evidence tests require a clean checkout and pass on it). No native/ changes, so no cargo run required (CI gate still runs it against the untouched crate).

## Release train

Missed v0.7.36 (tagged 2026-09-05 10:44Z, which carried #784/#786/#787/#794/#796/#797/#798/#799); rides the next `experiential` release — Python-only, so no native wheel dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)