### PR TITLE
fix(gateway): preserve signed tool IDs through output and replay

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -35,6 +35,12 @@ It serves:
 this same gateway application. It does not create a router HTTP server. Gateway startup and readiness
 perform no provider request. Only an authorized model request may cross the provider boundary.
 
+Tool-call identifiers on Chat Completions and Responses are opaque strings of 1 to
+65,536 characters. Replay the complete returned identifier in both the assistant call
+and its tool result, including any signature suffix. The gateway preserves the identifier
+verbatim on OpenAI-compatible Chat routes; it does not decode or strip provider signatures.
+Provider-specific wire restrictions still apply when routing to a different API dialect.
+
 ## The data plane
 
 The gateway has exactly one data plane: a native Rust HTTP server compiled as

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -39,6 +39,8 @@ Tool-call identifiers on Chat Completions and Responses are opaque strings of 1 
 65,536 characters. Replay the complete returned identifier in both the assistant call
 and its tool result, including any signature suffix. The gateway preserves the identifier
 verbatim on OpenAI-compatible Chat routes; it does not decode or strip provider signatures.
+Output guardrail byte limits count the complete serialized completion, including
+tool IDs, tool names, arguments, and JSON framing.
 Provider-specific wire restrictions still apply when routing to a different API dialect.
 
 ## The data plane

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -33,6 +33,9 @@ _JSON_OBJECT_ADAPTER = TypeAdapter(JsonObject)
 ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "ultra", "max"]
 ChatMaxTokensField = Literal["max_tokens", "max_completion_tokens"]
 
+MAXIMUM_TOOL_CALL_ID_CHARACTERS: Final = 65_536
+"""Bound opaque tool identifiers, including provider-carried reasoning signatures."""
+
 DEFAULT_REASONING_EFFORT: Final[ReasoningEffort] = "medium"
 """Reasoning effort pinned by default for models known to accept the parameter.
 
@@ -198,7 +201,7 @@ class ToolCall(ContractModel):
     immutable artifacts but join gateway idempotency identity explicitly.
     """
 
-    call_id: str = Field(min_length=1, max_length=256)
+    call_id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     name: str = Field(min_length=1, max_length=256)
     arguments: JsonObject = Field(default_factory=dict)
     raw_arguments: str | None = Field(

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -23,7 +23,7 @@ from exp.common.models.gateway_catalog import (
     ExactModelPoolId,
     FailoverMode,
 )
-from exp.common.models.model import ReasoningEffort, ToolCall
+from exp.common.models.model import MAXIMUM_TOOL_CALL_ID_CHARACTERS, ReasoningEffort, ToolCall
 from exp.runtime.gateway.reasoning_blocks import (
     EncryptedReasoningBlock as EncryptedReasoningBlock,
 )
@@ -190,7 +190,9 @@ class GatewayMessage(ContractModel):
 
     role: Literal["system", "developer", "user", "assistant", "tool"]
     content: str | None = None
-    tool_call_id: str | None = Field(default=None, min_length=1, max_length=256)
+    tool_call_id: str | None = Field(
+        default=None, min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS
+    )
     tool_calls: tuple[ToolCall, ...] = ()
     tool_is_error: bool = Field(default=False, exclude=True)
     """Whether this tool result reports a failed tool invocation.

--- a/exp/runtime/gateway/guardrails/contracts.py
+++ b/exp/runtime/gateway/guardrails/contracts.py
@@ -140,9 +140,12 @@ class GuardrailCompletion(ContractModel):
     tool_calls: tuple[GuardrailToolCall, ...] = ()
 
     def content_bytes(self) -> int:
-        """Return UTF-8 size of text, refusal flag, and raw tool arguments."""
-        tool_bytes = sum(len(call.arguments.encode("utf-8")) for call in self.tool_calls)
-        return len(self.text.encode("utf-8")) + tool_bytes
+        """Return the UTF-8 size of the complete serialized classifier subject.
+
+        Include opaque tool IDs, names, and JSON framing as well as arguments
+        so the policy bounds the actual completion sent to the classifier.
+        """
+        return len(canonical_json_bytes(self))
 
 
 class ClassifierVerdict(ContractModel):

--- a/exp/runtime/gateway/guardrails/contracts.py
+++ b/exp/runtime/gateway/guardrails/contracts.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from pydantic import Field, model_validator
 
 from exp.common.core.artifacts import ArtifactId, ContractModel, JsonObject, canonical_json_bytes
+from exp.common.models.model import MAXIMUM_TOOL_CALL_ID_CHARACTERS
 from exp.runtime.gateway.contracts import (
     GatewayFailure,
     GatewayFailureClass,
@@ -126,7 +127,7 @@ class GuardrailPolicy(ContractModel):
 class GuardrailToolCall(ContractModel):
     """One completed tool invocation presented to an output check."""
 
-    call_id: str = Field(min_length=1, max_length=256)
+    call_id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     name: str = Field(min_length=1, max_length=256)
     arguments: str = Field(max_length=4_000_000)
 

--- a/exp/runtime/gateway/guardrails/contracts_test.py
+++ b/exp/runtime/gateway/guardrails/contracts_test.py
@@ -157,7 +157,7 @@ def test_request_content_bytes_count_the_compact_json_subject() -> None:
 
     assert request_content_bytes(request) == len(canonical_json_bytes(request))
     assert request_content_bytes(request) > len("hi") + len('{"q":"ab"}')
-    assert completion.content_bytes() == len("ok") + len('{"q":"ab"}')
+    assert completion.content_bytes() == len(canonical_json_bytes(completion))
 
 
 @pytest.mark.parametrize("length", [257, 65_536])

--- a/exp/runtime/gateway/guardrails/contracts_test.py
+++ b/exp/runtime/gateway/guardrails/contracts_test.py
@@ -158,3 +158,10 @@ def test_request_content_bytes_count_the_compact_json_subject() -> None:
     assert request_content_bytes(request) == len(canonical_json_bytes(request))
     assert request_content_bytes(request) > len("hi") + len('{"q":"ab"}')
     assert completion.content_bytes() == len("ok") + len('{"q":"ab"}')
+
+
+@pytest.mark.parametrize("length", [257, 65_536])
+def test_output_guardrail_preserves_long_tool_id(length: int) -> None:
+    """An output check accepts every bounded tool identifier emitted by the engine."""
+    call = GuardrailToolCall(call_id="x" * length, name="terminal", arguments="{}")
+    assert GuardrailCompletion(tool_calls=(call,)).tool_calls[0].call_id == "x" * length

--- a/exp/runtime/gateway/guardrails/enforcement_test.py
+++ b/exp/runtime/gateway/guardrails/enforcement_test.py
@@ -11,6 +11,7 @@ from collections.abc import Coroutine
 import httpx
 import pytest
 
+from exp.common.core.artifacts import canonical_json_bytes
 from exp.common.models.model import ToolCall
 from exp.runtime.gateway.contracts import (
     EncryptedReasoningBlock,
@@ -1124,3 +1125,44 @@ def test_cancel_swallowing_adapter_fail_closes_without_starving_others() -> None
             assert inspects.detached_inspect_count() == 0
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("limit_offset", [-1, 0])
+def test_signed_tool_ids_count_toward_output_subject_limit(limit_offset: int) -> None:
+    """The complete serialized subject is bounded before classifier dispatch."""
+    completion = GuardrailCompletion(
+        tool_calls=(
+            GuardrailToolCall(
+                call_id="toolu~sig1:" + "é" * 1_000,
+                name="terminal",
+                arguments="{}",
+            ),
+        ),
+    )
+    subject_bytes = len(canonical_json_bytes(completion))
+    engine, classifier = _engine(
+        classifier=ScriptedClassifier(),
+        checks=(_check("output-one", stage=GuardrailCheckStage.OUTPUT),),
+        max_response_bytes=subject_bytes + limit_offset,
+    )
+    policy = engine.policy_for("organization-one", "identity-one")
+    assert policy is not None
+    if limit_offset < 0:
+        with pytest.raises(GuardrailRejected):
+            _awaited(
+                engine.enforce_output(
+                    policy=policy,
+                    completion=completion,
+                    deadline_monotonic=200.0,
+                )
+            )
+        assert classifier.output_calls == 0
+    else:
+        _awaited(
+            engine.enforce_output(
+                policy=policy,
+                completion=completion,
+                deadline_monotonic=200.0,
+            )
+        )
+        assert classifier.output_calls == 1

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -682,6 +682,9 @@ pub struct ToolAccumulator {
     pub server: bool,
 }
 
+/// Opaque tool IDs share the Python model bound, including signature carriers.
+const MAXIMUM_TOOL_CALL_ID_CHARACTERS: usize = 65_536;
+
 impl ToolAccumulator {
     pub fn new(call_id: String, name: String) -> Self {
         Self {
@@ -708,7 +711,7 @@ impl ToolAccumulator {
         // exactly the same provider tool-call streams (a call the python
         // engine rejects must not become client-visible history here).
         if self.call_id.is_empty()
-            || self.call_id.chars().count() > 256
+            || self.call_id.chars().count() > MAXIMUM_TOOL_CALL_ID_CHARACTERS
             || self.name.is_empty()
             || self.name.chars().count() > 256
             || self

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -366,3 +366,21 @@ fn gemini_usage_folds_thoughts_into_output_tokens() {
     }))
     .is_err());
 }
+
+#[test]
+fn tool_id_bound_counts_characters_and_preserves_opaque_signatures() {
+    for id in [
+        format!("toolu_synthetic~sig1:{}", "YWJj+/=".repeat(110)),
+        format!("toolu_synthetic_sig1_{}", "YWJj+/=".repeat(110)),
+        "é".repeat(65_536),
+    ] {
+        let mut tool = ToolAccumulator::new(id.clone(), "terminal".into());
+        tool.raw_arguments = "{}".into();
+        assert_eq!(tool.complete().expect("bounded opaque id").call_id, id);
+    }
+    for id in [String::new(), "x".repeat(65_537)] {
+        let mut tool = ToolAccumulator::new(id, "terminal".into());
+        tool.raw_arguments = "{}".into();
+        assert!(tool.complete().is_err());
+    }
+}

--- a/exp/runtime/gateway/stream_contracts.py
+++ b/exp/runtime/gateway/stream_contracts.py
@@ -11,7 +11,7 @@ from enum import StrEnum
 from pydantic import Field, model_validator
 
 from exp.common.core.artifacts import ContractModel, JsonObject
-from exp.common.models.model import ToolCall
+from exp.common.models.model import MAXIMUM_TOOL_CALL_ID_CHARACTERS, ToolCall
 
 
 class GatewayUsage(ContractModel):
@@ -93,7 +93,9 @@ class GatewayEvent(ContractModel):
     redacted_thinking_data: str | None = None
     encrypted_content: str | None = None
     tool_call_index: int | None = Field(default=None, ge=0)
-    tool_call_id: str | None = Field(default=None, min_length=1, max_length=256)
+    tool_call_id: str | None = Field(
+        default=None, min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS
+    )
     tool_name: str | None = Field(default=None, min_length=1, max_length=256)
     raw_arguments_delta: str | None = None
     tool_call: ToolCall | None = None

--- a/exp/runtime/gateway/stream_contracts_test.py
+++ b/exp/runtime/gateway/stream_contracts_test.py
@@ -1,2 +1,18 @@
-"""Inline tests for the stream outcome contracts (currently exercised through
-``contracts_test`` and every consumer suite)."""
+"""Tests for stream outcome contracts."""
+
+import pytest
+
+from exp.runtime.gateway.stream_contracts import GatewayEvent, GatewayEventKind
+
+
+@pytest.mark.parametrize("length", [257, 65_536])
+def test_stream_started_event_preserves_long_tool_id(length: int) -> None:
+    """Provider tool IDs fit the same bound on output as on replay."""
+    event = GatewayEvent(
+        kind=GatewayEventKind.TOOL_CALL_STARTED,
+        sequence_number=0,
+        tool_call_index=0,
+        tool_call_id="x" * length,
+        tool_name="terminal",
+    )
+    assert event.tool_call_id == "x" * length

--- a/exp/runtime/gateway/tests/native_tool_ids_test.py
+++ b/exp/runtime/gateway/tests/native_tool_ids_test.py
@@ -1,0 +1,149 @@
+"""Signed tool identifiers round-trip through the served gateway and official SDK."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import cast
+
+import pytest
+from openai import OpenAI
+from openai.types.chat import ChatCompletionMessageParam
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import ModelCapabilities
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.tests.launch_test import _provider_frame, _ServedGateway, _unused_port
+
+
+@pytest.mark.parametrize("delimiter", ["~sig1:", "_sig1_"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_sdk_replays_signed_tool_id_through_native_gateway(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, delimiter: str, stream: bool
+) -> None:
+    """A stock SDK tool loop preserves the signature on output and upstream replay."""
+    call_id = "toolu_bdrk_synthetic" + delimiter + base64.b64encode(bytes(range(256)) * 3).decode()
+    received: list[JsonObject] = []
+
+    class Provider(BaseHTTPRequestHandler):
+        """Emit one signed tool call, then a text answer on the tool result."""
+
+        def do_POST(self) -> None:  # noqa: N802
+            """Capture the provider-bound history and serve finite SSE frames."""
+            received.append(json.loads(self.rfile.read(int(self.headers["content-length"]))))
+            if len(received) == 1:
+                delta = {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "terminal", "arguments": "{}"},
+                        }
+                    ],
+                }
+                finish = "tool_calls"
+            else:
+                delta = {"role": "assistant", "content": "done"}
+                finish = "stop"
+            frames = (
+                _provider_frame(
+                    {"choices": [{"index": 0, "delta": delta, "finish_reason": finish}]}
+                )
+                + _provider_frame(
+                    {"choices": [], "usage": {"prompt_tokens": 2, "completion_tokens": 2}}
+                )
+                + b"data: [DONE]\n\n"
+            )
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(frames)))
+            self.end_headers()
+            self.wfile.write(frames)
+
+        def log_message(self, format: str, *args: object) -> None:
+            """Keep synthetic request traffic out of test logs."""
+            del format, args
+
+    provider = ThreadingHTTPServer(("127.0.0.1", 0), Provider)
+    thread = threading.Thread(target=provider.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("TEST_PROVIDER_KEY", "synthetic-provider-key")
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url=f"http://127.0.0.1:{provider.server_port}/v1",
+        capabilities=ModelCapabilities(supports_tools=True),
+    )
+    gateway = _ServedGateway(tmp_path, _unused_port())
+    try:
+        gateway.start()
+        with OpenAI(
+            api_key=raw_key, base_url=f"http://127.0.0.1:{gateway.port}/v1", max_retries=0
+        ) as client:
+            messages: list[ChatCompletionMessageParam] = [
+                {"role": "user", "content": "use terminal"}
+            ]
+            if stream:
+                identifier = ""
+                arguments = ""
+                name = ""
+                with client.chat.completions.create(
+                    model="coding",
+                    messages=messages,
+                    stream=True,
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {"name": "terminal", "parameters": {"type": "object"}},
+                        }
+                    ],
+                ) as chunks:
+                    for chunk in chunks:
+                        for choice in chunk.choices:
+                            for call in choice.delta.tool_calls or []:
+                                identifier += call.id or ""
+                                if call.function:
+                                    arguments += call.function.arguments or ""
+                                    name += call.function.name or ""
+                assistant: ChatCompletionMessageParam = {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": identifier,
+                            "type": "function",
+                            "function": {"name": name, "arguments": arguments},
+                        }
+                    ],
+                }
+                assert identifier == call_id
+            else:
+                response = client.chat.completions.create(
+                    model="coding",
+                    messages=messages,
+                    tools=[
+                        {
+                            "type": "function",
+                            "function": {"name": "terminal", "parameters": {"type": "object"}},
+                        }
+                    ],
+                )
+                output = response.choices[0].message
+                assert output.tool_calls and output.tool_calls[0].id == call_id
+                # The SDK's serialized output is exactly what stock tool loops echo.
+                assistant = cast(ChatCompletionMessageParam, output.model_dump())
+            messages.extend([assistant, {"role": "tool", "tool_call_id": call_id, "content": "ok"}])
+            final = client.chat.completions.create(model="coding", messages=messages)
+            assert final.choices[0].message.content == "done"
+        assert len(received) == 2
+        replay = cast(list[JsonObject], received[1]["messages"])
+        calls = cast(list[JsonObject], replay[-2]["tool_calls"])
+        assert calls[0]["id"] == replay[-1]["tool_call_id"] == call_id
+    finally:
+        gateway.stop()
+        provider.shutdown()
+        provider.server_close()
+        thread.join(timeout=5)

--- a/exp/runtime/openai_protocol/tests/tool_ids_test.py
+++ b/exp/runtime/openai_protocol/tests/tool_ids_test.py
@@ -1,0 +1,120 @@
+"""Opaque tool IDs survive the public protocol and provider replay boundaries."""
+
+from __future__ import annotations
+
+import base64
+from typing import cast
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.models.providers.streaming_requests import openai_compatible_stream_payload
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+from exp.runtime.openai_protocol.requests import decode_chat, decode_responses
+
+
+@pytest.mark.parametrize("delimiter", ["~sig1:", "_sig1_"])
+def test_signed_tool_ids_replay_verbatim_on_chat_and_responses(delimiter: str) -> None:
+    """Opaque upstream signatures survive both public decoders and Chat dispatch."""
+    call_id = "toolu_bdrk_synthetic" + delimiter + base64.b64encode(bytes(range(256)) * 3).decode()
+    chat = decode_chat(
+        {
+            "model": "coding",
+            "messages": [
+                {"role": "user", "content": "use the tool"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "terminal", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": call_id, "content": "ok"},
+            ],
+        }
+    )
+    responses = decode_responses(
+        {
+            "model": "coding",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": "terminal",
+                    "arguments": "{}",
+                },
+                {"type": "function_call_output", "call_id": call_id, "output": "ok"},
+            ],
+        }
+    )
+    for decoded in (chat, responses):
+        assert decoded.request.messages[-2].tool_calls[0].call_id == call_id
+        assert decoded.request.messages[-1].tool_call_id == call_id
+        payload = openai_compatible_stream_payload("upstream", decoded.request)
+        messages = cast(list[JsonObject], payload["messages"])
+        assert messages[-2]["tool_calls"] == [
+            {"id": call_id, "type": "function", "function": {"name": "terminal", "arguments": "{}"}}
+        ]
+        assert messages[-1]["tool_call_id"] == call_id
+
+
+@pytest.mark.parametrize("length", [1, 256, 257, 65_536, 0, 65_537])
+@pytest.mark.parametrize(
+    "field", ["chat_call", "chat_result", "responses_call", "responses_result"]
+)
+def test_tool_id_length_boundary_is_field_scoped(length: int, field: str) -> None:
+    """Both call and result fields accept the bounded opaque ID and reject excess."""
+    call_id = "x" * length
+    payload: JsonObject
+    if field == "chat_call":
+        payload = {
+            "model": "coding",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "terminal", "arguments": "{}"},
+                        }
+                    ],
+                }
+            ],
+        }
+        param = "messages.0.tool_calls.0.id"
+    elif field == "chat_result":
+        payload = {
+            "model": "coding",
+            "messages": [{"role": "tool", "tool_call_id": call_id, "content": "ok"}],
+        }
+        param = "messages.0.tool_call_id"
+    elif field == "responses_call":
+        payload = {
+            "model": "coding",
+            "input": [
+                {"type": "function_call", "call_id": call_id, "name": "terminal", "arguments": "{}"}
+            ],
+        }
+        param = "input.0.call_id"
+    else:
+        payload = {
+            "model": "coding",
+            "input": [{"type": "function_call_output", "call_id": call_id, "output": "ok"}],
+        }
+        param = "input.0.call_id"
+    decoder = decode_chat if field.startswith("chat") else decode_responses
+    if length in (0, 65_537):
+        with pytest.raises(OpenAIProtocolError) as error:
+            decoder(payload)
+        assert error.value.detail.param == param
+        assert error.value.detail.code == "invalid_parameter"
+    else:
+        decoded = decoder(payload)
+        message = decoded.request.messages[0]
+        assert (
+            message.tool_calls[0].call_id if field.endswith("call") else message.tool_call_id
+        ) == call_id

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -20,7 +20,7 @@ from exp.common.models.content import (
     MAXIMUM_IMAGE_BASE64_BYTES,
     MAXIMUM_VIDEO_BASE64_BYTES,
 )
-from exp.common.models.model import ReasoningEffort
+from exp.common.models.model import MAXIMUM_TOOL_CALL_ID_CHARACTERS, ReasoningEffort
 from exp.runtime.gateway.reasoning_carrier import MAXIMUM_REASONING_CARRIER_BYTES
 from exp.runtime.openai_protocol.cache_control import EphemeralCacheControl
 
@@ -242,7 +242,7 @@ class _AssistantToolCall(_WireModel):
     carried for the one wire that can honor it.
     """
 
-    id: str = Field(min_length=1, max_length=256)
+    id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     type: Literal["function"] = "function"
     function: _FunctionCall
     cache_control: EphemeralCacheControl | None = None
@@ -270,7 +270,9 @@ class _Message(_WireModel):
     role: Literal["system", "developer", "user", "assistant", "tool"]
     content: str | tuple[_ContentPart, ...] | None = None
     tool_calls: tuple[_AssistantToolCall, ...] | None = None
-    tool_call_id: str | None = Field(default=None, min_length=1, max_length=256)
+    tool_call_id: str | None = Field(
+        default=None, min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS
+    )
     name: str | None = Field(default=None, min_length=1, max_length=256)
     """Tool function name on a ``role: "tool"`` message.
 
@@ -634,7 +636,7 @@ class _ResponseFunctionCall(_WireModel):
 
     type: Literal["function_call"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
-    call_id: str = Field(min_length=1, max_length=256)
+    call_id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     name: str = Field(min_length=1, max_length=256)
     namespace: str | None = Field(default=None, min_length=1, max_length=256)
     caller: JsonObject | None = None
@@ -663,7 +665,7 @@ class _ResponseFunctionOutput(_WireModel):
     """
 
     type: Literal["function_call_output"]
-    call_id: str = Field(min_length=1, max_length=256)
+    call_id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     name: str | None = Field(default=None, min_length=1, max_length=256)
     namespace: str | None = Field(default=None, min_length=1, max_length=256)
     caller: JsonObject | None = None
@@ -796,7 +798,7 @@ class _CustomToolCall(_WireModel):
     type: Literal["custom_tool_call"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     status: _EchoedItemStatus | None = None
-    call_id: str = Field(min_length=1, max_length=256)
+    call_id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     name: str = Field(min_length=1, max_length=256)
     namespace: str | None = Field(default=None, min_length=1, max_length=256)
     caller: JsonObject | None = None
@@ -811,7 +813,7 @@ class _CustomToolCallOutput(_WireModel):
     type: Literal["custom_tool_call_output"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     status: _EchoedItemStatus | None = None
-    call_id: str = Field(min_length=1, max_length=256)
+    call_id: str = Field(min_length=1, max_length=MAXIMUM_TOOL_CALL_ID_CHARACTERS)
     output: JsonValue
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.40"
+version = "0.7.41"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.35,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.36,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.35"
+version = "0.3.36"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.40"
+version = "0.7.41"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Tool loops failed when an OpenAI-compatible upstream returned a tool ID carrying an opaque reasoning signature. The gateway accepted short IDs but rejected replay above 256 characters; the native stream accumulator independently rejected long IDs on output.

Raise the shared Python tool-ID limit and the native accumulator limit to 65,536 characters, preserving the complete ID without parsing, stripping, or rewriting signature suffixes. Apply the same bound to Chat/Responses call and result fields, canonical calls, stream events, and output guardrails. Empty and oversized IDs still fail validation. Output guardrails count the complete serialized completion, including tool IDs and names, so large IDs cannot bypass classifier payload limits. Provider-specific restrictions on other wire dialects are unchanged.

Includes release versions `experiential 0.7.41` and `exp-gateway-native 0.3.36`; Platform will need both published wheels before its follow-up pin can resolve. Do not merge or publish as part of this review request.

Validation:
- Reproduced the original decoder rejection before the fix, then reproduced the separate native output rejection with the new socket test.
- 191 focused tests pass, including a stock OpenAI SDK two-request loop over real sockets for both `~sig1:` and `_sig1_`, streaming and non-streaming output, plus length-bound and exact upstream replay checks.
- Full-repository Ruff, formatting, and ty checks pass.
- All 205 Rust tests and Clippy pass.
- All 143 guardrail and native tool-loop tests pass after the review fix, including exact-limit acceptance and one-byte-over rejection before classifier dispatch.
- Rebased onto the latest main, with cross-protocol regressions in their own package test module to avoid concurrent append conflicts; 306 protocol, guardrail, and native SDK socket tests pass on the rebased head.
- Full local non-live suite: 3,784 passed, 1 skipped (Python 3.12, xdist loadfile to preserve existing module-scoped scenario ordering).
- Current-head packaging CI passed, including all five native wheel targets and installed-wheel release evidence. All current-head CI checks pass, including the full gate and the 0.7.41 packaging run. Greptile is 5/5 on this head, and all review threads are resolved.

No customer payloads or signatures are committed. Tests use synthetic signatures. This is not a production deployment or verification of the customer's live upstream route.
