### PR TITLE
gateway: budget-truncated Anthropic/Bedrock tool calls settle incomplete; pre-stream 4xx keeps the provider code and files content filters as refusals (native 0.3.39)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -377,6 +377,19 @@ credential may still serve, but a terminal answer is the customer's 400
 (`provider_credential_rejected` / `provider_account_quota`) naming their provider and what to
 fix, and settlement files it as `invalid_request`. House rungs keep the operator-actionable classes.
 
+**Tool calls cut off at the output budget are incomplete, not malformed.** On wires that reveal the
+stop reason only after the tool block closes (Anthropic `message_delta`, Bedrock `messageStop`), a
+tool call whose arguments fail to parse at its block stop is held rather than failed; a
+provider-declared `max_tokens` truncation then drops the unfinished call and ends the stream
+`incomplete` (the caller's remedy is a larger budget), while any other ending surfaces the parse
+failure as the malformed stream it is, exactly as the Chat-compatible `finish_reason: length` path
+already did.
+
+**Pre-stream 4xx bodies keep the provider's code.** When a client-error body's sentence must be
+dropped by the identifier screen, the provider's documented code or type token (`invalid_value`,
+`INVALID_ARGUMENT`) is relayed instead of nothing, and a content-filter code under a 4xx (Azure,
+Gemini) is filed and answered as a `refusal` rather than a request-shape error.
+
 **Pre-dispatch context-window refusal.** Before any reservation or provider call, admission
 lower-bounds the prompt's token count from its UTF-8 text bytes (at six bytes per token, below
 what real tokenizers produce on prose, code, or CJK text; inline media is not counted) and

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.38"
+version = "0.3.39"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.38"
+version = "0.3.39"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.38"
+version = "0.3.39"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -9,6 +9,7 @@
 
 mod anthropic;
 mod bedrock;
+mod deferred_tools;
 mod gemini;
 mod openai;
 
@@ -399,6 +400,11 @@ pub struct Normalizer {
     // Caller-known label words (the dispatched model id) exempt from the
     // provider-identifier screen on stream-error detail.
     request_words: Vec<String>,
+    // A tool call whose arguments failed to parse at its block stop, held
+    // until the stop reason arrives (Anthropic `message_delta`, Bedrock
+    // `messageStop` both follow the block): a budget truncation drops the
+    // call and ends Incomplete; any other ending surfaces this failure.
+    deferred_tool_failure: Option<Failure>,
 }
 
 impl Normalizer {
@@ -432,6 +438,7 @@ impl Normalizer {
             gemini_tool_index: 0,
             reasoning_content_route_sha256,
             request_words: Vec::new(),
+            deferred_tool_failure: None,
         }
     }
 

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -6,7 +6,7 @@
 use serde_json::Value;
 
 use super::{
-    complete_streamed_tool, finish_open_tools, malformed, optional_text, parse_object,
+    finish_open_tools, finish_open_tools_truncated, malformed, optional_text, parse_object,
     refusal_failure, Normalizer,
 };
 use crate::encode::compact_json;
@@ -230,10 +230,14 @@ impl Normalizer {
             "content_block_stop" => {
                 let index = require_u64(&payload, "index", "Anthropic content index")
                     .map_err(|message| malformed(&message))? as u32;
-                if let Some(tool) = self.tools.get_mut(&index) {
+                if let Some(mut tool) = self.tools.remove(&index) {
                     if !tool.completed {
-                        complete_streamed_tool(index, tool, &mut events)?;
+                        // The stop reason arrives in the following
+                        // message_delta, so a fragment left open by the
+                        // output budget cannot be told from garbage yet.
+                        self.complete_tool_deferring_failure(index, &mut tool, &mut events);
                     }
+                    self.tools.insert(index, tool);
                 }
             }
             "message_delta" => {
@@ -272,7 +276,13 @@ impl Normalizer {
                 }
             }
             "message_stop" => {
-                events.extend(finish_open_tools(&mut self.tools)?);
+                let truncated = self.stop_reason.as_deref() == Some("max_tokens");
+                self.resolve_deferred_tool_failure(truncated)?;
+                events.extend(if truncated {
+                    finish_open_tools_truncated(&mut self.tools)?
+                } else {
+                    finish_open_tools(&mut self.tools)?
+                });
                 let input_tokens = bounded_ledger_sum(
                     &[self.input_tokens, self.cache_read, self.cache_write],
                     "Anthropic input",
@@ -509,5 +519,71 @@ mod tests {
             }
             other => panic!("unexpected events: {other:?}"),
         }
+    }
+
+    fn tool_fragment_stream(stop_reason: &str) -> Vec<SseEvent> {
+        vec![
+            frame(serde_json::json!({
+                "type": "message_start",
+                "message": {"id": "msg_1", "usage": {"input_tokens": 5, "output_tokens": 0}},
+            })),
+            frame(serde_json::json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "toolu_1", "name": "lookup", "input": {}},
+            })),
+            frame(serde_json::json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": "{\"city\": \"Par"},
+            })),
+            frame(serde_json::json!({"type": "content_block_stop", "index": 0})),
+            frame(serde_json::json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": null},
+                "usage": {"output_tokens": 7},
+            })),
+            frame(serde_json::json!({"type": "message_stop"})),
+        ]
+    }
+
+    #[test]
+    fn a_tool_call_cut_off_by_the_output_budget_is_incomplete_not_malformed() {
+        // Anthropic reveals max_tokens only in message_delta, AFTER the tool
+        // block stopped with its arguments still an open fragment. That is the
+        // provider's own truncation: the unfinished call is dropped and the
+        // stream ends Incomplete (raise max_tokens), never a 502.
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let mut events = Vec::new();
+        for frame in tool_fragment_stream("max_tokens") {
+            events.extend(
+                normalizer
+                    .feed(&frame)
+                    .expect("truncated tool stream normalizes"),
+            );
+        }
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, Event::ToolCallCompleted { .. })));
+        assert!(matches!(events.last(), Some(Event::Incomplete)));
+    }
+
+    #[test]
+    fn a_tool_call_with_garbage_arguments_still_fails_when_the_provider_finished() {
+        let mut normalizer = Normalizer::new(Dialect::AnthropicMessages);
+        let frames = tool_fragment_stream("tool_use");
+        let mut outcome = Ok(Vec::new());
+        for frame in &frames {
+            outcome = normalizer.feed(frame);
+            if outcome.is_err() {
+                break;
+            }
+        }
+        let failure = outcome.expect_err("unparsable arguments on a finished turn are malformed");
+        assert_eq!(
+            failure.failure_class,
+            crate::errors::FailureClass::MalformedResponse
+        );
+        assert!(failure.safe_message.contains("not valid JSON"));
     }
 }

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -3,7 +3,7 @@
 
 use serde_json::{Map, Value};
 
-use super::{complete_streamed_tool, malformed, parse_object, refusal_failure, Normalizer};
+use super::{malformed, parse_object, refusal_failure, Normalizer};
 use crate::errors::{Failure, FailureClass};
 use crate::events::{bedrock_usage, require_string, require_u64, Event, ToolAccumulator};
 
@@ -203,7 +203,9 @@ impl Normalizer {
             return Ok(Vec::new());
         };
         let mut events = Vec::new();
-        complete_streamed_tool(index, &mut tool, &mut events)?;
+        // The stop reason arrives in the following messageStop, so a fragment
+        // left open by the output budget cannot be told from garbage yet.
+        self.complete_tool_deferring_failure(index, &mut tool, &mut events);
         Ok(events)
     }
 
@@ -220,6 +222,11 @@ impl Normalizer {
 
     /// Map the retained Bedrock stop reason to one terminal gateway event.
     fn bedrock_terminal(&mut self, reason: &str) -> Event {
+        let truncated = matches!(reason, "max_tokens" | "model_context_window_exceeded");
+        if let Err(failure) = self.resolve_deferred_tool_failure(truncated) {
+            self.tools.clear();
+            return Event::Failed(failure);
+        }
         if !self.tools.is_empty() {
             self.tools.clear();
             return Event::Failed(Failure::new(
@@ -488,6 +495,46 @@ mod bedrock_tests {
         assert_eq!(events[1]["kind"], "usage");
         assert_eq!(events[2]["kind"], "failed");
         assert_eq!(events[2]["failure_class"], "malformed_response");
+    }
+
+    #[test]
+    fn bedrock_tool_fragment_at_the_output_budget_is_incomplete_not_malformed() {
+        let fragment = |stop_reason: &str| {
+            vec![
+                event(
+                    "contentBlockStart",
+                    &json!({
+                        "contentBlockIndex": 0,
+                        "start": {"toolUse": {"toolUseId": "call-1", "name": "lookup"}},
+                    }),
+                ),
+                event(
+                    "contentBlockDelta",
+                    &json!({"contentBlockIndex": 0, "delta": {"toolUse": {"input": "{\"city\": \"Par"}}}),
+                ),
+                event("contentBlockStop", &json!({"contentBlockIndex": 0})),
+                event("messageStop", &json!({"stopReason": stop_reason})),
+                event(
+                    "metadata",
+                    &json!({"usage": {"inputTokens": 1, "outputTokens": 1}}),
+                ),
+            ]
+        };
+        let (events, failure) = run_stream(&fragment("max_tokens"));
+        assert!(failure.is_none());
+        assert!(!events
+            .iter()
+            .any(|event| event["kind"] == "tool_call_completed"));
+        assert_eq!(
+            events.last().map(|event| event["kind"].clone()),
+            Some(json!("incomplete"))
+        );
+
+        let (events, failure) = run_stream(&fragment("end_turn"));
+        assert!(failure.is_none());
+        let last = events.last().expect("terminal");
+        assert_eq!(last["kind"], "failed");
+        assert_eq!(last["failure_class"], "malformed_response");
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/dialects/deferred_tools.rs
+++ b/exp/runtime/gateway/native/src/dialects/deferred_tools.rs
@@ -1,0 +1,42 @@
+//! Tool calls whose arguments fail to parse at their block stop, on wires
+//! that reveal the stop reason only afterwards (Anthropic `message_delta`,
+//! Bedrock `messageStop`). A provider-declared budget truncation makes the open
+//! fragment the provider's own honest cut (dropped, stream Incomplete); any
+//! other ending surfaces the parse failure as the malformed stream it is.
+
+use super::{complete_streamed_tool, Normalizer};
+use crate::errors::Failure;
+use crate::events::{Event, ToolAccumulator};
+
+impl Normalizer {
+    /// Complete one tool call at its block stop when the stop reason is not
+    /// yet known. A parse failure is HELD rather than raised: the provider may
+    /// be about to say `max_tokens`, which makes the open fragment its own
+    /// truncation (dropped, stream Incomplete), not a malformed stream.
+    pub(super) fn complete_tool_deferring_failure(
+        &mut self,
+        index: u32,
+        tool: &mut ToolAccumulator,
+        events: &mut Vec<Event>,
+    ) {
+        let mut tool_events = Vec::new();
+        match complete_streamed_tool(index, tool, &mut tool_events) {
+            Ok(()) => events.extend(tool_events),
+            Err(failure) => {
+                if self.deferred_tool_failure.is_none() {
+                    self.deferred_tool_failure = Some(failure);
+                }
+            }
+        }
+    }
+
+    /// Resolve a held tool-argument failure at the terminal: a provider-declared
+    /// budget truncation forgives it (the unfinished call was dropped), anything
+    /// else surfaces it now.
+    pub(super) fn resolve_deferred_tool_failure(&mut self, truncated: bool) -> Result<(), Failure> {
+        match self.deferred_tool_failure.take() {
+            Some(failure) if !truncated => Err(failure),
+            _ => Ok(()),
+        }
+    }
+}

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -133,6 +133,55 @@ pub fn rejected_detail(dialect: Dialect, body: &str, request_words: &[&str]) -> 
     sanitized_detail(message, request_words)
 }
 
+/// The provider's own error code or type from one client-error body, as a
+/// bounded identifier token (`invalid_value`, `content_filter`,
+/// `invalid_request_error`, `INVALID_ARGUMENT`, or a numeric status).
+///
+/// Read only from the dialect's documented code field; it is a vocabulary
+/// token, never prose, so it is safe to relay when [`rejected_detail`] has to
+/// drop the sentence (a provider explanation naming a request or account
+/// handle otherwise left the caller with nothing but "verify the request
+/// fields"). It also classifies the body: a content-filter code is the
+/// model's verdict on the content, not a request-shape error.
+pub fn rejected_code(dialect: Dialect, body: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(body).ok()?;
+    let error = match dialect {
+        Dialect::BedrockConverseStream => return None,
+        _ => value.get("error")?,
+    };
+    let candidate = match dialect {
+        Dialect::GeminiGenerateContent => error.get("status").or_else(|| error.get("code")),
+        _ => error
+            .get("code")
+            .filter(|code| !code.is_null())
+            .or_else(|| error.get("type")),
+    }?;
+    let token = match candidate {
+        Value::String(text) => text.clone(),
+        Value::Number(number) => number.to_string(),
+        _ => return None,
+    };
+    let identifier = !token.is_empty()
+        && token.len() <= 64
+        && token
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'));
+    identifier.then_some(token)
+}
+
+/// Whether one provider code token says nothing beyond "the request was
+/// rejected": the family-wide type every 4xx carries, or a bare numeric
+/// status. Such a token is still classified but never relayed as detail, so a
+/// body whose sentence had to drop keeps the generic message rather than
+/// gaining a meaningless suffix.
+pub fn generic_error_code(token: &str) -> bool {
+    let lower = token.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "invalid_request_error" | "invalid_request" | "bad_request" | "error" | "invalid_argument"
+    ) || lower.chars().all(|c| c.is_ascii_digit())
+}
+
 /// One provider sentence reduced to bounded, single-line, printable text.
 ///
 /// Control characters end the candidate rather than being escaped: their
@@ -389,6 +438,43 @@ mod tests {
         // Any other message keeps the content-free failure.
         let other = r#"{"error": {"message": "This model is not available to your account."}}"#;
         assert_eq!(rejected_parameter(Dialect::OpenAiCompatible, other), None);
+    }
+
+    #[test]
+    fn rejected_code_reads_the_documented_code_field_as_a_bounded_token() {
+        let openai = r#"{"error": {"code": "invalid_value", "type": "invalid_request_error", "message": "x"}}"#;
+        assert_eq!(
+            rejected_code(Dialect::OpenAiResponses, openai).as_deref(),
+            Some("invalid_value")
+        );
+        let typed = r#"{"error": {"code": null, "type": "invalid_request_error", "message": "x"}}"#;
+        assert_eq!(
+            rejected_code(Dialect::OpenAiCompatible, typed).as_deref(),
+            Some("invalid_request_error")
+        );
+        let numeric = r#"{"error": {"code": 400, "message": "x"}}"#;
+        assert_eq!(
+            rejected_code(Dialect::OpenAiCompatible, numeric).as_deref(),
+            Some("400")
+        );
+        let anthropic =
+            r#"{"type": "error", "error": {"type": "invalid_request_error", "message": "x"}}"#;
+        assert_eq!(
+            rejected_code(Dialect::AnthropicMessages, anthropic).as_deref(),
+            Some("invalid_request_error")
+        );
+        let gemini = r#"{"error": {"code": 400, "status": "INVALID_ARGUMENT", "message": "x"}}"#;
+        assert_eq!(
+            rejected_code(Dialect::GeminiGenerateContent, gemini).as_deref(),
+            Some("INVALID_ARGUMENT")
+        );
+        // Prose or hostile shapes are never a token; Bedrock has no code field.
+        let prose = r#"{"error": {"code": "not a code!{}", "message": "x"}}"#;
+        assert_eq!(rejected_code(Dialect::OpenAiCompatible, prose), None);
+        assert_eq!(
+            rejected_code(Dialect::BedrockConverseStream, r#"{"message": "x"}"#),
+            None
+        );
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/stream_errors.rs
+++ b/exp/runtime/gateway/native/src/stream_errors.rs
@@ -152,6 +152,14 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| haystack.contains(needle))
 }
 
+/// Whether one provider code is an AUTHORITATIVE content verdict (a content
+/// filter, safety, or data-inspection code). Used where only the code may
+/// decide, never a sentence: a pre-stream 4xx body's prose can say "blocked by"
+/// about a rate limit or a firewall.
+pub fn is_refusal_code(code: Option<&str>) -> bool {
+    code.is_some_and(|value| REFUSAL_CODES.contains(&value.trim().to_ascii_lowercase().as_str()))
+}
+
 /// Classify one provider-declared error from its raw code and message.
 ///
 /// Content verdicts win first (a content filter may arrive under an

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -7,7 +7,10 @@ use serde_json::Value;
 
 use crate::dialects::Dialect;
 use crate::errors::{Failure, FailureClass};
-use crate::param_attribution::{rejected_detail, rejected_model_not_found, rejected_parameter};
+use crate::param_attribution::{
+    generic_error_code, rejected_code, rejected_detail, rejected_model_not_found,
+    rejected_parameter,
+};
 
 /// Build the shared pooled upstream client, mirroring the pooling constants in
 /// `providers.async_transport` (64 keep-alive) and its no-redirect policy so a
@@ -199,9 +202,28 @@ pub async fn open_stream(
             .and_then(Value::as_str)
             .into_iter()
             .collect();
+        let code = body
+            .as_deref()
+            .and_then(|body| rejected_code(dialect, body));
         let detail = body
             .as_deref()
-            .and_then(|body| rejected_detail(dialect, body, &request_words));
+            .and_then(|body| rejected_detail(dialect, body, &request_words))
+            // A sentence the identifier screen dropped still leaves the
+            // provider's own code token: "invalid_value" beats "verify the
+            // request fields" for the caller and the ledger alike. A generic
+            // family type or bare status adds nothing and is not relayed.
+            .or_else(|| code.clone().filter(|token| !generic_error_code(token)));
+        // A content-filter CODE under a 4xx is the model's verdict on the
+        // content (Azure and Gemini answer 400 for it), not a request-shape
+        // error: file and answer it as a refusal, detail kept ledger-only.
+        // Only the authoritative code decides here; a sentence saying
+        // "blocked by" could be about a firewall or a limit.
+        if crate::stream_errors::is_refusal_code(code.as_deref()) {
+            return Err(
+                Failure::new(FailureClass::Refusal, "provider refused the request")
+                    .with_provider_detail(detail),
+            );
+        }
         return Err(failure
             .with_rejected_parameter(parameter)
             .with_provider_detail(detail));
@@ -315,6 +337,92 @@ mod tests {
         assert!(
             !failure.safe_message.contains("request fields"),
             "the caller must never be told to fix their fields for a provider billing state"
+        );
+    }
+
+    async fn open_against_body(status_line: &str, body: &'static str, model: &str) -> Failure {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let status_line = status_line.to_string();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buffer = [0u8; 8192];
+            let _ = socket.read(&mut buffer).await;
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\ncontent-type: application/json\r\n\
+                 content-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            socket.write_all(response.as_bytes()).await.expect("write");
+        });
+        let client = build_client(Duration::from_secs(2)).expect("client");
+        open_stream(
+            &client,
+            &format!("http://{addr}/v1/chat/completions"),
+            &HashMap::new(),
+            "idem-4xx",
+            &serde_json::json!({"model": model, "messages": []}),
+            None,
+            Duration::from_secs(5),
+            Dialect::OpenAiCompatible,
+        )
+        .await
+        .expect_err("a 4xx must classify as a failure")
+    }
+
+    #[tokio::test]
+    async fn a_dropped_provider_sentence_still_relays_the_provider_code() {
+        // The sentence names an account handle, so the identifier screen drops
+        // it; the caller still learns WHICH rejection it was.
+        let failure = open_against_body(
+            "400 Bad Request",
+            "{\"error\":{\"code\":\"invalid_value\",\"type\":\"invalid_request_error\",\
+             \"message\":\"Invalid value for organization org_a1b2c3d4e5f6: not allowed\"}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
+        assert_eq!(failure.provider_detail.as_deref(), Some("invalid_value"));
+        assert_eq!(
+            failure.public_error().message,
+            "provider rejected the request: invalid_value"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blocked_by_sentence_without_a_refusal_code_stays_a_request_error() {
+        let failure = open_against_body(
+            "400 Bad Request",
+            "{\"error\":{\"code\":\"invalid_value\",\"message\":\"Request blocked by the \
+             organization policy for this parameter.\"}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
+    }
+
+    #[tokio::test]
+    async fn a_content_filter_4xx_is_a_refusal_not_a_request_shape_error() {
+        let failure = open_against_body(
+            "400 Bad Request",
+            "{\"error\":{\"code\":\"content_filter\",\"message\":\"The response was \
+             filtered due to the prompt triggering the content management policy.\"}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::Refusal);
+        assert_eq!(failure.public_error().status_code, 400);
+        assert_eq!(failure.public_error().code, "refusal");
+        // The sanitized sentence (or the code token when it must drop) rides
+        // to the ledger; a refusal never relays it to the caller.
+        assert!(failure.provider_detail.is_some());
+        assert_eq!(
+            failure.public_error().message,
+            "provider refused the request"
         );
     }
 

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -1585,7 +1585,9 @@ def test_provider_400_keeps_the_generic_message_for_a_body_dump(
     """A multi-line provider message is a payload, not an explanation.
 
     The mock provider's 400 message spans lines and names an internal
-    deployment and account; nothing from it may reach the caller.
+    deployment and account; nothing from it may reach the caller. Only the
+    provider's documented code token (``unknown_parameter``) is relayed in its
+    place, so the caller still learns which rejection it was.
     """
     rejected = httpx.post(
         f"{engine.base}/v1/chat/completions",
@@ -1600,8 +1602,7 @@ def test_provider_400_keeps_the_generic_message_for_a_body_dump(
     assert "internal-deployment-7" not in json.dumps(rejected.json())
     assert "4711" not in json.dumps(rejected.json())
     assert rejected.json()["error"]["message"] == (
-        "provider rejected the request; verify the request fields against "
-        "the model alias capabilities"
+        "provider rejected the request: unknown_parameter"
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.38,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.39,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.38"
+version = "0.3.39"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
Second pass over the 2026-09-06 prod ledger (6h, 10:00-16:00 UTC), after #830:

1. ~90 malformed_response 502s/6h were tool calls whose arguments were still an
   open JSON fragment when the provider cut the stream at max_tokens ("EOF while
   parsing"), on Anthropic (59) and Bedrock. The Chat-compatible wire already
   treated finish_reason=length that way (#796 for Responses); Anthropic and
   Bedrock could not, because they reveal the stop reason only AFTER the tool
   block closes. `Normalizer::complete_tool_deferring_failure` now HOLDS the
   parse failure at content_block_stop / contentBlockStop and
   `resolve_deferred_tool_failure` settles it at the terminal: a
   provider-declared truncation drops the unfinished call and ends Incomplete
   (finish_reason length / stop_reason max_tokens: raise the budget), anything
   else surfaces the malformed stream exactly as before. New child module
   dialects/deferred_tools.rs keeps dialects.rs inside the line budget.

2. 256 invalid_request rows/6h across 38 orgs read only "provider rejected the
   request; verify the request fields": the provider's sentence named a request or
   account handle, so the identifier screen dropped it and nothing else was kept.
   `rejected_code` now reads the dialect's documented code/type token
   (invalid_value, INVALID_ARGUMENT, a numeric status) and relays it when the
   sentence must drop, for the caller and the ledger. A content-filter code under a
   4xx (Azure, Gemini) is classified through the shared stream-error vocabulary and
   filed and answered as a refusal, not a request-shape error.

Gates: cargo fmt/clippy(-D warnings)/test (235) clean; ruff/ty clean; parity,
bridge, settlement, layout suites green; full pytest -q recorded in the PR.

## Fixtures
- Anthropic: a tool block left as an open JSON fragment, then `message_delta stop_reason=max_tokens` -> no ToolCallCompleted, stream ends Incomplete; the same fragment with `stop_reason=tool_use` -> malformed_response as before.
- Bedrock: same pair (`stopReason=max_tokens` -> incomplete; `end_turn` -> malformed_response).
- `rejected_code` per dialect (OpenAI code/type incl. numeric, Anthropic type, Gemini status, Bedrock none); `generic_error_code` (family types and bare statuses are never relayed).
- Live-socket 400s: a sentence dropped by the identifier screen still relays `invalid_value`; a `content_filter` 400 is a refusal with the detail ledger-only.
- The existing body-dump end-to-end test now expects `provider rejected the request: unknown_parameter` (the documented code token; the dump itself still never reaches the caller).

## Gates
`cargo fmt --check`, `cargo clippy --no-default-features -D warnings`, `cargo test --no-default-features` (235) clean. `ruff check`, `ruff format --check`, `ty check` clean. Full `pytest -q`: 3846 passed, 6 skipped.

## Release
Native crate 0.3.38 -> 0.3.39 (root pin `>=0.3.39`). Held for the next experiential release together with any further error-review fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)