### PR TITLE
release: bump experiential to 0.7.40 (alert-bucket coercions)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.39"
+version = "0.7.40"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.39"
+version = "0.7.40"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump shipping #804 (forced `tool_choice` → `auto` with disclosure on the releases that reject it; Anthropic-unsupported strict schemas degrade with disclosure; `developer` → `system` on Chat wires; empty/whitespace text turns never reach the Anthropic wire). Native crate unchanged at 0.3.35 (Python-only). Cutting the GitHub Release for v0.7.40 after this merges publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)