### PR TITLE
gateway: coerce forced tool_choice and Anthropic-unsupported strict schemas with disclosure; fold developer→system on Chat wires

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -382,7 +382,7 @@ The `capability_parity` row reports the per-release forced-choice fact as
 `developer` message is emitted as `system` without disclosure: OpenAI defines the two roles
 identically (developer-provided instructions the model follows regardless of user messages),
 while the third-party servers behind that dialect enumerate only the classic roles and reject
-`developer` by name; the native Responses wire keeps the role it defines. On a reasoning route that accepts sampling only at `reasoning_effort=none`
+`developer` by name; the native Responses wire keeps the role it defines. The Anthropic wire also rejects an empty text block anywhere and a turn whose text is all whitespace, while it accepts an empty assistant content array in any position (verified live 2026-09-05): an assistant turn with no readable text dispatches as an empty array, a system prompt with none is omitted, empty blocks inside richer turns drop with their cache breakpoints migrated, and an empty or whitespace-only user turn (which no array form can carry) is refused by name before dispatch. On a reasoning route that accepts sampling only at `reasoning_effort=none`
 (`sampling_requires_reasoning_none`, e.g. gpt-5.6-sol/luna), a `temperature`/`top_p` sent with
 reasoning on is dropped and disclosed as `temperature->dropped(set_reasoning_effort_none)` rather
 than rejected — the model accepts sampling, just not at that effort, so the request serves and the

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -362,8 +362,27 @@ on the canonical ladder (ties prefer the lower level), ANY effort on a route wit
 support at all drops (first-party clients pin effort globally, so a named rejection made whole
 sessions unusable against non-reasoning models the provider itself serves fine without the
 parameter; the Messages surface's verbatim `output_config.effort` is stripped with it so the
-dropped value reaches the provider through no channel), and `strict: true` tools degrade to
-best-effort schemas. On a reasoning route that accepts sampling only at `reasoning_effort=none`
+dropped value reaches the provider through no channel), `strict: true` tools degrade to
+best-effort schemas, and a forced `tool_choice` (`required`/`any`, or a named tool) relaxes to
+`auto` as `tool_choice->auto`. Two Anthropic wire facts feed those last two
+(`exp/runtime/models/providers/anthropic_tool_compat.py`, verified live 2026-09-05): Claude Fable
+5.1 and Mythos 5.1 answer a forced choice with a 400 by name on every request, and every model
+rejects a forced choice beside a budgeted `thinking: enabled` config, so the Anthropic builder
+declines those requests as `forced_tool_choice` before dispatch (narrowing prefers a rung that can
+force a tool, such as an aggregator rung of the same alias, and keeps the caller's selector
+verbatim there); and the strict validator compiles tool schemas into a grammar and 400s by name on
+keywords it cannot express (`maxItems`, `oneOf`, `minimum`, an unsupported `format`, a recursive
+`$ref`, ...), so a strict tool using one is declined as `strict_tools` on Anthropic rungs, which
+narrows to a strict-capable rung when the route has one and otherwise drops only `strict`, never
+a schema keyword. The same validator requires `additionalProperties: false` on every object, so
+strict tool schemas reaching an Anthropic rung have their objects closed with the
+`tools.parameters.additionalProperties->false` disclosure, exactly like structured-output schemas.
+The `capability_parity` row reports the per-release forced-choice fact as
+`supports_forced_tool_choice`. On the OpenAI-compatible Chat Completions wire a canonical
+`developer` message is emitted as `system` without disclosure: OpenAI defines the two roles
+identically (developer-provided instructions the model follows regardless of user messages),
+while the third-party servers behind that dialect enumerate only the classic roles and reject
+`developer` by name; the native Responses wire keeps the role it defines. On a reasoning route that accepts sampling only at `reasoning_effort=none`
 (`sampling_requires_reasoning_none`, e.g. gpt-5.6-sol/luna), a `temperature`/`top_p` sent with
 reasoning on is dropped and disclosed as `temperature->dropped(set_reasoning_effort_none)` rather
 than rejected — the model accepts sampling, just not at that effort, so the request serves and the

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1713,3 +1713,18 @@ def test_decode_names_a_duplicate_tool_use_id_instead_of_crashing() -> None:
         )
     assert rejected.value.status_code == 400
     assert rejected.value.detail.param == "messages.1"
+
+
+def test_forced_tool_choice_decodes_to_the_canonical_forced_forms() -> None:
+    """``any`` and a named ``tool`` reach the canonical forced forms admission
+    narrows and coerces on; ``auto`` and ``none`` stay open selectors."""
+    tools = [{"name": "lookup", "input_schema": {"type": "object"}}]
+    forced_any = decode_messages(_body(tool_choice={"type": "any"}, tools=tools))
+    assert forced_any.request.tool_choice == "required"
+    forced_named = decode_messages(
+        _body(tool_choice={"type": "tool", "name": "lookup"}, tools=tools)
+    )
+    assert forced_named.request.tool_choice == GatewayNamedToolChoice(name="lookup")
+    assert decode_messages(
+        _body(tool_choice={"type": "auto"}, tools=tools)
+    ).request.tool_choice == ("auto")

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -33,6 +33,7 @@ from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.capability_policy import (
     coerce_generation_parameters,
     coerce_route_rejections,
+    coerce_strict_tool_schemas,
     coerce_structured_text_schema,
 )
 from exp.runtime.models.providers.errors import (
@@ -212,18 +213,18 @@ def admitted_route_requests(
         provider_request = provider_request.model_copy(
             update={"stream": True, "include_usage": True}
         )
-    # The surviving rungs decide whether the structured-output schema needs
-    # its objects closed; a route that lost every Anthropic rung above is
-    # dispatched with the caller's schema verbatim.
-    coercion = coerce_structured_text_schema(
-        tuple(profile for profile, _client in resolved_wires),
-        admitted_request,
-    )
-    if coercion is not None:
+    # The surviving rungs decide whether the structured-output schema and the
+    # strict tool schemas need their objects closed; a route that lost every
+    # Anthropic rung above is dispatched with the caller's schemas verbatim.
+    surviving_profiles = tuple(profile for profile, _client in resolved_wires)
+    for coerce_schema in (coerce_structured_text_schema, coerce_strict_tool_schemas):
+        coercion = coerce_schema(surviving_profiles, admitted_request)
+        if coercion is None:
+            continue
         admitted_request = coercion.request
         coercion_disclosures = (*coercion_disclosures, *coercion.disclosures)
         public_request, provider_request = route_generation_parameter_requests(
-            tuple(profile for profile, _client in resolved_wires),
+            surviving_profiles,
             admitted_request,
         )
         provider_request = provider_request.model_copy(

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -26,9 +26,11 @@ from exp.runtime.gateway.contracts import (
     ExecutionSnapshot,
     GatewayApiSurface,
     GatewayMessage,
+    GatewayNamedToolChoice,
     GatewayRequest,
     GatewayToolDefinition,
 )
+from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_admission import (
     _prefer_cache_capable_rungs,
     admitted_route_requests,
@@ -1010,3 +1012,210 @@ def test_tier_without_a_card_rejects_while_byok_forwards_any_tier() -> None:
         authorization=byok_route.snapshot.authorization,
     )
     assert provider.service_tier == "priority"
+
+
+class _CoercionCounter:
+    """Count coercion recordings without a live ledger."""
+
+    def __init__(self) -> None:
+        """Start at zero recorded coercions."""
+        self.recorded = 0
+
+    def record_admission_coercions(self, count: int) -> None:
+        """Accumulate one admission's disclosure count."""
+        self.recorded += count
+
+
+_TOOL_CAPABLE = GatewayDeploymentMetadata(
+    capabilities=GatewayDeploymentCapabilities(
+        supports_streaming=True,
+        supports_strict_tools=True,
+        supports_streaming_tool_arguments=True,
+    )
+)
+"""One rung declaration that admits every tool control these tests send."""
+
+
+def _fable_and_shim_wires(
+    *, shim_model: str = "anthropic/claude-fable-5-1"
+) -> tuple[tuple[GatewayWireProfile, NativeWireClient], ...]:
+    """Pair a native fable-5-1 rung with an OpenAI-compatible aggregator rung."""
+    client = cast(NativeWireClient, object())
+    return (
+        (
+            GatewayWireProfile(
+                dialect="anthropic_messages",
+                url="https://anthropic.test",
+                model_id="claude-fable-5-1",
+            ),
+            client,
+        ),
+        (
+            GatewayWireProfile(
+                dialect="openai_compatible", url="https://shim.test", model_id=shim_model
+            ),
+            client,
+        ),
+    )
+
+
+def _forced_choice_request(
+    surface: GatewayApiSurface, choice: Literal["required"] | GatewayNamedToolChoice
+) -> GatewayRequest:
+    """Build one streaming request forcing the lookup tool on ``surface``."""
+    return GatewayRequest(
+        surface=surface,
+        messages=(GatewayMessage(role="user", content="weather in Paris"),),
+        tools=(GatewayToolDefinition(name="lookup", parameters={"type": "object"}),),
+        tool_choice=choice,
+        stream=True,
+        include_usage=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("surface", "choice"),
+    (
+        (GatewayApiSurface.CHAT_COMPLETIONS, "required"),
+        (GatewayApiSurface.RESPONSES, GatewayNamedToolChoice(name="lookup")),
+        (GatewayApiSurface.MESSAGES, "required"),
+    ),
+)
+def test_a_forced_choice_narrows_to_the_rung_that_can_force_tools(
+    surface: GatewayApiSurface, choice: Literal["required"] | GatewayNamedToolChoice
+) -> None:
+    """fable-5-1 declines ``any``/``tool`` by name, so a waterfall with an
+    aggregator rung serves the caller's forced choice VERBATIM on that rung
+    and discloses nothing."""
+    deployments = (
+        _deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),
+        _deployment("shim", gateway=_TOOL_CAPABLE),
+    )
+    route = _mixed_route("maximize_availability", deployments, surface)
+    accounting = _CoercionCounter()
+    narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        _fable_and_shim_wires(),
+        _forced_choice_request(surface, choice),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+    assert tuple(item.deployment_id for item in narrowed.deployments) == ("shim",)
+    assert provider.tool_choice == choice
+    assert public.ignored_parameters == ()
+    assert accounting.recorded == 0
+
+
+@pytest.mark.parametrize(
+    ("surface", "choice"),
+    (
+        (GatewayApiSurface.CHAT_COMPLETIONS, GatewayNamedToolChoice(name="lookup")),
+        (GatewayApiSurface.RESPONSES, "required"),
+        (GatewayApiSurface.MESSAGES, GatewayNamedToolChoice(name="lookup")),
+    ),
+)
+def test_a_forced_choice_relaxes_to_auto_with_disclosure_when_no_rung_can_force(
+    surface: GatewayApiSurface, choice: Literal["required"] | GatewayNamedToolChoice
+) -> None:
+    """An all-fable-5-1 route (production shape: ~45 requests in 6h failed
+    post-dispatch across all three surfaces) serves under ``auto`` and tells
+    the caller through ``ignored_parameters``."""
+    deployments = (_deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),)
+    route = _mixed_route("maximize_availability", deployments, surface)
+    accounting = _CoercionCounter()
+    narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        _fable_and_shim_wires()[:1],
+        _forced_choice_request(surface, choice),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+    assert tuple(item.deployment_id for item in narrowed.deployments) == ("native",)
+    assert provider.tool_choice == "auto"
+    assert public.tool_choice == "auto"
+    assert public.ignored_parameters == ("tool_choice->auto",)
+    assert accounting.recorded == 1
+
+
+_MAX_ITEMS_SCHEMA: JsonObject = {
+    "type": "object",
+    "properties": {"cities": {"type": "array", "items": {"type": "string"}, "maxItems": 3}},
+    "required": ["cities"],
+    "additionalProperties": False,
+}
+
+
+def _strict_tool_request(parameters: JsonObject) -> GatewayRequest:
+    """Build one streaming Chat request carrying a single strict tool."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="list cities"),),
+        tools=(GatewayToolDefinition(name="list", parameters=parameters, strict=True),),
+        stream=True,
+        include_usage=True,
+    )
+
+
+def test_a_strict_schema_the_anthropic_validator_rejects_prefers_a_strict_capable_rung() -> None:
+    """``maxItems`` under ``strict`` is a known Anthropic 400 (18 requests in
+    6h in production), so the waterfall narrows to the OpenAI-compatible rung
+    that honors strict verbatim and nothing is disclosed."""
+    deployments = (
+        _deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),
+        _deployment("shim", gateway=_TOOL_CAPABLE),
+    )
+    route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.CHAT_COMPLETIONS)
+    accounting = _CoercionCounter()
+    narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        _fable_and_shim_wires(),
+        _strict_tool_request(_MAX_ITEMS_SCHEMA),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+    assert tuple(item.deployment_id for item in narrowed.deployments) == ("shim",)
+    assert provider.tools[0].strict is True
+    assert provider.tools[0].parameters == _MAX_ITEMS_SCHEMA
+    assert public.ignored_parameters == ()
+    assert accounting.recorded == 0
+
+
+def test_a_strict_schema_no_rung_can_honor_drops_strict_and_keeps_the_schema() -> None:
+    """On an all-Anthropic route the disclosed degrade drops only ``strict``;
+    the schema, ``maxItems`` included, still reaches the model as guidance."""
+    deployments = (_deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),)
+    route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.CHAT_COMPLETIONS)
+    accounting = _CoercionCounter()
+    narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        _fable_and_shim_wires()[:1],
+        _strict_tool_request(_MAX_ITEMS_SCHEMA),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+    assert tuple(item.deployment_id for item in narrowed.deployments) == ("native",)
+    assert provider.tools[0].strict is False
+    assert provider.tools[0].parameters == _MAX_ITEMS_SCHEMA
+    assert public.ignored_parameters == ("tools.strict->false",)
+    assert accounting.recorded == 1
+
+
+def test_an_open_strict_schema_is_closed_for_the_anthropic_rung_with_disclosure() -> None:
+    """A strict tool whose objects leave ``additionalProperties`` open is a
+    400 by name on Anthropic ("must be explicitly set to false"); admission
+    closes the objects, keeps ``strict``, and discloses the tightening."""
+    deployments = (_deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),)
+    route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.CHAT_COMPLETIONS)
+    accounting = _CoercionCounter()
+    open_schema: JsonObject = {"type": "object", "properties": {"city": {"type": "string"}}}
+    _narrowed, _wires_out, public, provider = admitted_route_requests(
+        route,
+        _fable_and_shim_wires()[:1],
+        _strict_tool_request(open_schema),
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+    assert provider.tools[0].strict is True
+    assert provider.tools[0].parameters == {**open_schema, "additionalProperties": False}
+    assert public.ignored_parameters == ("tools.parameters.additionalProperties->false",)
+    assert accounting.recorded == 1

--- a/exp/runtime/gateway/native_bridge_errors.py
+++ b/exp/runtime/gateway/native_bridge_errors.py
@@ -12,6 +12,7 @@ _PUBLIC_REQUEST_CAPABILITY_PARAMS = {
     GatewayApiSurface.CHAT_COMPLETIONS: {
         "developer_messages": "messages",
         "function_tools": "tools",
+        "forced_tool_choice": "tool_choice",
         "image_input": "messages",
         "image_url_input": "messages",
         "video_input": "messages",
@@ -33,6 +34,7 @@ _PUBLIC_REQUEST_CAPABILITY_PARAMS = {
     GatewayApiSurface.RESPONSES: {
         "developer_messages": "instructions",
         "function_tools": "tools",
+        "forced_tool_choice": "tool_choice",
         "image_input": "input",
         "image_url_input": "input",
         "video_input": "input",
@@ -53,6 +55,7 @@ _PUBLIC_REQUEST_CAPABILITY_PARAMS = {
     GatewayApiSurface.MESSAGES: {
         "developer_messages": "system",
         "function_tools": "tools",
+        "forced_tool_choice": "tool_choice",
         "image_input": "messages",
         "image_url_input": "messages",
         "video_input": "messages",

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -71,6 +71,7 @@ _PublicErrorType = Literal[
     (
         ("developer_messages", "messages", "instructions", "system"),
         ("function_tools", "tools", "tools", "tools"),
+        ("forced_tool_choice", "tool_choice", "tool_choice", "tool_choice"),
         (
             "parallel_tool_calls",
             "parallel_tool_calls",

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -1,0 +1,254 @@
+"""Anthropic Messages wire facts about tool selection and strict tool schemas.
+
+Two provider rules decide, before dispatch, whether one Anthropic rung can
+carry a tool request verbatim: which models reject a forced ``tool_choice``
+outright, and which JSON Schema keywords the grammar-constrained ``strict``
+validator refuses. Both are checked structurally here so route admission can
+prefer a rung that honors the request and otherwise fall back to the
+capability-preservation policy's disclosed coercion, instead of dispatching a
+call the provider is known to 400.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+
+from pydantic import JsonValue
+
+from exp.common.core.artifacts import JsonObject
+
+# Exact point releases, NOT generation prefixes: the provider's tool-use
+# documentation names "Claude Fable 5.1 and Claude Mythos 5.1" as the models
+# whose `any`/`tool` selectors return a 400 (verified live 2026-09-05: fable-5-1
+# rejects with and without a thinking config, while fable-5, opus-5, sonnet-5,
+# opus-4-8, sonnet-4-6, sonnet-4-5, and haiku-4-5 all accept `any` and `tool`).
+# A dated snapshot id (`claude-fable-5-1-20260901`) inherits its release's rule.
+_ANTHROPIC_FORCED_TOOL_CHOICE_REJECTING_RELEASES = (
+    "claude-fable-5-1",
+    "claude-mythos-5-1",
+)
+
+
+def anthropic_rejects_forced_tool_choice(model_id: str) -> bool:
+    """Return whether one Anthropic model rejects a forced ``tool_choice`` by name.
+
+    Args:
+        model_id: Exact Anthropic model identifier.
+
+    Returns:
+        ``True`` when the model answers ``tool_choice.type`` of ``any`` or
+        ``tool`` with a 400 regardless of the rest of the request.
+    """
+    normalized = model_id.lower().replace(".", "-").replace("_", "-")
+    return any(
+        normalized == release or normalized.startswith(f"{release}-")
+        for release in _ANTHROPIC_FORCED_TOOL_CHOICE_REJECTING_RELEASES
+    )
+
+
+ANTHROPIC_STRICT_STRING_FORMATS = frozenset(
+    {
+        "date-time",
+        "time",
+        "date",
+        "duration",
+        "email",
+        "hostname",
+        "uri",
+        "ipv4",
+        "ipv6",
+        "uuid",
+    }
+)
+"""String ``format`` values the strict validator accepts (the provider's
+structured-outputs JSON Schema limitations, verified live 2026-09-05: ``uuid``
+passes, ``uri-reference`` is rejected by name)."""
+
+_UNSUPPORTED_SCHEMA_KEYWORDS = (
+    # Composition and conditionals: only anyOf and allOf are supported.
+    "oneOf",
+    "not",
+    "if",
+    "then",
+    "else",
+    # Numeric constraints.
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    # Array constraints beyond minItems of 0 or 1.
+    "maxItems",
+    "uniqueItems",
+    "contains",
+    "minContains",
+    "maxContains",
+    "prefixItems",
+    # Object constraints beyond properties/required/additionalProperties.
+    "minProperties",
+    "maxProperties",
+    "propertyNames",
+    "patternProperties",
+    "dependentRequired",
+    "dependentSchemas",
+    "unevaluatedProperties",
+)
+"""Keywords the strict validator rejects by name wherever they appear, in the
+order a violation is reported.
+
+Every entry was verified live on 2026-09-05 (``tools.0.custom: ... property
+'<keyword>' is not supported``). ``minLength``, ``maxLength``, and ``pattern``
+are deliberately absent: the published limitations list the two length
+constraints as unsupported, but the live validator accepts all three, and a
+check stricter than the provider would degrade strict tools the provider
+honors. ``additionalProperties`` is not a keyword rejection either: the
+validator requires it to be ``false`` on every object, which admission
+satisfies by closing the schema (a tightening) rather than by dropping
+``strict``."""
+
+_SUBSCHEMA_MAP_KEYS = ("properties", "$defs", "definitions")
+"""Keys whose values map names to subschemas."""
+
+_SUBSCHEMA_LIST_KEYS = ("anyOf", "allOf")
+"""Supported keys whose values list subschemas."""
+
+_SUBSCHEMA_SINGLE_KEYS = ("items", "additionalProperties")
+"""Keys whose values are one subschema (when they are objects)."""
+
+
+def anthropic_strict_schema_unsupported(schema: JsonObject) -> str | None:
+    """Name the first strict-mode limitation one tool ``input_schema`` violates.
+
+    The walk is purely structural: it descends the standard container and
+    composition keywords and never resolves or rewrites anything. A schema
+    that passes here is not guaranteed to compile (the provider owns its
+    grammar), but a schema that fails here is a known pre-dispatch 400 on
+    every current Anthropic model.
+
+    Args:
+        schema: One caller tool ``parameters`` / ``input_schema`` object.
+
+    Returns:
+        A short caller-neutral reason (``keyword 'maxItems'``,
+        ``format 'uri-reference'``, ``recursive $ref``), or ``None`` when the
+        schema uses only supported features.
+    """
+    for reason in _schema_violations(schema):
+        return reason
+    if _has_circular_definitions(schema):
+        return "recursive $ref"
+    return None
+
+
+def _schema_violations(node: JsonObject) -> Iterator[str]:
+    """Yield strict-mode violations of one node and its subschemas, in order."""
+    for keyword in _UNSUPPORTED_SCHEMA_KEYWORDS:
+        if keyword in node:
+            yield f"keyword {keyword!r}"
+    min_items = node.get("minItems")
+    if min_items is not None and min_items not in (0, 1):
+        yield "keyword 'minItems' outside 0..1"
+    string_format = node.get("format")
+    if isinstance(string_format, str) and string_format not in ANTHROPIC_STRICT_STRING_FORMATS:
+        yield f"format {string_format!r}"
+    enum_values = node.get("enum")
+    if isinstance(enum_values, list) and any(
+        isinstance(value, (dict, list)) for value in enum_values
+    ):
+        yield "complex enum values"
+    reference = node.get("$ref")
+    if isinstance(reference, str) and not reference.startswith("#"):
+        yield "external $ref"
+    all_of = node.get("allOf")
+    if isinstance(all_of, list) and any(
+        isinstance(member, dict) and "$ref" in member for member in all_of
+    ):
+        yield "allOf member with $ref"
+    yield from _child_violations(node)
+
+
+def _child_violations(node: JsonObject) -> Iterator[str]:
+    """Yield violations from every subschema reachable through supported keys."""
+    for key in _SUBSCHEMA_MAP_KEYS:
+        children = node.get(key)
+        if isinstance(children, dict):
+            for child in children.values():
+                if isinstance(child, dict):
+                    yield from _schema_violations(child)
+    for key in _SUBSCHEMA_LIST_KEYS:
+        members = node.get(key)
+        if isinstance(members, list):
+            for member in members:
+                if isinstance(member, dict):
+                    yield from _schema_violations(member)
+    for key in _SUBSCHEMA_SINGLE_KEYS:
+        single = node.get(key)
+        if isinstance(single, dict):
+            yield from _schema_violations(single)
+
+
+def _has_circular_definitions(schema: JsonObject) -> bool:
+    """Return whether any local definition references itself, directly or not.
+
+    The provider rejects "self-referencing or mutually-referencing
+    definitions" (verified live 2026-09-05), so the check builds the
+    definition-to-definition reference graph over ``$defs`` and
+    ``definitions`` and looks for a cycle, plus a bare ``#`` reference to
+    the schema root, which is recursion by construction.
+    """
+    definitions: dict[str, JsonObject] = {}
+    for key in ("$defs", "definitions"):
+        table = schema.get(key)
+        if isinstance(table, dict):
+            for name, definition in table.items():
+                if isinstance(definition, dict):
+                    definitions[name] = definition
+    if any(reference == "#" for reference in _references(schema)):
+        return True
+    graph = {
+        name: {
+            target
+            for target in (_definition_name(reference) for reference in _references(definition))
+            if target is not None
+        }
+        for name, definition in definitions.items()
+    }
+    visiting: set[str] = set()
+    settled: set[str] = set()
+
+    def cyclic(name: str) -> bool:
+        """Depth-first cycle probe over the definition reference graph."""
+        if name in settled:
+            return False
+        if name in visiting:
+            return True
+        visiting.add(name)
+        if any(cyclic(target) for target in graph.get(name, set())):
+            return True
+        visiting.discard(name)
+        settled.add(name)
+        return False
+
+    return any(cyclic(name) for name in graph)
+
+
+def _definition_name(reference: str) -> str | None:
+    """Return the local definition a ``#/$defs/<name>`` style reference names."""
+    for prefix in ("#/$defs/", "#/definitions/"):
+        if reference.startswith(prefix):
+            return reference[len(prefix) :]
+    return None
+
+
+def _references(node: Mapping[str, JsonValue]) -> Iterator[str]:
+    """Yield every ``$ref`` string inside one node, including nested ones."""
+    reference = node.get("$ref")
+    if isinstance(reference, str):
+        yield reference
+    for value in node.values():
+        if isinstance(value, dict):
+            yield from _references(value)
+        elif isinstance(value, list):
+            for member in value:
+                if isinstance(member, dict):
+                    yield from _references(member)

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -241,10 +241,16 @@ def _has_circular_definitions(schema: JsonObject) -> bool:
 
 
 def _definition_name(reference: str) -> str | None:
-    """Return the local definition a ``#/$defs/<name>`` style reference names."""
+    """Return the local definition a ``#/$defs/<name>...`` reference points into.
+
+    A pointer that descends past the definition (``#/$defs/node/properties/child``)
+    still depends on that definition, so only the first path segment names the
+    graph node; a self-reference through such a pointer is a cycle too.
+    """
     for prefix in ("#/$defs/", "#/definitions/"):
         if reference.startswith(prefix):
-            return reference[len(prefix) :]
+            name = reference[len(prefix) :].split("/", 1)[0]
+            return name or None
     return None
 
 

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -17,16 +17,24 @@ from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
 
-# Exact point releases, NOT generation prefixes: the provider's tool-use
-# documentation names "Claude Fable 5.1 and Claude Mythos 5.1" as the models
-# whose `any`/`tool` selectors return a 400 (verified live 2026-09-05: fable-5-1
-# rejects with and without a thinking config, while fable-5, opus-5, sonnet-5,
-# opus-4-8, sonnet-4-6, sonnet-4-5, and haiku-4-5 all accept `any` and `tool`).
-# A dated snapshot id (`claude-fable-5-1-20260901`) inherits its release's rule.
 _ANTHROPIC_FORCED_TOOL_CHOICE_REJECTING_RELEASES = (
     "claude-fable-5-1",
     "claude-mythos-5-1",
 )
+"""Exact point releases whose ``tool_choice`` ``any``/``tool`` return a 400 by name.
+
+The provider's tool-use documentation ("Forcing tool use") states two rules:
+(1) "Claude Fable 5.1 and Claude Mythos 5.1: ``any`` and ``tool`` return a 400
+error", and (2) "Manual extended thinking (``thinking: {type: enabled}``):
+``any`` and ``tool`` are not supported ... Adaptive thinking supports forced
+tool use". Rule (1) is this table; rule (2) is a per-request check in the
+Anthropic payload builder. Verified live 2026-09-05: fable-5-1 rejects with no
+thinking config and under adaptive thinking, while fable-5, opus-5, sonnet-5,
+opus-4-8, sonnet-4-6, sonnet-4-5, and haiku-4-5 all accept ``any`` and ``tool``.
+Entries are therefore exact RELEASES, never generation prefixes: a new point
+release (claude-fable-5-2) matches nothing here and must be probed live and
+added deliberately, not assumed from its generation. A dated snapshot id
+(``claude-fable-5-1-20260901``) inherits its release's rule."""
 
 
 def anthropic_rejects_forced_tool_choice(model_id: str) -> bool:

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -245,11 +245,15 @@ def _definition_name(reference: str) -> str | None:
 
     A pointer that descends past the definition (``#/$defs/node/properties/child``)
     still depends on that definition, so only the first path segment names the
-    graph node; a self-reference through such a pointer is a cycle too.
+    graph node; a self-reference through such a pointer is a cycle too. The
+    segment is a JSON Pointer token (RFC 6901), so ``~1`` and ``~0`` decode to
+    ``/`` and ``~`` after the split, and the result matches the raw
+    ``$defs`` key of a definition whose name carries those characters.
     """
     for prefix in ("#/$defs/", "#/definitions/"):
         if reference.startswith(prefix):
-            name = reference[len(prefix) :].split("/", 1)[0]
+            token = reference[len(prefix) :].split("/", 1)[0]
+            name = token.replace("~1", "/").replace("~0", "~")
             return name or None
     return None
 

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -205,56 +205,63 @@ def _has_circular_definitions(schema: JsonObject) -> bool:
     the schema root, which is recursion by construction.
     """
     definitions: dict[str, JsonObject] = {}
-    for key in ("$defs", "definitions"):
-        table = schema.get(key)
+    for table_key in ("$defs", "definitions"):
+        table = schema.get(table_key)
         if isinstance(table, dict):
             for name, definition in table.items():
                 if isinstance(definition, dict):
-                    definitions[name] = definition
+                    # Nodes are keyed by the full pointer to the definition:
+                    # ``$defs`` and legacy ``definitions`` are separate
+                    # namespaces, so a name present in both is two nodes.
+                    definitions[f"#/{table_key}/{_pointer_token(name)}"] = definition
     if any(reference == "#" for reference in _references(schema)):
         return True
     graph = {
-        name: {
+        node: {
             target
-            for target in (_definition_name(reference) for reference in _references(definition))
+            for target in (_definition_node(reference) for reference in _references(definition))
             if target is not None
         }
-        for name, definition in definitions.items()
+        for node, definition in definitions.items()
     }
     visiting: set[str] = set()
     settled: set[str] = set()
 
-    def cyclic(name: str) -> bool:
+    def cyclic(node: str) -> bool:
         """Depth-first cycle probe over the definition reference graph."""
-        if name in settled:
+        if node in settled:
             return False
-        if name in visiting:
+        if node in visiting:
             return True
-        visiting.add(name)
-        if any(cyclic(target) for target in graph.get(name, set())):
+        visiting.add(node)
+        if any(cyclic(target) for target in graph.get(node, set())):
             return True
-        visiting.discard(name)
-        settled.add(name)
+        visiting.discard(node)
+        settled.add(node)
         return False
 
-    return any(cyclic(name) for name in graph)
+    return any(cyclic(node) for node in graph)
 
 
-def _definition_name(reference: str) -> str | None:
-    """Return the local definition a ``#/$defs/<name>...`` reference points into.
+def _pointer_token(name: str) -> str:
+    """Encode one definition name as a JSON Pointer token (RFC 6901)."""
+    return name.replace("~", "~0").replace("/", "~1")
+
+
+def _definition_node(reference: str) -> str | None:
+    """Return the full-pointer node a ``#/$defs/<name>...`` reference points into.
 
     A pointer that descends past the definition (``#/$defs/node/properties/child``)
-    still depends on that definition, so only the first path segment names the
-    graph node; a self-reference through such a pointer is a cycle too. The
-    segment is a JSON Pointer token (RFC 6901), so ``~1`` and ``~0`` decode to
-    ``/`` and ``~`` after the split, and the result matches the raw
-    ``$defs`` key of a definition whose name carries those characters.
+    still depends on that definition, so the node is the pointer truncated to
+    its namespace and first token; a self-reference through such a pointer is
+    a cycle too. The token stays in its RFC 6901 encoded form (``~1`` for
+    ``/``, ``~0`` for ``~``), which is how the node table keys it, so
+    ``#/$defs/foo`` and ``#/definitions/foo`` remain distinct nodes.
     """
     for prefix in ("#/$defs/", "#/definitions/"):
         if reference.startswith(prefix):
             token = reference[len(prefix) :].split("/", 1)[0]
-            name = token.replace("~1", "/").replace("~0", "~")
-            return name or None
+            return f"{prefix}{token}" if token else None
     return None
 
 

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -1,0 +1,220 @@
+"""Tests for the Anthropic tool-selection and strict-schema wire facts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import JsonValue
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_rejects_forced_tool_choice,
+    anthropic_strict_schema_unsupported,
+)
+
+
+def test_forced_tool_choice_rejection_is_an_exact_release_fact() -> None:
+    """Only the releases the provider names reject a forced choice (live 2026-09-05).
+
+    Fable 5.1 and Mythos 5.1 answer ``any``/``tool`` with a 400 by name; the
+    rest of the adaptive generation (fable-5, opus-5, sonnet-5, opus-4-8) and
+    the budgeted families (sonnet-4-6, sonnet-4-5, haiku-4-5) accept them, so
+    the match is on the exact point release, never the generation prefix.
+    """
+    for model in (
+        "claude-fable-5-1",
+        "claude-fable-5.1",
+        "claude-mythos-5-1",
+        "claude-fable-5-1-20260901",
+    ):
+        assert anthropic_rejects_forced_tool_choice(model), model
+    for model in (
+        "claude-fable-5",
+        "claude-mythos-5",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5",
+        "claude-fable-5-10",
+    ):
+        assert not anthropic_rejects_forced_tool_choice(model), model
+
+
+def _object(properties: JsonObject, **extra: JsonValue) -> JsonObject:
+    """Build one closed object schema over ``properties`` plus extra keywords."""
+    schema: JsonObject = {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties),
+        "additionalProperties": False,
+    }
+    schema.update(extra)
+    return schema
+
+
+@pytest.mark.parametrize(
+    ("schema", "reason"),
+    (
+        (
+            _object({"xs": {"type": "array", "items": {"type": "string"}, "maxItems": 3}}),
+            "keyword 'maxItems'",
+        ),
+        (
+            _object({"xs": {"type": "array", "items": {"type": "string"}, "minItems": 2}}),
+            "keyword 'minItems' outside 0..1",
+        ),
+        (
+            _object({"xs": {"type": "array", "items": {"type": "string"}, "uniqueItems": True}}),
+            "keyword 'uniqueItems'",
+        ),
+        (_object({"n": {"type": "integer", "minimum": 0}}), "keyword 'minimum'"),
+        (_object({"n": {"type": "integer", "exclusiveMinimum": 0}}), "keyword 'exclusiveMinimum'"),
+        (_object({"n": {"type": "number", "multipleOf": 0.5}}), "keyword 'multipleOf'"),
+        (
+            _object({"v": {"oneOf": [{"type": "string"}, {"type": "integer"}]}}),
+            "keyword 'oneOf'",
+        ),
+        (_object({"v": {"not": {"type": "string"}}}), "keyword 'not'"),
+        (
+            _object(
+                {"v": {"type": "string"}},
+                **{"if": {"properties": {"v": {"const": "a"}}}, "then": {"required": ["v"]}},
+            ),
+            "keyword 'if'",
+        ),
+        (_object({"name": {"type": "string"}}, minProperties=1), "keyword 'minProperties'"),
+        (
+            _object({"name": {"type": "string"}}, propertyNames={"pattern": "^[a-z]+$"}),
+            "keyword 'propertyNames'",
+        ),
+        (
+            _object({"name": {"type": "string"}}, patternProperties={"^x_": {"type": "string"}}),
+            "keyword 'patternProperties'",
+        ),
+        (
+            _object({"name": {"type": "string"}}, dependentRequired={"name": ["other"]}),
+            "keyword 'dependentRequired'",
+        ),
+        (
+            _object({"name": {"type": "string"}}, unevaluatedProperties=False),
+            "keyword 'unevaluatedProperties'",
+        ),
+        (
+            _object({"xs": {"type": "array", "prefixItems": [{"type": "string"}]}}),
+            "keyword 'prefixItems'",
+        ),
+        (
+            _object({"xs": {"type": "array", "items": {"type": "string"}, "contains": {}}}),
+            "keyword 'contains'",
+        ),
+        (_object({"v": {"type": "string", "format": "uri-reference"}}), "format 'uri-reference'"),
+        (_object({"v": {"enum": [{"a": 1}, {"a": 2}]}}), "complex enum values"),
+        (_object({"v": {"$ref": "http://example.com/schema.json"}}), "external $ref"),
+        (
+            _object(
+                {"v": {"allOf": [{"$ref": "#/$defs/thing"}, {"type": "string"}]}},
+                **{"$defs": {"thing": {"type": "string"}}},
+            ),
+            "allOf member with $ref",
+        ),
+        (
+            _object(
+                {"v": {"$ref": "#/$defs/node"}},
+                **{
+                    "$defs": {
+                        "node": {
+                            "type": "object",
+                            "properties": {"child": {"$ref": "#/$defs/node"}},
+                            "additionalProperties": False,
+                        }
+                    }
+                },
+            ),
+            "recursive $ref",
+        ),
+        (
+            _object(
+                {"v": {"$ref": "#/definitions/a"}},
+                definitions={
+                    "a": {"properties": {"b": {"$ref": "#/definitions/b"}}},
+                    "b": {"properties": {"a": {"$ref": "#/definitions/a"}}},
+                },
+            ),
+            "recursive $ref",
+        ),
+        (_object({"v": {"$ref": "#"}}), "recursive $ref"),
+    ),
+)
+def test_strict_validator_limitations_are_found_structurally(
+    schema: JsonObject, reason: str
+) -> None:
+    """Each keyword the live strict validator 400s by name (2026-09-05) is named."""
+    assert anthropic_strict_schema_unsupported(schema) == reason
+
+
+def test_limitations_are_found_inside_nested_containers() -> None:
+    """The walk reaches properties, items, $defs, anyOf/allOf, and additionalProperties."""
+    nested = _object(
+        {
+            "outer": {
+                "type": "object",
+                "properties": {
+                    "list": {
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {"type": "object", "properties": {"n": {"maximum": 5}}},
+                            ]
+                        },
+                    }
+                },
+            }
+        }
+    )
+    assert anthropic_strict_schema_unsupported(nested) == "keyword 'maximum'"
+    in_defs = _object(
+        {"v": {"$ref": "#/$defs/thing"}},
+        **{"$defs": {"thing": {"type": "string", "format": "byte"}}},
+    )
+    assert anthropic_strict_schema_unsupported(in_defs) == "format 'byte'"
+    in_additional: JsonObject = {
+        "type": "object",
+        "additionalProperties": {"type": "integer", "minimum": 1},
+    }
+    assert anthropic_strict_schema_unsupported(in_additional) == "keyword 'minimum'"
+
+
+def test_supported_features_pass_untouched() -> None:
+    """Everything the provider accepts live passes, including features the
+    published limitations list as unsupported but the validator honors
+    (``minLength``/``maxLength``); an open object is not a violation here
+    because admission closes it instead of dropping ``strict``."""
+    supported = _object(
+        {
+            "name": {"type": "string", "minLength": 1, "maxLength": 10, "pattern": "^[a-z]+$"},
+            "when": {"type": "string", "format": "date-time"},
+            "id": {"type": "string", "format": "uuid"},
+            "kind": {"enum": ["a", "b", 1, True, None]},
+            "fixed": {"const": "x"},
+            "tags": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "maybe": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None},
+            "both": {"allOf": [{"type": "string"}, {"minLength": 0}]},
+            "thing": {"$ref": "#/$defs/thing"},
+            "inner": {"type": "object", "properties": {"open": {"type": "string"}}},
+        },
+        **{"$defs": {"thing": {"type": "object", "properties": {"leaf": {"type": "string"}}}}},
+    )
+    assert anthropic_strict_schema_unsupported(supported) is None
+    # Definitions that reference each other without a cycle are fine.
+    acyclic = _object(
+        {"v": {"$ref": "#/$defs/a"}},
+        **{
+            "$defs": {
+                "a": {"type": "object", "properties": {"b": {"$ref": "#/$defs/b"}}},
+                "b": {"type": "string"},
+            }
+        },
+    )
+    assert anthropic_strict_schema_unsupported(acyclic) is None

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -144,6 +144,25 @@ def _object(properties: JsonObject, **extra: JsonValue) -> JsonObject:
             "recursive $ref",
         ),
         (_object({"v": {"$ref": "#"}}), "recursive $ref"),
+        (
+            # A pointer that descends into the definition still depends on it.
+            _object(
+                {"v": {"$ref": "#/$defs/node"}},
+                **{
+                    "$defs": {
+                        "node": {
+                            "type": "object",
+                            "properties": {
+                                "child": {"type": "string"},
+                                "again": {"$ref": "#/$defs/node/properties/child"},
+                            },
+                            "additionalProperties": False,
+                        }
+                    }
+                },
+            ),
+            "recursive $ref",
+        ),
     ),
 )
 def test_strict_validator_limitations_are_found_structurally(

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -172,6 +172,35 @@ def test_strict_validator_limitations_are_found_structurally(
     assert anthropic_strict_schema_unsupported(schema) == reason
 
 
+def test_escaped_pointer_tokens_resolve_to_their_definitions() -> None:
+    """RFC 6901 escapes (``~1`` for ``/``, ``~0`` for ``~``) decode after the
+    split, so a recursive definition whose name carries those characters is
+    still a cycle; a non-recursive escaped name passes."""
+    slash_cycle = _object(
+        {"v": {"$ref": "#/$defs/a~1b"}},
+        **{
+            "$defs": {
+                "a/b": {
+                    "type": "object",
+                    "properties": {"again": {"$ref": "#/$defs/a~1b/properties/again"}},
+                    "additionalProperties": False,
+                }
+            }
+        },
+    )
+    assert anthropic_strict_schema_unsupported(slash_cycle) == "recursive $ref"
+    tilde_cycle = _object(
+        {"v": {"$ref": "#/definitions/x~0y"}},
+        definitions={"x~y": {"anyOf": [{"type": "string"}, {"$ref": "#/definitions/x~0y"}]}},
+    )
+    assert anthropic_strict_schema_unsupported(tilde_cycle) == "recursive $ref"
+    acyclic = _object(
+        {"v": {"$ref": "#/$defs/a~1b"}},
+        **{"$defs": {"a/b": {"type": "string"}}},
+    )
+    assert anthropic_strict_schema_unsupported(acyclic) is None
+
+
 def test_limitations_are_found_inside_nested_containers() -> None:
     """The walk reaches properties, items, $defs, anyOf/allOf, and additionalProperties."""
     nested = _object(

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -201,6 +201,53 @@ def test_escaped_pointer_tokens_resolve_to_their_definitions() -> None:
     assert anthropic_strict_schema_unsupported(acyclic) is None
 
 
+def test_definition_namespaces_stay_distinct() -> None:
+    """``$defs`` and legacy ``definitions`` are separate namespaces: a name
+    present in both is two graph nodes, a ``$ref`` resolves to the namespace
+    it names, and only a genuinely recursive node is flagged."""
+    # (a) Same name in both namespaces; only the ``definitions`` one recurses.
+    only_legacy_recursive = _object(
+        {"v": {"$ref": "#/$defs/node"}},
+        **{
+            "$defs": {"node": {"type": "string"}},
+            "definitions": {
+                "node": {"anyOf": [{"type": "string"}, {"$ref": "#/definitions/node"}]}
+            },
+        },
+    )
+    assert anthropic_strict_schema_unsupported(only_legacy_recursive) == "recursive $ref"
+    # The mirror image: a recursive ``$defs`` node beside a plain legacy twin.
+    only_defs_recursive = _object(
+        {"v": {"$ref": "#/definitions/node"}},
+        **{
+            "$defs": {"node": {"anyOf": [{"type": "string"}, {"$ref": "#/$defs/node"}]}},
+            "definitions": {"node": {"type": "string"}},
+        },
+    )
+    assert anthropic_strict_schema_unsupported(only_defs_recursive) == "recursive $ref"
+    # Neither recurses, even though each namespace's ``node`` refers to the
+    # OTHER namespace's ``node``: conflating the names would report a cycle.
+    cross_namespace_acyclic = _object(
+        {"v": {"$ref": "#/$defs/node"}},
+        **{
+            "$defs": {"node": {"$ref": "#/definitions/node"}},
+            "definitions": {"node": {"type": "string"}},
+        },
+    )
+    assert anthropic_strict_schema_unsupported(cross_namespace_acyclic) is None
+    # (b) A ``$ref`` into ``definitions`` resolves there even when an
+    # identically named ``$defs`` entry exists: the legacy node's own
+    # violation is found through it, the ``$defs`` twin is irrelevant.
+    resolves_to_legacy = _object(
+        {"v": {"$ref": "#/definitions/node"}},
+        **{
+            "$defs": {"node": {"type": "string"}},
+            "definitions": {"node": {"$ref": "#/definitions/node"}},
+        },
+    )
+    assert anthropic_strict_schema_unsupported(resolves_to_legacy) == "recursive $ref"
+
+
 def test_limitations_are_found_inside_nested_containers() -> None:
     """The walk reaches properties, items, $defs, anyOf/allOf, and additionalProperties."""
     nested = _object(

--- a/exp/runtime/models/providers/capability_parity.py
+++ b/exp/runtime/models/providers/capability_parity.py
@@ -18,6 +18,9 @@ from exp.common.core.artifacts import ContractModel
 from exp.common.models.catalog import GatewayDeploymentCapabilities
 from exp.common.models.content import MEDIA_HANDLE_PROVIDERS
 from exp.common.models.model import ReasoningEffort
+from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_rejects_forced_tool_choice,
+)
 from exp.runtime.models.providers.audios import AUDIO_DIALECTS
 from exp.runtime.models.providers.documents import PDF_URL_DIALECTS
 from exp.runtime.models.providers.images import IMAGE_URL_DIALECTS
@@ -27,7 +30,7 @@ from exp.runtime.models.providers.reasoning_compat import (
 )
 from exp.runtime.models.providers.videos import VIDEO_DIALECTS, VIDEO_URL_DIALECTS
 
-CAPABILITY_PARITY_SCHEMA_VERSION = 5
+CAPABILITY_PARITY_SCHEMA_VERSION = 6
 """Version of the parity-row contract; bump on any field change."""
 
 
@@ -41,6 +44,13 @@ class DeploymentCapabilityParity(ContractModel):
     supports_streaming: bool
     supports_developer_messages: bool
     supports_strict_tools: bool
+    supports_forced_tool_choice: bool
+    """Whether this rung can force a tool (``tool_choice`` ``required`` or a
+    named tool) on any request. Engine ground truth, not a declaration: the
+    Anthropic releases that answer a forced choice with a 400 by name (Fable
+    5.1, Mythos 5.1) report ``False``; every other rung reports ``True``. The
+    per-request rule that a budgeted ``thinking: enabled`` config cannot ride
+    beside a forced choice is not a rung fact and is not reflected here."""
     supports_parallel_tool_calls: bool
     supports_structured_text: bool
     supports_stop_sequences: bool
@@ -138,6 +148,9 @@ def deployment_capability_parity(
         supports_streaming=capabilities.supports_streaming,
         supports_developer_messages=capabilities.supports_developer_messages,
         supports_strict_tools=capabilities.supports_strict_tools,
+        supports_forced_tool_choice=not (
+            dialect == "anthropic_messages" and anthropic_rejects_forced_tool_choice(model_id)
+        ),
         supports_parallel_tool_calls=capabilities.supports_parallel_tool_calls,
         supports_structured_text=capabilities.supports_structured_text,
         supports_stop_sequences=capabilities.supports_stop_sequences,

--- a/exp/runtime/models/providers/capability_parity_test.py
+++ b/exp/runtime/models/providers/capability_parity_test.py
@@ -232,3 +232,35 @@ def test_parity_row_projects_audio_declarations_onto_the_wire() -> None:
         reasoning_wire_format="gemini_thinking",
     )
     assert undeclared.supports_audio_input is False
+
+
+def test_parity_row_reports_forced_tool_choice_as_engine_ground_truth() -> None:
+    """Fable 5.1 and Mythos 5.1 on the Anthropic wire cannot force a tool; the
+    same listing through an OpenAI-compatible aggregator, and every other
+    model, report support (the fact is dialect-scoped, verified live 2026-09-05)."""
+    declared = GatewayDeploymentCapabilities(supports_streaming=True, supports_strict_tools=True)
+    fable = deployment_capability_parity(
+        provider="anthropic",
+        model_id="claude-fable-5-1",
+        dialect="anthropic_messages",
+        capabilities=declared,
+        reasoning_wire_format="anthropic_adaptive",
+    )
+    assert fable.supports_forced_tool_choice is False
+    assert fable.schema_version == CAPABILITY_PARITY_SCHEMA_VERSION == 6
+    opus = deployment_capability_parity(
+        provider="anthropic",
+        model_id="claude-opus-5",
+        dialect="anthropic_messages",
+        capabilities=declared,
+        reasoning_wire_format="anthropic_adaptive",
+    )
+    assert opus.supports_forced_tool_choice is True
+    aggregated = deployment_capability_parity(
+        provider="openrouter",
+        model_id="anthropic/claude-fable-5-1",
+        dialect="openai_compatible",
+        capabilities=declared,
+        reasoning_wire_format="reasoning",
+    )
+    assert aggregated.supports_forced_tool_choice is True

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -22,7 +22,11 @@ from typing import TYPE_CHECKING
 from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
-from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.gateway.contracts import (
+    GatewayNamedToolChoice,
+    GatewayRequest,
+    GatewayToolDefinition,
+)
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -52,6 +56,15 @@ if TYPE_CHECKING:
 
 STRICT_TOOLS_DISCLOSURE = "tools.strict->false"
 """Disclosure recorded when strict tools degrade to best-effort schemas."""
+
+FORCED_TOOL_CHOICE_DISCLOSURE = "tool_choice->auto"
+"""Disclosure recorded when a forced tool choice relaxes to ``auto`` because no
+rung can force a tool (the model rejects it by name, or a budgeted thinking
+config forbids it)."""
+
+STRICT_TOOL_SCHEMA_CLOSED_DISCLOSURE = "tools.parameters.additionalProperties->false"
+"""Disclosure recorded when strict tool schemas have their objects closed for a
+rung whose strict validator requires it."""
 
 EFFORT_DROP_DISCLOSURE = "reasoning_effort"
 """Disclosure recorded when a zero-reasoning route drops the caller effort."""
@@ -525,10 +538,15 @@ def _without_clear_thinking_edits(context_management: JsonObject) -> JsonObject 
 def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoercion | None:
     """Build the disclosed coercion for one preflight capability rejection.
 
-    Three coercions exist, all only here — after every rung declined the
+    Four coercions exist, all only here — after every rung declined the
     verbatim request — and all only as a disclosed substitution. Degrading
     ``strict: true`` tools to best-effort schemas weakens a correctness
-    guarantee. Dropping ``service_tier`` changes pricing and latency
+    guarantee. Relaxing a forced ``tool_choice`` to ``auto`` weakens a
+    structural guarantee the same way (the model still sees the tools and the
+    prompt, so it usually calls one, but nothing forces it); a named
+    rejection instead would fail every forced-choice request against a model
+    the provider serves fine under ``auto``. Dropping ``service_tier``
+    changes pricing and latency
     semantics, which the caller can act on only when told, so the drop is
     disclosed rather than silent. Images inside TOOL results degrade to
     placeholder text on an image-incapable route because the block is baked
@@ -562,6 +580,15 @@ def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoerci
         return RequestCoercion(
             request=request.model_copy(update={"service_tier": None}),
             disclosures=(SERVICE_TIER_DROP_DISCLOSURE,),
+        )
+    if capability == "forced_tool_choice":
+        if request.tool_choice != "required" and not isinstance(
+            request.tool_choice, GatewayNamedToolChoice
+        ):
+            return None
+        return RequestCoercion(
+            request=request.model_copy(update={"tool_choice": "auto"}),
+            disclosures=(FORCED_TOOL_CHOICE_DISCLOSURE,),
         )
     if capability != "strict_tools" or not any(tool.strict for tool in request.tools):
         return None
@@ -693,6 +720,52 @@ def coerce_structured_text_schema(
             }
         ),
         disclosures=(CLOSED_SCHEMA_DISCLOSURE,),
+    )
+
+
+def coerce_strict_tool_schemas(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+) -> RequestCoercion | None:
+    """Close every object in each ``strict`` tool schema for a rung that needs it.
+
+    The Anthropic strict validator requires ``additionalProperties: false``
+    on every object of a strict tool's ``input_schema`` (verified live
+    2026-09-05: an absent or ``true`` value is a 400 by name), exactly as it
+    does for structured-output schemas. Closing the objects tightens the
+    input contract the caller already asked to have enforced, so it is a
+    disclosed coercion rather than a reason to drop ``strict``. Non-strict
+    tools, schemas already closed everywhere, and routes with no rung on such
+    a dialect pass through untouched.
+
+    Args:
+        profiles: Ordered wire profiles for the rungs the request will reach.
+        request: Admitted request, after generation-parameter narrowing.
+
+    Returns:
+        The disclosed substitution to dispatch, or ``None`` when nothing
+        needs closing.
+    """
+    if not any(tool.strict for tool in request.tools):
+        return None
+    if not any(
+        profile.dialect in _SCHEMA_DIALECTS_REQUIRING_CLOSED_OBJECTS for profile in profiles
+    ):
+        return None
+    changed_any = False
+    tools: list[GatewayToolDefinition] = []
+    for tool in request.tools:
+        if not tool.strict:
+            tools.append(tool)
+            continue
+        closed, changed = _close_schema_objects(tool.parameters)
+        changed_any = changed_any or changed
+        tools.append(tool.model_copy(update={"parameters": closed}) if changed else tool)
+    if not changed_any:
+        return None
+    return RequestCoercion(
+        request=request.model_copy(update={"tools": tuple(tools)}),
+        disclosures=(STRICT_TOOL_SCHEMA_CLOSED_DISCLOSURE,),
     )
 
 

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -538,8 +538,8 @@ def _without_clear_thinking_edits(context_management: JsonObject) -> JsonObject 
 def coerce_capability(capability: str, request: GatewayRequest) -> RequestCoercion | None:
     """Build the disclosed coercion for one preflight capability rejection.
 
-    Four coercions exist, all only here — after every rung declined the
-    verbatim request — and all only as a disclosed substitution. Degrading
+    Four coercions exist, all only here (after every rung declined the
+    verbatim request) and all only as a disclosed substitution. Degrading
     ``strict: true`` tools to best-effort schemas weakens a correctness
     guarantee. Relaxing a forced ``tool_choice`` to ``auto`` weakens a
     structural guarantee the same way (the model still sees the tools and the

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -934,3 +934,68 @@ def test_the_thinking_coercion_leaves_anthropic_bearing_routes_alone() -> None:
         ),
     )
     assert coerce_generation_parameters((_openai_reasoning_profile(),), with_blocks) is None
+
+
+def test_forced_tool_choice_relaxes_to_auto_only_as_a_disclosed_coercion() -> None:
+    """``required`` and a named tool relax to ``auto`` with the drop disclosed."""
+    from exp.runtime.gateway.contracts import GatewayNamedToolChoice
+
+    tools = (GatewayToolDefinition(name="lookup", parameters={"type": "object"}),)
+    for forced in ("required", GatewayNamedToolChoice(name="lookup")):
+        coercion = coerce_capability(
+            "forced_tool_choice", _request(tools=tools, tool_choice=forced)
+        )
+        assert coercion is not None
+        assert coercion.request.tool_choice == "auto"
+        assert coercion.request.tools == tools
+        assert coercion.disclosures == ("tool_choice->auto",)
+    # Nothing to relax on an open or absent selector.
+    for open_choice in ("auto", "none", None):
+        assert (
+            coerce_capability("forced_tool_choice", _request(tools=tools, tool_choice=open_choice))
+            is None
+        )
+
+
+def test_strict_tool_schemas_close_their_objects_for_a_closing_dialect() -> None:
+    """Strict tool objects gain ``additionalProperties: false`` on an Anthropic
+    route (the strict validator requires it, live 2026-09-05); non-strict tools,
+    already-closed schemas, and routes with no such rung are left alone."""
+    from exp.runtime.models.providers.capability_policy import coerce_strict_tool_schemas
+
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    shim = GatewayWireProfile(dialect="openai_compatible", url="https://shim.test")
+    open_schema: JsonObject = {
+        "type": "object",
+        "properties": {"inner": {"type": "object", "properties": {"x": {"type": "string"}}}},
+    }
+    request = _request(
+        tools=(
+            GatewayToolDefinition(name="strict", parameters=open_schema, strict=True),
+            GatewayToolDefinition(name="plain", parameters=open_schema),
+        )
+    )
+    coercion = coerce_strict_tool_schemas((anthropic, shim), request)
+    assert coercion is not None
+    assert coercion.disclosures == ("tools.parameters.additionalProperties->false",)
+    strict_tool, plain_tool = coercion.request.tools
+    assert strict_tool.strict is True
+    assert strict_tool.parameters == {
+        "type": "object",
+        "properties": {
+            "inner": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "additionalProperties": False,
+            }
+        },
+        "additionalProperties": False,
+    }
+    assert plain_tool.parameters == open_schema
+    # The original request is never mutated in place.
+    assert request.tools[0].parameters == open_schema
+
+    assert coerce_strict_tool_schemas((shim,), request) is None
+    closed_request = coercion.request
+    assert coerce_strict_tool_schemas((anthropic,), closed_request) is None
+    assert coerce_strict_tool_schemas((anthropic,), _request()) is None

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -69,6 +69,7 @@ def anthropic_messages_stream_payload(
     del supports_logprobs
     system_parts: list[tuple[str, tuple[JsonObject, ...]]] = []
     messages: list[JsonObject] = []
+    displaced_marker: JsonObject | None = None
     for message in request.messages:
         if message.role in {"system", "developer"}:
             if message.content is None:
@@ -92,6 +93,20 @@ def anthropic_messages_stream_payload(
                 system_parts.append((message.content, message.provider_text_blocks))
             continue
         role, blocks = anthropic_blocks(message)
+        if not blocks:
+            # An assistant turn with no readable text dispatches as an empty
+            # array (accepted live) and so has no block of its own to carry a
+            # caller cache marker. The breakpoint migrates across the turn
+            # boundary by the same rule the block-run helper applies within a
+            # turn: onto the closest retained block before it (the empty turn
+            # adds no readable bytes, so the cached prefix is the same one),
+            # else onto the first retained block after it.
+            marker = _cache_marker(message.provider_text_blocks)
+            if marker is not None and not _mark_last_block(messages, marker):
+                displaced_marker = marker
+        elif displaced_marker is not None:
+            blocks = _mark_first_block(blocks, displaced_marker)
+            displaced_marker = None
         if messages and messages[-1].get("role") == role:
             existing = messages[-1].get("content")
             if not isinstance(existing, list):
@@ -295,6 +310,50 @@ def anthropic_messages_stream_payload(
         payload["stop_sequences"] = list(request.stop)
     _require_forced_tool_choice_support(model_id, request, payload)
     return payload
+
+
+_UNMARKABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+"""Content block types the wire refuses to carry a ``cache_control`` marker on."""
+
+
+def _cache_marker(blocks: tuple[JsonObject, ...]) -> JsonObject | None:
+    """Return the first caller cache marker in a block run, if any."""
+    for block in blocks:
+        marker = block.get("cache_control")
+        if isinstance(marker, dict):
+            return marker
+    return None
+
+
+def _mark_last_block(messages: list[JsonObject], marker: JsonObject) -> bool:
+    """Attach ``marker`` to the last emitted block that can carry one.
+
+    Returns:
+        Whether a block took the marker; a block already marked counts, since
+        one marker per boundary suffices.
+    """
+    if not messages:
+        return False
+    content = messages[-1].get("content")
+    if not isinstance(content, list) or not content:
+        return False
+    last = content[-1]
+    if not isinstance(last, dict) or last.get("type") in _UNMARKABLE_BLOCK_TYPES:
+        return False
+    if "cache_control" not in last:
+        content[-1] = {**last, "cache_control": marker}
+    return True
+
+
+def _mark_first_block(blocks: list[JsonObject], marker: JsonObject) -> list[JsonObject]:
+    """Return ``blocks`` with ``marker`` on the first block that can carry one."""
+    for index, block in enumerate(blocks):
+        if block.get("type") in _UNMARKABLE_BLOCK_TYPES:
+            continue
+        if "cache_control" not in block:
+            return [*blocks[:index], {**block, "cache_control": marker}, *blocks[index + 1 :]]
+        return blocks
+    return blocks
 
 
 def _require_forced_tool_choice_support(

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -28,7 +28,10 @@ from exp.runtime.models.providers.reasoning_compat import (
     anthropic_reasoning_effort,
     anthropic_thinking_budget_tokens,
 )
-from exp.runtime.models.providers.wire_messages import anthropic_blocks
+from exp.runtime.models.providers.wire_messages import (
+    anthropic_blocks,
+    retained_cache_marked_blocks,
+)
 from exp.runtime.openai_protocol.model_adapter import model_request as gateway_model_request
 
 
@@ -135,9 +138,19 @@ def anthropic_messages_stream_payload(
                         dict(block),
                         separated=(part_leads if position == 0 else inner_separated),
                     )
-            payload["system"] = system_blocks
+            # The wire rejects an empty system text block anywhere and a
+            # system prompt whose text is all whitespace ("system: text
+            # content blocks must be non-empty" / "must contain non-whitespace
+            # text", verified live 2026-09-05). Empty blocks drop with their
+            # breakpoints migrated; a prompt left with no readable text is
+            # omitted, since an absent system field is what it says.
+            retained_system = retained_cache_marked_blocks(system_blocks)
+            if any(str(block.get("text", "")).strip() for block in retained_system):
+                payload["system"] = retained_system
         else:
-            payload["system"] = "\n\n".join(content for content, _ in system_parts)
+            joined_system = "\n\n".join(content for content, _ in system_parts)
+            if joined_system.strip():
+                payload["system"] = joined_system
     if request.tools:
         tools: list[JsonObject] = []
         for tool in request.tools:

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -326,23 +326,30 @@ def _cache_marker(blocks: tuple[JsonObject, ...]) -> JsonObject | None:
 
 
 def _mark_last_block(messages: list[JsonObject], marker: JsonObject) -> bool:
-    """Attach ``marker`` to the last emitted block that can carry one.
+    """Attach ``marker`` to the closest earlier emitted block that can carry one.
+
+    Collapsed (empty) turns are skipped on the way back: consecutive empty
+    assistant turns all sit on the same cache boundary, so every marker they
+    carried collapses onto the same retained block instead of deferring to a
+    later one, which would cache a larger prefix than the caller asked for.
 
     Returns:
         Whether a block took the marker; a block already marked counts, since
         one marker per boundary suffices.
     """
-    if not messages:
-        return False
-    content = messages[-1].get("content")
-    if not isinstance(content, list) or not content:
-        return False
-    last = content[-1]
-    if not isinstance(last, dict) or last.get("type") in _UNMARKABLE_BLOCK_TYPES:
-        return False
-    if "cache_control" not in last:
-        content[-1] = {**last, "cache_control": marker}
-    return True
+    for emitted in reversed(messages):
+        content = emitted.get("content")
+        if not isinstance(content, list):
+            return False
+        if not content:
+            continue
+        last = content[-1]
+        if not isinstance(last, dict) or last.get("type") in _UNMARKABLE_BLOCK_TYPES:
+            return False
+        if "cache_control" not in last:
+            content[-1] = {**last, "cache_control": marker}
+        return True
+    return False
 
 
 def _mark_first_block(blocks: list[JsonObject], marker: JsonObject) -> list[JsonObject]:

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -12,6 +12,10 @@ from exp.runtime.gateway.contracts import (
     GatewayNamedToolChoice,
     GatewayRequest,
 )
+from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_rejects_forced_tool_choice,
+    anthropic_strict_schema_unsupported,
+)
 from exp.runtime.models.providers.bedrock_requests import converse_body
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
@@ -49,6 +53,11 @@ def anthropic_messages_stream_payload(
         Native Messages request with streaming enabled.
 
     Raises:
+        ProviderCapabilityError: A ``strict`` tool schema uses a keyword the
+            provider's strict validator rejects (``strict_tools``), or the
+            request forces a tool the model or its thinking mode cannot force
+            (``forced_tool_choice``); both let route admission prefer a rung
+            that honors the request and otherwise coerce with disclosure.
         ProviderResponseError: Instruction or message content is malformed.
     """
     # Anthropic Messages has no compatible logprob request/response surface in
@@ -141,6 +150,13 @@ def anthropic_messages_stream_payload(
             if tool.description is not None:
                 translated["description"] = tool.description
             if tool.strict:
+                # The strict validator compiles the schema into a grammar and
+                # 400s by name on keywords it cannot express (verified live
+                # 2026-09-05: ``maxItems`` on every current model). Declining
+                # here keeps the schema intact and lets admission drop only
+                # ``strict`` when no rung can honor it.
+                if anthropic_strict_schema_unsupported(tool.parameters) is not None:
+                    raise ProviderCapabilityError(capability="strict_tools")
                 translated["strict"] = True
             # Anthropic-native tool annotations forward verbatim on this
             # wire only; the provider owns their validity rules. An absent
@@ -264,7 +280,38 @@ def anthropic_messages_stream_payload(
         payload["output_config"] = output_config
     if request.stop:
         payload["stop_sequences"] = list(request.stop)
+    _require_forced_tool_choice_support(model_id, request, payload)
     return payload
+
+
+def _require_forced_tool_choice_support(
+    model_id: str,
+    request: GatewayRequest,
+    payload: JsonObject,
+) -> None:
+    """Decline a forced ``tool_choice`` this rung is known to reject.
+
+    Two provider rules apply (both verified live 2026-09-05). Fable 5.1 and
+    Mythos 5.1 answer ``any`` and ``tool`` with a 400 on every request, even
+    with no thinking config. Every model rejects a forced choice beside a
+    budgeted ``thinking: enabled`` config ("Thinking may not be enabled when
+    tool_choice forces tool use"), whether the caller sent that config or the
+    rung derived it from an effort; adaptive thinking carries a forced choice
+    fine. ``auto`` and ``none`` are never affected.
+
+    Raises:
+        ProviderCapabilityError: ``forced_tool_choice`` when the built payload
+            would be rejected.
+    """
+    forced = request.tool_choice == "required" or isinstance(
+        request.tool_choice, GatewayNamedToolChoice
+    )
+    if not forced:
+        return
+    thinking = payload.get("thinking")
+    budgeted_thinking = isinstance(thinking, dict) and thinking.get("type") == "enabled"
+    if budgeted_thinking or anthropic_rejects_forced_tool_choice(model_id):
+        raise ProviderCapabilityError(capability="forced_tool_choice")
 
 
 def gemini_generate_content_stream_payload(

--- a/exp/runtime/models/providers/messages_payloads_test.py
+++ b/exp/runtime/models/providers/messages_payloads_test.py
@@ -1,1 +1,150 @@
-"""Messages-family payload builders are exercised in streaming_requests_test.py."""
+"""Anthropic builder tool-selection and strict-schema preflight; the rest of the
+Messages-family builders are exercised in streaming_requests_test.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import (
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayNamedToolChoice,
+    GatewayRequest,
+    GatewayToolDefinition,
+)
+from exp.runtime.models.providers.errors import ProviderCapabilityError
+from exp.runtime.models.providers.messages_payloads import anthropic_messages_stream_payload
+
+_LOOKUP = GatewayToolDefinition(
+    name="lookup",
+    parameters={
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+        "additionalProperties": False,
+    },
+)
+
+
+def _tool_request(**overrides: object) -> GatewayRequest:
+    """Build one streaming Messages request carrying the lookup tool."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="weather in Paris"),),
+        tools=(_LOOKUP,),
+        stream=True,
+        include_usage=True,
+    )
+    return request.model_copy(update=dict(overrides))
+
+
+def _capability(exc_info: pytest.ExceptionInfo[ProviderCapabilityError]) -> str:
+    """Return the capability literal of one raised preflight rejection."""
+    return exc_info.value.capability
+
+
+@pytest.mark.parametrize("choice", ("required", GatewayNamedToolChoice(name="lookup")))
+def test_fable_5_1_declines_a_forced_tool_choice_before_dispatch(
+    choice: str | GatewayNamedToolChoice,
+) -> None:
+    """The release rejects ``any``/``tool`` by name (live 2026-09-05, with or
+    without a thinking config), so the rung declines at build time and route
+    admission can prefer another rung or relax to ``auto`` with disclosure."""
+    with pytest.raises(ProviderCapabilityError) as raised:
+        anthropic_messages_stream_payload(
+            "claude-fable-5-1",
+            _tool_request(tool_choice=choice),
+            supports_reasoning=True,
+            reasoning_effort="medium",
+        )
+    assert _capability(raised) == "forced_tool_choice"
+    # auto and none stay servable on the same model.
+    for open_choice in ("auto", "none", None):
+        payload = anthropic_messages_stream_payload(
+            "claude-fable-5-1", _tool_request(tool_choice=open_choice)
+        )
+        assert payload.get("tool_choice") == (
+            {"type": open_choice} if open_choice is not None else None
+        )
+
+
+def test_other_releases_force_tools_verbatim_under_adaptive_thinking() -> None:
+    """opus-5 (and every non-5.1 release probed live) carries ``any``/``tool``
+    verbatim, including beside the adaptive thinking config the rung emits."""
+    payload = anthropic_messages_stream_payload(
+        "claude-opus-5",
+        _tool_request(tool_choice="required", reasoning_effort="high"),
+        supports_reasoning=True,
+    )
+    assert payload["tool_choice"] == {"type": "any"}
+    assert payload["thinking"] == {"type": "adaptive"}
+    named = anthropic_messages_stream_payload(
+        "claude-sonnet-4-6",
+        _tool_request(tool_choice=GatewayNamedToolChoice(name="lookup")),
+    )
+    assert named["tool_choice"] == {"type": "tool", "name": "lookup"}
+
+
+def test_budgeted_thinking_cannot_ride_beside_a_forced_choice() -> None:
+    """Every model answers a forced choice plus ``thinking: enabled`` with
+    "Thinking may not be enabled when tool_choice forces tool use" (live
+    2026-09-05), whether the caller sent the budget or the rung derived one
+    from an effort on a budgeted-only model."""
+    with pytest.raises(ProviderCapabilityError) as caller_budget:
+        anthropic_messages_stream_payload(
+            "claude-sonnet-4-6",
+            _tool_request(
+                tool_choice="required",
+                provider_thinking_config={"type": "enabled", "budget_tokens": 1024},
+                maximum_output_tokens=4096,
+            ),
+            supports_reasoning=True,
+        )
+    assert _capability(caller_budget) == "forced_tool_choice"
+    with pytest.raises(ProviderCapabilityError) as derived_budget:
+        anthropic_messages_stream_payload(
+            "claude-haiku-4-5",
+            _tool_request(tool_choice="required", reasoning_effort="medium"),
+            supports_reasoning=True,
+        )
+    assert _capability(derived_budget) == "forced_tool_choice"
+    # A disabled config forces fine on a model that accepts it.
+    payload = anthropic_messages_stream_payload(
+        "claude-sonnet-4-6",
+        _tool_request(tool_choice="required", provider_thinking_config={"type": "disabled"}),
+        supports_reasoning=True,
+    )
+    assert payload["tool_choice"] == {"type": "any"}
+    assert payload["thinking"] == {"type": "disabled"}
+
+
+_ARRAY_WITH_MAX_ITEMS: JsonObject = {
+    "type": "object",
+    "properties": {"cities": {"type": "array", "items": {"type": "string"}, "maxItems": 3}},
+    "required": ["cities"],
+    "additionalProperties": False,
+}
+
+
+def test_strict_tools_with_unsupported_keywords_decline_as_strict_tools() -> None:
+    """A strict schema the strict validator cannot compile (``maxItems``, live
+    2026-09-05 on every current model) is declined as ``strict_tools`` with the
+    schema untouched, so admission drops only ``strict`` when no rung can honor it."""
+    strict = GatewayToolDefinition(name="list", parameters=_ARRAY_WITH_MAX_ITEMS, strict=True)
+    with pytest.raises(ProviderCapabilityError) as raised:
+        anthropic_messages_stream_payload("claude-fable-5-1", _tool_request(tools=(strict,)))
+    assert _capability(raised) == "strict_tools"
+
+    # The same schema without strict forwards verbatim, and a supported strict
+    # schema keeps its strict flag on the wire.
+    loose = strict.model_copy(update={"strict": False})
+    payload = anthropic_messages_stream_payload("claude-fable-5-1", _tool_request(tools=(loose,)))
+    tools = payload["tools"]
+    assert isinstance(tools, list)
+    assert tools[0] == {"name": "list", "input_schema": _ARRAY_WITH_MAX_ITEMS}
+    clean = _LOOKUP.model_copy(update={"strict": True})
+    payload = anthropic_messages_stream_payload("claude-fable-5-1", _tool_request(tools=(clean,)))
+    tools = payload["tools"]
+    assert isinstance(tools, list)
+    assert tools[0]["strict"] is True

--- a/exp/runtime/models/providers/messages_payloads_test.py
+++ b/exp/runtime/models/providers/messages_payloads_test.py
@@ -245,6 +245,23 @@ def test_a_marker_on_a_collapsed_assistant_turn_moves_to_a_neighboring_block() -
         {"type": "text", "text": "continue", "cache_control": {"type": "ephemeral"}}
     ]
 
+    # Consecutive collapsed turns sit on one boundary: both markers land on
+    # the same earlier block, none defers forward to a later, larger prefix.
+    consecutive = payload_for(
+        GatewayMessage(role="user", content="hello"),
+        GatewayMessage(role="assistant", content=" \n", provider_text_blocks=marked_blank),
+        GatewayMessage(role="assistant", content=" \n", provider_text_blocks=marked_blank),
+        GatewayMessage(role="user", content="continue"),
+    )
+    assert consecutive == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}],
+        },
+        {"role": "assistant", "content": []},
+        {"role": "user", "content": [{"type": "text", "text": "continue"}]},
+    ]
+
     # A block that already carries a marker keeps its own (one per boundary),
     # and a whitespace run beside a tool call is not collapsed at all, so its
     # marker stays where the caller put it.

--- a/exp/runtime/models/providers/messages_payloads_test.py
+++ b/exp/runtime/models/providers/messages_payloads_test.py
@@ -148,3 +148,57 @@ def test_strict_tools_with_unsupported_keywords_decline_as_strict_tools() -> Non
     tools = payload["tools"]
     assert isinstance(tools, list)
     assert tools[0]["strict"] is True
+
+
+def test_system_prompts_with_no_readable_text_are_omitted() -> None:
+    """The wire rejects an empty system text block and an all-whitespace
+    system prompt ("system: text content blocks must be non-empty" / "must
+    contain non-whitespace text", live 2026-09-05); a prompt with nothing to
+    read is omitted, and a readable one keeps its exact bytes."""
+
+    def payload_for(*system: GatewayMessage) -> JsonObject:
+        """Build the Anthropic payload for ``system`` turns plus one user turn."""
+        request = GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(*system, GatewayMessage(role="user", content="hi")),
+            stream=True,
+            include_usage=True,
+        )
+        return anthropic_messages_stream_payload("claude-fable-5-1", request)
+
+    assert "system" not in payload_for(GatewayMessage(role="system", content=""))
+    assert "system" not in payload_for(GatewayMessage(role="system", content="  \n"))
+    assert "system" not in payload_for(
+        GatewayMessage(role="system", content="  "), GatewayMessage(role="system", content="")
+    )
+    # Whitespace beside real instructions is accepted, so the joined bytes stay exact.
+    assert (
+        payload_for(
+            GatewayMessage(role="system", content="  "),
+            GatewayMessage(role="system", content="rules"),
+        )["system"]
+        == "  \n\nrules"
+    )
+    # A cache-marked run drops its empty blocks with the breakpoint migrated.
+    marked = payload_for(
+        GatewayMessage(
+            role="system",
+            content="rules",
+            provider_text_blocks=(
+                {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": "rules"},
+            ),
+        )
+    )
+    assert marked["system"] == [
+        {"type": "text", "text": "rules", "cache_control": {"type": "ephemeral"}}
+    ]
+    assert "system" not in payload_for(
+        GatewayMessage(
+            role="system",
+            content="",
+            provider_text_blocks=(
+                {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+            ),
+        )
+    )

--- a/exp/runtime/models/providers/messages_payloads_test.py
+++ b/exp/runtime/models/providers/messages_payloads_test.py
@@ -202,3 +202,85 @@ def test_system_prompts_with_no_readable_text_are_omitted() -> None:
             ),
         )
     )
+
+
+def test_a_marker_on_a_collapsed_assistant_turn_moves_to_a_neighboring_block() -> None:
+    """A whitespace-only assistant run that carried a cache breakpoint has no
+    block of its own once it dispatches as an empty array, so the marker lands
+    on the closest retained block before it, or on the first block after it
+    when nothing precedes, and never on a thinking block."""
+    marked_blank: tuple[JsonObject, ...] = (
+        {"type": "text", "text": " \n", "cache_control": {"type": "ephemeral"}},
+    )
+
+    def payload_for(*messages: GatewayMessage) -> list[JsonObject]:
+        """Return the emitted Anthropic messages for ``messages``."""
+        request = GatewayRequest(
+            surface=GatewayApiSurface.MESSAGES,
+            messages=messages,
+            stream=True,
+            include_usage=True,
+        )
+        built = anthropic_messages_stream_payload("claude-fable-5-1", request)["messages"]
+        assert isinstance(built, list)
+        return built
+
+    before = payload_for(
+        GatewayMessage(role="user", content="hello"),
+        GatewayMessage(role="assistant", content=" \n", provider_text_blocks=marked_blank),
+        GatewayMessage(role="user", content="continue"),
+    )
+    assert before[0]["content"] == [
+        {"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}
+    ]
+    assert before[1] == {"role": "assistant", "content": []}
+    assert before[2]["content"] == [{"type": "text", "text": "continue"}]
+
+    after = payload_for(
+        GatewayMessage(role="assistant", content=" \n", provider_text_blocks=marked_blank),
+        GatewayMessage(role="user", content="continue"),
+    )
+    assert after[0] == {"role": "assistant", "content": []}
+    assert after[1]["content"] == [
+        {"type": "text", "text": "continue", "cache_control": {"type": "ephemeral"}}
+    ]
+
+    # A block that already carries a marker keeps its own (one per boundary),
+    # and a whitespace run beside a tool call is not collapsed at all, so its
+    # marker stays where the caller put it.
+    already = payload_for(
+        GatewayMessage(
+            role="user",
+            content="hello",
+            provider_text_blocks=(
+                {
+                    "type": "text",
+                    "text": "hello",
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                },
+            ),
+        ),
+        GatewayMessage(role="assistant", content=" \n", provider_text_blocks=marked_blank),
+        GatewayMessage(role="user", content="continue"),
+    )
+    assert already[0]["content"] == [
+        {"type": "text", "text": "hello", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+    ]
+    from exp.runtime.gateway.contracts import ToolCall
+
+    beside_tool = payload_for(
+        GatewayMessage(role="user", content="hello"),
+        GatewayMessage(
+            role="assistant",
+            content=" \n",
+            provider_text_blocks=marked_blank,
+            tool_calls=(
+                ToolCall(call_id="call-1", name="lookup", arguments={}, raw_arguments="{}"),
+            ),
+        ),
+        GatewayMessage(role="tool", content="found", tool_call_id="call-1"),
+    )
+    assert beside_tool[1]["content"] == [
+        {"type": "text", "text": " \n", "cache_control": {"type": "ephemeral"}},
+        {"type": "tool_use", "id": "call-1", "name": "lookup", "input": {}},
+    ]

--- a/exp/runtime/models/providers/openai_payloads_test.py
+++ b/exp/runtime/models/providers/openai_payloads_test.py
@@ -1,1 +1,63 @@
-"""OpenAI-family payload builders are exercised in streaming_requests_test.py."""
+"""Instruction-role emission per OpenAI-family wire; the rest of the builders
+are exercised in streaming_requests_test.py."""
+
+from __future__ import annotations
+
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.runtime.models.providers.openai_payloads import (
+    openai_compatible_stream_payload,
+    openai_responses_stream_payload,
+)
+
+
+def _developer_conversation() -> GatewayRequest:
+    """Build one request with a leading and a mid-conversation developer turn."""
+    return GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="developer", content="Follow policy."),
+            GatewayMessage(role="user", content="hi"),
+            GatewayMessage(role="assistant", content="hello"),
+            GatewayMessage(role="developer", content="Now be terse."),
+            GatewayMessage(role="user", content="go"),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+
+
+def test_chat_wire_emits_developer_instructions_as_system() -> None:
+    """The Chat Completions wire folds ``developer`` into ``system`` losslessly.
+
+    OpenAI defines both roles identically (developer-provided instructions the
+    model follows regardless of user messages), and the third-party
+    OpenAI-compatible servers behind this dialect enumerate only the classic
+    roles (an Azure AI Foundry DeepSeek rung answered ``developer is not one of
+    ['system', 'assistant', 'user', 'tool', 'function']`` in production), so
+    the fold needs no disclosure and applies to every provider on the wire.
+    """
+    payload = openai_compatible_stream_payload("deepseek-v4-flash", _developer_conversation())
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    assert [message["role"] for message in messages] == [
+        "system",
+        "user",
+        "assistant",
+        "system",
+        "user",
+    ]
+    assert messages[0]["content"] == "Follow policy."
+    assert messages[3]["content"] == "Now be terse."
+    assert "developer" not in str(payload)
+
+
+def test_responses_wire_keeps_the_developer_role_it_defines() -> None:
+    """The native Responses wire owns the ``developer`` role: leading instructions
+    ride ``instructions`` and a later developer turn keeps its role verbatim."""
+    payload = openai_responses_stream_payload(
+        "gpt-5.4", _developer_conversation(), supports_temperature=True
+    )
+    assert payload["instructions"] == "Follow policy."
+    items = payload["input"]
+    assert isinstance(items, list)
+    assert {"role": "developer", "content": "Now be terse."} in items

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -836,7 +836,7 @@ def route_generation_parameter_requests(
 
     if any(profile.dialect == "anthropic_messages" for profile in profiles) and any(
         message.role == "user"
-        and not message.content
+        and not (message.content or "").strip()
         and not message.content_parts
         and message.provider_anthropic_block is None
         and message.provider_native_item is None
@@ -844,15 +844,18 @@ def route_generation_parameter_requests(
     ):
         # The Anthropic wire rejects empty text content blocks post-dispatch
         # ("text content blocks must be non-empty"; 2026-09-05, six orgs on
-        # claude-fable routes). Empty blocks inside a richer turn drop
-        # loss-free at conversion, but a user turn that is entirely empty
-        # has nothing to send and dropping the whole message would change
-        # conversation structure, so it is refused by name pre-dispatch.
+        # claude-fable routes) and a user turn whose text is all whitespace
+        # ("text content blocks must contain non-whitespace text"; a user
+        # message must have non-empty content, so unlike an assistant turn
+        # it cannot dispatch as an empty array). Empty blocks inside a richer
+        # turn drop loss-free at conversion, but a user turn with no readable
+        # text has nothing to send and dropping the whole message would
+        # change conversation structure, so it is refused by name pre-dispatch.
         raise ProviderParameterError(
             message=(
-                "A user message with empty content cannot be served by this "
-                "model route: the provider rejects empty text content blocks. "
-                "Add content to the message or remove it."
+                "A user message with empty or whitespace-only content cannot be "
+                "served by this model route: the provider rejects empty text "
+                "content blocks. Add content to the message or remove it."
             ),
             param="messages",
             code="invalid_parameter",

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4370,7 +4370,17 @@ def test_route_refuses_a_whole_empty_user_turn_before_an_anthropic_dispatch() ->
     with pytest.raises(ProviderParameterError) as rejected:
         route_generation_parameter_requests((anthropic,), request)
     assert rejected.value.param == "messages"
-    assert "empty content" in str(rejected.value)
+    assert "empty or whitespace-only content" in str(rejected.value)
+
+    # A whitespace-only user turn is the same refusal: the wire rejects it
+    # ("text content blocks must contain non-whitespace text", live
+    # 2026-09-05) and a user message cannot dispatch as an empty array.
+    whitespace = request.model_copy(
+        update={"messages": (*request.messages[:2], GatewayMessage(role="user", content="\n "))}
+    )
+    with pytest.raises(ProviderParameterError) as rejected_whitespace:
+        route_generation_parameter_requests((anthropic,), whitespace)
+    assert rejected_whitespace.value.param == "messages"
 
     # An all-empty cache-marked block run is the same empty turn (the blocks
     # must flatten to the content, so all-empty blocks imply empty content)

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -357,7 +357,9 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         # fable-5-1 and sonnet-4-6). An assistant turn that carries only
         # empty or whitespace text therefore dispatches as an empty array:
         # the turn stays in place, so conversation structure is preserved,
-        # and nothing the model could read is lost.
+        # and nothing the model could read is lost. A cache marker on the
+        # dropped run is re-homed by the payload builder onto the closest
+        # retained block of a neighboring turn.
         blocks = []
     return "assistant", blocks
 

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -179,7 +179,7 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
     return items
 
 
-def _retained_cache_marked_blocks(
+def retained_cache_marked_blocks(
     blocks: tuple[JsonObject, ...] | list[JsonObject],
 ) -> list[JsonObject]:
     """Drop empty text blocks while keeping their cache breakpoints.
@@ -227,7 +227,7 @@ def _anthropic_multimodal_blocks(message: GatewayMessage) -> list[JsonObject]:
     Returns:
         The ordered Anthropic content blocks for the turn.
     """
-    marked = _retained_cache_marked_blocks(message.provider_text_blocks)
+    marked = retained_cache_marked_blocks(message.provider_text_blocks)
     blocks: list[JsonObject] = []
     text_index = 0
     for part in message.content_parts:
@@ -295,7 +295,7 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             # The caller's exact interleaving is preserved: an image before
             # its question reads differently from one after it.
             return "user", _anthropic_multimodal_blocks(message)
-        marked_run = _retained_cache_marked_blocks(message.provider_text_blocks)
+        marked_run = retained_cache_marked_blocks(message.provider_text_blocks)
         if marked_run:
             # The cache-marked run re-emits the caller's blocks with empty
             # ones dropped loss-free (the wire rejects them and they carry
@@ -329,15 +329,10 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
             # route admission rejects the combination before dispatch.
             raise ProviderResponseError("encrypted reasoning cannot replay on the Anthropic wire")
     if message.provider_text_blocks:
-        blocks.extend(message.provider_text_blocks)
+        # Empty marked blocks drop with their breakpoints migrated, exactly
+        # as on user turns; the wire rejects an empty text block anywhere.
+        blocks.extend(retained_cache_marked_blocks(message.provider_text_blocks))
     elif message.content:
-        blocks.append({"type": "text", "text": message.content})
-    elif message.content is not None and not blocks and not message.tool_calls:
-        # An empty assistant text block is rejected by this wire, and an
-        # agent that answers with a tool call alone sends exactly that
-        # (OpenCode 1.18.26, captured live 2026-09-02). The block re-emits
-        # only when it is the entire turn, where dropping it would leave an
-        # empty content array the wire also rejects.
         blocks.append({"type": "text", "text": message.content})
     for call in message.tool_calls:
         tool_use: JsonObject = {
@@ -351,6 +346,19 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         if call.cache_control is not None:
             tool_use["cache_control"] = call.cache_control
         blocks.append(tool_use)
+    if blocks and all(
+        block.get("type") == "text" and not str(block.get("text", "")).strip() for block in blocks
+    ):
+        # The wire rejects a text block that is empty ("text content blocks
+        # must be non-empty") and a turn whose text is all whitespace ("must
+        # contain non-whitespace text"), while it accepts an EMPTY assistant
+        # content array in any position and whitespace text beside a
+        # tool_use or another text block (all verified live 2026-09-05 on
+        # fable-5-1 and sonnet-4-6). An assistant turn that carries only
+        # empty or whitespace text therefore dispatches as an empty array:
+        # the turn stays in place, so conversation structure is preserved,
+        # and nothing the model could read is lost.
+        blocks = []
     return "assistant", blocks
 
 

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -422,6 +422,19 @@ def openai_chat_message(
 ) -> JsonObject:
     """Translate one gateway message to OpenAI Chat wire JSON.
 
+    A canonical ``developer`` message is emitted as ``system`` on this wire.
+    OpenAI's Chat Completions reference gives the two roles one definition
+    ("Developer-provided instructions that the model should follow, regardless
+    of messages sent by the user"), distinguished only by the model generation
+    each was introduced for (``developer`` replaces ``system`` from o1 on, and
+    those models accept ``system`` by converting it), so the fold is lossless
+    and needs no disclosure. It applies to every provider on the Chat wire
+    because this dialect never carries direct OpenAI traffic (that is the
+    Responses dialect) and the third-party OpenAI-compatible servers behind
+    it (Azure AI Foundry, DeepSeek, vLLM, and the like) enumerate the classic
+    roles only and 400 on ``developer`` by name. The Responses builder keeps
+    ``developer`` verbatim, since that wire defines the role.
+
     ``reasoning_route_sha256`` is the active preserved-thinking route identity
     for this rung (Fireworks or Hunyuan); an unsealed ``reasoning_content``
     block forwards to the provider only when it names that exact route.
@@ -442,7 +455,7 @@ def openai_chat_message(
             tool_payload["name"] = message.provider_tool_name
         return tool_payload
     payload: JsonObject = {
-        "role": message.role,
+        "role": "system" if message.role == "developer" else message.role,
         "content": (
             [
                 {"type": "text", "text": part.text}

--- a/exp/runtime/models/providers/wire_messages_test.py
+++ b/exp/runtime/models/providers/wire_messages_test.py
@@ -110,3 +110,56 @@ def test_empty_text_blocks_drop_loss_free_on_the_anthropic_wire() -> None:
     run = blocks[0]["content"]
     assert isinstance(run, list)
     assert [block["type"] for block in run if isinstance(block, dict)] == ["image"]
+
+
+def test_assistant_turns_with_no_readable_text_dispatch_as_an_empty_array() -> None:
+    """The wire rejects an empty text block anywhere and an all-whitespace
+    assistant turn, yet accepts an empty assistant content array in any
+    position and whitespace text beside another block (verified live
+    2026-09-05 on fable-5-1 and sonnet-4-6). Production kept hitting
+    "text content blocks must be non-empty" about once a minute on
+    chat_completions after the tool-call-only shape was fixed; these are the
+    remaining Chat shapes."""
+    from exp.runtime.gateway.contracts import ThinkingBlock, ToolCall
+
+    call = ToolCall(call_id="call-1", name="lookup", arguments={}, raw_arguments="{}")
+    # An empty assistant turn alone (a replayed cut-off or refused turn).
+    _role, blocks = anthropic_blocks(GatewayMessage(role="assistant", content=""))
+    assert blocks == []
+    # A whitespace-only assistant turn alone.
+    _role, blocks = anthropic_blocks(GatewayMessage(role="assistant", content=" \n"))
+    assert blocks == []
+    # Whitespace beside a tool call is accepted by the wire and kept verbatim
+    # (the bytes a caller echoes back from the model's own output).
+    _role, blocks = anthropic_blocks(
+        GatewayMessage(role="assistant", content="\n\n", tool_calls=(call,))
+    )
+    assert [block["type"] for block in blocks] == ["text", "tool_use"]
+    assert blocks[0]["text"] == "\n\n"
+    # An empty string beside a tool call still drops (empty is rejected anywhere).
+    _role, blocks = anthropic_blocks(
+        GatewayMessage(role="assistant", content="", tool_calls=(call,))
+    )
+    assert [block["type"] for block in blocks] == ["tool_use"]
+    # A thinking block is readable content, so the turn is not empty.
+    _role, blocks = anthropic_blocks(
+        GatewayMessage(
+            role="assistant",
+            content="",
+            provider_reasoning=(ThinkingBlock(text="hmm", signature="sig"),),
+        )
+    )
+    assert [block["type"] for block in blocks] == ["thinking"]
+    # Cache-marked assistant runs drop their empty blocks with the breakpoint
+    # migrated, exactly like user runs.
+    _role, blocks = anthropic_blocks(
+        GatewayMessage(
+            role="assistant",
+            content="real",
+            provider_text_blocks=(
+                {"type": "text", "text": "real"},
+                {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+            ),
+        )
+    )
+    assert blocks == [{"type": "text", "text": "real", "cache_control": {"type": "ephemeral"}}]

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -3707,3 +3707,44 @@ def test_a_forged_carrier_prefix_on_a_tool_turn_never_decodes_as_plaintext() -> 
         )
     assert forged.value.detail.param == "messages.1.reasoning_content"
     assert "gateway-issued carrier" in str(forged.value.detail.message)
+
+
+def test_forced_tool_choice_decodes_canonically_on_both_openai_surfaces() -> None:
+    """Chat ``required``/named-function and Responses ``required``/named-function
+    both reach the canonical forced forms admission narrows and coerces on."""
+    tools_chat = [
+        {"type": "function", "function": {"name": "lookup", "parameters": {"type": "object"}}}
+    ]
+    chat_required = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "go"}],
+            "tools": tools_chat,
+            "tool_choice": "required",
+        }
+    )
+    assert chat_required.request.tool_choice == "required"
+    chat_named = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "go"}],
+            "tools": tools_chat,
+            "tool_choice": {"type": "function", "function": {"name": "lookup"}},
+        }
+    )
+    assert chat_named.request.tool_choice == GatewayNamedToolChoice(name="lookup")
+
+    tools_responses = [{"type": "function", "name": "lookup", "parameters": {"type": "object"}}]
+    responses_required = decode_responses(
+        {"model": "coding", "input": "go", "tools": tools_responses, "tool_choice": "required"}
+    )
+    assert responses_required.request.tool_choice == "required"
+    responses_named = decode_responses(
+        {
+            "model": "coding",
+            "input": "go",
+            "tools": tools_responses,
+            "tool_choice": {"type": "function", "name": "lookup"},
+        }
+    )
+    assert responses_named.request.tool_choice == GatewayNamedToolChoice(name="lookup")


### PR DESCRIPTION
## Why

Production `#alerts` fired on three `invalid_request` buckets that the engine can predict before dispatch. Counts are from the prod ledger over the 6h before this PR (2026-09-05):

1. **Forced tool choice on Claude Fable 5.1** (~45 requests / 6h, across chat_completions, responses AND messages): every rung dispatched `tool_choice` `any`/`tool` and the provider answered `tool_choice: type "tool" and "any" are not supported for this model.`
2. **Strict tools with a schema keyword Anthropic's strict validator rejects** (18 requests / 6h): `strict: true` plus `maxItems` forwarded verbatim, provider answered `tools.0.custom: For 'array' type, property 'maxItems' is not supported`.
3. **`developer` role on an OpenAI-compatible Chat wire** (deepseek-v4-flash, Responses surface, Azure AI Foundry rung): `The request is invalid: developer is not one of ['system', 'assistant', 'user', 'tool', 'function']`.

## Live provider evidence (api.anthropic.com, 2026-09-05, x-api-key auth)

Forced tool choice, `tools=[get_weather]`, verbatim provider messages:

| model | `any`, no thinking | `tool`, no thinking | `any` + `thinking: adaptive` | `any` + `thinking: enabled/1024` |
|---|---|---|---|---|
| claude-fable-5-1 | 400 `tool_choice: type "tool" and "any" are not supported for this model.` | 400 (same) | 400 (same) | 400 `Thinking may not be enabled when tool_choice forces tool use.` |
| claude-fable-5 | 200 tool_use | 200 tool_use | 200 tool_use | 400 `Thinking may not be enabled when tool_choice forces tool use.` |
| claude-opus-5 | 200 | 200 | 200 | 400 (same) |
| claude-sonnet-5 | 200 | 200 | 200 | 400 (same) |
| claude-opus-4-8 | 200 | 200 | 200 | 400 (same) |
| claude-sonnet-4-6 | 200 | 200 | 200 | 400 (same) |
| claude-sonnet-4-5 | 200 | 200 | 400 `adaptive thinking is not supported on this model` | 400 (same) |
| claude-haiku-4-5 | 200 | 200 | 400 (adaptive unsupported) | 400 (same) |

`{"type":"auto"}` returned 200 with a `tool_use` block on every model, including fable-5-1. So the forced-choice rejection is an **exact point-release fact (5.1), not a generation fact**: the task brief expected the fable-5 family to reject and it does not. The provider's tool-use docs agree ("Claude Fable 5.1 and Claude Mythos 5.1: `any` and `tool` return a 400 error"; "Manual extended thinking (`thinking: {type: "enabled"}`): `any` and `tool` are not supported ... Adaptive thinking ... supports forced tool use").

Strict tool schemas (`strict: true`, `tool_choice: auto`), same tool on every model above: `maxItems` → 400 `tools.0.custom: For 'array' type, property 'maxItems' is not supported`; the same tool without `strict` → 200. A per-keyword sweep on claude-sonnet-4-6 (verbatim messages):

- 400 `For 'object' type, 'additionalProperties' must be explicitly set to false` (absent, at any nesting level); 400 `'additionalProperties: true' is not supported`
- 400 `For 'array' type, 'minItems' values other than 0 or 1 are not supported`; `uniqueItems`, `contains`, `prefixItems`: `property '<kw>' is not supported`
- 400 `For 'integer' type, property 'minimum' is not supported`; same for `exclusiveMinimum`, `multipleOf`
- 400 `Schema type 'oneOf' is not supported`; `Schema keyword 'not' is not supported`; `property 'if' is not supported`
- 400 `property 'minProperties' / 'propertyNames' / 'patternProperties' / 'dependentRequired' / 'unevaluatedProperties' is not supported`
- 400 `Schema type 'enum - complex' is not supported`; `External schema references are not supported`; `Circular reference detected in schema definitions: node -> node`; `Cannot merge allOf schemas: schema 0 contains $ref`
- 400 `For 'string' type, format 'uri-reference' is not supported`
- 200: `minItems` 0/1, `minLength`, `maxLength`, `pattern`, `format: uuid`, `anyOf`, plain `allOf`, internal `$ref`, `const`, `default`, primitive `enum`

Note: the published limitations list `minLength`/`maxLength` as unsupported, but the live validator accepts them, so the engine deliberately does NOT treat them as violations (a check stricter than the provider would degrade strict tools the provider honors).

4. **Residual empty text blocks on the Anthropic wire** (about once a minute after 0.7.36 rolled, chat_completions, claude-fable-5.1, six orgs): `provider rejected the request: messages: text content blocks must be non-empty`, post-dispatch. #799 fixed the tool-call-only shape and deliberately re-emitted an empty assistant text block when it was the entire turn, on the assumption that an empty content array is rejected too. Live evidence (below) shows the opposite: the empty ARRAY is accepted, so that shape and its whitespace sibling are the remaining leaks.

## Live provider evidence, bucket 4 (api.anthropic.com, 2026-09-05, sonnet-4-6 and fable-5-1)

| Anthropic payload shape | result |
|---|---|
| assistant `[{text: ""}, tool_use]` | 400 `messages: text content blocks must be non-empty` |
| assistant `[{text: "\n\n"}, tool_use]` | 200 |
| assistant `[{text: ""}]` alone | 400 `messages: text content blocks must be non-empty` |
| assistant `[{text: " "}]` alone | 400 `messages: text content blocks must contain non-whitespace text` |
| assistant `[{text: " "}, {text: "ok"}]` | 200 |
| assistant `content: []` (mid-conversation, as last message, as first message, two in a row; both models) | 200 |
| assistant `content: ""` (string) | 200 |
| tool_result `content` `""` / `[]` / `" "` / `[{text: ""}]` | 200 (all four) |
| user `"\n"` or `[{text: " "}]` | 400 `messages: text content blocks must contain non-whitespace text` |
| user `""` or `[]` | 400 `messages.0: user messages must have non-empty content` |
| user `[{text: "hi"}, {text: " "}]` | 200 |
| user `[{text: ""}, {text: "x"}]` | 400 `messages: text content blocks must be non-empty` |
| system `""` (string) | 200 |
| system `"  "` | 400 `system: text content blocks must contain non-whitespace text` |
| system `[{text: ""}]` and `[{text: "a"}, {text: ""}]` | 400 `system: text content blocks must be non-empty` |

Rule the engine now follows (`anthropic_blocks`, the Anthropic builder's system emission, and the pre-dispatch admission check): an empty text block never dispatches anywhere; an assistant turn with no readable text dispatches as an empty content array (position-preserving, accepted live); whitespace text beside another block is kept verbatim (accepted live, and it is the caller echoing the model's own bytes); cache-marked assistant and system runs drop empty blocks with their breakpoints migrated (the existing user-run helper, now shared as `retained_cache_marked_blocks`); a system prompt with no readable text is omitted; a user turn that is empty OR whitespace-only is refused by name before dispatch, because a user message has no empty-array form. Tool results are left alone.

Chat Completions shapes through the local gateway on fable-5-1, released 0.7.36 vs this branch:

| Chat shape | released 0.7.36 | this branch |
|---|---|---|
| assistant `content: ""` alone (then user) | 400 `provider rejected the request: messages: text content blocks must be non-empty` | 200 |
| assistant `content: " \n"` alone | 400 `... must contain non-whitespace text` | 200 |
| assistant `"\n\n"` + `tool_calls` | 200 | 200 (unchanged bytes) |
| assistant `""` + `tool_calls` | 200 (#799) | 200 |
| tool message `content: ""` | 200 | 200 |
| system `"  "` alone | 400 `provider rejected the request: system: text content blocks must contain non-whitespace text` | 200 (system omitted) |
| system `""` + system `"Be terse."` | 200 | 200 (unchanged bytes) |
| user `"\n"` | 400 post-dispatch (provider text) | 400 pre-dispatch, named: `A user message with empty or whitespace-only content cannot be served by this model route ...` (`param: messages`) |

## Design: preflight → per-rung narrowing → disclosed coercion

All three buckets ride the existing capability path (`preflight_gateway_request` / payload build in `protocol_compatible_indexes`, then `coerce_route_rejections` → `coerce_capability`), the same one `strict_tools`, `service_tier`, and `image_input` already use.

- **`exp/runtime/models/providers/anthropic_tool_compat.py`** (new): `anthropic_rejects_forced_tool_choice(model_id)` (exact releases `claude-fable-5-1`, `claude-mythos-5-1`, plus dated snapshots of them) and `anthropic_strict_schema_unsupported(schema)` (a purely structural walk over properties/items/$defs/anyOf/allOf/additionalProperties naming the first unsupported keyword, unsupported `format`, complex enum, external `$ref`, `allOf`+`$ref`, or a circular definition graph).
- **Anthropic builder** (`messages_payloads.py`): a strict tool whose schema fails the structural check raises `ProviderCapabilityError("strict_tools")` (schema untouched); a `required`/named `tool_choice` raises the new `forced_tool_choice` capability when the model is a rejecting release OR the built payload carries `thinking: {type: enabled}` (caller-sent or effort-derived on haiku). `auto`/`none` and adaptive thinking are unaffected.
- **Narrowing** prefers a rung that honors the request verbatim: a waterfall with an aggregator (`openai_compatible`) rung beside fable-5-1 serves `required`/named choice and strict+`maxItems` on that rung with nothing disclosed (admission tests cover both).
- **Coercion** (`capability_policy.py`) when every rung declines: `forced_tool_choice` → `tool_choice: auto`, disclosed as `tool_choice->auto`; `strict_tools` → the existing `tools.strict->false` drop (schema, `maxItems` included, still reaches the model as guidance). Mixed rejections keep the existing rule (only the tier drops).
- **Open strict objects**: the strict validator also demands `additionalProperties: false` on every object, so `coerce_strict_tool_schemas` closes strict tools' objects for routes with an Anthropic rung, disclosed as `tools.parameters.additionalProperties->false`, mirroring the existing structured-output closing. This keeps `strict` (a tightening) instead of dropping it.
- **Capability parity**: `DeploymentCapabilityParity.supports_forced_tool_choice` (engine ground truth, dialect-scoped), `CAPABILITY_PARITY_SCHEMA_VERSION` 5 → 6.
- **Error scoping**: `forced_tool_choice` → public field `tool_choice` on all three surfaces (`native_bridge_errors.py`).
- **Developer role**: `openai_chat_message` emits a canonical `developer` message as `system` on the Chat Completions wire for every provider on that dialect. OpenAI's Chat Completions reference defines both roles identically ("Developer-provided instructions that the model should follow, regardless of messages sent by the user"; `developer` "replace[s] the previous `system` messages" from o1 on, and those models accept `system`), so the fold is lossless and carries NO disclosure. It applies to every provider on the wire because the dialect never carries direct OpenAI traffic (that is `openai_responses`) and the third-party servers behind it enumerate only the classic roles. The Responses builder keeps `developer` verbatim (that wire defines the role).
- All three public surfaces already decode forced choices into the canonical forms (`required` / `GatewayNamedToolChoice`); decode tests added per surface.

## End-to-end proof (local `exp` gateway, real providers, same root config on both engines)

| check | released 0.7.36 | this branch |
|---|---|---|
| Messages `/v1/messages` fable-5-1 `tool_choice: {type: any}` | 400 `provider rejected the request: tool_choice: type "tool" and "any" are not supported for this model.` | 200, `tool_use`, `x-experiential-ignored-parameters: ["tool_choice->auto"]` |
| Chat fable-5-1 `tool_choice: "required"` | 400 (same provider text) | 200, `tool_calls=[get_weather]`, `["tool_choice->auto"]` |
| Responses fable-5-1 `tool_choice: {type: function, name}` | 400 (same) | 200, `function_call`, `["tool_choice->auto"]` |
| Chat fable-5-1 strict tool with `maxItems` | 400 `tools.0.custom: For 'array' type, property 'maxItems' is not supported` | 200, tool call, `["tools.strict->false"]` |
| Chat fable-5-1 strict tool, open object | 400 `'additionalProperties' must be explicitly set to false` | 200, tool call, `["tools.parameters.additionalProperties->false"]` |
| Chat DeepSeek-V4-Pro (Azure AI Foundry, silen-resource) `developer` message | 200 | 200 (fold covered by the payload-builder unit test) |

**Verification gap, bucket 3 (developer→system): proven by unit test only.** The Foundry deployments reachable with the credentials available here (silen-resource `DeepSeek-V4-Pro` and `deepseek-v4-flash`) ACCEPT `developer` both directly and through the released 0.7.36 engine, so the production 400 came from a different Azure AI Foundry deployment that I could not reach, and no live old-vs-new contrast exists for this bucket. What is proven: `openai_payloads_test.py` asserts the exact Chat Completions payload emits `system` for every `developer` turn (leading and mid-conversation) and that the Responses payload keeps `developer`; the live DeepSeek call through this branch returned 200 with the folded payload.

## Gates (run locally, worktree venv, Python 3.13)

- `ruff check .` and `ruff format --check .`: clean
- `ty check`: clean
- `pytest -q` (full repo): **3753 passed, 6 skipped, 1 failed**. The failure is `exp/runtime/gateway/tests/native_truncation_test.py::test_every_truncation_class_classifies_and_the_process_survives` (`('nothing','fin','chat-stream')` answers 504 `deadline_exceeded` instead of 502); it fails identically at a clean `origin/main` (1a40a9ce) in the same venv and is the known macOS-only environmental failure (Linux CI green). Nothing in this PR touches truncation or the Rust plane.

## Deliberately not changed

- The sub-16 `max_tokens` floors and the shapes #799 already fixed (this PR only adds the assistant-turn, system, and whitespace cases in bucket 4); the Claude Code version gate; tool id sanitization (open #801 touches `wire_messages.py`; this PR's edits there are the one-line role fold, the assistant empty-turn handling in `anthropic_blocks`, and making the cache-marked-run helper public; I will rebase over #801 if it lands first).
- No schema keyword is ever stripped or rewritten; the only schema mutation is closing objects (adding `additionalProperties: false`), disclosed.
- No `.rs` change, no crate bump, no package version bump (a separate release PR does that).
- The `developer_messages` preflight requirement is untouched: a rung declaring `supports_developer_messages: false` still rejects at preflight; the fold only changes what the Chat wire emits for rungs that admit the role.
- `structured_text` schemas are not run through the new keyword check (out of scope; today they only get the existing object-closing coercion).
- Admission still applies at most ONE capability coercion per request (the existing contract). A request that needs two (a forced choice AND a strict tool with `maxItems`, both on an all-fable-5-1 route) drops `strict` first and then surfaces the forced-choice rejection as a field-scoped 400 on `tool_choice`, which the caller can act on. Widening the retry to a bounded loop is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





