### PR TITLE
release: bump experiential to 0.7.41 (native unchanged at 0.3.35)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.40"
+version = "0.7.41"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.40"
+version = "0.7.41"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Experiential-only release carrying #817 — tool/function/structured-format description bounds raised to the uniform 65,536 (matching the Messages surface and GatewayToolDefinition) with a self-explanatory over-limit 400 stating the limit and arriving length. This is the prod "omp" coding-agent wedge: an 8,292-char tool description 400d every agentic turn at the old 8,192 cap while api.openai.com serves 66,000+ (probed live).

v0.7.40 (tagged earlier today by another session) already carries #815 (reasoning_content replay degrade) and #804; #817 merged just after that cut, so it rides this bump. Python-only: `exp-gateway-native` stays 0.3.35. No other open gateway PRs (#818/#814/#801) are batched in — not ordered for this train.

After merge: GitHub release v0.7.41 (publish workflow ships wheels), then the platform pin PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)