### PR TITLE
release: bump experiential to 0.7.43 (native 0.3.38: stream-error classification, BYOK credential failures as the customer's 400)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.42"
+version = "0.7.43"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.42"
+version = "0.7.43"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Carries #830: provider-declared stream errors are classified by what the
provider said (caller input -> 400 relaying the sentence; content verdicts ->
refusal; rate limit / overload -> throttled; quota, credential, not-found codes
-> their classes; only provider faults stay "provider stream failed"), OpenAI
error frames read nested envelopes and numeric codes, the request's model id is
exempt from the detail screen, and a rejected credential or exhausted account
on a customer-managed (BYOK) rung is the customer's own 400 while keeping ladder
failover to other rungs.

Native wheel changes: exp-gateway-native 0.3.37 -> 0.3.38.

Release notes for v0.7.43: packages experiential 0.7.43 and exp-gateway-native 0.3.38. PR: https://github.com/experientiallabs/experiential/pull/830

🤖 Generated with [Claude Code](https://claude.com/claude-code)