### PR TITLE
release: bump experiential to 0.7.39 (service_tier pass-through pricing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.38"
+version = "0.7.39"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.38"
+version = "0.7.39"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump shipping #812 (flex/priority `service_tier` pass-through pricing on host lanes). Native crate unchanged at 0.3.35 (Python-only). Cutting the GitHub Release for v0.7.39 after this merges publishes to PyPI.