### PR TITLE
release: bump experiential to 0.7.37 (native unchanged at 0.3.35)

### DIFF
--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -692,9 +692,10 @@ class _ResponseReasoningItem(_WireModel):
     provider resolves it from stored state. An id-only item is carried
     verbatim to homogeneous native Responses routes (the only wire that
     can resolve the id) and the provider judges resolvability with its own
-    error — the hosted-item posture. That provider behavior is documented
-    from the SDK contract, not verified live (no key in the development
-    environment, 2026-09-05).
+    error — the hosted-item posture. Verified live 2026-09-05
+    (api.openai.com, gpt-5.1): a stored response's reasoning item replayed
+    by id with no encrypted_content completed with 200 under BOTH
+    ``store: true`` and ``store: false``.
     """
 
     type: Literal["reasoning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.36"
+version = "0.7.37"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.36"
+version = "0.7.37"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Experiential-only release carrying #803 — the Chat tool-message `name` round-trip that unwedges hermes-agent's first tool call — plus the reasoning-item docstring correction (the #797 id-only replay posture is live-verified in both store modes, per the session lead's probe recorded on #797). Python-only: no native wheel change, `exp-gateway-native` stays 0.3.35.

Urgency context: platform docs PR #1307 advertises hermes-agent while the deployed 0.7.36 engine still 400s its first tool call ("Invalid value for 'messages.N.name'"), so this closes a live docs-vs-behavior gap.

After merge: GitHub release v0.7.37 (publish workflow ships wheels), then the platform pin PR (`experiential==0.7.37`, native pin unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)