### PR TITLE
gateway: flex/priority service_tier pass-through pricing on host lanes (v1, requested-tier)

### DIFF
--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -561,14 +561,10 @@ class GatewayLongContextTier(ContractModel):
 class GatewayServiceTierPrices(ContractModel):
     """PASS-THROUGH rates for one provider processing tier (flex / priority).
 
-    OpenAI's ``service_tier`` selectors reprice the WHOLE request: ``flex`` is
-    discounted (best-effort, slower), ``priority`` is a premium. When the
-    caller requests a tier that a host-funded deployment carries here, these
-    rates replace the base schedule for every dimension and the request bills
-    pass-through at the tier's price (no markup). ``None`` on a dimension means
-    the tier rate is unknown exactly as on the base schedule; it never inherits
-    the base rate. v1 bills by the REQUESTED tier; a later change will bill by
-    the tier the provider actually served.
+    OpenAI's ``service_tier`` reprices the WHOLE request (``flex`` discounted,
+    ``priority`` premium): these rates replace the base schedule for every
+    dimension at cost, no markup. ``None`` on a dimension is unknown exactly as
+    on the base schedule (never the base rate). v1 bills the REQUESTED tier.
     """
 
     input_micro_usd_per_million_tokens: int | None = Field(default=None, ge=0)
@@ -603,11 +599,8 @@ class GatewayTokenPrices(ContractModel):
     """Pass-through rates when the caller requests ``service_tier='priority'``."""
 
     def service_tier(self, tier: str | None) -> GatewayServiceTierPrices | None:
-        """The pass-through rate card for a requested tier, or ``None``.
-
-        ``default``/``auto`` and unknown tiers carry no override (they bill the
-        base schedule); only ``flex`` and ``priority`` name a card here.
-        """
+        """The pass-through card for a requested tier, or ``None`` (default/auto
+        and unknown tiers bill the base schedule; only flex/priority card)."""
         if tier == "flex":
             return self.flex
         if tier == "priority":
@@ -615,13 +608,9 @@ class GatewayTokenPrices(ContractModel):
         return None
 
     def for_service_tier(self, tier: str | None) -> GatewayTokenPrices:
-        """The effective attribution schedule when the caller requests ``tier``.
-
-        A flex/priority card replaces the base rates whole-request (pass-through
-        at cost, no markup), and long-context repricing is dropped because the
-        tier card already governs the entire request. Any other tier (or no
-        card) returns ``self`` unchanged. v1 keys on the REQUESTED tier.
-        """
+        """The effective schedule when the caller requests ``tier``: a flex/
+        priority card replaces the base rates whole-request (pass-through, no
+        markup) and drops long-context; any other tier returns ``self``."""
         card = self.service_tier(tier)
         if card is None:
             return self

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -558,6 +558,25 @@ class GatewayLongContextTier(ContractModel):
     reasoning_micro_usd_per_million_tokens: int | None = Field(default=None, ge=0)
 
 
+class GatewayServiceTierPrices(ContractModel):
+    """PASS-THROUGH rates for one provider processing tier (flex / priority).
+
+    OpenAI's ``service_tier`` selectors reprice the WHOLE request: ``flex`` is
+    discounted (best-effort, slower), ``priority`` is a premium. When the
+    caller requests a tier that a host-funded deployment carries here, these
+    rates replace the base schedule for every dimension and the request bills
+    pass-through at the tier's price (no markup). ``None`` on a dimension means
+    the tier rate is unknown exactly as on the base schedule; it never inherits
+    the base rate. v1 bills by the REQUESTED tier; a later change will bill by
+    the tier the provider actually served.
+    """
+
+    input_micro_usd_per_million_tokens: int | None = Field(default=None, ge=0)
+    cached_input_micro_usd_per_million_tokens: int | None = Field(default=None, ge=0)
+    output_micro_usd_per_million_tokens: int | None = Field(default=None, ge=0)
+    reasoning_micro_usd_per_million_tokens: int | None = Field(default=None, ge=0)
+
+
 class GatewayTokenPrices(ContractModel):
     """Integer gateway attribution rates for one provider deployment.
 
@@ -578,6 +597,41 @@ class GatewayTokenPrices(ContractModel):
     the full 1M window at standard pricing (no tier), so current Anthropic
     deployments leave this ``None``.
     """
+    flex: GatewayServiceTierPrices | None = None
+    """Pass-through rates when the caller requests ``service_tier='flex'``."""
+    priority: GatewayServiceTierPrices | None = None
+    """Pass-through rates when the caller requests ``service_tier='priority'``."""
+
+    def service_tier(self, tier: str | None) -> GatewayServiceTierPrices | None:
+        """The pass-through rate card for a requested tier, or ``None``.
+
+        ``default``/``auto`` and unknown tiers carry no override (they bill the
+        base schedule); only ``flex`` and ``priority`` name a card here.
+        """
+        if tier == "flex":
+            return self.flex
+        if tier == "priority":
+            return self.priority
+        return None
+
+    def for_service_tier(self, tier: str | None) -> GatewayTokenPrices:
+        """The effective attribution schedule when the caller requests ``tier``.
+
+        A flex/priority card replaces the base rates whole-request (pass-through
+        at cost, no markup), and long-context repricing is dropped because the
+        tier card already governs the entire request. Any other tier (or no
+        card) returns ``self`` unchanged. v1 keys on the REQUESTED tier.
+        """
+        card = self.service_tier(tier)
+        if card is None:
+            return self
+        return GatewayTokenPrices(
+            input_micro_usd_per_million_tokens=card.input_micro_usd_per_million_tokens,
+            cached_input_micro_usd_per_million_tokens=card.cached_input_micro_usd_per_million_tokens,
+            output_micro_usd_per_million_tokens=card.output_micro_usd_per_million_tokens,
+            reasoning_micro_usd_per_million_tokens=card.reasoning_micro_usd_per_million_tokens,
+            long_context=None,
+        )
 
 
 class GatewayDeploymentMetadata(ContractModel):

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -783,3 +783,42 @@ def test_astra_responses_capability_slots_default_off() -> None:
     assert caps.supports_reasoning_effort_update is False
     # Defaulted addition contributes zero identity bytes.
     assert caps.model_dump(mode="json", by_alias=True, exclude_defaults=True) == {}
+
+
+def test_for_service_tier_reprices_whole_request_for_flex_and_priority() -> None:
+    """A requested flex/priority card replaces the base schedule whole-request;
+    other tiers (and no card) leave the base schedule unchanged."""
+    from exp.common.models.catalog import GatewayServiceTierPrices, GatewayTokenPrices
+
+    prices = GatewayTokenPrices(
+        input_micro_usd_per_million_tokens=1_000_000,
+        cached_input_micro_usd_per_million_tokens=100_000,
+        output_micro_usd_per_million_tokens=4_000_000,
+        reasoning_micro_usd_per_million_tokens=4_000_000,
+        flex=GatewayServiceTierPrices(
+            input_micro_usd_per_million_tokens=500_000,
+            output_micro_usd_per_million_tokens=2_000_000,
+        ),
+        priority=GatewayServiceTierPrices(
+            input_micro_usd_per_million_tokens=2_000_000,
+            output_micro_usd_per_million_tokens=8_000_000,
+        ),
+    )
+
+    flex = prices.for_service_tier("flex")
+    assert flex.input_micro_usd_per_million_tokens == 500_000
+    assert flex.output_micro_usd_per_million_tokens == 2_000_000
+    # A dimension absent on the card stays honestly unpriced, never the base.
+    assert flex.cached_input_micro_usd_per_million_tokens is None
+    assert flex.long_context is None
+
+    priority = prices.for_service_tier("priority")
+    assert priority.input_micro_usd_per_million_tokens == 2_000_000
+    assert priority.output_micro_usd_per_million_tokens == 8_000_000
+
+    # default/auto/None and an unpriced tier carry no override.
+    assert prices.for_service_tier("default") is prices
+    assert prices.for_service_tier("auto") is prices
+    assert prices.for_service_tier(None) is prices
+    no_card = GatewayTokenPrices(input_micro_usd_per_million_tokens=1)
+    assert no_card.for_service_tier("flex") is no_card

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -486,12 +486,14 @@ class ModelCapabilities(ContractModel):
     service_tier_pricing_enabled: bool = False
     """Whether this model carries per-provider-tier PASS-THROUGH pricing.
 
-    When set, a HOST-funded rung forwards ``service_tier`` to the provider (see
-    ``GatewayWireProfile.forwards_service_tier``) and settlement bills the SERVED
-    tier at the price card's per-tier rates; a tier request to a model without
-    this fails closed at the reservation seam (platform ``P1034``). BYOK rungs
-    forward regardless. Additive and excluded from the capability identity
-    digest: tier pricing propagates through the catalog publish, not the digest.
+    When set, a HOST-funded rung forwards ``service_tier`` to the provider for a
+    tier it carries a card for (see ``GatewayWireProfile.forwards_tier``) and
+    settlement bills the REQUESTED tier at that card's per-tier rates (v1 prices
+    the requested tier; billing the served tier the provider reports back is a
+    follow-up). A flex/priority request to a model with no card for that tier
+    fails closed at admission. BYOK rungs forward regardless. Additive and
+    excluded from the capability identity digest: tier pricing propagates
+    through the catalog publish, not the digest.
     """
 
     @field_validator(

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -483,6 +483,16 @@ class ModelCapabilities(ContractModel):
     output_cost_per_million_tokens_usd: float | None = Field(default=None, ge=0)
     cached_input_cost_per_million_tokens_usd: float | None = Field(default=None, ge=0)
     cache_write_cost_per_million_tokens_usd: float | None = Field(default=None, ge=0)
+    service_tier_pricing_enabled: bool = False
+    """Whether this model carries per-provider-tier PASS-THROUGH pricing.
+
+    When set, a HOST-funded rung forwards ``service_tier`` to the provider (see
+    ``GatewayWireProfile.forwards_service_tier``) and settlement bills the SERVED
+    tier at the price card's per-tier rates; a tier request to a model without
+    this fails closed at the reservation seam (platform ``P1034``). BYOK rungs
+    forward regardless. Additive and excluded from the capability identity
+    digest: tier pricing propagates through the catalog publish, not the digest.
+    """
 
     @field_validator(
         "input_cost_per_million_tokens_usd",
@@ -562,6 +572,10 @@ class ModelCapabilities(ContractModel):
             "output_cost_per_million_tokens_usd",
             "cached_input_cost_per_million_tokens_usd",
             "cache_write_cost_per_million_tokens_usd",
+            # Pricing/policy, not a protocol-boundary capability: kept out of the
+            # identity like the cost fields so enabling per-tier pass-through
+            # pricing propagates through the catalog publish, not a re-digest.
+            "service_tier_pricing_enabled",
         }
         excluded.add("supports_completions")
         # Image generation is admitted fail-closed on its own surface, so the

--- a/exp/common/models/model_test.py
+++ b/exp/common/models/model_test.py
@@ -131,6 +131,7 @@ def test_model_request_keeps_tool_contract_and_capabilities_deterministic() -> N
         "output_cost_per_million_tokens_usd": None,
         "cached_input_cost_per_million_tokens_usd": None,
         "cache_write_cost_per_million_tokens_usd": None,
+        "service_tier_pricing_enabled": False,
     }
     with pytest.raises(ValidationError, match="named tool_choice"):
         ModelRequest(

--- a/exp/runtime/gateway/execution_resolution.py
+++ b/exp/runtime/gateway/execution_resolution.py
@@ -57,6 +57,11 @@ def _resolved_wire_profile(
             model_id=profile.model_id or runtime_model.snapshot.model_id,
             billing_customer_managed=(deployment.billing_source == BillingSource.CUSTOMER_MANAGED),
             service_tier_pricing_enabled=capabilities.service_tier_pricing_enabled,
+            service_tier_cards=frozenset(
+                tier
+                for tier in ("flex", "priority")
+                if deployment.gateway.prices.service_tier(tier) is not None
+            ),
             minimum_temperature=(
                 max(profile.minimum_temperature, capabilities.minimum_temperature)
                 if capabilities.minimum_temperature is not None

--- a/exp/runtime/gateway/execution_resolution.py
+++ b/exp/runtime/gateway/execution_resolution.py
@@ -56,6 +56,7 @@ def _resolved_wire_profile(
             profile,
             model_id=profile.model_id or runtime_model.snapshot.model_id,
             billing_customer_managed=(deployment.billing_source == BillingSource.CUSTOMER_MANAGED),
+            service_tier_pricing_enabled=capabilities.service_tier_pricing_enabled,
             minimum_temperature=(
                 max(profile.minimum_temperature, capabilities.minimum_temperature)
                 if capabilities.minimum_temperature is not None

--- a/exp/runtime/gateway/execution_resolution_test.py
+++ b/exp/runtime/gateway/execution_resolution_test.py
@@ -212,3 +212,21 @@ def test_profile_resolution_binds_the_deployment_billing_source() -> None:
     hosted = _deployment(None).model_copy(update={"billing_source": BillingSource.HOST_MANAGED})
     house = _resolved_wire_profile(hosted, _resolved(_NativeClient(base), ModelCapabilities()))
     assert house.billing_customer_managed is False
+    # A house rung stays untiered by default, so service_tier is not forwarded.
+    assert house.service_tier_pricing_enabled is False
+    assert house.forwards_service_tier is False
+
+
+def test_profile_resolution_forwards_service_tier_on_a_tier_priced_house_lane() -> None:
+    """A host-funded rung whose model carries per-tier pass-through pricing
+    forwards service_tier even though the caller does not pay the provider
+    directly; settlement bills the served tier at cost."""
+    base = GatewayWireProfile(dialect="openai_compatible", url="https://provider.test")
+    hosted = _deployment(None).model_copy(update={"billing_source": BillingSource.HOST_MANAGED})
+    tiered = _resolved_wire_profile(
+        hosted,
+        _resolved(_NativeClient(base), ModelCapabilities(service_tier_pricing_enabled=True)),
+    )
+    assert tiered.billing_customer_managed is False
+    assert tiered.service_tier_pricing_enabled is True
+    assert tiered.forwards_service_tier is True

--- a/exp/runtime/gateway/execution_resolution_test.py
+++ b/exp/runtime/gateway/execution_resolution_test.py
@@ -10,6 +10,7 @@ from exp.common.models import BillingSource, ModelCapabilities, ModelSnapshot
 from exp.common.models.catalog import (
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
+    GatewayServiceTierPrices,
     GatewayTokenPrices,
 )
 from exp.common.models.gateway_catalog import ExactModelDeployment
@@ -218,15 +219,38 @@ def test_profile_resolution_binds_the_deployment_billing_source() -> None:
 
 
 def test_profile_resolution_forwards_service_tier_on_a_tier_priced_house_lane() -> None:
-    """A host-funded rung whose model carries per-tier pass-through pricing
-    forwards service_tier even though the caller does not pay the provider
-    directly; settlement bills the served tier at cost."""
+    """A host-funded rung whose model carries a per-tier pass-through CARD
+    forwards that tier even though the caller does not pay the provider
+    directly; settlement bills the requested tier at the card's cost. The card
+    set is per-tier: a flex-carded lane forwards flex, not priority."""
     base = GatewayWireProfile(dialect="openai_compatible", url="https://provider.test")
     hosted = _deployment(None).model_copy(update={"billing_source": BillingSource.HOST_MANAGED})
+    # Author a flex-only card on the deployment's gateway prices.
+    flex_carded = hosted.model_copy(
+        update={
+            "gateway": hosted.gateway.model_copy(
+                update={
+                    "prices": GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=1_000_000,
+                        output_micro_usd_per_million_tokens=4_000_000,
+                        flex=GatewayServiceTierPrices(
+                            input_micro_usd_per_million_tokens=500_000,
+                            output_micro_usd_per_million_tokens=2_000_000,
+                        ),
+                    )
+                }
+            )
+        }
+    )
     tiered = _resolved_wire_profile(
-        hosted,
+        flex_carded,
         _resolved(_NativeClient(base), ModelCapabilities(service_tier_pricing_enabled=True)),
     )
     assert tiered.billing_customer_managed is False
     assert tiered.service_tier_pricing_enabled is True
     assert tiered.forwards_service_tier is True
+    # The card set is wired from the deployment prices, and forwarding is
+    # per-tier: flex bills (card present), priority strips (no card).
+    assert tiered.service_tier_cards == frozenset({"flex"})
+    assert tiered.forwards_tier("flex") is True
+    assert tiered.forwards_tier("priority") is False

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from typing import cast
 
 from exp.common.core.artifacts import JsonObject
+from exp.common.models.gateway_catalog import ExactModelDeployment
 from exp.runtime.gateway.boundary import boundary_protocol_error
 from exp.runtime.gateway.budgets import (
     BudgetReservationRejected,
@@ -185,6 +186,27 @@ def _failure_from_payload(payload: object) -> GatewayFailure | None:
         provider_detail=(
             provider_detail if isinstance(provider_detail, str) and provider_detail else None
         ),
+    )
+
+
+def _deployment_priced_for_service_tier(
+    deployment: ExactModelDeployment,
+    service_tier: str | None,
+) -> ExactModelDeployment:
+    """Reprice one deployment for a requested flex/priority processing tier.
+
+    v1 bills the REQUESTED tier: when the caller names a tier the deployment
+    carries a pass-through card for, the card's rates replace the base schedule
+    on a copy used only for THIS reservation, so the ceiling, the stored
+    per-token rates, and settlement all bill the tier transparently. No tier (or
+    no card) returns the deployment unchanged. The copy stays Python-side and
+    never crosses the native boundary.
+    """
+    effective = deployment.gateway.prices.for_service_tier(service_tier)
+    if effective is deployment.gateway.prices:
+        return deployment
+    return deployment.model_copy(
+        update={"gateway": deployment.gateway.model_copy(update={"prices": effective})}
     )
 
 
@@ -368,7 +390,10 @@ class NativeAttemptAccounting:
             candidate = claim_route_from(self._health, keys, 0)
             last_failure = None
         while candidate is not None:
-            deployment = route.deployments[candidate]
+            deployment = _deployment_priced_for_service_tier(
+                route.deployments[candidate],
+                getattr(entry.request, "service_tier", None),
+            )
             try:
                 attempt_id = self._write_ledger.start_attempt(
                     snapshot=route.snapshot,

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -192,16 +192,25 @@ def _failure_from_payload(payload: object) -> GatewayFailure | None:
 def _deployment_priced_for_service_tier(
     deployment: ExactModelDeployment,
     service_tier: str | None,
+    *,
+    forwards_tier: bool,
 ) -> ExactModelDeployment:
     """Reprice one deployment for a requested flex/priority processing tier.
 
-    v1 bills the REQUESTED tier: when the caller names a tier the deployment
-    carries a pass-through card for, the card's rates replace the base schedule
-    on a copy used only for THIS reservation, so the ceiling, the stored
-    per-token rates, and settlement all bill the tier transparently. No tier (or
-    no card) returns the deployment unchanged. The copy stays Python-side and
-    never crosses the native boundary.
+    v1 bills the REQUESTED tier: when the SELECTED candidate actually FORWARDS
+    the tier to its provider and carries a pass-through card for it, the card's
+    rates replace the base schedule on a copy used only for THIS reservation, so
+    the ceiling, the stored per-token rates, and settlement all bill the tier
+    transparently. ``forwards_tier`` is the admission-time forwarding decision
+    for this exact depth (``GatewayWireProfile.forwards_tier``); gating on it
+    keeps FORWARD and BILL consistent even if a card ever sits on a lane whose
+    wire would strip the tier (non-tier dialect, tier disabled) — such a depth
+    runs the provider's base schedule, so it must bill the base schedule too. No
+    tier, no forwarding, or no card returns the deployment unchanged. The copy
+    stays Python-side and never crosses the native boundary.
     """
+    if not forwards_tier:
+        return deployment
     effective = deployment.gateway.prices.for_service_tier(service_tier)
     if effective is deployment.gateway.prices:
         return deployment
@@ -393,6 +402,10 @@ class NativeAttemptAccounting:
             deployment = _deployment_priced_for_service_tier(
                 route.deployments[candidate],
                 getattr(entry.request, "service_tier", None),
+                forwards_tier=(
+                    candidate < len(entry.tier_forwarded_by_depth)
+                    and entry.tier_forwarded_by_depth[candidate]
+                ),
             )
             try:
                 attempt_id = self._write_ledger.start_attempt(

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -512,3 +512,48 @@ def test_provider_detail_crosses_the_boundary_only_as_a_string() -> None:
         {"failure_class": "invalid_request", "safe_message": "x", "provider_detail": ""}
     )
     assert empty_detail is not None and empty_detail.provider_detail is None
+
+
+def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() -> None:
+    """A requested tier with a pass-through card reprices the deployment copy;
+    no tier, or a tier the deployment lacks, returns the deployment unchanged."""
+    from exp.common.models.catalog import (
+        GatewayDeploymentMetadata,
+        GatewayServiceTierPrices,
+        GatewayTokenPrices,
+    )
+    from exp.common.models.gateway_catalog import ExactModelDeployment
+    from exp.runtime.gateway.native_accounting import _deployment_priced_for_service_tier
+
+    deployment = ExactModelDeployment(
+        deployment_id="d1",
+        source_alias="d1",
+        exact_model_id="exact-one",
+        connection="connection-d1",
+        provider="openai",
+        provider_model="provider-model",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        gateway=GatewayDeploymentMetadata(
+            prices=GatewayTokenPrices(
+                input_micro_usd_per_million_tokens=1_000_000,
+                output_micro_usd_per_million_tokens=4_000_000,
+                flex=GatewayServiceTierPrices(
+                    input_micro_usd_per_million_tokens=500_000,
+                    output_micro_usd_per_million_tokens=2_000_000,
+                ),
+            )
+        ),
+    )
+
+    flex = _deployment_priced_for_service_tier(deployment, "flex")
+    assert flex is not deployment
+    assert flex.gateway.prices.input_micro_usd_per_million_tokens == 500_000
+    assert flex.gateway.prices.output_micro_usd_per_million_tokens == 2_000_000
+    # Identity and everything else is preserved on the copy.
+    assert flex.deployment_id == "d1" and flex.exact_model_id == "exact-one"
+
+    # No tier, default/auto, and a tier the deployment does not carry: unchanged.
+    assert _deployment_priced_for_service_tier(deployment, None) is deployment
+    assert _deployment_priced_for_service_tier(deployment, "default") is deployment
+    assert _deployment_priced_for_service_tier(deployment, "priority") is deployment

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -546,7 +546,7 @@ def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() 
         ),
     )
 
-    flex = _deployment_priced_for_service_tier(deployment, "flex")
+    flex = _deployment_priced_for_service_tier(deployment, "flex", forwards_tier=True)
     assert flex is not deployment
     assert flex.gateway.prices.input_micro_usd_per_million_tokens == 500_000
     assert flex.gateway.prices.output_micro_usd_per_million_tokens == 2_000_000
@@ -554,6 +554,103 @@ def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() 
     assert flex.deployment_id == "d1" and flex.exact_model_id == "exact-one"
 
     # No tier, default/auto, and a tier the deployment does not carry: unchanged.
-    assert _deployment_priced_for_service_tier(deployment, None) is deployment
-    assert _deployment_priced_for_service_tier(deployment, "default") is deployment
-    assert _deployment_priced_for_service_tier(deployment, "priority") is deployment
+    assert _deployment_priced_for_service_tier(deployment, None, forwards_tier=False) is deployment
+    assert (
+        _deployment_priced_for_service_tier(deployment, "default", forwards_tier=False)
+        is deployment
+    )
+    assert (
+        _deployment_priced_for_service_tier(deployment, "priority", forwards_tier=False)
+        is deployment
+    )
+
+    # A carded tier that the SELECTED depth does not forward (a card on a lane
+    # whose wire would strip the tier) bills the BASE schedule, never the card:
+    # forwards_tier=False returns the deployment unchanged even though the flex
+    # card exists.
+    assert (
+        _deployment_priced_for_service_tier(deployment, "flex", forwards_tier=False) is deployment
+    )
+
+
+def test_start_attempt_reprices_only_when_the_selected_depth_forwards_the_tier() -> None:
+    """The reservation applies the tier card ONLY on a depth that forwards it.
+
+    Regression for the forward/bill divergence: a flex CARD on a lane the
+    selected depth does not forward reserves the BASE schedule, never the card,
+    so the gateway can never reserve the tier rate while the provider runs the
+    base schedule.
+    """
+    from exp.common.models.catalog import GatewayServiceTierPrices, GatewayTokenPrices
+
+    class _PriceCapturingLedger(_RecordingLedger):
+        """Recording ledger that also captures each reserved input rate."""
+
+        def __init__(self) -> None:
+            """Track the per-attempt reserved input rate alongside the base log."""
+            super().__init__()
+            self.reserved_input_micro: list[int | None] = []
+
+        def start_attempt(
+            self,
+            *,
+            snapshot: object,
+            deployment: ExactModelDeployment,
+            attempt_ordinal: int,
+            route_depth: int,
+            maximum_cost_micro_usd: int | None = None,
+            route_reason: str | None = None,
+            fallback_reason: str | None = None,
+        ) -> str:
+            """Record the reserved input rate, then reserve as the base fake does."""
+            self.reserved_input_micro.append(
+                deployment.gateway.prices.input_micro_usd_per_million_tokens
+            )
+            return super().start_attempt(
+                snapshot=snapshot,
+                deployment=deployment,
+                attempt_ordinal=attempt_ordinal,
+                route_depth=route_depth,
+                maximum_cost_micro_usd=maximum_cost_micro_usd,
+                route_reason=route_reason,
+                fallback_reason=fallback_reason,
+            )
+
+    carded = _deployment("deployment-a", connection_sha256="b" * 64).model_copy(
+        update={
+            "gateway": GatewayDeploymentMetadata(
+                capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+                prices=GatewayTokenPrices(
+                    input_micro_usd_per_million_tokens=1_000_000,
+                    output_micro_usd_per_million_tokens=4_000_000,
+                    flex=GatewayServiceTierPrices(
+                        input_micro_usd_per_million_tokens=500_000,
+                        output_micro_usd_per_million_tokens=2_000_000,
+                    ),
+                ),
+            )
+        }
+    )
+    route = _route((carded,))
+    flex_request = _request().model_copy(update={"service_tier": "flex"})
+
+    def _reserved_rate(*, forwards: bool) -> int | None:
+        ledger = _PriceCapturingLedger()
+        registry = NativeAttemptAccounting(ledger)  # type: ignore[arg-type]
+        registry.register(
+            InflightRequest(
+                authorization=route.snapshot.authorization,
+                route=route,
+                request=flex_request,
+                deadline_monotonic=time.monotonic() + 30,
+                tier_forwarded_by_depth=(forwards,),
+            )
+        )
+        _start(registry, ordinal=0)
+        assert len(ledger.reserved_input_micro) == 1
+        return ledger.reserved_input_micro[0]
+
+    # The selected depth forwards flex -> reserve at the flex card rate.
+    assert _reserved_rate(forwards=True) == 500_000
+    # Same flex card, but the selected depth strips the tier -> reserve at BASE.
+    assert _reserved_rate(forwards=False) == 1_000_000

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -111,13 +111,29 @@ def admitted_route_requests(
     """
     # A named processing tier (flex/priority) is a paid pricing choice, not a
     # best-effort hint: it fails CLOSED before any reservation when no rung can
-    # honor it (a host lane whose model has no per-tier pass-through pricing, and
-    # no BYOK rung). auto/default carry no price and never reject; they still
-    # drop with disclosure downstream where a rung declines them.
+    # honor it. Honoring means the SPECIFIC requested tier is billable on a
+    # forwarding rung: a BYOK rung forwards any tier (customer pays the provider
+    # directly, no platform card needed), while a house rung must carry a
+    # per-tier pass-through card for THIS tier (`prices.service_tier(tier)`).
+    # A model carded for flex only therefore rejects a priority request instead
+    # of forwarding it and silently billing the base rate while the provider
+    # charges the priority premium (underbill). auto/default carry no price and
+    # never reject; they still drop with disclosure downstream where a rung
+    # declines them.
     if request.service_tier is not None and request.service_tier not in ("auto", "default"):
+        tier = request.service_tier
         if not any(
-            profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_service_tier
-            for profile, _client in resolved_wires
+            profile.dialect in SERVICE_TIER_DIALECTS
+            and (
+                profile.billing_customer_managed
+                or (
+                    profile.service_tier_pricing_enabled
+                    and deployment.gateway.prices.service_tier(tier) is not None
+                )
+            )
+            for deployment, (profile, _client) in zip(
+                route.deployments, resolved_wires, strict=True
+            )
         ):
             raise ProviderCapabilityError(
                 capability="service_tier",

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -35,6 +35,7 @@ from exp.runtime.models.providers.capability_policy import (
     coerce_route_rejections,
     coerce_structured_text_schema,
 )
+from exp.runtime.models.providers.dialect_dispatch import SERVICE_TIER_DIALECTS
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -108,6 +109,24 @@ def admitted_route_requests(
         GatewayRoutingError: No rung is protocol-compatible and none named a
             rejection.
     """
+    # A named processing tier (flex/priority) is a paid pricing choice, not a
+    # best-effort hint: it fails CLOSED before any reservation when no rung can
+    # honor it (a host lane whose model has no per-tier pass-through pricing, and
+    # no BYOK rung). auto/default carry no price and never reject; they still
+    # drop with disclosure downstream where a rung declines them.
+    if request.service_tier is not None and request.service_tier not in ("auto", "default"):
+        if not any(
+            profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_service_tier
+            for profile, _client in resolved_wires
+        ):
+            raise ProviderCapabilityError(
+                capability="service_tier",
+                detail=(
+                    "This model does not offer a flex or priority processing tier. "
+                    "Remove service_tier, or choose a model with tiered pricing enabled."
+                ),
+            )
+
     admitted_request = request
     coercion_disclosures: tuple[str, ...] = ()
     full_route = route

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -109,31 +109,21 @@ def admitted_route_requests(
         GatewayRoutingError: No rung is protocol-compatible and none named a
             rejection.
     """
-    # A named processing tier (flex/priority) is a paid pricing choice, not a
-    # best-effort hint: it fails CLOSED before any reservation when no rung can
-    # honor it. Honoring means the SPECIFIC requested tier is billable on a
-    # forwarding rung: a BYOK rung forwards any tier (customer pays the provider
-    # directly, no platform card needed), while a house rung must carry a
-    # per-tier pass-through card for THIS tier (`prices.service_tier(tier)`).
-    # A model carded for flex only therefore rejects a priority request instead
-    # of forwarding it and silently billing the base rate while the provider
-    # charges the priority premium (underbill). auto/default carry no price and
-    # never reject; they still drop with disclosure downstream where a rung
-    # declines them.
-    if request.service_tier is not None and request.service_tier not in ("auto", "default"):
+    # flex/priority are the tiers we price as an OPT-IN pass-through, so they
+    # fail CLOSED before any reservation when no rung can BILL the requested one:
+    # a BYOK rung forwards any tier (customer pays the provider directly, no
+    # platform card needed), while a house rung must carry a per-tier card for
+    # THIS tier (`forwards_tier`). A model carded for flex only therefore rejects
+    # a priority request instead of forwarding it and silently billing the base
+    # rate while the provider charges the priority premium (underbill). Every
+    # OTHER tier (auto/default carry no price; scale and any future value) is
+    # never rejected here — a non-billable candidate simply strips it at payload
+    # build (billing-safe, disclosed), so only the opt-in priced tiers gate.
+    if request.service_tier in ("flex", "priority"):
         tier = request.service_tier
         if not any(
-            profile.dialect in SERVICE_TIER_DIALECTS
-            and (
-                profile.billing_customer_managed
-                or (
-                    profile.service_tier_pricing_enabled
-                    and deployment.gateway.prices.service_tier(tier) is not None
-                )
-            )
-            for deployment, (profile, _client) in zip(
-                route.deployments, resolved_wires, strict=True
-            )
+            profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_tier(tier)
+            for profile, _client in resolved_wires
         ):
             raise ProviderCapabilityError(
                 capability="service_tier",

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -35,7 +35,6 @@ from exp.runtime.models.providers.capability_policy import (
     coerce_route_rejections,
     coerce_structured_text_schema,
 )
-from exp.runtime.models.providers.dialect_dispatch import SERVICE_TIER_DIALECTS
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -121,10 +120,7 @@ def admitted_route_requests(
     # build (billing-safe, disclosed), so only the opt-in priced tiers gate.
     if request.service_tier in ("flex", "priority"):
         tier = request.service_tier
-        if not any(
-            profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_tier(tier)
-            for profile, _client in resolved_wires
-        ):
+        if not any(profile.forwards_tier(tier) for profile, _client in resolved_wires):
             raise ProviderCapabilityError(
                 capability="service_tier",
                 detail=(

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -416,8 +416,6 @@ def test_mixed_waterfall_drops_the_tier_to_serve_the_preserving_rung() -> None:
         tools=(GatewayToolDefinition(name="lookup", parameters={"type": "object"}),),
         parallel_tool_calls=True,
         service_tier="flex",
-        stream=True,
-        include_usage=True,
     )
 
     class _CoercionCounter:
@@ -803,3 +801,105 @@ def test_a_thinking_config_translates_through_admission_on_an_openai_route() -> 
     assert provider.provider_thinking_config is None
     assert provider.reasoning_effort == "medium"
     assert accounting.recorded == 1
+
+
+def test_named_processing_tier_fails_closed_when_no_rung_offers_it() -> None:
+    """A flex/priority request rejects fail-closed before reservation when no
+    rung can honor it: a host lane without per-tier pass-through pricing and no
+    BYOK rung. auto/default never reject."""
+    from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+
+    route = _mixed_route(
+        "maximize_availability",
+        (
+            _deployment(
+                "house",
+                provider="openai",
+                gateway=GatewayDeploymentMetadata(
+                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+                ),
+            ),
+        ),
+        GatewayApiSurface.CHAT_COMPLETIONS,
+    )
+    client = cast(NativeWireClient, object())
+    # House rung: billing_customer_managed False and no tier pricing, so it does
+    # not forward service_tier.
+    wires = ((GatewayWireProfile(dialect="openai_compatible", url="https://house.test"), client),)
+    accounting = cast(NativeAttemptAccounting, object())
+
+    for tier in ("flex", "priority"):
+        request = GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="go"),),
+            service_tier=tier,
+        )
+        with pytest.raises(ProviderCapabilityError) as exc:
+            admitted_route_requests(
+                route,
+                wires,
+                request,
+                accounting=accounting,
+                authorization=route.snapshot.authorization,
+            )
+        assert exc.value.capability == "service_tier"
+
+    # auto/default are not paid tiers and never reject here.
+    for tier in ("auto", "default"):
+        request = GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content="go"),),
+            service_tier=tier,
+        )
+        admitted_route_requests(
+            route,
+            wires,
+            request,
+            accounting=accounting,
+            authorization=route.snapshot.authorization,
+        )
+
+
+def test_tier_priced_host_lane_admits_the_named_tier() -> None:
+    """A host rung whose model carries per-tier pricing forwards the tier, so a
+    flex request is admitted (not rejected)."""
+    from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+
+    route = _mixed_route(
+        "maximize_availability",
+        (
+            _deployment(
+                "house",
+                provider="openai",
+                gateway=GatewayDeploymentMetadata(
+                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+                ),
+            ),
+        ),
+        GatewayApiSurface.CHAT_COMPLETIONS,
+    )
+    client = cast(NativeWireClient, object())
+    wires = (
+        (
+            GatewayWireProfile(
+                dialect="openai_compatible",
+                url="https://house.test",
+                service_tier_pricing_enabled=True,
+            ),
+            client,
+        ),
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="go"),),
+        service_tier="flex",
+    )
+    _narrowed, _wires_out, _public, provider = admitted_route_requests(
+        route,
+        wires,
+        request,
+        accounting=cast(NativeAttemptAccounting, object()),
+        authorization=route.snapshot.authorization,
+    )
+    # The tier survives to the provider request on the tier-priced house lane.
+    assert provider.service_tier == "flex"

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -849,8 +849,10 @@ def test_named_processing_tier_fails_closed_when_no_rung_offers_it() -> None:
             )
         assert exc.value.capability == "service_tier"
 
-    # auto/default are not paid tiers and never reject here.
-    for tier in ("auto", "default"):
+    # auto/default carry no price, and `scale` (a valid OpenAI tier we do not
+    # price as opt-in) is stripped downstream, not rejected: only flex/priority
+    # gate at admission.
+    for tier in ("auto", "default", "scale"):
         request = GatewayRequest(
             surface=GatewayApiSurface.CHAT_COMPLETIONS,
             messages=(GatewayMessage(role="user", content="go"),),
@@ -898,6 +900,7 @@ def test_tier_priced_host_lane_admits_the_named_tier() -> None:
                 dialect="openai_compatible",
                 url="https://house.test",
                 service_tier_pricing_enabled=True,
+                service_tier_cards=frozenset({"flex"}),
             ),
             client,
         ),
@@ -957,6 +960,7 @@ def test_tier_without_a_card_rejects_while_byok_forwards_any_tier() -> None:
                 dialect="openai_compatible",
                 url="https://house.test",
                 service_tier_pricing_enabled=True,
+                service_tier_cards=frozenset({"flex"}),
             ),
             client,
         ),

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -6,7 +6,12 @@ from typing import Literal, cast
 import pytest
 
 from exp.common.core.artifacts import JsonObject
-from exp.common.models.catalog import GatewayDeploymentCapabilities, GatewayDeploymentMetadata
+from exp.common.models.catalog import (
+    GatewayDeploymentCapabilities,
+    GatewayDeploymentMetadata,
+    GatewayServiceTierPrices,
+    GatewayTokenPrices,
+)
 from exp.common.models.content import (
     AudioContentPart,
     ImageContentPart,
@@ -872,7 +877,15 @@ def test_tier_priced_host_lane_admits_the_named_tier() -> None:
                 "house",
                 provider="openai",
                 gateway=GatewayDeploymentMetadata(
-                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+                    capabilities=GatewayDeploymentCapabilities(supports_streaming=True),
+                    prices=GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=1_000_000,
+                        output_micro_usd_per_million_tokens=4_000_000,
+                        flex=GatewayServiceTierPrices(
+                            input_micro_usd_per_million_tokens=500_000,
+                            output_micro_usd_per_million_tokens=2_000_000,
+                        ),
+                    ),
                 ),
             ),
         ),
@@ -903,3 +916,93 @@ def test_tier_priced_host_lane_admits_the_named_tier() -> None:
     )
     # The tier survives to the provider request on the tier-priced house lane.
     assert provider.service_tier == "flex"
+
+
+def test_tier_without_a_card_rejects_while_byok_forwards_any_tier() -> None:
+    """The reject keys on the SPECIFIC requested tier's card, not just the lane:
+    a house model carded for flex only rejects a priority request (no card ->
+    would underbill), while a BYOK rung forwards any tier with no platform card
+    (the customer pays the provider directly)."""
+    from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+
+    accounting = cast(NativeAttemptAccounting, object())
+    client = cast(NativeWireClient, object())
+    streaming = GatewayDeploymentCapabilities(supports_streaming=True)
+
+    # House model carries a FLEX card only.
+    flex_only_route = _mixed_route(
+        "maximize_availability",
+        (
+            _deployment(
+                "house",
+                provider="openai",
+                gateway=GatewayDeploymentMetadata(
+                    capabilities=streaming,
+                    prices=GatewayTokenPrices(
+                        input_micro_usd_per_million_tokens=1_000_000,
+                        output_micro_usd_per_million_tokens=4_000_000,
+                        flex=GatewayServiceTierPrices(
+                            input_micro_usd_per_million_tokens=500_000,
+                            output_micro_usd_per_million_tokens=2_000_000,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        GatewayApiSurface.CHAT_COMPLETIONS,
+    )
+    house_wires = (
+        (
+            GatewayWireProfile(
+                dialect="openai_compatible",
+                url="https://house.test",
+                service_tier_pricing_enabled=True,
+            ),
+            client,
+        ),
+    )
+    priority_request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="go"),),
+        service_tier="priority",
+    )
+    with pytest.raises(ProviderCapabilityError) as exc:
+        admitted_route_requests(
+            flex_only_route,
+            house_wires,
+            priority_request,
+            accounting=accounting,
+            authorization=flex_only_route.snapshot.authorization,
+        )
+    assert exc.value.capability == "service_tier"
+
+    # A BYOK rung (billing_customer_managed) forwards ANY tier with no card.
+    byok_route = _mixed_route(
+        "maximize_availability",
+        (
+            _deployment(
+                "byok",
+                provider="openai",
+                gateway=GatewayDeploymentMetadata(capabilities=streaming),
+            ),
+        ),
+        GatewayApiSurface.CHAT_COMPLETIONS,
+    )
+    byok_wires = (
+        (
+            GatewayWireProfile(
+                dialect="openai_compatible",
+                url="https://byok.test",
+                billing_customer_managed=True,
+            ),
+            client,
+        ),
+    )
+    _n, _w, _p, provider = admitted_route_requests(
+        byok_route,
+        byok_wires,
+        priority_request,
+        accounting=accounting,
+        authorization=byok_route.snapshot.authorization,
+    )
+    assert provider.service_tier == "priority"

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -647,6 +647,10 @@ class NativeControlPlane(
                 signers=tuple(signers),
                 dispatch_bindings=tuple(dispatch_bindings),
                 reasoning_carrier_authorities=tuple(carrier_authorities),
+                tier_forwarded_by_depth=tuple(
+                    profile.forwards_tier(provider_request.service_tier)
+                    for profile, _client in resolved_wires
+                ),
             )
         )
         response: JsonObject = {

--- a/exp/runtime/gateway/native_bridge_errors.py
+++ b/exp/runtime/gateway/native_bridge_errors.py
@@ -72,6 +72,10 @@ _PUBLIC_REQUEST_CAPABILITY_PARAMS = {
 
 
 _ATTACHMENT_CAPABILITY_MESSAGES = {
+    "service_tier": (
+        "This model does not offer a flex or priority processing tier. "
+        "Remove service_tier, or choose a model with tiered pricing enabled."
+    ),
     "image_input": (
         "The selected model route cannot accept image input. "
         "Send text only or choose an image-capable model alias."

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -119,6 +119,13 @@ class InflightRequest:
     signers: tuple[GatewayDispatchSigner | None, ...] = ()
     dispatch_bindings: tuple[FrozenDispatchBinding | None, ...] = ()
     reasoning_carrier_authorities: tuple[ReasoningCarrierAuthority | None, ...] = ()
+    # Whether each route depth actually FORWARDS the requested service tier to
+    # its provider (``GatewayWireProfile.forwards_tier``), captured at admission
+    # where the resolved wire profiles exist. The accounting reprice gates on
+    # this so it applies the per-tier card ONLY on a depth that emits the tier —
+    # forward and bill stay consistent even if a card sits on a lane that would
+    # strip it. Empty on surfaces without a service tier (images, embeddings).
+    tier_forwarded_by_depth: tuple[bool, ...] = ()
 
     def __post_init__(self) -> None:
         """Size the per-deployment attempt counters to the frozen route."""

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -79,6 +79,16 @@ def completion_timeout_seconds(
     return max(configured_timeout_seconds, min(scaled, MAXIMUM_COMPLETION_TIMEOUT_SECONDS))
 
 
+SERVICE_TIER_DIALECTS = frozenset({"openai_responses", "openai_compatible"})
+"""Wire dialects with a request field that preserves the caller's service tier.
+
+Canonical here (the lowest module both the wire dispatch and the profile share);
+``dialect_dispatch`` re-exports it so existing import paths are unchanged. A tier
+on any other dialect is stripped or declined, so ``forwards_tier`` gates on it to
+keep FORWARD and BILL consistent by construction.
+"""
+
+
 @dataclass(frozen=True)
 class GatewayWireProfile:
     """Everything a gateway data plane needs to dispatch one provider call.
@@ -339,13 +349,16 @@ class GatewayWireProfile:
     def forwards_tier(self, tier: str | None) -> bool:
         """Whether this rung emits and can BILL the SPECIFIC requested ``tier``.
 
-        Forwarding is per-tier so forward and bill agree on whichever candidate
-        is selected: a BYOK rung forwards any tier (the caller pays the provider
-        directly), while a host-funded rung forwards a tier only when it carries
-        a pass-through card for THAT tier (else it strips the tier and runs the
-        provider default at the base rate — billing-safe and disclosed).
+        The single source of truth for FORWARD == BILL: forwarding is per-tier
+        AND requires a tier-capable wire dialect, so the accounting reprice and
+        the payload emission can never diverge. No tier -> False; a dialect with
+        no ``service_tier`` wire field -> False (it would strip or decline);
+        BYOK -> True (the caller pays the provider directly); otherwise the
+        host-funded rung must carry a pass-through card for THAT tier (else it
+        strips the tier and runs the provider default at the base rate —
+        billing-safe and disclosed).
         """
-        if tier is None:
+        if tier is None or self.dialect not in SERVICE_TIER_DIALECTS:
             return False
         if self.billing_customer_managed:
             return True

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -114,9 +114,17 @@ class GatewayWireProfile:
     Normally a host-funded rung strips the tier (the gateway bills catalog
     rates while a tier changes provider pricing). A model whose catalog carries
     per-tier PASS-THROUGH pricing sets this so the tier reaches the provider on
-    the house lane too, and settlement bills the served tier at cost. BYOK
-    rungs forward regardless (``billing_customer_managed``); this only widens
-    the host-funded case for opted-in models.
+    the house lane too, and settlement bills the REQUESTED tier at that card's
+    cost. BYOK rungs forward regardless (``billing_customer_managed``); this
+    only widens the host-funded case for opted-in models.
+    """
+    service_tier_cards: frozenset[str] = frozenset()
+    """The named tiers this host-funded rung carries a pass-through card for.
+
+    Forwarding is PER-TIER, not lane-level: a mixed route may pair a rung
+    carded for ``flex`` with one that is not, and the tier is emitted only on
+    the candidate that can also BILL it. Populated from the deployment's
+    per-tier price cards; BYOK ignores it (it forwards every tier).
     """
     forwards_prompt_cache_key: bool = False
     """Whether this rung's provider routes by ``prompt_cache_key``.
@@ -327,6 +335,21 @@ class GatewayWireProfile:
         host-funded rungs whose model carries per-tier pass-through pricing.
         """
         return self.billing_customer_managed or self.service_tier_pricing_enabled
+
+    def forwards_tier(self, tier: str | None) -> bool:
+        """Whether this rung emits and can BILL the SPECIFIC requested ``tier``.
+
+        Forwarding is per-tier so forward and bill agree on whichever candidate
+        is selected: a BYOK rung forwards any tier (the caller pays the provider
+        directly), while a host-funded rung forwards a tier only when it carries
+        a pass-through card for THAT tier (else it strips the tier and runs the
+        provider default at the base rate — billing-safe and disclosed).
+        """
+        if tier is None:
+            return False
+        if self.billing_customer_managed:
+            return True
+        return self.service_tier_pricing_enabled and tier in self.service_tier_cards
 
 
 class ProviderHttpClient(abc.ABC):

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -108,6 +108,16 @@ class GatewayWireProfile:
     """Whether the exact model accepts explicit sampling temperature."""
 
     billing_customer_managed: bool = False
+    service_tier_pricing_enabled: bool = False
+    """Whether this HOST-funded rung may still forward ``service_tier``.
+
+    Normally a host-funded rung strips the tier (the gateway bills catalog
+    rates while a tier changes provider pricing). A model whose catalog carries
+    per-tier PASS-THROUGH pricing sets this so the tier reaches the provider on
+    the house lane too, and settlement bills the served tier at cost. BYOK
+    rungs forward regardless (``billing_customer_managed``); this only widens
+    the host-funded case for opted-in models.
+    """
     forwards_prompt_cache_key: bool = False
     """Whether this rung's provider routes by ``prompt_cache_key``.
 
@@ -308,6 +318,15 @@ class GatewayWireProfile:
             or self.maximum_output_tokens <= 0
         ):
             raise ValueError("gateway wire maximum_output_tokens must be a positive integer")
+
+    @property
+    def forwards_service_tier(self) -> bool:
+        """Whether this rung emits ``service_tier`` to the provider.
+
+        True on BYOK rungs (the caller pays the provider directly) and on
+        host-funded rungs whose model carries per-tier pass-through pricing.
+        """
+        return self.billing_customer_managed or self.service_tier_pricing_enabled
 
 
 class ProviderHttpClient(abc.ABC):

--- a/exp/runtime/models/providers/base_test.py
+++ b/exp/runtime/models/providers/base_test.py
@@ -323,3 +323,42 @@ def test_complete_passes_the_derived_timeout_to_the_transport() -> None:
     assert len(transport.timeouts) == 2
     for observed, derived in zip(transport.timeouts, (480.0, DEFAULT_TIMEOUT_SECONDS), strict=True):
         assert derived - 1.0 < observed <= derived
+
+
+def test_forwards_tier_requires_a_card_and_a_tier_capable_dialect() -> None:
+    """`forwards_tier` is the single FORWARD == BILL gate: per-tier card AND a
+    tier-capable wire dialect, with BYOK forwarding any tier."""
+    # Host lane carded for flex on a tier-capable dialect: flex forwards,
+    # priority (no card) and auto/None do not.
+    flex_host = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://house.test",
+        service_tier_pricing_enabled=True,
+        service_tier_cards=frozenset({"flex"}),
+    )
+    assert flex_host.forwards_tier("flex") is True
+    assert flex_host.forwards_tier("priority") is False
+    assert flex_host.forwards_tier("auto") is False
+    assert flex_host.forwards_tier(None) is False
+
+    # The SAME flex card on a non-tier dialect never forwards (the wire would
+    # strip or decline the tier) -> reprice must not fire either.
+    flex_on_anthropic = GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        service_tier_pricing_enabled=True,
+        service_tier_cards=frozenset({"flex"}),
+    )
+    assert flex_on_anthropic.forwards_tier("flex") is False
+
+    # BYOK forwards any tier on a tier-capable dialect without a platform card,
+    # but still not on a non-tier dialect.
+    byok = GatewayWireProfile(
+        dialect="openai_responses", url="https://byok.test", billing_customer_managed=True
+    )
+    assert byok.forwards_tier("flex") is True
+    assert byok.forwards_tier("priority") is True
+    byok_anthropic = GatewayWireProfile(
+        dialect="anthropic_messages", url="https://byok.test", billing_customer_managed=True
+    )
+    assert byok_anthropic.forwards_tier("flex") is False

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -127,7 +127,7 @@ def dialect_stream_payload(
             supports_reasoning=profile.supports_reasoning,
             reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
-            forwards_service_tier=profile.forwards_service_tier,
+            forwards_service_tier=profile.forwards_tier(provider_request.service_tier),
             forwards_prompt_cache_key=profile.forwards_prompt_cache_key,
         )
     if profile.dialect == "anthropic_messages":
@@ -197,7 +197,7 @@ def dialect_stream_payload(
             fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
             hunyuan_reasoning_route_sha256=profile.hunyuan_reasoning_route_sha256,
             reasoning_output_exposed=profile.reasoning_output_exposed,
-            forwards_service_tier=profile.forwards_service_tier,
+            forwards_service_tier=profile.forwards_tier(provider_request.service_tier),
             forwards_prompt_cache_key=profile.forwards_prompt_cache_key,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -13,6 +13,7 @@ from urllib.parse import urlsplit
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.runtime.models.providers.base import SERVICE_TIER_DIALECTS as SERVICE_TIER_DIALECTS
 from exp.runtime.models.providers.errors import ProviderCapabilityError
 from exp.runtime.models.providers.fireworks import (
     require_responses_continuation_channel,
@@ -78,10 +79,6 @@ def fireworks_continuation_required(profile: GatewayWireProfile, request: Gatewa
         and bool(request.tools)
         and request.tool_choice != "none"
     )
-
-
-SERVICE_TIER_DIALECTS = frozenset({"openai_responses", "openai_compatible"})
-"""Wire dialects with a request field that preserves the caller's service tier."""
 
 
 def dialect_stream_payload(

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -127,7 +127,7 @@ def dialect_stream_payload(
             supports_reasoning=profile.supports_reasoning,
             reasoning_effort=required_reasoning_effort,
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
-            forwards_service_tier=profile.billing_customer_managed,
+            forwards_service_tier=profile.forwards_service_tier,
             forwards_prompt_cache_key=profile.forwards_prompt_cache_key,
         )
     if profile.dialect == "anthropic_messages":
@@ -197,7 +197,7 @@ def dialect_stream_payload(
             fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
             hunyuan_reasoning_route_sha256=profile.hunyuan_reasoning_route_sha256,
             reasoning_output_exposed=profile.reasoning_output_exposed,
-            forwards_service_tier=profile.billing_customer_managed,
+            forwards_service_tier=profile.forwards_service_tier,
             forwards_prompt_cache_key=profile.forwards_prompt_cache_key,
         )
     raise ProviderCapabilityError(capability=f"wire_dialect:{profile.dialect}")

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -502,17 +502,18 @@ def route_generation_parameter_requests(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
         ignore("inference_geo")
-    # A provider tier forwards only where the caller pays that provider
-    # directly (BYOK) on a tier-preserving wire; a route with no such rung
-    # strips the tier up front with the same 'service_tier' disclosure the
-    # capability_policy drop path uses, so every rung serves and waterfalls
-    # stay deterministic. Host-funded rungs never emit it (they bill catalog
-    # rates while the tier changes provider pricing: flex discounted,
-    # priority premium) but stay in the route as untiered fallbacks; the
-    # dialect decline in dialect_stream_payload still guards mixed routes
-    # where an eligible rung keeps the tier alive.
+    # A provider tier forwards where the caller pays that provider directly
+    # (BYOK) OR on a host-funded rung whose model carries per-tier pass-through
+    # pricing (profile.forwards_service_tier folds both), on a tier-preserving
+    # wire; a route with no such rung strips the tier up front with the same
+    # 'service_tier' disclosure the capability_policy drop path uses, so every
+    # rung serves and waterfalls stay deterministic. Host-funded rungs WITHOUT
+    # tier pricing never emit it (they bill catalog rates while the tier changes
+    # provider pricing: flex discounted, priority premium) but stay in the route
+    # as untiered fallbacks; the dialect decline in dialect_stream_payload still
+    # guards mixed routes where an eligible rung keeps the tier alive.
     if request.service_tier is not None and not any(
-        profile.dialect in SERVICE_TIER_DIALECTS and profile.billing_customer_managed
+        profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_service_tier
         for profile in profiles
     ):
         ignore("service_tier")

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -503,17 +503,19 @@ def route_generation_parameter_requests(
     ):
         ignore("inference_geo")
     # A provider tier forwards where the caller pays that provider directly
-    # (BYOK) OR on a host-funded rung whose model carries per-tier pass-through
-    # pricing (profile.forwards_service_tier folds both), on a tier-preserving
-    # wire; a route with no such rung strips the tier up front with the same
-    # 'service_tier' disclosure the capability_policy drop path uses, so every
-    # rung serves and waterfalls stay deterministic. Host-funded rungs WITHOUT
-    # tier pricing never emit it (they bill catalog rates while the tier changes
-    # provider pricing: flex discounted, priority premium) but stay in the route
-    # as untiered fallbacks; the dialect decline in dialect_stream_payload still
-    # guards mixed routes where an eligible rung keeps the tier alive.
+    # (BYOK) OR on a host-funded rung that carries a per-tier pass-through card
+    # for THIS SPECIFIC tier (profile.forwards_tier), on a tier-preserving wire.
+    # Forwarding is per-tier, not lane-level: the shared request keeps the tier
+    # as long as ANY candidate can bill it, and each non-billable candidate
+    # strips it at its own payload build (openai_payloads gated on
+    # forwards_tier), so forward and bill agree on whichever candidate is
+    # selected. A route where NO candidate can bill the tier strips it up front
+    # with the same 'service_tier' disclosure the capability_policy drop path
+    # uses. Host-funded rungs without a card for this tier never emit it (they
+    # bill catalog rates while the tier changes provider pricing: flex
+    # discounted, priority premium) but stay in the route as untiered fallbacks.
     if request.service_tier is not None and not any(
-        profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_service_tier
+        profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_tier(request.service_tier)
         for profile in profiles
     ):
         ignore("service_tier")

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -515,8 +515,7 @@ def route_generation_parameter_requests(
     # bill catalog rates while the tier changes provider pricing: flex
     # discounted, priority premium) but stay in the route as untiered fallbacks.
     if request.service_tier is not None and not any(
-        profile.dialect in SERVICE_TIER_DIALECTS and profile.forwards_tier(request.service_tier)
-        for profile in profiles
+        profile.forwards_tier(request.service_tier) for profile in profiles
     ):
         ignore("service_tier")
         provider_updates["service_tier"] = None

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -3752,6 +3752,65 @@ def test_service_tier_route_shaping_forwards_on_byok_and_discloses_elsewhere() -
     assert foreign_provider.service_tier is None
 
 
+def test_service_tier_forwarding_is_per_card_not_lane_level() -> None:
+    """A mixed route emits the tier only on the candidate that can BILL it.
+
+    Regression for the underbill window: the route admits because ONE host rung
+    carries a flex card, but a fallback host rung carded only for `priority`
+    must NOT forward the flex tier (its `service_tier_pricing_enabled` is True).
+    If it did and were selected, the provider would run flex (discounted) while
+    the gateway billed the base rate. Route shaping keeps the tier alive for the
+    flex-carded rung; the priority-only rung strips it at its own payload build,
+    so forward and bill agree on whichever candidate is selected.
+    """
+    request = _tiered_request(GatewayApiSurface.CHAT_COMPLETIONS)
+    flex_carded = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://flex.test",
+        model_id="model-x",
+        service_tier_pricing_enabled=True,
+        service_tier_cards=frozenset({"flex"}),
+    )
+    priority_only = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://priority.test",
+        model_id="model-x",
+        service_tier_pricing_enabled=True,
+        service_tier_cards=frozenset({"priority"}),
+    )
+    public, provider = route_generation_parameter_requests((flex_carded, priority_only), request)
+    # The tier survives route shaping (the flex-carded rung can bill it).
+    assert "service_tier" not in public.ignored_parameters
+    assert provider.service_tier == "flex"
+    # The selected candidate decides emission: flex-carded emits, priority-only
+    # strips (no flex card -> no underbill if it is the one that serves).
+    assert dialect_stream_payload(flex_carded, provider)["service_tier"] == "flex"
+    assert "service_tier" not in dialect_stream_payload(priority_only, provider)
+
+
+def test_service_tier_scale_strips_on_host_lane_without_rejecting() -> None:
+    """`scale` (a valid tier we do not price as opt-in) strips on a host lane.
+
+    A flex-carded host rung carries a card for flex only; a `scale` request is
+    not rejected and not forwarded — it is stripped with disclosure and the
+    provider runs its default at the base rate (billing-safe).
+    """
+    scale_request = _tiered_request(GatewayApiSurface.CHAT_COMPLETIONS).model_copy(
+        update={"service_tier": "scale"}
+    )
+    flex_carded = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://flex.test",
+        model_id="model-x",
+        service_tier_pricing_enabled=True,
+        service_tier_cards=frozenset({"flex"}),
+    )
+    public, provider = route_generation_parameter_requests((flex_carded,), scale_request)
+    assert "service_tier" in public.ignored_parameters
+    assert provider.service_tier is None
+    assert "service_tier" not in dialect_stream_payload(flex_carded, provider)
+
+
 def test_narrowing_surfaces_the_first_rung_rejection_not_the_route_shape() -> None:
     """When no rung serves, the caller sees the first rung's own field-scoped reason.
 


### PR DESCRIPTION
Lets a host-funded model forward the caller's OpenAI `service_tier` (flex/priority) and bill that tier **pass-through, at cost**. Fixes "flex has no effect on GPT-5.6 Sol": today `service_tier` forwards only on BYOK rungs; every host lane strips it.

## Behavior (v1 = requested tier)
- **Opt-in per model** via `ModelCapabilities.service_tier_pricing_enabled` (excluded from the capability identity digest, like the cost fields — enabling propagates through the catalog publish, no re-digest).
- **Forward** `service_tier` on a host lane when the model carries per-tier pass-through pricing (`GatewayWireProfile.forwards_service_tier` = BYOK **or** tier-priced host).
- **Bill the requested tier** at its per-tier card: `GatewayTokenPrices.flex`/`.priority` (`GatewayServiceTierPrices`) replace the base rates whole-request; reservation reprices via `for_service_tier()` and reserves conservatively at the tier rate. No settle-side change, no `gateway_start_attempt` change.
- **Fail closed** before any spend: a real tier (flex/priority) requested where the **specific tier** isn't billable on a forwarding rung — BYOK forwards any tier; a house rung needs a card for *that* tier — rejects with `ProviderCapabilityError(capability="service_tier")` → HTTP 400 `unsupported_capability`, param `service_tier`: *"This model does not offer a flex or priority processing tier…"*. So a flex-only model rejects a priority request instead of underbilling. `auto`/`default` never reject.
- BYOK unchanged.

## Not in v1 (documented follow-up)
Billing the **served** tier (OpenAI can degrade flex→default under load and echoes the served tier) needs the native/Rust plane to surface it. Until then a degraded-flex request bills at the flex rate — **customer-favorable**, a bounded platform cost, never an overcharge.

## Platform counterpart
experientiallabs/platform PR (per-tier rate columns on `model_providers` + `service_tier_pricing_enabled`, flowing into the snapshot as `GatewayTokenPrices.flex/priority` + the capability), pinning this release. Enables **flex on Sol** (flex = 50% of base); priority holds until its rate is confirmed (rejects cleanly meanwhile).

## Tests
Forwarding gate; `for_service_tier` repricing; reservation reprice; per-tier-card reject (flex-carded model rejects priority; BYOK forwards any tier). 145 service_tier tests pass; broad models/gateway sweep 1619 passed. ruff + ty clean. (The ~73 native failures in the shared venv are pre-existing stale-wheel artifacts, identical on baseline.)