### PR TITLE
release: bump experiential to 0.7.42 (native 0.3.37: gateway-emulated stop sequences)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.41"
+version = "0.7.42"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.41"
+version = "0.7.42"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Carries #821: stop sequences on OpenAI Responses rungs are emulated in the
native data plane instead of rejected (Claude Code auto-mode classifier and
every Chat client sending `stop` on Luna/Sol/Terra/Astra), the Anthropic
server-tool rejection names the tool (Claude Code's WebSearch), capability
rejections record the public field in the ledger, and prompts certain to
exceed every context window on the route are refused before dispatch.

Native wheel changes: exp-gateway-native 0.3.36 -> 0.3.37 (new
StopSequenceGuard relay filter, Event::StoppedAtSequence, Messages
stop_reason: stop_sequence).

Release notes to attach to v0.7.42: packages experiential 0.7.42 and exp-gateway-native 0.3.37. PR: https://github.com/experientiallabs/experiential/pull/821

🤖 Generated with [Claude Code](https://claude.com/claude-code)