### PR TITLE
gateway: replayed plaintext reasoning_content degrades with disclosure instead of 400ing

### DIFF
--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -728,8 +728,13 @@ def test_hunyuan_mixed_carrier_and_plaintext_history_round_trips(tmp_path: Path)
     assert messages[3]["reasoning_content"] == plain
 
 
-def test_plaintext_reasoning_is_rejected_on_a_route_without_exposure(tmp_path: Path) -> None:
-    """A rung that never issued plaintext reasoning rejects it by name."""
+def test_plaintext_reasoning_degrades_on_a_route_without_exposure(tmp_path: Path) -> None:
+    """A rung that cannot replay plaintext reasoning drops it with disclosure.
+
+    The block is baked into the caller's transcript (an earlier exposed-rung
+    turn or a client re-serialization), so admission serves the request and
+    discloses the drop — previously a named 400 that killed every session
+    the moment it switched from a reasoning-exposed model to any other."""
     _manager, raw_key = _configured_gateway(tmp_path, capabilities=ModelCapabilities())
     control = NativeControlPlane(
         load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
@@ -744,9 +749,15 @@ def test_plaintext_reasoning_is_rejected_on_a_route_without_exposure(tmp_path: P
             ],
         }
     )
-    with pytest.raises(NativeBridgeError) as rejected:
-        _admit(control, raw_key, body)
-    assert json.loads(rejected.value.public_error_json)["param"] == "messages.reasoning_content"
+    admitted = _admit(control, raw_key, body)
+    assert (
+        "messages.reasoning_content->dropped(unsupported_by_provider)"
+        in admitted["ignored_parameters"]
+    )
+    route = cast("list[JsonObject]", admitted["route"])
+    payload = cast("JsonObject", route[0]["upstream_payload"])
+    sent_messages = cast("list[JsonObject]", payload["messages"])
+    assert all("reasoning_content" not in message for message in sent_messages)
 
 
 def test_hunyuan_endpoint_without_exposure_capability_strips_reasoning(

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -750,10 +750,8 @@ def test_plaintext_reasoning_degrades_on_a_route_without_exposure(tmp_path: Path
         }
     )
     admitted = _admit(control, raw_key, body)
-    assert (
-        "messages.reasoning_content->dropped(unsupported_by_provider)"
-        in admitted["ignored_parameters"]
-    )
+    ignored = cast("list[str]", admitted["ignored_parameters"])
+    assert "messages.reasoning_content->dropped(unsupported_by_provider)" in ignored
     route = cast("list[JsonObject]", admitted["route"])
     payload = cast("JsonObject", route[0]["upstream_payload"])
     sent_messages = cast("list[JsonObject]", payload["messages"])

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -667,22 +667,21 @@ def route_generation_parameter_requests(
         for message in request.messages
         for block in message.provider_reasoning
     )
-    if exposed_reasoning_present:
-        if not any(profile.reasoning_output_exposed for profile in profiles):
-            raise ProviderParameterError(
-                message=(
-                    "The parameter 'messages.reasoning_content' carries plaintext reasoning, "
-                    "which only a model that exposes its reasoning can replay. Remove the "
-                    "field or choose a reasoning-exposed model alias."
-                ),
-                param="messages.reasoning_content",
-                code="unsupported_parameter",
-            )
-        if not all(profile.reasoning_output_exposed for profile in profiles):
-            ignore(
-                "messages.reasoning_content",
-                "messages.reasoning_content->dropped(unsupported_by_provider)",
-            )
+    if exposed_reasoning_present and not all(
+        profile.reasoning_output_exposed for profile in profiles
+    ):
+        # Plaintext reasoning is baked into the caller's transcript (an
+        # earlier turn on a reasoning-exposed rung, or a client-side AI-SDK
+        # re-serialization), so a route that cannot replay it drops the block
+        # with disclosure instead of rejecting: "remove the field" is not
+        # actionable for a framework-managed history, and a session that ever
+        # touched an exposed model would otherwise die the moment it switches
+        # models. Exposing rungs — when the route has any — still forward the
+        # plaintext verbatim; the others omit it at encoding.
+        ignore(
+            "messages.reasoning_content",
+            "messages.reasoning_content->dropped(unsupported_by_provider)",
+        )
     history_thinking_present = any(
         block.kind in {"thinking", "redacted_thinking"}
         for message in request.messages

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4099,12 +4099,24 @@ def test_plaintext_reasoning_replays_only_on_an_exposing_rung() -> None:
     assert anthropic_messages[1]["content"] == [{"type": "text", "text": '{"command": "ls"}'}]
 
 
-def test_plaintext_reasoning_route_gate_rejects_discloses_or_forwards() -> None:
-    """No exposing rung -> named 400; mixed -> disclosed drop; all exposing -> silent."""
+def test_plaintext_reasoning_route_gate_discloses_or_forwards() -> None:
+    """No exposing rung -> disclosed drop; mixed -> disclosed drop; all exposing -> silent.
+
+    Plaintext reasoning is baked into the transcript (an earlier exposed-rung
+    turn or a client re-serialization), so a route that cannot replay it
+    degrades instead of rejecting — previously a 400 that killed every
+    session the moment it switched from an exposed model to any other.
+    """
     request = _exposed_reasoning_request()
-    with pytest.raises(ProviderParameterError) as rejected:
-        route_generation_parameter_requests((_exposed_profile(exposed=False),), request)
-    assert rejected.value.param == "messages.reasoning_content"
+    public, provider = route_generation_parameter_requests(
+        (_exposed_profile(exposed=False),), request
+    )
+    assert (
+        "messages.reasoning_content->dropped(unsupported_by_provider)" in public.ignored_parameters
+    )
+    payload = openai_compatible_stream_payload("hy4-preview", provider)
+    payload_messages = cast("list[JsonObject]", payload["messages"])
+    assert all("reasoning_content" not in message for message in payload_messages)
 
     public, _provider = route_generation_parameter_requests(
         (

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -695,15 +695,15 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
             # history and route admission decides which rungs may carry it.
             scheme = scheme_for_carrier(message.reasoning_content)
             if scheme is None:
-                if calls:
-                    # A tool turn's reasoning is only ever issued as the sealed
-                    # carrier that binds it to its calls and issuing rung;
-                    # plaintext here was never ours and would bypass that bond.
-                    raise invalid_field(
-                        param,
-                        f"'{param}' must be a gateway-issued carrier on an assistant "
-                        "tool-call turn.",
-                    )
+                # Plaintext reasoning is caller-owned history on ANY assistant
+                # turn, tool-call turns included: AI-SDK clients re-serialize a
+                # reasoning part onto the same assistant message as its tool
+                # calls, and exposure-gated providers themselves emit
+                # reasoning_content on tool turns. The field is baked into the
+                # transcript, so rejecting it wedges every session that ever
+                # touched a reasoning-exposed model (the sealed-carrier bond
+                # applies only to text presented AS a gateway-issued carrier,
+                # which keeps its strict path below).
                 try:
                     provider_reasoning = (
                         ExposedReasoningContentBlock(content=message.reasoning_content),

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -504,31 +504,36 @@ def test_chat_decoder_accepts_plaintext_reasoning_as_exposed_history() -> None:
     assert (
         reasoning_only.request.messages[1].provider_reasoning[0].kind == "exposed_reasoning_content"
     )
-    # A tool-call turn's reasoning is only ever issued as the sealed carrier,
-    # so plaintext there was never ours and is rejected by name.
-    with pytest.raises(OpenAIProtocolError) as tool_turn:
-        decode_chat(
-            {
-                "model": "coding",
-                "messages": [
-                    {"role": "user", "content": "look it up"},
-                    {
-                        "role": "assistant",
-                        "content": None,
-                        "reasoning_content": "plaintext on a tool turn",
-                        "tool_calls": [
-                            {
-                                "id": "call-one",
-                                "type": "function",
-                                "function": {"name": "lookup", "arguments": "{}"},
-                            }
-                        ],
-                    },
-                    {"role": "tool", "tool_call_id": "call-one", "content": "done"},
-                ],
-            }
-        )
-    assert tool_turn.value.detail.param == "messages.1.reasoning_content"
+    # Plaintext on a tool-call turn is caller-owned history too: AI-SDK
+    # clients re-serialize a reasoning part onto the same assistant message
+    # as its tool calls, and exposure-gated providers emit reasoning_content
+    # on tool turns. It decodes like any other plaintext (previously a 400
+    # that wedged every cross-model session); the sealed-carrier bond keeps
+    # its strict path for text presented AS a carrier.
+    tool_turn = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "look it up"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "plaintext on a tool turn",
+                    "tool_calls": [
+                        {
+                            "id": "call-one",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+            ],
+        }
+    )
+    tool_turn_message = tool_turn.request.messages[1]
+    assert tool_turn_message.provider_reasoning[0].kind == "exposed_reasoning_content"
+    assert tool_turn_message.tool_calls[0].name == "lookup"
     # An empty string is not reasoning; it names its field.
     with pytest.raises(OpenAIProtocolError) as raised:
         decode_chat(
@@ -3555,3 +3560,113 @@ def test_a_name_on_a_non_tool_message_stays_a_named_400() -> None:
     assert error.value.status_code == 400
     assert error.value.detail.param == "messages.0"
     assert "name is valid only for tool messages" in str(error.value.detail.message)
+
+
+def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sessions() -> None:
+    """The prod OpenCode + gpt-6-astra wedge: rc in history serves everywhere.
+
+    A session that touched a reasoning-exposed rung (or whose AI-SDK client
+    re-serializes reasoning parts) carries plaintext reasoning_content in its
+    transcript — on tool-call turns too. A non-exposed route now drops the
+    block with disclosure and dispatches without it; an exposed route
+    forwards it verbatim beside the tool calls. Previously both repro shapes
+    400d ("must be a gateway-issued carrier on an assistant tool-call turn" /
+    "carries plaintext reasoning"), killing the session the moment it
+    switched models.
+    """
+    from exp.runtime.models.providers.base import GatewayWireProfile
+    from exp.runtime.models.providers.streaming_requests import (
+        dialect_stream_payload,
+        route_generation_parameter_requests,
+    )
+
+    astra = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://astra.test/v1",
+        model_id="gpt-6-astra",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+    )
+    exposed = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        model_id="hy4-preview",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        reasoning_output_exposed=True,
+    )
+
+    # Repro A (the exact prod screenshot shape): rc beside tool_calls.
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "what time is it"},
+                {
+                    "role": "assistant",
+                    "reasoning_content": "The user wants the time; call get_time.",
+                    "tool_calls": [
+                        {
+                            "id": "call_rc1",
+                            "type": "function",
+                            "function": {"name": "get_time", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_rc1", "content": "12:00"},
+                {"role": "user", "content": "thanks, and the date?"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_time",
+                        "description": "d",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        }
+    )
+    public, provider = route_generation_parameter_requests((astra,), decoded.request)
+    assert (
+        "messages.reasoning_content->dropped(unsupported_by_provider)" in public.ignored_parameters
+    )
+    payload = dialect_stream_payload(astra, provider.model_copy(update={"stream": True}))
+    astra_messages = cast(list[JsonObject], payload["messages"])
+    assert all("reasoning_content" not in message for message in astra_messages)
+    assert astra_messages[1]["tool_calls"]
+
+    # The same history onto an exposed route forwards the plaintext verbatim
+    # beside the tool calls (the provider's own wire shape) — no demand for a
+    # sealed carrier on history the gateway never issued.
+    public_exposed, provider_exposed = route_generation_parameter_requests(
+        (exposed,), decoded.request
+    )
+    assert not any("reasoning_content" in path for path in public_exposed.ignored_parameters)
+    exposed_payload = dialect_stream_payload(
+        exposed, provider_exposed.model_copy(update={"stream": True})
+    )
+    exposed_messages = cast(list[JsonObject], exposed_payload["messages"])
+    assert exposed_messages[1]["reasoning_content"] == "The user wants the time; call get_time."
+    assert exposed_messages[1]["tool_calls"]
+
+    # Repro B: rc on a plain assistant turn, non-exposed route.
+    decoded_b = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "A", "reasoning_content": "thinking..."},
+                {"role": "user", "content": "again"},
+            ],
+        }
+    )
+    public_b, provider_b = route_generation_parameter_requests((astra,), decoded_b.request)
+    assert (
+        "messages.reasoning_content->dropped(unsupported_by_provider)"
+        in public_b.ignored_parameters
+    )
+    payload_b = dialect_stream_payload(astra, provider_b.model_copy(update={"stream": True}))
+    plain_messages = cast(list[JsonObject], payload_b["messages"])
+    assert all("reasoning_content" not in message for message in plain_messages)

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -3670,3 +3670,40 @@ def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sess
     payload_b = dialect_stream_payload(astra, provider_b.model_copy(update={"stream": True}))
     plain_messages = cast(list[JsonObject], payload_b["messages"])
     assert all("reasoning_content" not in message for message in plain_messages)
+
+
+def test_a_forged_carrier_prefix_on_a_tool_turn_never_decodes_as_plaintext() -> None:
+    """The sealed-carrier boundary holds: a spoofed carrier is a named 400.
+
+    Caller plaintext on tool-call turns decodes as caller-owned exposed
+    history, but text carrying a gateway carrier PREFIX must parse as the
+    genuine gateway-issued carrier or reject — it never falls back to the
+    plaintext path, so untrusted input cannot be interpreted as (or
+    substituted for) gateway-issued reasoning bound to the calls.
+    """
+    with pytest.raises(OpenAIProtocolError) as forged:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {"role": "user", "content": "look it up"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "reasoning_content": (
+                            "x-experiential-fireworks-reasoning-v2:not-a-real-carrier"
+                        ),
+                        "tool_calls": [
+                            {
+                                "id": "call-one",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+                ],
+            }
+        )
+    assert forged.value.detail.param == "messages.1.reasoning_content"
+    assert "gateway-issued carrier" in str(forged.value.detail.message)


### PR DESCRIPTION
## What this is

Prod-reported wedge (OpenCode + gpt-6-astra, user screenshot): a session whose transcript carries plaintext `reasoning_content` — from an earlier turn on a reasoning-exposed rung (#790's plaintext exposure) or a client-side AI-SDK reasoning-part re-serialization — died the moment it hit a route that could not replay the field. gpt-6-astra itself never emits `reasoning_content` (4 live probes: streamed/non-streamed, with/without effort), so the field always enters from elsewhere and is baked into the framework-managed history: the full wedge signature. Model switching mid-session is normal client behavior.

## The two rejection sites, both now degrade

**1. Decode (the exact screenshot error):** plaintext `reasoning_content` beside `tool_calls` raised `"'messages.N.reasoning_content' must be a gateway-issued carrier on an assistant tool-call turn."` It now decodes as caller-owned exposed history like any other plaintext turn — AI-SDK clients re-serialize a reasoning part onto the same assistant message as its tool calls, and exposure-gated providers (DeepSeek/Tencent) themselves emit `reasoning_content` on tool turns. The sealed-carrier bond is untouched: text presented AS a gateway-issued carrier (recognized scheme prefix) keeps its strict validation, so gateway-issued state integrity is unchanged.

**2. Route shaping (the broader class):** a route with NO exposing rung raised `"carries plaintext reasoning, which only a model that exposes its reasoning can replay."` It now drops the block with the `messages.reasoning_content->dropped(unsupported_by_provider)` disclosure — the identical path the mixed route already used since #790 — and the per-rung encoders omit it exactly as before (all five dialects already skip exposed blocks gracefully; no encoder changes). An exposed rung, when the route has one, still forwards the plaintext verbatim — now on tool-call turns too, which is the provider's own wire shape (this also serves the screenshot case if the user's alias was exposure-gated). Narrowing still prefers the exposing rung on mixed waterfalls (unchanged, pinned). No reasoning item is ever fabricated upstream from plaintext (the #787 no-fabrication rule).

## Fixtures

- The exact prod repro shapes end to end (decode → route shaping → dispatch payload): Repro A (`[user, assistant{reasoning_content, tool_calls:[get_time]}, tool, user]` on a non-exposed route) serves with the disclosure and no `reasoning_content` on the wire; the same history on an exposed rung forwards the plaintext verbatim beside the tool calls; Repro B (plain-turn rc) same posture.
- Admission-level pin through the real control plane (native bridge): admitted, disclosed, upstream payload clean.
- Three old-contract pins updated: the decoder tool-turn rejection, the route-gate named 400, and the bridge-level rejection — each now pins the disclosure contract.
- Wedge-stress harness round 4 extended (W13/W14): both repro shapes serve on the real chat engine with no `reasoning_content` leaked upstream — 18/18 attacks ok on this build.

## Gates

`ruff format/check` + `ty check` clean; full `pytest -q` green (3734 on the committed tree — the two w16 evidence tests require a clean checkout and pass on it). Python-only; no native crate change.

## Release

Rides the next `experiential` release (0.7.40; 0.7.39 is already tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)