### PR TITLE
gateway: raise tool/format description bounds to the uniform 65,536; name the over-limit rejection

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -158,7 +158,7 @@ class StructuredTextFormat(ContractModel):
     """A strict structured-text output schema requested by the caller."""
 
     name: str = Field(min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=65_536)
     json_schema: JsonObject
     strict: bool = True
 

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -582,6 +582,18 @@ def _shape_message(param: str, details: list[ErrorDetails]) -> str | None:
     expected: list[str] = []
     got: str | None = None
     for detail in details:
+        if detail["type"] == "string_too_long":
+            # The bound and the arriving LENGTH are both display-safe facts
+            # (the value itself is never echoed); stating them saves the
+            # caller from bisecting the ceiling out of a bare rejection.
+            context = detail.get("ctx") or {}
+            maximum = context.get("max_length")
+            value = detail.get("input")
+            if isinstance(maximum, int) and isinstance(value, str):
+                return (
+                    f"Invalid value for '{param}': expected at most "
+                    f"{maximum:,} characters, but got {len(value):,}."
+                )
         phrase = _EXPECTED_BY_ERROR_TYPE.get(detail["type"])
         if detail["type"] in {"literal_error", "enum"}:
             context = detail.get("ctx") or {}

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -3748,3 +3748,90 @@ def test_forced_tool_choice_decodes_canonically_on_both_openai_surfaces() -> Non
         }
     )
     assert responses_named.request.tool_choice == GatewayNamedToolChoice(name="lookup")
+
+
+def test_tool_description_bounds_are_uniform_and_named_on_both_surfaces() -> None:
+    """65,536-char descriptions serve; 65,537 is a self-explanatory named 400.
+
+    Prod report: an 8,292-char tool description 400d every agentic turn at
+    the old 8,192 bound while the provider itself serves 66,000+ (probed
+    live 2026-09-05). The bound now matches the Messages surface and the
+    canonical GatewayToolDefinition, and the over-limit rejection states the
+    limit and the arriving length instead of forcing the caller to bisect.
+    """
+    reporter_sized = "x" * 8_292
+    at_bound = "x" * 65_536
+    over_bound = "x" * 65_537
+
+    for description in (reporter_sized, at_bound):
+        decoded = decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "t",
+                            "description": description,
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            }
+        )
+        assert decoded.request.tools[0].description == description
+
+    with pytest.raises(OpenAIProtocolError) as chat_over:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "t",
+                            "description": over_bound,
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            }
+        )
+    assert chat_over.value.detail.param == "tools.0.function.description"
+    assert "at most 65,536 characters" in str(chat_over.value.detail.message)
+    assert "65,537" in str(chat_over.value.detail.message)
+
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": "hi",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "t",
+                    "description": at_bound,
+                    "parameters": {"type": "object"},
+                }
+            ],
+        }
+    )
+    assert decoded.request.tools[0].description == at_bound
+    with pytest.raises(OpenAIProtocolError) as responses_over:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": "hi",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "t",
+                        "description": over_bound,
+                        "parameters": {"type": "object"},
+                    }
+                ],
+            }
+        )
+    assert responses_over.value.detail.param == "tools.0.description"
+    assert "at most 65,536 characters" in str(responses_over.value.detail.message)

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -3835,3 +3835,77 @@ def test_tool_description_bounds_are_uniform_and_named_on_both_surfaces() -> Non
         )
     assert responses_over.value.detail.param == "tools.0.description"
     assert "at most 65,536 characters" in str(responses_over.value.detail.message)
+
+
+def test_structured_format_description_bounds_are_uniform_and_named() -> None:
+    """The response_format and text.format description bounds match the tools'."""
+    at_bound = "x" * 65_536
+    over_bound = "x" * 65_537
+
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "shape",
+                    "description": at_bound,
+                    "schema": {"type": "object"},
+                },
+            },
+        }
+    )
+    assert decoded.request.structured_text is not None
+    assert decoded.request.structured_text.description == at_bound
+    with pytest.raises(OpenAIProtocolError) as chat_over:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "shape",
+                        "description": over_bound,
+                        "schema": {"type": "object"},
+                    },
+                },
+            }
+        )
+    assert chat_over.value.detail.param == "response_format.json_schema.description"
+    assert "at most 65,536 characters" in str(chat_over.value.detail.message)
+
+    decoded = decode_responses(
+        {
+            "model": "coding",
+            "input": "hi",
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "shape",
+                    "description": at_bound,
+                    "schema": {"type": "object"},
+                }
+            },
+        }
+    )
+    assert decoded.request.structured_text is not None
+    assert decoded.request.structured_text.description == at_bound
+    with pytest.raises(OpenAIProtocolError) as responses_over:
+        decode_responses(
+            {
+                "model": "coding",
+                "input": "hi",
+                "text": {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "shape",
+                        "description": over_bound,
+                        "schema": {"type": "object"},
+                    }
+                },
+            }
+        )
+    assert responses_over.value.detail.param == "text.format.description"
+    assert "at most 65,536 characters" in str(responses_over.value.detail.message)

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -89,6 +89,17 @@ _MAXIMUM_FILE_ID_CHARACTERS = 512
 """Longest OpenAI Files handle accepted on the wire."""
 
 
+_MAXIMUM_DESCRIPTION_CHARACTERS = 65_536
+"""Tool, function, and structured-format description bound, both surfaces.
+
+Matches the Messages surface and the canonical GatewayToolDefinition bound.
+The provider itself accepts far larger values (probed live 2026-09-05,
+api.openai.com: 8,292, 30,000, and 66,000-character descriptions all
+serve), and real agent toolsets exceeded the earlier 8,192 bound (prod
+report: an 8,292-character tool description 400d every agentic turn). The
+request-body size cap remains the effective total limit."""
+
+
 class _ResponsesImagePart(_WireModel):
     """One Responses ``input_image`` content part.
 
@@ -366,7 +377,7 @@ class _FunctionDefinition(_WireModel):
     """One function schema offered through Chat Completions."""
 
     name: str = Field(min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=_MAXIMUM_DESCRIPTION_CHARACTERS)
     parameters: JsonObject = Field(default_factory=dict)
     strict: bool = False
 
@@ -382,7 +393,7 @@ class _StructuredSchema(_WireModel):
     """Named strict JSON Schema in a Chat response format."""
 
     name: str = Field(min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=_MAXIMUM_DESCRIPTION_CHARACTERS)
     schema_: JsonObject = Field(alias="schema")
     strict: bool = True
 
@@ -588,7 +599,7 @@ class _ResponseTool(_WireModel):
 
     type: Literal["function"] = "function"
     name: str = Field(min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=_MAXIMUM_DESCRIPTION_CHARACTERS)
     parameters: JsonObject = Field(default_factory=dict)
     strict: bool | None = None
 
@@ -724,7 +735,7 @@ class _ResponseFormat(_WireModel):
 
     type: Literal["text", "json_schema"]
     name: str | None = Field(default=None, min_length=1, max_length=256)
-    description: str | None = Field(default=None, max_length=8_192)
+    description: str | None = Field(default=None, max_length=_MAXIMUM_DESCRIPTION_CHARACTERS)
     schema_: JsonObject | None = Field(default=None, alias="schema")
     strict: bool = True
 


### PR DESCRIPTION
## What this is

Prod report (X/Twitter, the "omp" coding agent on chat completions + streaming + tools): every agentic turn failed 400 `"Invalid value for 'tools.4.function.description'."` on a tool description of 8,292 chars. Live bisection put the prod threshold at exactly 8,192; live probes show api.openai.com serves 8,292 / 30,000 / 66,000-char descriptions (all 200). The 8,192 cap was an arbitrary 8x inconsistency against the gateway's own sibling ceilings (`GatewayToolDefinition.description` and the Messages surface, both 65,536).

## The fix

- All four OpenAI-protocol description bounds (chat `function.description`, chat structured `response_format` schema description, Responses function tool description, Responses `text.format` description) move to one shared `_MAXIMUM_DESCRIPTION_CHARACTERS = 65_536`, and `StructuredTextFormat.description` in contracts matches — one uniform gateway-wide bound; the request-body size cap remains the effective total limit.
- Still fail-closed above the bound: tools are caller-resendable (NOT history-borne), so a clear named 400 is the correct posture — no degrade. But the rejection is now self-explanatory: the pydantic `string_too_long` mapping states the limit and the arriving LENGTH (`"Invalid value for 'tools.0.function.description': expected at most 65,536 characters, but got 65,537."`) — display-safe facts only, the value is never echoed — instead of the bare field name the reporter had to bisect against.
- Rust: no parallel description cap exists in the native crate (grep of `native/src` confirms; the wedge-harness attack against the real served engine is the arbiter and passes).

## Fixtures

- Repo: 8,292 (reporter's exact size) and 65,536 decode on both surfaces; 65,537 is a named 400 carrying both the limit and the arriving length, chat (`tools.0.function.description`) and Responses (`tools.0.description`).
- Wedge-stress harness W15 (real served chat engine): the 8,292-char description streams end to end with tools; 65,537 returns the self-explanatory 400.

## Gates

ruff format/check + ty clean; full pytest green (3732 + this PR's tests on the committed tree; the two w16 evidence tests require a clean checkout and pass on it). Python-only.

## Release

Rides 0.7.40 with #815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)