### PR TITLE
release: bump experiential to 0.7.38 (native unchanged at 0.3.35)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.37"
+version = "0.7.38"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.37"
+version = "0.7.38"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only. Ships #810 (tenant-namespaced `prompt_cache_key` affinity on OpenAI/Tencent rungs; LiteLLM message-dump tolerance). Python-only change set since 0.7.37; the native crate stays at 0.3.35, so the publish uploads only the Python distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)