### PR TITLE
Carry hosted request context through native admission and replay

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -445,3 +445,21 @@ Azure, and OpenRouter share compatible-stream coverage; Gemini and Bedrock have 
 fixtures. Live provider cells remain explicitly `not_run_requires_credentials` until a separately
 authorized run supplies dated evidence. Deterministic fixtures do not imply hosted-provider
 availability, billing, or account-specific behavior.
+
+
+### Hosted request policy context
+
+A trusted host ingress may set `X-Exp-Request-Context` to an opaque value of
+at most 1,024 bytes. The engine does not authenticate it. Hosts must overwrite
+all public copies and keep the native listener private before using it for
+policy. Missing, duplicated, invalid, or oversized values become `None`.
+
+A control plane can implement `call_with_context(method, argument, context)` to
+wrap native callbacks. It runs on the same Python worker thread as admission,
+including model discovery, batch submission, and the claim before idempotency
+replay. Implementations must restore per-request state in `finally`. HTTP
+contexts are task scoped; Responses WebSocket frames retain the upgrade's
+context. Detached settlement work has no request context. No context is added
+to provider payloads or durable ledger records. Existing control planes without
+the hook retain their callback signatures. A typed 403 from route resolution
+is propagated before replay lookup so a saved response cannot bypass policy.

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/exp_gateway_native.pyi
+++ b/exp/runtime/gateway/native/exp_gateway_native.pyi
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import Protocol
 
 __version__: str
+supports_request_context: bool
 
 class _ControlPlane(Protocol):
     """The callback surface the data plane requires (see NativeControlPlane)."""
@@ -26,6 +27,11 @@ class _ControlPlane(Protocol):
     def readiness(self, argument: str) -> str: ...
     def close_thread_resources(self, argument: str) -> str: ...
 
+class _ContextControlPlane(Protocol):
+    """Optional host wrapper for native callbacks, including absent context."""
+
+    def call_with_context(self, method: str, argument: str, context: str | None) -> str: ...
+
 class ShutdownHandle:
     """Embedder-owned stop signal for one `serve` call."""
 
@@ -33,7 +39,7 @@ class ShutdownHandle:
 
 def shutdown_handle() -> ShutdownHandle: ...
 def serve(
-    control_plane: _ControlPlane,
+    control_plane: _ControlPlane | _ContextControlPlane,
     config_json: str,
     shutdown: ShutdownHandle | None = None,
     on_listening: Callable[[], None] | None = None,

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/bridge.rs
+++ b/exp/runtime/gateway/native/src/bridge.rs
@@ -27,6 +27,7 @@ use crate::errors::PublicError;
 struct Job {
     method: &'static str,
     argument: String,
+    context: Option<String>,
     responder: oneshot::Sender<Result<String, PublicError>>,
 }
 
@@ -89,6 +90,7 @@ impl Bridge {
                     .send(Job {
                         method,
                         argument,
+                        context: crate::request_context::current(),
                         responder,
                     })
                     .is_ok(),
@@ -154,7 +156,7 @@ fn worker_loop(receiver: &Mutex<mpsc::Receiver<Job>>, object: &Py<PyAny>) {
             // the receive lock, so one poisoned call cannot take down the
             // pool.
             let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                control_plane_call(py, object, job.method, job.argument)
+                control_plane_call(py, object, job.method, job.argument, job.context)
             }))
             .unwrap_or_else(|_| Err(PublicError::internal()));
             let _ = job.responder.send(outcome);
@@ -178,9 +180,17 @@ fn control_plane_call(
     object: &Py<PyAny>,
     method: &'static str,
     argument: String,
+    context: Option<String>,
 ) -> Result<String, PublicError> {
     let bound = object.bind(py);
-    match bound.call_method1(method, (argument,)) {
+    // Opt-in host hook runs even when context is absent, allowing fail-closed
+    // policies. Ordinary local control planes retain their exact callback API.
+    let result = match bound.hasattr("call_with_context") {
+        Ok(true) => bound.call_method1("call_with_context", (method, argument, context)),
+        Ok(false) => bound.call_method1(method, (argument,)),
+        Err(error) => return Err(public_error_from_pyerr(py, &error)),
+    };
+    match result {
         Ok(result) => result
             .extract::<String>()
             .map_err(|_| PublicError::internal()),
@@ -336,5 +346,28 @@ class Plane:
             serde_json::to_value(&error).expect("error serializes"),
             serde_json::to_value(PublicError::internal()).expect("error serializes"),
         );
+    }
+    #[test]
+    fn request_context_reaches_host_hook_and_missing_context_stays_missing() {
+        Python::initialize();
+        let object = Python::attach(|py| {
+            pyo3::types::PyModule::from_code(py, c"class Plane:\n def call_with_context(self, method, argument, context):\n  return method + ':' + (context or 'unknown')\n", c"context.py", c"context")
+                .unwrap().getattr("Plane").unwrap().call0().unwrap().unbind()
+        });
+        let bridge = Bridge::new(object, 2).unwrap();
+        block_on(async {
+            let (left, right) = tokio::join!(
+                crate::request_context::REQUEST_CONTEXT
+                    .scope(Some("US".into()), bridge.call("admit", "{}".into())),
+                crate::request_context::REQUEST_CONTEXT
+                    .scope(Some("BY".into()), bridge.call("claim_scope", "{}".into()))
+            );
+            assert_eq!(left.unwrap(), "admit:US");
+            assert_eq!(right.unwrap(), "claim_scope:BY");
+            assert_eq!(
+                bridge.call("batch_create", "{}".into()).await.unwrap(),
+                "batch_create:unknown"
+            );
+        });
     }
 }

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -20,6 +20,7 @@ mod metrics;
 mod param_attribution;
 mod relay;
 mod replay;
+mod request_context;
 mod respond;
 mod responses_retention;
 mod route_batches;
@@ -684,5 +685,6 @@ fn exp_gateway_native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(normalize_stream_fixture, module)?)?;
     module.add_function(wrap_pyfunction!(failure_public_error_fixture, module)?)?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    module.add("supports_request_context", true)?;
     Ok(())
 }

--- a/exp/runtime/gateway/native/src/request_context.rs
+++ b/exp/runtime/gateway/native/src/request_context.rs
@@ -1,0 +1,73 @@
+//! Opaque transport context for an embedder's request policy.
+//!
+//! This header is NOT authenticated by the engine. An embedder using it for
+//! authority must strip public copies and set it at its trusted ingress.
+//! It is never added to provider payloads, replay identities, or ledger rows.
+
+use axum::extract::Request;
+use axum::http::HeaderMap;
+use axum::middleware::Next;
+use axum::response::Response;
+
+tokio::task_local! {
+    pub(crate) static REQUEST_CONTEXT: Option<String>;
+}
+
+/// Treat absent, duplicate, oversized, or malformed context as unavailable.
+pub(crate) fn from_headers(headers: &HeaderMap) -> Option<String> {
+    let mut values = headers.get_all("x-exp-request-context").iter();
+    let first = values.next()?;
+    if values.next().is_some() || first.as_bytes().len() > 1024 {
+        return None;
+    }
+    first
+        .to_str()
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+/// Bind context to this HTTP task, including callbacks before replay lookup.
+pub(crate) async fn scope_request(request: Request, next: Next) -> Response {
+    let context = from_headers(request.headers());
+    REQUEST_CONTEXT.scope(context, next.run(request)).await
+}
+
+/// Capture a context before a callback crosses to a Python worker thread.
+pub(crate) fn current() -> Option<String> {
+    REQUEST_CONTEXT.try_with(Clone::clone).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ambiguous_context_is_unavailable() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(from_headers(&headers), None);
+        headers.insert("x-exp-request-context", "US".parse().unwrap());
+        assert_eq!(from_headers(&headers), Some("US".into()));
+        headers.append("x-exp-request-context", "BY".parse().unwrap());
+        assert_eq!(from_headers(&headers), None);
+        headers.insert("x-exp-request-context", "x".repeat(1025).parse().unwrap());
+        assert_eq!(from_headers(&headers), None);
+    }
+
+    #[tokio::test]
+    async fn concurrent_requests_and_missing_context_are_isolated() {
+        let (left, right) = tokio::join!(
+            REQUEST_CONTEXT.scope(Some("US".into()), async {
+                tokio::task::yield_now().await;
+                current()
+            }),
+            REQUEST_CONTEXT.scope(Some("BY".into()), async {
+                tokio::task::yield_now().await;
+                current()
+            })
+        );
+        assert_eq!(left, Some("US".into()));
+        assert_eq!(right, Some("BY".into()));
+        assert_eq!(current(), None);
+    }
+}

--- a/exp/runtime/gateway/native/src/route_responses_ws.rs
+++ b/exp/runtime/gateway/native/src/route_responses_ws.rs
@@ -73,7 +73,11 @@ pub(crate) async fn responses_ws(
         return error_response(&error);
     }
     let connection_headers = request_headers(&headers);
-    upgrade.on_upgrade(move |socket| serve_socket(state, connection_headers, socket))
+    let context = crate::request_context::current();
+    upgrade.on_upgrade(move |socket| {
+        crate::request_context::REQUEST_CONTEXT
+            .scope(context, serve_socket(state, connection_headers, socket))
+    })
 }
 
 /// The 426 answered for a GET that is not a well-formed WebSocket upgrade.

--- a/exp/runtime/gateway/native/src/server.rs
+++ b/exp/runtime/gateway/native/src/server.rs
@@ -179,7 +179,12 @@ pub async fn run(
     } else {
         app
     };
-    let app = app.fallback(unknown_route).with_state(state);
+    let app = app
+        .fallback(unknown_route)
+        .layer(axum::middleware::from_fn(
+            crate::request_context::scope_request,
+        ))
+        .with_state(state);
     let listener = tokio::net::TcpListener::bind((config.host.as_str(), config.port))
         .await
         .map_err(|error| format!("failed to bind {}:{}: {error}", config.host, config.port))?

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -861,6 +861,14 @@ class NativeControlPlane(
                 resolve_route_profiles(self._components.runtime_catalogs, route)
             except NativeDialectUnavailableError as exc:
                 return _escalation(str(exc))
+            except NativeBridgeError as exc:
+                if json.loads(exc.public_error_json)["status_code"] == 403:
+                    raise
+            except OpenAIProtocolError as exc:
+                # Authorization policy must run before an existing replay can
+                # return content, not only before a new upstream dispatch.
+                if exc.status_code == 403:
+                    raise NativeBridgeError(exc) from exc
             except Exception:  # noqa: BLE001 - the owner's admission records this failure.
                 pass
         key = replay_key(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5107,3 +5107,26 @@ def test_internal_admission_failures_log_the_real_exception(
     assert str(fields["request_id"]).startswith("request-")
     assert fields["exception_type"] == "KeyError"
     assert fields["operation"] == "native_admit"
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_claim_scope_rejects_route_policy_before_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wrapped: bool
+) -> None:
+    """A cached operation cannot skip a fresh geographic/organization refusal."""
+    control, raw_key = _control_plane(tmp_path)
+    _claim_scope(control, raw_key, _chat_body(), idempotency_key="policy-operation")
+
+    def deny(*args: object, **kwargs: object) -> None:
+        """Model a resolver's typed policy refusal."""
+        error = OpenAIProtocolError(
+            status_code=403, code="model_location_not_supported", message="Location not supported."
+        )
+        if wrapped:
+            raise NativeBridgeError(error)
+        raise error
+
+    monkeypatch.setattr(type(control._components.routes), "resolve_direct", deny)
+    with pytest.raises(NativeBridgeError) as error:
+        _claim_scope(control, raw_key, _chat_body(), idempotency_key="policy-operation")
+    assert json.loads(error.value.public_error_json)["status_code"] == 403

--- a/exp/runtime/gateway/tests/native_request_context_test.py
+++ b/exp/runtime/gateway/tests/native_request_context_test.py
@@ -1,0 +1,163 @@
+"""Prove HTTP and WebSocket transport context against the compiled engine."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import httpx
+import pytest
+from websockets.sync.client import connect
+
+from exp.runtime.gateway.native_bridge import NativeBridgeError
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+native = pytest.importorskip("exp_gateway_native")
+
+
+class _PolicyProbe:
+    """Reject before provider work while recording each native callback context."""
+
+    def __init__(self) -> None:
+        """Initialize the content-free callback trace."""
+        self.seen: list[tuple[str, str | None]] = []
+
+    def call_with_context(self, method: str, argument: str, context: str | None) -> str:
+        """Authenticate the fixture and refuse every data operation by policy."""
+        self.seen.append((method, context))
+        if method == "authenticate":
+            return "{}"
+        raise NativeBridgeError(
+            OpenAIProtocolError(
+                status_code=403,
+                code="probe_policy",
+                message="Probe policy refused the request.",
+            )
+        )
+
+
+@contextmanager
+def _server(probe: _PolicyProbe) -> Iterator[str]:
+    """Serve the real native listener on loopback and always drain its thread."""
+    with socket.socket() as reserved:
+        reserved.bind(("127.0.0.1", 0))
+        port = reserved.getsockname()[1]
+    ready = threading.Event()
+    stop = native.shutdown_handle()
+    errors: list[Exception] = []
+
+    def run() -> None:
+        """Run the extension with an explicit shutdown signal, without subprocesses."""
+        try:
+            native.serve(
+                probe,
+                json.dumps(
+                    {
+                        "host": "127.0.0.1",
+                        "port": port,
+                        "callback_permits": 2,
+                        "request_timeout_seconds": 10.0,
+                        "graceful_timeout_seconds": 2.0,
+                    }
+                ),
+                stop,
+                ready.set,
+            )
+        except Exception as error:  # noqa: BLE001 - report the server thread's failure to the test
+            errors.append(error)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    try:
+        assert ready.wait(10), errors
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        stop.request_shutdown()
+        thread.join(10)
+        assert not thread.is_alive()
+        assert not errors
+
+
+def test_all_admission_surfaces_receive_transport_context() -> None:
+    """Discovery, inference, batch and replay all reach the same scoped hook."""
+    probe = _PolicyProbe()
+    with _server(probe) as origin, httpx.Client(base_url=origin) as client:
+        for method, path, body, extra in (
+            ("GET", "/v1/models", None, {}),
+            ("GET", "/v1/models/demo", None, {}),
+            ("POST", "/v1/chat/completions", {"model": "demo", "messages": []}, {}),
+            (
+                "POST",
+                "/v1/chat/completions",
+                {"model": "demo", "messages": []},
+                {"idempotency-key": "one"},
+            ),
+            ("POST", "/v1/responses", {"model": "demo", "input": "hello"}, {}),
+            ("POST", "/v1/messages", {"model": "demo", "messages": [], "max_tokens": 1}, {}),
+            ("POST", "/v1/embeddings", {"model": "demo", "input": "hello"}, {}),
+            ("POST", "/v1/images/generations", {"model": "demo", "prompt": "hello"}, {}),
+            (
+                "POST",
+                "/v1/batches",
+                {
+                    "input_file_id": "file-one",
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h",
+                },
+                {},
+            ),
+        ):
+            response = client.request(
+                method,
+                path,
+                json=body,
+                headers={
+                    "authorization": "Bearer fixture-key",
+                    "x-exp-request-context": "BY",
+                    **extra,
+                },
+            )
+            assert response.status_code == 403, (path, response.text)
+        assert all(context == "BY" for _, context in probe.seen)
+        assert {method for method, _ in probe.seen} >= {
+            "models",
+            "model_detail",
+            "admit",
+            "claim_scope",
+            "batch_create",
+        }
+        client.get("/v1/models", headers={"authorization": "Bearer fixture-key"})
+        assert probe.seen[-1] == ("models", None)
+
+
+def test_websocket_frames_keep_upgrade_context_and_ignore_body_spoofs() -> None:
+    """The upgrade callback's spawned task does not lose geographic authority."""
+    probe = _PolicyProbe()
+    with (
+        _server(probe) as origin,
+        connect(
+            origin.replace("http:", "ws:") + "/v1/responses",
+            additional_headers={
+                "authorization": "Bearer fixture-key",
+                "x-exp-request-context": "BY",
+            },
+        ) as stream,
+    ):
+        for _ in range(2):
+            stream.send(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "demo",
+                        "input": "hello",
+                        "metadata": {"country": "US"},
+                    }
+                )
+            )
+            response = json.loads(stream.recv(timeout=10))
+            assert response["status"] == 403
+        assert sum(method == "admit" for method, _ in probe.seen) == 2
+        assert all(context == "BY" for _, context in probe.seen)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.37"
+version = "0.7.38"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.35,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.36,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -535,43 +535,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.37"
+version = "0.7.38"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -1478,7 +1478,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1517,7 +1517,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1529,7 +1529,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1559,9 +1559,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1573,7 +1573,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
The hosted gateway needs the caller's verified location during route admission, including before returning a cached response. Native callbacks currently lose this transport context, and the replay probe swallows route-policy 403s.

Carry a bounded, opaque `X-Exp-Request-Context` through HTTP and Responses WebSocket callbacks to an optional host `call_with_context` hook. Missing or ambiguous context stays unknown. Propagate typed policy 403s before replay lookup. The engine does not authenticate the header; hosted ingress must overwrite public copies and keep the listener private. Ordinary local control planes retain their callback API. The shipped type stub exposes the capability flag and accepts context-hook-only hosts.

Prepare Experiential 0.7.38 and native 0.3.36 for the dependent Platform country policy. No release is published by this PR.

Validation: 134 Python bridge and served-transport tests; 207 Rust tests; full repository Ruff check, format check and ty check. Served native tests cover discovery, HTTP inference surfaces, batches, idempotent claims and multiple WebSocket frames. Concurrent callback tests prove context isolation and missing-context behavior.
