### PR TITLE
gateway: emulate stop sequences on Responses rungs, name Anthropic server tools and the rejected field, refuse over-window prompts pre-dispatch (native 0.3.37)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -342,8 +342,28 @@ representation and drops it like summary deltas. Streaming emits the Anthropic
 lifecycle (`message_start`, `ping`, content blocks, `message_delta` with the mapped stop reason
 and usage, `message_stop`, or one terminal `error` event); the non-streaming body is the
 Anthropic message object. Completed streams stop with `end_turn` (`tool_use` when tool calls are
-present) and token-limited streams with `max_tokens`. The Anthropic protocol defines no
+present), token-limited streams with `max_tokens`, and a caller stop sequence that the gateway
+matched with `stop_sequence` plus the exact matched string. The Anthropic protocol defines no
 idempotency header, so this surface never joins the keyed replay stores.
+
+**Gateway-emulated stop sequences.** The OpenAI Responses API has no stop field, so a rung on
+that dialect admits `stop` / `stop_sequences` regardless of its catalog flag and the admitted
+route entry carries the caller's exact sequences instead of the payload. The native data plane
+cuts visible text at the first match (withholding only the shortest tail that could still start
+a sequence, so a match may span delta boundaries), discards what the model says afterwards,
+keeps draining lifecycle and usage events so settlement stays exact, and terminates the stream
+with a stop-sequence outcome: `finish_reason: stop` on Chat, `status: completed` on Responses,
+and `stop_reason: stop_sequence` on Messages. Reasoning, tool arguments, and refusals are never
+inspected. Rungs whose provider honours `stop` natively (Chat-compatible, Anthropic, Gemini,
+Bedrock) keep forwarding it on the wire.
+
+**Pre-dispatch context-window refusal.** Before any reservation or provider call, admission
+lower-bounds the prompt's token count from its UTF-8 text bytes (at six bytes per token, below
+what real tokenizers produce on prose, code, or CJK text; inline media is not counted) and
+refuses with `code: context_length_exceeded` and the exact numbers when even that lower bound
+exceeds the largest declared context window on the route. Anything under the bound dispatches
+and is left to the provider's precise count; output budgets are never refused here, a too-small
+ceiling is an `incomplete` answer.
 
 Exposure-gated reasoning rungs (Tencent Hunyuan, DeepSeek — rows the catalog stamps
 `reasoning_output_exposed`) return the model's plaintext `reasoning_content` on every non-tool

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.36"
+version = "0.3.37"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.36"
+version = "0.3.37"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.36"
+version = "0.3.37"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -378,7 +378,10 @@ impl ChatSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::Incomplete | Event::PausedTurn => {
+            Event::Completed
+            | Event::Incomplete
+            | Event::StoppedAtSequence(_)
+            | Event::PausedTurn => {
                 self.terminal = true;
                 let finish_reason = if matches!(event, Event::Incomplete) {
                     "length"
@@ -388,7 +391,9 @@ impl ChatSseEncoder {
                     "stop"
                 };
                 let mut frames = Vec::new();
-                if matches!(event, Event::Completed) && self.reasoning.candidate()?.is_some() {
+                if matches!(event, Event::Completed | Event::StoppedAtSequence(_))
+                    && self.reasoning.candidate()?.is_some()
+                {
                     let carrier = self.reasoning_content_carrier.as_ref().ok_or_else(|| {
                         invalid_provider_stream(
                             "Chat reasoning content was not sealed by the gateway authority.",
@@ -630,7 +635,10 @@ pub fn completed_chat_body_with_carrier(
         "refusal": if refusal.is_empty() { Value::Null } else { Value::String(refusal) },
         "tool_calls": if tool_calls.is_empty() { Value::Null } else { Value::Array(tool_calls) },
     });
-    if matches!(terminal, Event::Completed) && has_tool_calls && reasoning.is_some() {
+    if matches!(terminal, Event::Completed | Event::StoppedAtSequence(_))
+        && has_tool_calls
+        && reasoning.is_some()
+    {
         // A tool turn's reasoning round-trips as the sealed opaque carrier
         // (never raw plaintext — that would be a CoT-injection vector on the
         // way back in), so `reasoning_content` carries the carrier.

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -56,8 +56,19 @@ pub(super) fn stop_reason(terminal: &Event, saw_tool_use: bool) -> &'static str 
     match terminal {
         Event::Incomplete => "max_tokens",
         Event::PausedTurn => "pause_turn",
+        // A gateway-emulated stop cut the visible text: the caller's sequence
+        // ended the turn, exactly as Anthropic reports a native match.
+        Event::StoppedAtSequence(_) => "stop_sequence",
         _ if saw_tool_use => "tool_use",
         _ => "end_turn",
+    }
+}
+
+/// The matched stop sequence for the `stop_sequence` field, or null.
+pub(super) fn stop_sequence_value(terminal: &Event) -> Value {
+    match terminal {
+        Event::StoppedAtSequence(sequence) => Value::String(sequence.clone()),
+        _ => Value::Null,
     }
 }
 
@@ -390,7 +401,10 @@ impl MessagesSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::Incomplete | Event::PausedTurn => {
+            Event::Completed
+            | Event::Incomplete
+            | Event::StoppedAtSequence(_)
+            | Event::PausedTurn => {
                 self.terminal = true;
                 if self.refusal_seen {
                     return Ok(vec![error_frame(&refusal_failure())]);
@@ -403,7 +417,7 @@ impl MessagesSseEncoder {
                         "type": "message_delta",
                         "delta": {
                             "stop_reason": stop_reason(event, self.saw_tool_use),
-                            "stop_sequence": Value::Null,
+                            "stop_sequence": stop_sequence_value(event),
                         },
                         "usage": messages_usage(self.usage.as_ref()),
                     }),

--- a/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
@@ -237,7 +237,7 @@ pub fn completed_messages_body_with_ignored(
         "model": model,
         "content": content,
         "stop_reason": stop_reason(terminal, saw_tool_use),
-        "stop_sequence": Value::Null,
+        "stop_sequence": super::stop_sequence_value(terminal),
         "usage": messages_usage(usage.as_ref()),
     });
     super::disclose_ignored_parameters(&mut body, ignored_parameters);

--- a/exp/runtime/gateway/native/src/encode_responses.rs
+++ b/exp/runtime/gateway/native/src/encode_responses.rs
@@ -235,7 +235,9 @@ impl ResponsesSseEncoder {
                 }
                 Ok(Vec::new())
             }
-            Event::Completed | Event::PausedTurn => self.finish("completed", None),
+            Event::Completed | Event::StoppedAtSequence(_) | Event::PausedTurn => {
+                self.finish("completed", None)
+            }
             Event::Incomplete => self.finish("incomplete", None),
             Event::Failed(failure) => self.finish("failed", Some(failure)),
         }

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -306,6 +306,10 @@ pub enum Event {
     Usage(Usage),
     Completed,
     Incomplete,
+    /// The gateway cut the stream at one of the caller's stop sequences on a
+    /// wire that has no stop field (OpenAI Responses). Settles as completed;
+    /// the Messages encoder reports `stop_sequence` with this exact value.
+    StoppedAtSequence(String),
     /// Anthropic `pause_turn` terminal: the provider paused a long-running
     /// server-tool turn and expects the caller to resend the conversation to
     /// continue it. Settlement treats it like a completed turn; the Messages
@@ -318,7 +322,11 @@ impl Event {
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
-            Event::Completed | Event::Incomplete | Event::PausedTurn | Event::Failed(_)
+            Event::Completed
+                | Event::Incomplete
+                | Event::StoppedAtSequence(_)
+                | Event::PausedTurn
+                | Event::Failed(_)
         )
     }
 
@@ -609,7 +617,9 @@ pub fn simplified_event(event: &Event) -> Value {
             }
             payload
         }
-        Event::Completed => serde_json::json!({"kind": "completed"}),
+        // A stop-sequence cut is a completed turn to every python consumer
+        // (guardrails, retention); only the public encoders name the sequence.
+        Event::Completed | Event::StoppedAtSequence(_) => serde_json::json!({"kind": "completed"}),
         Event::Incomplete => serde_json::json!({"kind": "incomplete"}),
         Event::PausedTurn => serde_json::json!({"kind": "paused_turn"}),
         Event::Failed(failure) => serde_json::json!({

--- a/exp/runtime/gateway/native/src/guardrails.rs
+++ b/exp/runtime/gateway/native/src/guardrails.rs
@@ -107,7 +107,11 @@ pub fn apply_text_replacement(events: &[Event], replacement: &str) -> Vec<Event>
                 rewritten.push(Event::TextDelta(replacement.to_string()));
                 inserted = true;
             }
-            Event::Completed | Event::Incomplete | Event::PausedTurn | Event::Failed(_)
+            Event::Completed
+            | Event::Incomplete
+            | Event::StoppedAtSequence(_)
+            | Event::PausedTurn
+            | Event::Failed(_)
                 if !inserted =>
             {
                 rewritten.push(Event::TextDelta(replacement.to_string()));

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -32,6 +32,7 @@ mod route_responses_ws;
 mod server;
 mod settlement;
 mod sse;
+mod stop_sequences;
 mod upstream;
 mod waterfall;
 

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -16,6 +16,7 @@ use crate::dialects::{
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 use crate::metrics::METRICS;
+use crate::stop_sequences::StopSequenceGuard;
 use crate::waterfall::CommittedAttempt;
 
 /// Map one collection failure to its public error, honoring the shared
@@ -144,7 +145,13 @@ pub struct UpstreamRelay {
     stream: BoxStream<'static, reqwest::Result<Bytes>>,
     decoder: FrameDecoder,
     normalizer: Normalizer,
+    /// Normalized events not yet passed through the stop-sequence guard.
     pending: VecDeque<Event>,
+    /// Guarded events ready to yield.
+    ready: VecDeque<Event>,
+    /// Gateway-emulated stop sequences for this rung, when the provider wire
+    /// carries none; `None` passes every event straight through.
+    stop_guard: Option<StopSequenceGuard>,
     eof: bool,
     first_byte_recorded: bool,
     /// Fail-fast bound for the very first provider byte. Once the first byte
@@ -206,6 +213,8 @@ impl UpstreamRelay {
                 reasoning_content_route_sha256,
             ),
             pending: VecDeque::new(),
+            ready: VecDeque::new(),
+            stop_guard: None,
             eof: false,
             first_byte_recorded: false,
             first_byte_deadline,
@@ -218,6 +227,29 @@ impl UpstreamRelay {
     /// the winning attempt's time-to-first-token.
     pub fn first_token_at(&self) -> Option<SystemTime> {
         self.first_token_at
+    }
+
+    /// Enforce the caller's stop sequences on this relay's visible text.
+    /// Installed before the first event is yielded; an empty set is a no-op.
+    pub fn set_stop_sequences<I, S>(&mut self, sequences: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.stop_guard = StopSequenceGuard::new(sequences);
+    }
+
+    /// Move one normalized event through the stop-sequence guard (if any)
+    /// onto the ready queue.
+    fn guard_next_pending(&mut self) -> bool {
+        let Some(event) = self.pending.pop_front() else {
+            return false;
+        };
+        match self.stop_guard.as_mut() {
+            Some(guard) => self.ready.extend(guard.filter(event)),
+            None => self.ready.push_back(event),
+        }
+        true
     }
 
     /// Route an abnormal stream termination through the normalizer's recovery.
@@ -243,7 +275,7 @@ impl UpstreamRelay {
         request_started: Instant,
     ) -> Result<Option<Event>, Failure> {
         loop {
-            if let Some(event) = self.pending.pop_front() {
+            if let Some(event) = self.ready.pop_front() {
                 // Every yielded event exits here, so this is the one place that
                 // stamps time-to-first-token: the first event carrying visible
                 // model output. Prefix events peeked during commit also passed
@@ -253,6 +285,9 @@ impl UpstreamRelay {
                     self.first_token_at = Some(SystemTime::now());
                 }
                 return Ok(Some(event));
+            }
+            if self.guard_next_pending() {
+                continue;
             }
             if self.eof {
                 return Ok(None);
@@ -448,6 +483,69 @@ mod tests {
         assert!(
             relay.first_token_at().is_some(),
             "the first content delta stamps time-to-first-token"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_sequences_cut_the_relayed_text_and_keep_usage_and_settlement_exact() {
+        // A Chat-compatible stream stands in for any dialect: "</block>" spans
+        // two content deltas, more text follows it, then usage and the
+        // provider's own terminal arrive. The guard cuts at the match, drops
+        // the trailing text, still yields the usage, and replaces the terminal.
+        let frames = vec![
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"allow</bl\"}}]}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"ock>ignored\"}}]}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3}}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from(
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            )),
+            Ok::<_, reqwest::Error>(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let mut relay = UpstreamRelay::from_stream(
+            stream::iter(frames).boxed(),
+            Dialect::OpenAiCompatible,
+            Instant::now() + Duration::from_secs(5),
+        );
+        relay.set_stop_sequences(["</block>"]);
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let per_chunk = Duration::from_secs(5);
+        let mut events = Vec::new();
+        loop {
+            match relay.next_event(deadline, per_chunk, Instant::now()).await {
+                Ok(Some(event)) => {
+                    let terminal = event.is_terminal();
+                    events.push(event);
+                    if terminal {
+                        break;
+                    }
+                }
+                Ok(None) => panic!("the stream must end on a terminal"),
+                Err(failure) => panic!("unexpected failure: {failure:?}"),
+            }
+        }
+        let text: String = events
+            .iter()
+            .filter_map(|event| match event {
+                Event::TextDelta(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "allow", "text stops exactly before the sequence");
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, Event::Usage(usage) if usage.has_token_counts())),
+            "usage still reaches settlement after the cut"
+        );
+        assert!(
+            matches!(events.last(), Some(Event::StoppedAtSequence(sequence)) if sequence == "</block>"),
+            "the terminal names the matched sequence"
         );
     }
 

--- a/exp/runtime/gateway/native/src/responses_retention.rs
+++ b/exp/runtime/gateway/native/src/responses_retention.rs
@@ -201,7 +201,9 @@ impl ResponsesRetention {
                 self.hosted
                     .insert(*output_index, RetainedHostedItem { item: item.clone() });
             }
-            Event::Completed => self.finish_open_items(ProviderOutputItemStatus::Completed),
+            Event::Completed | Event::StoppedAtSequence(_) => {
+                self.finish_open_items(ProviderOutputItemStatus::Completed)
+            }
             Event::Incomplete | Event::Failed(_) => {
                 self.finish_open_items(ProviderOutputItemStatus::Incomplete);
             }

--- a/exp/runtime/gateway/native/src/stop_sequences.rs
+++ b/exp/runtime/gateway/native/src/stop_sequences.rs
@@ -1,0 +1,451 @@
+//! Gateway-emulated stop sequences.
+//!
+//! The OpenAI Responses API has no `stop` field, so a caller's stop sequences
+//! never reach that wire. Instead the admitted route entry carries the exact
+//! sequences and this guard applies them to the decoded event stream: visible
+//! text is cut at the first match, everything the model says afterwards is
+//! discarded, and the stream terminates with [`Event::StoppedAtSequence`] so
+//! the public encoders report the matched sequence the way a native provider
+//! would (`finish_reason: stop` on Chat, `stop_reason: stop_sequence` on
+//! Messages).
+//!
+//! A sequence may straddle delta boundaries, so the guard withholds the
+//! shortest tail of text that is still a proper prefix of some sequence and
+//! releases it once the next delta rules the match out. Only visible text is
+//! inspected: reasoning, tool arguments, and refusals pass through untouched.
+//! Nothing here logs request or completion text.
+
+use crate::events::Event;
+
+/// Which delta variant carried the withheld text, so it re-emits in kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TextShape {
+    Plain,
+    Provider { output_index: u32, item_id: String },
+}
+
+/// Stateful stop-sequence filter for one upstream relay.
+#[derive(Debug)]
+pub struct StopSequenceGuard {
+    sequences: Vec<String>,
+    /// Visible text not yet released: at most `max_len - 1` bytes, every one
+    /// of them the start of some sequence.
+    buffer: String,
+    shape: Option<TextShape>,
+    matched: Option<String>,
+}
+
+impl StopSequenceGuard {
+    /// Build a guard for the caller's sequences; `None` when there is nothing
+    /// to enforce, so the relay skips the filter entirely.
+    pub fn new<I, S>(sequences: I) -> Option<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let sequences: Vec<String> = sequences
+            .into_iter()
+            .map(Into::into)
+            .filter(|sequence| !sequence.is_empty())
+            .collect();
+        if sequences.is_empty() {
+            return None;
+        }
+        Some(Self {
+            sequences,
+            buffer: String::new(),
+            shape: None,
+            matched: None,
+        })
+    }
+
+    /// The sequence that ended the stream, once one has matched.
+    #[cfg(test)]
+    pub fn matched(&self) -> Option<&str> {
+        self.matched.as_deref()
+    }
+
+    /// Filter one decoded event into zero or more outward events.
+    pub fn filter(&mut self, event: Event) -> Vec<Event> {
+        if let Some(sequence) = self.matched.clone() {
+            return match event {
+                // Everything the model said after the match is discarded.
+                Event::TextDelta(_) | Event::ProviderTextDelta { .. } => Vec::new(),
+                // The model's own ending is irrelevant: the caller's stop
+                // sequence ended this turn. A provider failure still fails.
+                Event::Completed | Event::Incomplete | Event::PausedTurn => {
+                    vec![Event::StoppedAtSequence(sequence)]
+                }
+                other => vec![other],
+            };
+        }
+        match event {
+            Event::TextDelta(text) => self.push_text(TextShape::Plain, &text),
+            Event::ProviderTextDelta {
+                output_index,
+                item_id,
+                delta,
+            } => self.push_text(
+                TextShape::Provider {
+                    output_index,
+                    item_id,
+                },
+                &delta,
+            ),
+            // Item boundaries and terminals close the text they follow: the
+            // withheld tail can no longer complete a sequence across them, and
+            // a match held open for a longer candidate commits as it stands.
+            Event::ProviderOutputItemStarted { .. }
+            | Event::ProviderOutputItemCompleted { .. }
+            | Event::ToolCallStarted { .. }
+            | Event::ServerToolUseStarted { .. }
+            | Event::HostedToolItemStarted { .. }
+            | Event::Completed
+            | Event::Incomplete
+            | Event::PausedTurn
+            | Event::Failed(_) => {
+                let mut events = self.finish_text();
+                if let Some(sequence) = self.matched.clone() {
+                    events.push(match event {
+                        Event::Completed | Event::Incomplete | Event::PausedTurn => {
+                            Event::StoppedAtSequence(sequence)
+                        }
+                        other => other,
+                    });
+                } else {
+                    events.push(event);
+                }
+                events
+            }
+            other => vec![other],
+        }
+    }
+
+    fn push_text(&mut self, shape: TextShape, text: &str) -> Vec<Event> {
+        let mut events = Vec::new();
+        if self.shape.as_ref().is_some_and(|current| *current != shape) {
+            events.extend(self.flush());
+        }
+        self.shape = Some(shape);
+        self.buffer.push_str(text);
+        if let Some((index, sequence)) = self.earliest_match() {
+            if self.longer_match_still_possible(index, &sequence) {
+                // "ab" has matched but "abc" may still complete: release the
+                // text before the match and hold the rest, so the sequence
+                // reported never depends on where the provider split its
+                // deltas. A boundary or terminal resolves the hold.
+                if index > 0 {
+                    let released: String = self.buffer.drain(..index).collect();
+                    events.push(self.delta(released));
+                }
+                return events;
+            }
+            events.extend(self.commit_match(index, sequence));
+            return events;
+        }
+        let keep = self.pending_prefix_len();
+        let release_len = self.buffer.len() - keep;
+        if release_len > 0 {
+            let released: String = self.buffer.drain(..release_len).collect();
+            events.push(self.delta(released));
+        }
+        events
+    }
+
+    /// Whether some longer sequence could still match at `index` once more
+    /// text arrives: the buffer tail from `index` is a proper prefix of it.
+    fn longer_match_still_possible(&self, index: usize, matched: &str) -> bool {
+        let tail = &self.buffer[index..];
+        self.sequences.iter().any(|candidate| {
+            candidate.len() > matched.len()
+                && candidate.len() > tail.len()
+                && candidate.starts_with(tail)
+        })
+    }
+
+    /// Emit the visible text before `index`, record the match, and drop the
+    /// rest of the buffer.
+    fn commit_match(&mut self, index: usize, sequence: String) -> Vec<Event> {
+        let mut events = Vec::new();
+        let visible = self.buffer[..index].to_string();
+        if !visible.is_empty() {
+            events.push(self.delta(visible));
+        }
+        self.buffer.clear();
+        self.matched = Some(sequence);
+        events
+    }
+
+    /// Close the current text run at an item boundary or terminal: a held
+    /// match (kept open only for a longer candidate) commits now, otherwise
+    /// the withheld tail is released as text.
+    fn finish_text(&mut self) -> Vec<Event> {
+        if let Some((index, sequence)) = self.earliest_match() {
+            return self.commit_match(index, sequence);
+        }
+        self.flush()
+    }
+
+    /// Earliest sequence occurrence in the buffer: lowest index wins, then
+    /// the longest sequence starting there (a longer sequence is the more
+    /// specific stop the caller asked for).
+    fn earliest_match(&self) -> Option<(usize, String)> {
+        let mut best: Option<(usize, &str)> = None;
+        for sequence in &self.sequences {
+            if let Some(index) = self.buffer.find(sequence.as_str()) {
+                let better = match best {
+                    None => true,
+                    Some((best_index, best_sequence)) => {
+                        index < best_index
+                            || (index == best_index && sequence.len() > best_sequence.len())
+                    }
+                };
+                if better {
+                    best = Some((index, sequence.as_str()));
+                }
+            }
+        }
+        best.map(|(index, sequence)| (index, sequence.to_string()))
+    }
+
+    /// Length of the longest buffer tail that is a proper prefix of some
+    /// sequence, i.e. text that could still complete a match.
+    fn pending_prefix_len(&self) -> usize {
+        let mut keep = 0usize;
+        for sequence in &self.sequences {
+            let bound = sequence.len().min(self.buffer.len());
+            // Proper prefixes only: a full occurrence was already handled.
+            let mut length = if bound == sequence.len() {
+                bound - 1
+            } else {
+                bound
+            };
+            while length > 0 {
+                if sequence.is_char_boundary(length) && self.buffer.ends_with(&sequence[..length]) {
+                    keep = keep.max(length);
+                    break;
+                }
+                length -= 1;
+            }
+        }
+        keep
+    }
+
+    fn flush(&mut self) -> Vec<Event> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+        let text = std::mem::take(&mut self.buffer);
+        vec![self.delta(text)]
+    }
+
+    fn delta(&self, text: String) -> Event {
+        match &self.shape {
+            Some(TextShape::Provider {
+                output_index,
+                item_id,
+            }) => Event::ProviderTextDelta {
+                output_index: *output_index,
+                item_id: item_id.clone(),
+                delta: text,
+            },
+            _ => Event::TextDelta(text),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::simplified_event;
+
+    fn text(events: &[Event]) -> String {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                Event::TextDelta(text) => Some(text.as_str()),
+                Event::ProviderTextDelta { delta, .. } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn stopped_at(event: Option<&Event>, expected: &str) -> bool {
+        matches!(event, Some(Event::StoppedAtSequence(sequence)) if sequence == expected)
+    }
+
+    fn run(sequences: &[&str], deltas: &[&str], terminal: Event) -> Vec<Event> {
+        let mut guard = StopSequenceGuard::new(sequences.iter().copied()).expect("sequences");
+        let mut out = Vec::new();
+        for delta in deltas {
+            out.extend(guard.filter(Event::TextDelta((*delta).to_string())));
+        }
+        out.extend(guard.filter(terminal));
+        out
+    }
+
+    #[test]
+    fn empty_or_blank_sequences_build_no_guard() {
+        assert!(StopSequenceGuard::new(Vec::<String>::new()).is_none());
+        assert!(StopSequenceGuard::new(["", ""]).is_none());
+        assert!(StopSequenceGuard::new(["", "END"]).is_some());
+    }
+
+    #[test]
+    fn a_match_inside_one_delta_cuts_the_text_and_ends_with_the_sequence() {
+        let out = run(
+            &["</severity>"],
+            &["<severity>high</severity>trailing"],
+            Event::Completed,
+        );
+        assert_eq!(text(&out), "<severity>high");
+        assert!(stopped_at(out.last(), "</severity>"));
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn a_match_spanning_delta_boundaries_is_withheld_until_it_resolves() {
+        let out = run(
+            &["</block>"],
+            &["allow</bl", "ock>ignored", " more"],
+            Event::Incomplete,
+        );
+        assert_eq!(text(&out), "allow");
+        // The provider's own max-tokens ending is superseded by the stop.
+        assert!(stopped_at(out.last(), "</block>"));
+    }
+
+    #[test]
+    fn a_false_prefix_is_released_once_the_next_delta_rules_it_out() {
+        let out = run(&["</block>"], &["a</b", "x", "c"], Event::Completed);
+        assert_eq!(text(&out), "a</bxc");
+        assert!(matches!(out.last(), Some(Event::Completed)));
+    }
+
+    #[test]
+    fn a_pending_prefix_at_the_terminal_is_flushed_before_it() {
+        let out = run(&["DONE"], &["work DO"], Event::Completed);
+        let kinds: Vec<_> = out.iter().map(simplified_event).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                simplified_event(&Event::TextDelta("work ".to_string())),
+                simplified_event(&Event::TextDelta("DO".to_string())),
+                simplified_event(&Event::Completed),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_earliest_sequence_wins_and_the_longer_one_breaks_ties() {
+        let out = run(&["ab", "abc", "zzz"], &["xxabcd"], Event::Completed);
+        assert_eq!(text(&out), "xx");
+        assert!(stopped_at(out.last(), "abc"));
+    }
+
+    #[test]
+    fn overlapping_sequences_resolve_the_same_regardless_of_chunking() {
+        // "ab" then "c" in separate deltas must still report "abc", exactly as
+        // "abc" in one delta does: providers control delta boundaries, the
+        // caller's stop semantics must not.
+        let split = run(&["ab", "abc"], &["xxab", "cd"], Event::Completed);
+        let whole = run(&["ab", "abc"], &["xxabcd"], Event::Completed);
+        assert_eq!(text(&split), "xx");
+        assert_eq!(text(&whole), "xx");
+        assert!(stopped_at(split.last(), "abc"));
+        assert!(stopped_at(whole.last(), "abc"));
+        // The text before the held match is released immediately, not at the end.
+        let mut guard = StopSequenceGuard::new(["ab", "abc"]).expect("sequences");
+        let out = guard.filter(Event::TextDelta("xxab".to_string()));
+        assert_eq!(text(&out), "xx");
+        assert!(
+            guard.matched().is_none(),
+            "the shorter match is held for the longer one"
+        );
+        // A different continuation commits the shorter sequence.
+        let out = guard.filter(Event::TextDelta("z".to_string()));
+        assert!(out.is_empty());
+        assert_eq!(guard.matched(), Some("ab"));
+    }
+
+    #[test]
+    fn a_held_shorter_match_commits_at_the_terminal() {
+        let out = run(&["ab", "abc"], &["xxab"], Event::Completed);
+        assert_eq!(text(&out), "xx");
+        assert!(stopped_at(out.last(), "ab"));
+        let out = run(&["ab", "abc"], &["xxab"], Event::Incomplete);
+        assert!(stopped_at(out.last(), "ab"));
+    }
+
+    #[test]
+    fn provider_text_deltas_re_emit_with_their_item_identity() {
+        let mut guard = StopSequenceGuard::new(["END"]).expect("sequences");
+        let out = guard.filter(Event::ProviderTextDelta {
+            output_index: 1,
+            item_id: "msg_1".to_string(),
+            delta: "hello E".to_string(),
+        });
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            &out[0],
+            Event::ProviderTextDelta { output_index: 1, item_id, delta }
+                if item_id == "msg_1" && delta == "hello "
+        ));
+        let out = guard.filter(Event::ProviderTextDelta {
+            output_index: 1,
+            item_id: "msg_1".to_string(),
+            delta: "NDafter".to_string(),
+        });
+        assert!(out.is_empty());
+        assert_eq!(guard.matched(), Some("END"));
+        // Lifecycle and usage events after the match still flow; text does not.
+        let out = guard.filter(Event::Usage(crate::events::Usage::default()));
+        assert!(matches!(out.as_slice(), [Event::Usage(_)]));
+        assert!(guard
+            .filter(Event::TextDelta("late".to_string()))
+            .is_empty());
+        let out = guard.filter(Event::Completed);
+        assert_eq!(out.len(), 1);
+        assert!(stopped_at(out.first(), "END"));
+    }
+
+    #[test]
+    fn a_provider_failure_after_the_match_still_fails() {
+        let mut guard = StopSequenceGuard::new(["END"]).expect("sequences");
+        guard.filter(Event::TextDelta("xEND".to_string()));
+        let failure = crate::errors::Failure::new(
+            crate::errors::FailureClass::Transport,
+            "provider transport failed; retry the request",
+        );
+        let out = guard.filter(Event::Failed(failure));
+        assert!(matches!(out.as_slice(), [Event::Failed(_)]));
+    }
+
+    #[test]
+    fn multibyte_text_never_splits_a_character() {
+        let out = run(&["—end"], &["héllo —e", "nd tail"], Event::Completed);
+        assert_eq!(text(&out), "héllo ");
+        assert!(stopped_at(out.last(), "—end"));
+        let out = run(&["—end"], &["héllo —", "x"], Event::Completed);
+        assert_eq!(text(&out), "héllo —x");
+    }
+
+    #[test]
+    fn non_text_events_pass_through_and_item_boundaries_flush_the_tail() {
+        let mut guard = StopSequenceGuard::new(["END"]).expect("sequences");
+        let out = guard.filter(Event::TextDelta("keep E".to_string()));
+        assert_eq!(text(&out), "keep ");
+        let out = guard.filter(Event::ProviderOutputItemCompleted {
+            output_index: 0,
+            item_id: None,
+            kind: crate::events::ProviderOutputItemKind::Message,
+            status: None,
+            phase: None,
+        });
+        assert_eq!(text(&out), "E");
+        assert!(matches!(
+            out.last(),
+            Some(Event::ProviderOutputItemCompleted { .. })
+        ));
+    }
+}

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -79,6 +79,12 @@ pub struct DeploymentWire {
     /// stripped. Defaults false so every other provider is unchanged.
     #[serde(default)]
     pub reasoning_output_exposed: bool,
+    /// Caller stop sequences the data plane enforces on this rung's stream
+    /// because the provider wire has no stop field (OpenAI Responses). The
+    /// relay cuts visible text at the first match and terminates with
+    /// `Event::StoppedAtSequence`. Empty when the payload carries `stop`.
+    #[serde(default)]
+    pub stop_sequences: Vec<String>,
     pub idempotency_key: String,
     /// Deployment override for the flat first-byte allowance; the serving
     /// configuration's default applies when absent.
@@ -550,6 +556,7 @@ async fn run_attempt(
         ),
         None => UpstreamRelay::new(response, dialect, first_byte_deadline),
     };
+    relay.set_stop_sequences(wire.stop_sequences.iter().cloned());
     let mut usage: Option<Usage> = None;
     let mut tool_names: Vec<String> = Vec::new();
     let mut withheld: Vec<Event> = Vec::new();
@@ -727,6 +734,7 @@ mod tests {
             fireworks_reasoning_route_sha256: None,
             hunyuan_reasoning_route_sha256: None,
             reasoning_output_exposed: false,
+            stop_sequences: Vec::new(),
             idempotency_key: "op".to_string(),
             time_to_first_byte_base_seconds: base,
             time_to_first_byte_seconds_per_million_input_tokens: slope,

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -27,8 +27,12 @@ from exp.runtime.gateway.native_execution import (
 )
 from exp.runtime.gateway.native_responses import ContinuationContext
 from exp.runtime.gateway.prompt_cache_affinity import provider_prompt_cache_key
+from exp.runtime.gateway.prompt_size import require_prompt_fits_context_window
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
-from exp.runtime.models.providers import preflight_gateway_request
+from exp.runtime.models.providers import (
+    emulated_gateway_capabilities,
+    preflight_gateway_request,
+)
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.capability_policy import (
     coerce_generation_parameters,
@@ -119,6 +123,11 @@ def admitted_route_requests(
     # OTHER tier (auto/default carry no price; scale and any future value) is
     # never rejected here — a non-billable candidate simply strips it at payload
     # build (billing-safe, disclosed), so only the opt-in priced tiers gate.
+    # A prompt that cannot fit any rung's context window is refused HERE, before
+    # a reservation or a provider call: the provider would only 400 it back
+    # (charging nothing but costing a round trip and an opaque message).
+    require_prompt_fits_context_window(route, request)
+
     if request.service_tier in ("flex", "priority"):
         tier = request.service_tier
         if not any(profile.forwards_tier(tier) for profile, _client in resolved_wires):
@@ -413,6 +422,7 @@ def protocol_compatible_indexes(
                 model_capabilities=deployment.capabilities,
                 public_stream=public_stream,
                 route_provider=deployment.provider,
+                emulated_capabilities=emulated_gateway_capabilities(profile.dialect),
             )
             dialect_stream_payload(profile, provider_request)
         except (ProviderParameterError, ProviderCapabilityError) as exc:

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -20,6 +20,7 @@ from exp.common.models.content import (
     VideoContentPart,
 )
 from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.common.models.model import ModelCapabilities
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     DirectTarget,
@@ -38,6 +39,7 @@ from exp.runtime.gateway.native_admission import (
     route_rejection,
 )
 from exp.runtime.gateway.native_dispatch import NativeWireClient
+from exp.runtime.gateway.prompt_size import MAXIMUM_BYTES_PER_TOKEN
 from exp.runtime.gateway.routing import GatewayRoute
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderCapabilityError, ProviderParameterError
@@ -1219,3 +1221,35 @@ def test_an_open_strict_schema_is_closed_for_the_anthropic_rung_with_disclosure(
     assert provider.tools[0].parameters == {**open_schema, "additionalProperties": False}
     assert public.ignored_parameters == ("tools.parameters.additionalProperties->false",)
     assert accounting.recorded == 1
+
+
+def test_a_prompt_certain_to_overflow_the_route_is_refused_before_shaping() -> None:
+    """The context-window refusal runs first: no rung shaping, no accounting, exact numbers."""
+    deployments = (
+        _deployment("shim").model_copy(
+            update={"capabilities": ModelCapabilities(context_window_tokens=100)}
+        ),
+        _deployment("native").model_copy(
+            update={"capabilities": ModelCapabilities(context_window_tokens=200)}
+        ),
+    )
+    route = _mixed_route("maximize_availability", deployments)
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="x" * (201 * MAXIMUM_BYTES_PER_TOKEN)),),
+    )
+
+    with pytest.raises(ProviderParameterError) as caught:
+        admitted_route_requests(
+            route,
+            _wires(),
+            request,
+            # Never reached: the refusal precedes every coercion or reservation.
+            accounting=cast(NativeAttemptAccounting, object()),
+            authorization=route.snapshot.authorization,
+        )
+
+    assert caught.value.code == "context_length_exceeded"
+    assert caught.value.param == "messages"
+    assert "at least 201 tokens" in str(caught.value)
+    assert "200 tokens" in str(caught.value)

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -58,6 +58,9 @@ from exp.runtime.gateway.native_bridge_errors import (
     escalation as _escalation,
 )
 from exp.runtime.gateway.native_bridge_errors import (
+    ledger_capability_message,
+)
+from exp.runtime.gateway.native_bridge_errors import (
     public_capability_error as _public_capability_error,
 )
 from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
@@ -112,6 +115,8 @@ from exp.runtime.gateway.reasoning_carrier import (
 )
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
 from exp.runtime.models.providers import (
+    emulated_gateway_capabilities,
+    emulated_stop_sequences,
     preflight_gateway_request,
     require_gateway_provider,
 )
@@ -532,6 +537,7 @@ class NativeControlPlane(
                     model_capabilities=deployment.capabilities,
                     public_stream=public_request.stream,
                     route_provider=deployment.provider,
+                    emulated_capabilities=emulated_gateway_capabilities(profile.dialect),
                 )
                 upstream_payload = dialect_stream_payload(profile, provider_request)
                 upstream_body, dispatch_signer = frozen_dispatch(profile, client, upstream_payload)
@@ -548,6 +554,7 @@ class NativeControlPlane(
                         upstream_payload,
                         upstream_body,
                         headers=request_headers,
+                        stop_sequences=emulated_stop_sequences(profile.dialect, provider_request),
                     )
                 )
                 signers.append(dispatch_signer)
@@ -591,18 +598,29 @@ class NativeControlPlane(
             # capability path names the capability, so a triager sees which
             # request feature the route cannot preserve.
             failure = normalized_provider_failure(exc)
-            self._accounting.finish_request_quietly(authorization, failure)
-            public_error = (
-                _public_capability_error(
+            if isinstance(exc, ProviderCapabilityError):
+                public_error = _public_capability_error(
                     exc,
                     provider_request.surface,
                     public_stream=public_request.stream,
                     public_tools=bool(public_request.tools),
                     developer_messages_param=decoded.developer_messages_param,
                 )
-                if isinstance(exc, ProviderCapabilityError)
-                else public_failure_error(failure, param=exc.param)
-            )
+                # The ledger keeps the capability-free generic sentence, but a
+                # bare "cannot preserve a requested capability" is untriageable
+                # from an alert. Append the PUBLIC field the caller was told
+                # about (never the internal literal), so operators read
+                # "(field: stop)" without opening the request.
+                failure = failure.model_copy(
+                    update={
+                        "safe_message": ledger_capability_message(
+                            failure.safe_message, public_error.detail.param
+                        )
+                    }
+                )
+            else:
+                public_error = public_failure_error(failure, param=exc.param)
+            self._accounting.finish_request_quietly(authorization, failure)
             raise NativeBridgeError(public_error) from exc
         except GatewayRoutingError as exc:
             # A route/catalog that cannot be built during a rolling deploy is a

--- a/exp/runtime/gateway/native_bridge_errors.py
+++ b/exp/runtime/gateway/native_bridge_errors.py
@@ -185,3 +185,18 @@ def public_capability_error(
 def escalation(reason: str) -> str:
     """Return a content-free native admission escalation disposition."""
     return json.dumps({"escalate": reason}, separators=(",", ":"))
+
+
+def ledger_capability_message(safe_message: str, public_param: str | None) -> str:
+    """Suffix the public request field onto the ledger's generic capability sentence.
+
+    Args:
+        safe_message: The provider-neutral capability rejection text.
+        public_param: The caller-facing field the public 400 named, if any.
+
+    Returns:
+        The ledger message, with ``(field: <param>)`` appended when known.
+    """
+    if not public_param:
+        return safe_message
+    return f"{safe_message} (field: {public_param})"

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -4621,9 +4621,24 @@ def test_keyed_reasoning_content_joins_replay_identity(tmp_path: Path) -> None:
     assert json.loads(repeated.value.public_error_json)["code"] != "idempotency_conflict"
 
 
-def test_capability_rejection_names_the_public_request_field(tmp_path: Path) -> None:
-    """A pre-dispatch capability rejection names the exact public field."""
+def test_capability_rejection_names_the_public_request_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-dispatch capability rejection names the exact public field.
+
+    Both the caller's 400 and the ledger row name it: an alert that only
+    read "cannot preserve a requested capability" could not be triaged
+    without opening the request.
+    """
     control, raw_key = _control_plane(tmp_path)
+    recorded: list[GatewayFailure] = []
+    original_finish = control._accounting.finish_request_quietly  # noqa: SLF001
+
+    def _capture_finish(authorization: AuthorizationSnapshot, failure: GatewayFailure) -> None:
+        recorded.append(failure)
+        return original_finish(authorization, failure)
+
+    monkeypatch.setattr(control._accounting, "finish_request_quietly", _capture_finish)  # noqa: SLF001
     body = json.dumps(
         {
             "model": "coding",
@@ -4647,6 +4662,12 @@ def test_capability_rejection_names_the_public_request_field(tmp_path: Path) -> 
     assert "'input.0.role'" in payload["message"]
     assert "developer_messages" not in payload["message"]
     assert "canary" not in json.dumps(payload)
+    assert recorded, "the rejection records a durable failure"
+    ledger = recorded[-1]
+    assert ledger.failure_class == GatewayFailureClass.UNSUPPORTED_CAPABILITY
+    assert ledger.safe_message.endswith("(field: input.0.role)")
+    assert "developer_messages" not in ledger.safe_message
+    assert "canary" not in ledger.safe_message
 
 
 def test_reasoning_context_reflects_in_the_envelope_only_when_sent() -> None:

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -12,7 +12,7 @@ boundary encoding; this module owns the frozen semantics.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -545,6 +545,7 @@ def deployment_wire_entry(
     upstream_payload: JsonObject,
     upstream_body: str | None = None,
     headers: dict[str, str] | None = None,
+    stop_sequences: Sequence[str] = (),
 ) -> JsonObject:
     """Build one deployment's wire configuration for the admitted route.
 
@@ -562,6 +563,9 @@ def deployment_wire_entry(
         headers: Optional per-request headers overriding the profile's
             static wire headers (a beta token joining exactly the requests
             that carry its gated field).
+        stop_sequences: Caller stop sequences the data plane must enforce on
+            this rung's stream because the provider wire has no stop field
+            (OpenAI Responses). Empty when the provider honours them itself.
 
     Returns:
         The JSON-compatible wire entry consumed by the data plane.
@@ -580,6 +584,10 @@ def deployment_wire_entry(
         "fireworks_reasoning_route_sha256": profile.fireworks_reasoning_route_sha256,
         "hunyuan_reasoning_route_sha256": profile.hunyuan_reasoning_route_sha256,
         "reasoning_output_exposed": profile.reasoning_output_exposed,
+        # Gateway-emulated stop sequences: the stream is cut at the first
+        # match and terminates with a stop-sequence reason. Empty for rungs
+        # whose payload already carries the caller's stop field.
+        "stop_sequences": list(stop_sequences),
         "idempotency_key": deployment_operation_key(route, deployment),
         # First-byte allowance overrides; the data plane falls back to its
         # serving defaults when a deployment declares nothing.

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -20,10 +20,12 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 from exp.runtime.gateway.native_execution import (
     claim_route_from,
+    deployment_wire_entry,
     next_route_candidate,
     select_route_deployments,
 )
 from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.models.providers.base import GatewayWireProfile
 
 _KEYS: tuple[DeploymentHealthKey, ...] = (
     ("catalog" + "0" * 57, "deployment-a", "connection-a"),
@@ -464,7 +466,6 @@ def test_reasoning_wire_contract_conflict_excludes_the_alias(
     from exp.runtime.gateway.lifecycle import load_gateway_components
     from exp.runtime.gateway.lifecycle_test import _configured_gateway
     from exp.runtime.gateway.native_execution import native_serving_blockers
-    from exp.runtime.models.providers.base import GatewayWireProfile
     from exp.runtime.models.providers.gemini import GeminiClient
 
     original_wire_profile = GeminiClient.gateway_wire_profile
@@ -602,3 +603,22 @@ def test_cache_marker_predicate_sees_every_marker_carrier() -> None:
         ),
     )
     assert request_carries_cache_markers(request(messages=(marked_call,)))
+
+
+def test_wire_entry_carries_emulated_stop_sequences_for_the_data_plane() -> None:
+    """A Responses rung's entry names the caller's exact stop sequences; others carry none."""
+    route = _route()
+    profile = GatewayWireProfile(dialect="openai_responses", url="https://provider.test")
+
+    entry = deployment_wire_entry(
+        route,
+        route.deployment,
+        profile,
+        {"model": "gpt-5.6-luna"},
+        stop_sequences=("</severity>", "</block>"),
+    )
+    assert entry["stop_sequences"] == ["</severity>", "</block>"]
+    assert entry["dialect"] == "openai_responses"
+
+    default = deployment_wire_entry(route, route.deployment, profile, {"model": "gpt-5.6-luna"})
+    assert default["stop_sequences"] == []

--- a/exp/runtime/gateway/prompt_size.py
+++ b/exp/runtime/gateway/prompt_size.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""Pre-dispatch context-window check for the prompt itself.
+
+A prompt that cannot fit any rung's context window is doomed before dispatch:
+the provider only 400s it back, after a reservation, a round trip, and with a
+provider-specific message. The gateway has no tokenizer for every model, so it
+never guesses the exact count. It bounds it from BELOW: at
+:data:`MAXIMUM_BYTES_PER_TOKEN` bytes of UTF-8 text per token, real tokenizers
+on prose, code, or CJK text all produce MORE tokens than this estimate, so a
+prompt whose lower bound already exceeds the largest window on the route is
+certain to fail and is refused here with the exact numbers. The bound is a
+documented heuristic, not a tokenizer proof, so it is deliberately loose and
+the check abstains whenever any rung leaves its window undeclared. A prompt
+under the bound is dispatched and left to the provider's precise count; output
+budgets are never inspected (a too-small ceiling is an ``incomplete`` answer,
+not a refusal).
+
+Only text is counted. Inline media (images, audio, documents) tokenizes by its
+own rules and is left to the provider.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from exp.common.models.content import TextContentPart
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayRequest
+from exp.runtime.models.providers.errors import ProviderParameterError
+
+if TYPE_CHECKING:
+    from exp.runtime.gateway.routing import GatewayRoute
+
+# Conservative UTF-8 bytes per token. English prose runs near 4, code near
+# 3.5, CJK near 1.5 to 4.5, and even indentation-heavy code stays well under
+# this, so the estimate is a lower bound in practice. It is a heuristic, not a
+# tokenizer proof: only text dominated by very long whitespace runs could
+# approach it, which is why the margin is twice typical prose rather than the
+# tight 5 or 6 a precise count would allow.
+MAXIMUM_BYTES_PER_TOKEN = 8
+
+CONTEXT_LENGTH_EXCEEDED_CODE = "context_length_exceeded"
+
+
+def prompt_text_bytes(request: GatewayRequest) -> int:
+    """Count the UTF-8 bytes of every text the model will read.
+
+    Args:
+        request: Canonical gateway request.
+
+    Returns:
+        Bytes across message text, tool-call arguments, echoed provider items,
+        and tool definitions. Inline media parts contribute nothing.
+    """
+    total = 0
+    for message in request.messages:
+        if message.content is not None:
+            # ``content`` already joins every text part (the decoders mirror
+            # text parts into it), so parts are only read when it is absent.
+            total += len(message.content.encode("utf-8"))
+        else:
+            for part in message.content_parts:
+                if isinstance(part, TextContentPart):
+                    total += len(part.text.encode("utf-8"))
+        for call in message.tool_calls:
+            total += len(call.name.encode("utf-8"))
+            arguments = (
+                call.raw_arguments
+                if call.raw_arguments is not None
+                else json.dumps(call.arguments, separators=(",", ":"))
+            )
+            total += len(arguments.encode("utf-8"))
+        for verbatim in (message.provider_native_item, message.provider_anthropic_block):
+            if verbatim is not None:
+                total += len(json.dumps(verbatim, separators=(",", ":")).encode("utf-8"))
+    for tool in request.tools:
+        total += len(tool.name.encode("utf-8"))
+        if tool.description:
+            total += len(tool.description.encode("utf-8"))
+        total += len(json.dumps(tool.parameters, separators=(",", ":")).encode("utf-8"))
+    for entry in request.provider_server_tools:
+        total += len(json.dumps(entry, separators=(",", ":")).encode("utf-8"))
+    return total
+
+
+def minimum_prompt_tokens(request: GatewayRequest) -> int:
+    """Lower-bound the prompt's token count from its text bytes.
+
+    Args:
+        request: Canonical gateway request.
+
+    Returns:
+        The fewest tokens any realistic tokenizer produces for this text.
+    """
+    return prompt_text_bytes(request) // MAXIMUM_BYTES_PER_TOKEN
+
+
+def require_prompt_fits_context_window(route: GatewayRoute, request: GatewayRequest) -> None:
+    """Refuse a prompt that is certain to exceed every rung's context window.
+
+    Args:
+        route: Resolved ordered route. A rung without a declared window is
+            permissive (it may accept anything), so the check abstains unless
+            EVERY rung declares one; refusing is only ever certain then.
+        request: Canonical request about to be shaped and dispatched.
+
+    Raises:
+        ProviderParameterError: The prompt's lower-bound token count exceeds
+            the largest declared context window on the route
+            (``code='context_length_exceeded'``).
+    """
+    windows: list[int] = []
+    for deployment in route.deployments:
+        window = (
+            None
+            if deployment.capabilities is None
+            else deployment.capabilities.context_window_tokens
+        )
+        if window is None:
+            return
+        windows.append(window)
+    if not windows:
+        return
+    largest = max(windows)
+    text_bytes = prompt_text_bytes(request)
+    minimum = text_bytes // MAXIMUM_BYTES_PER_TOKEN
+    if minimum <= largest:
+        return
+    param = "input" if request.surface == GatewayApiSurface.RESPONSES else "messages"
+    raise ProviderParameterError(
+        message=(
+            f"The prompt is at least {minimum:,} tokens ({text_bytes:,} bytes of text), "
+            f"but the largest context window on this model route is {largest:,} tokens. "
+            "Shorten the conversation or choose a model with a larger context window."
+        ),
+        param=param,
+        code=CONTEXT_LENGTH_EXCEEDED_CODE,
+    )

--- a/exp/runtime/gateway/prompt_size_test.py
+++ b/exp/runtime/gateway/prompt_size_test.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""Tests for the pre-dispatch context-window refusal."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from exp.common.models.content import ImageContentPart, TextContentPart
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.common.models.model import ModelCapabilities, ToolCall
+from exp.runtime.gateway.contracts import (
+    AuthorizationSnapshot,
+    DirectTarget,
+    ExecutionSnapshot,
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayToolDefinition,
+)
+from exp.runtime.gateway.prompt_size import (
+    MAXIMUM_BYTES_PER_TOKEN,
+    minimum_prompt_tokens,
+    prompt_text_bytes,
+    require_prompt_fits_context_window,
+)
+from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.models.providers.errors import ProviderParameterError
+
+
+def _deployment(deployment_id: str, context_window_tokens: int | None) -> ExactModelDeployment:
+    return ExactModelDeployment(
+        deployment_id=deployment_id,
+        source_alias=deployment_id,
+        exact_model_id="exact-one",
+        connection=f"connection-{deployment_id}",
+        provider="openai",
+        provider_model="provider-model",
+        connection_sha256="b" * 64,
+        capabilities_sha256="c" * 64,
+        capabilities=(
+            None
+            if context_window_tokens is None
+            else ModelCapabilities(context_window_tokens=context_window_tokens)
+        ),
+    )
+
+
+def _route(*deployments: ExactModelDeployment) -> GatewayRoute:
+    authorization = AuthorizationSnapshot(
+        request_id="request-one",
+        organization_id="organization-one",
+        identity_id="identity-one",
+        virtual_key_id="key-one",
+        alias="public-model",
+        alias_revision_id="revision-one",
+        target=DirectTarget(pool_id="pool-one"),
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        catalog_sha256="a" * 64,
+        canonical_request_sha256="d" * 64,
+        deadline_monotonic=1.0,
+    )
+    return GatewayRoute(
+        snapshot=ExecutionSnapshot(
+            authorization=authorization,
+            exact_model_id="exact-one",
+            pool_id="pool-one",
+            deployment_ids=tuple(item.deployment_id for item in deployments),
+            failover_mode="maximize_availability",
+        ),
+        deployment=deployments[0],
+        fallback_deployments=deployments[1:],
+        route_reason="direct",
+    )
+
+
+def _request(
+    text: str, surface: GatewayApiSurface = GatewayApiSurface.CHAT_COMPLETIONS
+) -> GatewayRequest:
+    return GatewayRequest(surface=surface, messages=(GatewayMessage(role="user", content=text),))
+
+
+def test_text_bytes_count_every_text_the_model_reads_and_no_media() -> None:
+    """Message text, tool calls, and tool schemas count once each; inline images do not."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="system", content="sys"),
+            GatewayMessage(
+                role="user",
+                # The decoders mirror text parts into ``content``; it is counted once.
+                content="héllo",
+                content_parts=(
+                    TextContentPart(text="héllo"),
+                    ImageContentPart(
+                        media_type="image/png",
+                        data=base64.b64encode(b"\x89PNG" * 100).decode("ascii"),
+                    ),
+                ),
+            ),
+            GatewayMessage(
+                role="assistant",
+                content=None,
+                tool_calls=(ToolCall(call_id="call_1", name="lookup", arguments={"q": "x"}),),
+            ),
+        ),
+        tools=(
+            GatewayToolDefinition(name="lookup", description="d", parameters={"type": "object"}),
+        ),
+    )
+    expected = (
+        len(b"sys")
+        + len("héllo".encode())
+        + len(b"lookup")
+        + len(b'{"q":"x"}')
+        + len(b"lookup")
+        + len(b"d")
+        + len(b'{"type":"object"}')
+    )
+    assert prompt_text_bytes(request) == expected
+    assert minimum_prompt_tokens(request) == expected // MAXIMUM_BYTES_PER_TOKEN
+
+
+def test_raw_tool_arguments_are_counted_verbatim_when_present() -> None:
+    """A provider's exact argument text outranks the parsed object for byte counting."""
+    call = ToolCall(call_id="call_1", name="f", arguments={"a": 1}, raw_arguments='{"a":   1}')
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="assistant", content=None, tool_calls=(call,)),),
+    )
+    assert prompt_text_bytes(request) == len(b"f") + len(b'{"a":   1}')
+
+
+def test_a_prompt_certain_to_overflow_every_window_is_refused_with_the_numbers() -> None:
+    """The lower bound exceeds the largest window: refuse before dispatch, naming both numbers."""
+    route = _route(_deployment("small", 1_000), _deployment("large", 2_000))
+    # 2,001 tokens even at the most generous bytes-per-token; certain to fail on both rungs.
+    request = _request("x" * (2_001 * MAXIMUM_BYTES_PER_TOKEN))
+
+    with pytest.raises(ProviderParameterError) as caught:
+        require_prompt_fits_context_window(route, request)
+
+    assert caught.value.code == "context_length_exceeded"
+    assert caught.value.param == "messages"
+    assert "at least 2,001 tokens" in str(caught.value)
+    assert "largest context window on this model route is 2,000 tokens" in str(caught.value)
+
+
+def test_a_prompt_that_might_fit_the_largest_window_dispatches() -> None:
+    """Only certainty refuses: a prompt over the small rung but under the large one goes through."""
+    route = _route(_deployment("small", 1_000), _deployment("large", 2_000))
+    require_prompt_fits_context_window(route, _request("x" * (1_500 * MAXIMUM_BYTES_PER_TOKEN)))
+    # Exactly at the bound is not over it.
+    require_prompt_fits_context_window(route, _request("x" * (2_000 * MAXIMUM_BYTES_PER_TOKEN)))
+
+
+def test_routes_without_a_declared_window_never_refuse() -> None:
+    """No declaration means no bound: the provider's own count decides."""
+    route = _route(_deployment("unknown", None))
+    require_prompt_fits_context_window(route, _request("x" * 10_000_000))
+
+
+def test_one_undeclared_rung_makes_the_whole_route_abstain() -> None:
+    """An undeclared rung is permissive elsewhere, so certainty is gone and nothing is refused."""
+    route = _route(_deployment("small", 100), _deployment("unknown", None))
+    require_prompt_fits_context_window(route, _request("x" * (10_000 * MAXIMUM_BYTES_PER_TOKEN)))
+
+
+def test_the_responses_surface_names_its_input_field() -> None:
+    """The refusal points at the field the caller actually sent."""
+    route = _route(_deployment("small", 10))
+    request = _request("x" * (11 * MAXIMUM_BYTES_PER_TOKEN), GatewayApiSurface.RESPONSES)
+    with pytest.raises(ProviderParameterError) as caught:
+        require_prompt_fits_context_window(route, request)
+    assert caught.value.param == "input"

--- a/exp/runtime/models/providers/__init__.py
+++ b/exp/runtime/models/providers/__init__.py
@@ -25,6 +25,8 @@ from exp.runtime.models.providers.protocol import (
     AsyncCompletedModelClient,
     BoundedSyncModelClientAdapter,
     SyncModelClientAdapter,
+    emulated_gateway_capabilities,
+    emulated_stop_sequences,
     preflight_gateway_request,
     require_gateway_provider,
 )
@@ -65,6 +67,8 @@ __all__ = [
     "TinkerSamplingClient",
     "TinkerSdkSampler",
     "create_tinker_sampler",
+    "emulated_gateway_capabilities",
+    "emulated_stop_sequences",
     "preflight_gateway_request",
     "require_gateway_provider",
 ]

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -12,7 +12,6 @@ from exp.common.core.artifacts import JsonObject
 from exp.common.models import ChatMaxTokensField
 from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.models.providers.errors import (
-    ProviderCapabilityError,
     ProviderResponseError,
 )
 from exp.runtime.models.providers.fireworks import prepare_gateway_reasoning_history
@@ -54,11 +53,12 @@ def openai_responses_stream_payload(
         Native Responses request with storage disabled and streaming enabled.
 
     Raises:
-        ProviderCapabilityError: The request uses unsupported stop sequences.
         ProviderResponseError: An instruction message has no text.
     """
-    if request.stop:
-        raise ProviderCapabilityError(capability="stop_sequences")
+    # The Responses API has no stop field. Caller stop sequences never reach
+    # this wire; the native data plane emulates them from the wire entry's
+    # ``stop_sequences`` (see ``deployment_wire_entry``), cutting the stream
+    # at the first match and reporting a stop-sequence terminal.
     instructions: list[str] = []
     items: list[JsonObject] = []
     for message in request.messages:

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -182,6 +182,44 @@ class GatewayDispatchSigner(Protocol):
         ...
 
 
+# Wire dialects whose provider has no stop field but whose streams the native
+# data plane cuts itself: the OpenAI Responses API. A rung on one of these
+# dialects satisfies ``stop_sequences`` regardless of its catalog flag, because
+# the gateway, not the provider, honours the caller's sequences.
+STOP_SEQUENCE_EMULATED_DIALECTS: frozenset[str] = frozenset({"openai_responses"})
+
+
+def emulated_gateway_capabilities(dialect: str) -> frozenset[str]:
+    """Name the capabilities the data plane emulates for one wire dialect.
+
+    Args:
+        dialect: The rung's wire dialect (``GatewayWireProfile.dialect``).
+
+    Returns:
+        Capability labels admission treats as satisfied without a catalog
+        declaration; empty for dialects with nothing emulated.
+    """
+    if dialect in STOP_SEQUENCE_EMULATED_DIALECTS:
+        return frozenset({"stop_sequences"})
+    return frozenset()
+
+
+def emulated_stop_sequences(dialect: str, request: GatewayRequest) -> tuple[str, ...]:
+    """Return the stop sequences the data plane must enforce for one rung.
+
+    Args:
+        dialect: The rung's wire dialect.
+        request: Canonical request whose ``stop`` the provider wire cannot carry.
+
+    Returns:
+        The caller's exact sequences when this dialect emulates them; empty
+        when the provider honours ``stop`` natively (or none were requested).
+    """
+    if request.stop and dialect in STOP_SEQUENCE_EMULATED_DIALECTS:
+        return tuple(request.stop)
+    return ()
+
+
 def preflight_gateway_request(
     request: GatewayRequest,
     capabilities: GatewayDeploymentCapabilities,
@@ -189,6 +227,7 @@ def preflight_gateway_request(
     model_capabilities: ModelCapabilities | None = None,
     public_stream: bool | None = None,
     route_provider: str | None = None,
+    emulated_capabilities: frozenset[str] = frozenset(),
 ) -> None:
     """Reject gateway semantics a deployment cannot preserve before provider dispatch.
 
@@ -204,6 +243,10 @@ def preflight_gateway_request(
         route_provider: The deployment's catalog provider. A provider media
             handle is admissible only when this equals the handle's provider;
             ``None`` (standalone callers) admits no handle.
+        emulated_capabilities: Capability labels the data plane provides for
+            this rung itself (see ``emulated_gateway_capabilities``); a
+            requirement in this set passes even when the catalog declares it
+            unsupported.
 
     Raises:
         ProviderCapabilityError: A present request feature is unsupported.
@@ -282,7 +325,7 @@ def preflight_gateway_request(
     if request.stream and not caller_stream:
         requirements += ((True, capabilities.supports_streaming, "streaming"),)
     for requested, supported, capability in requirements:
-        if requested and not supported:
+        if requested and not supported and capability not in emulated_capabilities:
             raise ProviderCapabilityError(capability=capability)
     preflight_media_handles(
         request.media_handles,

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -39,6 +39,8 @@ from exp.runtime.models.providers.errors import (
 from exp.runtime.models.providers.protocol import (
     BoundedSyncModelClientAdapter,
     SyncModelClientAdapter,
+    emulated_gateway_capabilities,
+    emulated_stop_sequences,
     preflight_gateway_request,
     require_gateway_provider,
 )
@@ -257,6 +259,50 @@ def test_preflight_rejects_over_limit_stop_list_with_a_named_parameter_error() -
     at_limit = request.model_copy(update={"stop": ("a", "b", "c", "d", "e")})
     preflight_gateway_request(at_limit, capabilities)
     preflight_gateway_request(request, GatewayDeploymentCapabilities(supports_stop_sequences=True))
+
+
+def test_preflight_admits_an_undeclared_stop_when_the_data_plane_emulates_it() -> None:
+    """A Responses rung has no stop field, yet admits stop: the gateway cuts the stream itself."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        stop=("</severity>",),
+    )
+    undeclared = GatewayDeploymentCapabilities(supports_stop_sequences=False)
+
+    with pytest.raises(ProviderCapabilityError) as caught:
+        preflight_gateway_request(request, undeclared)
+    assert caught.value.capability == "stop_sequences"
+
+    assert emulated_gateway_capabilities("openai_responses") == frozenset({"stop_sequences"})
+    assert emulated_gateway_capabilities("openai_compatible") == frozenset()
+    preflight_gateway_request(
+        request,
+        undeclared,
+        emulated_capabilities=emulated_gateway_capabilities("openai_responses"),
+    )
+    # Emulation is per capability: an unrelated undeclared feature still rejects.
+    with pytest.raises(ProviderCapabilityError):
+        preflight_gateway_request(
+            request.model_copy(update={"stream": True}),
+            undeclared,
+            public_stream=True,
+            emulated_capabilities=emulated_gateway_capabilities("openai_responses"),
+        )
+
+
+def test_emulated_stop_sequences_follow_the_dialect_and_the_request() -> None:
+    """Only a Responses rung hands the caller's sequences to the data plane."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        stop=("</block>", "DONE"),
+    )
+    assert emulated_stop_sequences("openai_responses", request) == ("</block>", "DONE")
+    assert emulated_stop_sequences("anthropic_messages", request) == ()
+    assert (
+        emulated_stop_sequences("openai_responses", request.model_copy(update={"stop": ()})) == ()
+    )
 
 
 def test_tinker_is_explicitly_excluded_from_gateway_execution() -> None:

--- a/exp/runtime/models/providers/server_tools.py
+++ b/exp/runtime/models/providers/server_tools.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""Anthropic server tools on non-Anthropic routes: detection and the named rejection.
+
+Server tools (``web_search_20250305``-style ``tools`` entries and their echoed
+``server_tool_use`` / ``*_tool_result`` history blocks) execute inside
+Anthropic's API. A route served by any other provider cannot run them, and
+silently dropping a search the caller asked for would be a behavior lie, so
+the gateway rejects and names the exact tool. Claude Code is the common
+caller: its WebSearch tool issues these requests, so the message carries the
+client-facing tool name a Claude Code user recognises.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from exp.runtime.gateway.contracts import GatewayRequest
+
+# Client-facing labels for the server tools Claude Code exposes, keyed by the
+# Anthropic tool name. Unknown names render bare.
+ANTHROPIC_SERVER_TOOL_LABELS: Mapping[str, str] = {
+    "web_search": "Claude Code's WebSearch",
+    "web_fetch": "Claude Code's WebFetch",
+    "code_execution": "Anthropic code execution",
+}
+
+
+def anthropic_server_tool_names(request: GatewayRequest) -> tuple[str, ...]:
+    """Name every Anthropic server tool the request declares or echoes, in order.
+
+    Declared tools come from the ``tools`` array (``web_search_20250305``-style
+    entries carry a ``name``); echoed history blocks are ``server_tool_use``
+    (named) and ``web_search_tool_result`` (implicitly ``web_search``).
+
+    Args:
+        request: Canonical gateway request.
+
+    Returns:
+        Distinct server tool names, first occurrence first; empty when the
+        request carries no server tools.
+    """
+    names: list[str] = []
+
+    def add(name: object) -> None:
+        if isinstance(name, str) and name and name not in names:
+            names.append(name)
+
+    for entry in request.provider_server_tools:
+        add(entry.get("name") or entry.get("type"))
+    for message in request.messages:
+        block = message.provider_anthropic_block
+        if block is None:
+            continue
+        block_type = block.get("type")
+        if block_type == "server_tool_use":
+            add(block.get("name"))
+        elif isinstance(block_type, str) and block_type.endswith("_tool_result"):
+            add(block_type.removesuffix("_tool_result"))
+        # Any other verbatim block (a citation-bearing text block) is server
+        # tool OUTPUT, not a tool: it is detected by
+        # ``anthropic_server_tools_present`` but never named as one.
+    return tuple(names)
+
+
+def anthropic_server_tools_present(request: GatewayRequest) -> bool:
+    """Whether the request carries any Anthropic server tool or its echoed output.
+
+    Args:
+        request: Canonical gateway request.
+
+    Returns:
+        True for a declared server tool or any verbatim Anthropic history block
+        (``server_tool_use``, ``*_tool_result``, or a citation-bearing text
+        block), all of which only a native Anthropic route can replay.
+    """
+    return bool(request.provider_server_tools) or any(
+        message.provider_anthropic_block is not None for message in request.messages
+    )
+
+
+def anthropic_server_tools_message(names: Sequence[str]) -> str:
+    """Explain why named Anthropic server tools cannot run on this route.
+
+    Args:
+        names: Distinct server tool names present on the request; empty when
+            only echoed server-tool output (citation-bearing text) is present.
+
+    Returns:
+        A caller-facing sentence naming each tool and the Anthropic-only rule.
+    """
+    if not names:
+        return (
+            "The conversation carries echoed Anthropic server-tool output (web-search "
+            "citations or result blocks from an earlier turn). Anthropic server tools run "
+            "inside Anthropic's API, so Anthropic only allows them on Anthropic (Claude) "
+            "models; this model route is served by a different provider. Switch to a "
+            "Claude model alias for this conversation, or start a new one without the "
+            "server-tool turns."
+        )
+    labelled = ", ".join(
+        f"'{name}' ({ANTHROPIC_SERVER_TOOL_LABELS[name]})"
+        if name in ANTHROPIC_SERVER_TOOL_LABELS
+        else f"'{name}'"
+        for name in names
+    )
+    noun = "tool" if len(names) == 1 else "tools"
+    pronoun = "this tool" if len(names) == 1 else "these tools"
+    return (
+        f"The request uses the Anthropic server {noun} {labelled}. Anthropic server "
+        "tools run inside Anthropic's API, so Anthropic only allows them on Anthropic "
+        "(Claude) models; this model route is served by a different provider. Switch "
+        f"to a Claude model alias for requests that use {pronoun}, or disable "
+        f"{pronoun} and resend."
+    )

--- a/exp/runtime/models/providers/server_tools_test.py
+++ b/exp/runtime/models/providers/server_tools_test.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""Tests for naming Anthropic server tools in the non-Anthropic route rejection."""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.runtime.models.providers.server_tools import (
+    anthropic_server_tool_names,
+    anthropic_server_tools_message,
+    anthropic_server_tools_present,
+)
+
+
+def _messages_request(
+    *,
+    server_tools: tuple[JsonObject, ...] = (),
+    echoed_blocks: tuple[JsonObject, ...] = (),
+) -> GatewayRequest:
+    messages: list[GatewayMessage] = [GatewayMessage(role="user", content="search for it")]
+    for block in echoed_blocks:
+        messages.append(
+            GatewayMessage(role="assistant", content=None, provider_anthropic_block=block)
+        )
+    return GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=tuple(messages),
+        provider_server_tools=server_tools,
+    )
+
+
+def test_names_come_from_declared_tools_and_echoed_history_without_duplicates() -> None:
+    """Declared entries, server_tool_use blocks, and *_tool_result blocks all name the tool once."""
+    request = _messages_request(
+        server_tools=(
+            {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+            {"type": "web_fetch_20250910", "name": "web_fetch"},
+        ),
+        echoed_blocks=(
+            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {}},
+            {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1", "content": []},
+        ),
+    )
+    assert anthropic_server_tool_names(request) == ("web_search", "web_fetch")
+
+
+def test_a_result_block_alone_still_names_its_tool() -> None:
+    """A transcript carrying only the echoed result block still identifies web_search."""
+    request = _messages_request(
+        echoed_blocks=(
+            {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1", "content": []},
+        ),
+    )
+    assert anthropic_server_tool_names(request) == ("web_search",)
+
+
+def test_no_server_tools_means_no_names() -> None:
+    """A plain Messages request names nothing and is not flagged as carrying server tools."""
+    assert anthropic_server_tool_names(_messages_request()) == ()
+    assert anthropic_server_tools_present(_messages_request()) is False
+
+
+def test_a_citation_text_block_is_server_tool_output_but_never_a_tool_name() -> None:
+    """Echoed citation text is detected (only Anthropic can replay it) yet not misnamed."""
+    request = _messages_request(
+        echoed_blocks=(
+            {
+                "type": "text",
+                "text": "cited answer",
+                "citations": [{"type": "web_search_result_location"}],
+            },
+        ),
+    )
+    assert anthropic_server_tools_present(request) is True
+    assert anthropic_server_tool_names(request) == ()
+    message = anthropic_server_tools_message(())
+    assert "'text'" not in message
+    assert "echoed Anthropic server-tool output" in message
+    assert "Anthropic only allows them on Anthropic (Claude) models" in message
+
+
+def test_message_names_the_tool_its_claude_code_label_and_the_anthropic_only_rule() -> None:
+    """The caller reads which tool, what Claude Code calls it, and why it needs a Claude model."""
+    message = anthropic_server_tools_message(("web_search",))
+    assert "'web_search' (Claude Code's WebSearch)" in message
+    assert "Anthropic only allows them on Anthropic (Claude) models" in message
+    assert "Switch to a Claude model alias" in message
+    assert "this tool" in message and "these tools" not in message
+
+    plural = anthropic_server_tools_message(("web_search", "mystery_tool"))
+    assert "server tools 'web_search' (Claude Code's WebSearch), 'mystery_tool'" in plural
+    assert "these tools" in plural

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -70,6 +70,11 @@ from exp.runtime.models.providers.reasoning_compat import (
     anthropic_adaptive_only_thinking,
     anthropic_budgeted_enabled_only,
 )
+from exp.runtime.models.providers.server_tools import (
+    anthropic_server_tool_names,
+    anthropic_server_tools_message,
+    anthropic_server_tools_present,
+)
 
 if TYPE_CHECKING:
     from exp.runtime.models.providers.base import GatewayWireProfile
@@ -380,15 +385,9 @@ def route_generation_parameter_requests(
                     supported_efforts=profile_efforts,
                     param=effort_path,
                 )
-    if request.stop and any(profile.dialect == "openai_responses" for profile in profiles):
-        raise ProviderParameterError(
-            message=(
-                "The parameter 'stop' is not supported by every deployment in this model "
-                "route. Remove the field or choose a Chat-compatible model."
-            ),
-            param="stop",
-            code="unsupported_parameter",
-        )
+    # Stop sequences on a native Responses rung: the Responses API has no stop
+    # field, so the data plane emulates them (the wire entry carries the exact
+    # sequences and the stream is cut at the first match). Nothing to reject.
     if request.reasoning_summary is not None and not all(
         serves_reasoning_summary(profile) for profile in profiles
     ):
@@ -764,22 +763,17 @@ def route_generation_parameter_requests(
                 param="thinking.type",
                 code="unsupported_parameter",
             )
-    server_tools_present = bool(request.provider_server_tools) or any(
-        message.provider_anthropic_block is not None for message in request.messages
-    )
-    if server_tools_present and not all(
+    if anthropic_server_tools_present(request) and not all(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
-        # Server tools execute at the provider; silently dropping a search
-        # capability the caller asked for would be a behavior lie, so a
-        # route that cannot serve them rejects by name instead.
+        server_tool_names = anthropic_server_tool_names(request)
+        # Server tools execute inside Anthropic's API; silently dropping a
+        # search capability the caller asked for would be a behavior lie, so
+        # a route that cannot serve them rejects and NAMES the tool (Claude
+        # Code's WebSearch is the common case) so the caller knows which
+        # feature needs a Claude model.
         raise ProviderParameterError(
-            message=(
-                "The request carries Anthropic server tools (web_search-style "
-                "entries or their echoed result blocks) that only a native "
-                "Anthropic route can serve. Remove the server tools or choose "
-                "a different model alias."
-            ),
+            message=anthropic_server_tools_message(server_tool_names),
             param="tools",
             code="unsupported_parameter",
         )

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1512,18 +1512,28 @@ def test_payload_builder_rejects_conditional_sampling_without_admission() -> Non
         )
 
 
-def test_route_rejects_stop_before_native_responses_dispatch() -> None:
-    """Chat stop sequences never reach a Responses deployment that lacks the field."""
-    request = _chat_request().model_copy(update={"stop": ("DONE",)})
+def test_route_admits_stop_on_native_responses_and_keeps_it_off_the_wire() -> None:
+    """The Responses API has no stop field: the route admits stop for data-plane emulation.
 
-    with pytest.raises(ProviderParameterError) as raised:
-        route_generation_parameter_requests(
-            (GatewayWireProfile(dialect="openai_responses", url="https://provider.test"),),
-            request,
-        )
+    The canonical request keeps the caller's sequences (the wire entry hands
+    them to the native relay) while the provider payload never carries them.
+    """
+    request = _chat_request().model_copy(update={"stop": ("DONE", "</severity>")})
 
-    assert raised.value.code == "unsupported_parameter"
-    assert raised.value.param == "stop"
+    public_request, provider_request = route_generation_parameter_requests(
+        (GatewayWireProfile(dialect="openai_responses", url="https://provider.test"),),
+        request,
+    )
+
+    assert provider_request.stop == ("DONE", "</severity>")
+    assert "stop" not in public_request.ignored_parameters
+    payload = openai_responses_stream_payload(
+        "gpt-5.6-luna",
+        provider_request,
+        supports_temperature=True,
+    )
+    assert "stop" not in payload
+    assert "stop_sequences" not in payload
 
 
 def test_responses_logprob_request_is_rejected_instead_of_ignored() -> None:
@@ -2935,7 +2945,12 @@ def test_server_tools_reject_mixed_routes_by_name() -> None:
             route_generation_parameter_requests(profiles, request)
         assert raised.value.code == "unsupported_parameter"
         assert raised.value.param == "tools"
-        assert "Anthropic" in str(raised.value)
+        # The rejection names the exact tool, its Claude Code label, and the
+        # Anthropic-only rule, so a Claude Code user knows what to change.
+        message = str(raised.value)
+        assert "'web_search' (Claude Code's WebSearch)" in message
+        assert "Anthropic only allows them on Anthropic (Claude) models" in message
+        assert "Switch to a Claude model alias" in message
 
 
 def test_server_tools_keep_tool_choice_on_an_anthropic_route() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.36,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.37,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.36"
+version = "0.3.37"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What this is

Launch-week client failures on `gpt-5.6-luna` and the other OpenAI Responses routes, traced in the prod ledger (48h): 151 `unsupported_capability` rejections across 23 orgs on Luna (365 across `gpt-*`), 306 Anthropic server-tool rejections (every one Claude Code's WebSearch), an untriageable generic capability message in every alert, and no way to refuse a doomed prompt before the provider round trip. Four changes, one native crate bump.

### 1. Stop sequences on Responses rungs are gateway-emulated, not rejected
The Responses API has no stop field. Claude Code's auto-mode security classifier sends `stop_sequences: ["</severity>"]` / `["</block>"]` on every call (confirmed in the CLI binary), and any Chat client sending `stop` hit the same wall on Luna/Sol/Terra/Astra.
- Admission: `emulated_gateway_capabilities(dialect)` marks `stop_sequences` satisfied on `openai_responses`; `preflight_gateway_request` takes `emulated_capabilities`.
- Shaping/payload: the two Responses `stop` rejections are gone; the payload never carries `stop`; `deployment_wire_entry` carries the caller's exact `stop_sequences`.
- Data plane: new `stop_sequences.rs` `StopSequenceGuard`, installed on the `UpstreamRelay` per rung. Visible text is cut at the first match (withholding only the shortest tail that could still start a sequence, so matches span delta boundaries), trailing text is discarded, lifecycle and usage events keep draining so settlement stays exact, and the stream ends with the new `Event::StoppedAtSequence`: `finish_reason: stop` (Chat), `status: completed` (Responses), `stop_reason: stop_sequence` + the matched string (Messages). Reasoning, tool arguments, and refusals are never inspected. Native `stop` rungs (Chat-compatible, Anthropic, Gemini, Bedrock) are unchanged.

### 2. The server-tool rejection names the tool
New `server_tools.py`: declared entries and echoed `server_tool_use` / `*_tool_result` blocks name the tool, and the message reads: *"The request uses the Anthropic server tool 'web_search' (Claude Code's WebSearch). Anthropic server tools run inside Anthropic's API, so Anthropic only allows them on Anthropic (Claude) models; this model route is served by a different provider. Switch to a Claude model alias for requests that use this tool, or disable this tool and resend."*

### 3. The ledger names the rejected field
The recorded capability failure keeps its generic sentence but now ends `(field: stop)` (whatever public field the caller's 400 named, never the internal literal). Tonight's `unsupported_capability` alert would have read the field instead of "cannot preserve a requested capability".

### 4. Pre-dispatch context-window refusal
New `prompt_size.py`: a lower bound on prompt tokens from UTF-8 text bytes (6 bytes/token, below what real tokenizers produce on prose, code, or CJK; inline media uncounted; `content` counted once, not again via mirrored text parts). When even that bound exceeds the largest declared context window on the route, admission refuses with `code: context_length_exceeded`, the estimated and allowed token counts, before any coercion, reservation, or provider call. Output budgets are untouched: a too-small ceiling stays an `incomplete` answer.

## Fixtures
- Rust: 10 guard unit tests (in-delta match, boundary-spanning match, false prefix release, terminal flush, earliest/longest tie-break, provider-item re-emission, post-match failure, multibyte safety, item-boundary flush) + an end-to-end relay test (cut text, usage still yielded, `StoppedAtSequence` terminal).
- Python: stop admitted on Responses with `stop` absent from the payload; preflight emulation is per capability; wire entry carries the sequences; server-tool names from declared and echoed blocks; message wording; ledger `(field: …)` on the bridge test; prompt-size counting (text once, media excluded, raw tool arguments), certain-overflow refusal with numbers, may-fit dispatch, undeclared-window never refuses, Responses names `input`; admission refuses before shaping.

## Gates
`cargo fmt --check`, `cargo clippy --no-default-features -D warnings`, `cargo test --no-default-features` (216) clean. `ruff check`, `ruff format --check`, `ty check` clean. Full `pytest -q`: 3841 passed, 6 skipped.

## Release
Native crate `exp-gateway-native` 0.3.36 → 0.3.37 (root pin `>=0.3.37`). Publish the native wheel first, then the next `experiential` release, then the platform repin. Docs: `gateway-architecture.md` gains the emulated-stop and context-window sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
