### PR TITLE
gateway: warn instead of reject for unsupported temperature/top_p and parallel_tool_calls; serialize tool calls per rung (native 0.3.40)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -390,6 +390,20 @@ dropped by the identifier screen, the provider's documented code or type token (
 `INVALID_ARGUMENT`) is relayed instead of nothing, and a content-filter code under a 4xx (Azure,
 Gemini) is filed and answered as a `refusal` rather than a request-shape error.
 
+**Sampling controls a route cannot carry are dropped with disclosure, not refused.** A
+`temperature` or `top_p` sent to a route where some rung's provider rejects the field outright (a
+reasoning model such as GPT-6 Astra) is dropped and disclosed (`temperature->dropped(unsupported_by_provider)`)
+so the model still answers with its own default; the 400 remains only for a value outside a
+supporting route's declared range, which is a genuine caller error.
+
+**`parallel_tool_calls` is honoured on every route.** A rung whose wire carries the control forwards it.
+On a rung without it (Gemini, Bedrock, an OpenAI-compatible server that ignores the field), `true` is
+dropped as the provider's own default (`parallel_tool_calls->dropped(provider_default)`) and `false` is
+emulated by the data plane, which serializes that rung's stream to its first tool call per turn and
+drops later calls in the same turn, start to completion, including their Responses item lifecycle
+(`parallel_tool_calls->emulated(serialized_by_gateway)`). The model receives one result on the next
+turn and re-issues the remaining calls then, which is the sequential behaviour the caller asked for.
+
 **Pre-dispatch context-window refusal.** Before any reservation or provider call, admission
 lower-bounds the prompt's token count from its UTF-8 text bytes (at six bytes per token, below
 what real tokenizers produce on prose, code, or CJK text; inline media is not counted) and

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -672,6 +672,10 @@ class GatewayRequest(ContractModel):
     :func:`canonical_request_sha256`: the same body at a different tier is a
     different provider price and schedule."""
     ignored_parameters: tuple[str, ...] = Field(default=(), exclude=True)
+    """The caller sent ``parallel_tool_calls: false`` and at least one admitted
+    rung has no such wire control: the data plane serializes those rungs' tool
+    calls to one per turn instead. Disclosed through ``ignored_parameters``."""
+    serialize_tool_calls: bool = Field(default=False, exclude=True)
     """Disclosed compatibility decisions applied to this request.
 
     A plain field path names a control accepted but intentionally omitted

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.39"
+version = "0.3.40"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.39"
+version = "0.3.40"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.39"
+version = "0.3.40"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -34,6 +34,7 @@ mod settlement;
 mod sse;
 mod stop_sequences;
 mod stream_errors;
+mod tool_serialization;
 mod upstream;
 mod waterfall;
 

--- a/exp/runtime/gateway/native/src/relay.rs
+++ b/exp/runtime/gateway/native/src/relay.rs
@@ -17,6 +17,7 @@ use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 use crate::metrics::METRICS;
 use crate::stop_sequences::StopSequenceGuard;
+use crate::tool_serialization::ToolCallSerializer;
 use crate::waterfall::CommittedAttempt;
 
 /// Map one collection failure to its public error, honoring the shared
@@ -152,6 +153,8 @@ pub struct UpstreamRelay {
     /// Gateway-emulated stop sequences for this rung, when the provider wire
     /// carries none; `None` passes every event straight through.
     stop_guard: Option<StopSequenceGuard>,
+    /// Gateway-emulated `parallel_tool_calls: false`: one tool call per turn.
+    tool_serializer: Option<ToolCallSerializer>,
     /// The provider of a customer-managed (BYOK) rung: a credential or account
     /// failure the provider declares on this stream, before or after commit,
     /// is re-owned as the customer's. `None` on house rungs.
@@ -219,6 +222,7 @@ impl UpstreamRelay {
             pending: VecDeque::new(),
             ready: VecDeque::new(),
             stop_guard: None,
+            tool_serializer: None,
             customer_managed_provider: None,
             eof: false,
             first_byte_recorded: false,
@@ -251,6 +255,12 @@ impl UpstreamRelay {
         self.customer_managed_provider = provider;
     }
 
+    /// Serialize this relay's tool calls to one per turn (the caller sent
+    /// `parallel_tool_calls: false` to a wire without that control).
+    pub fn set_serialize_tool_calls(&mut self, serialize: bool) {
+        self.tool_serializer = serialize.then(ToolCallSerializer::new);
+    }
+
     /// Enforce the caller's stop sequences on this relay's visible text.
     /// Installed before the first event is yielded; an empty set is a no-op.
     pub fn set_stop_sequences<I, S>(&mut self, sequences: I)
@@ -274,6 +284,12 @@ impl UpstreamRelay {
                 failure.clone(),
                 provider,
             ));
+        }
+        if let Some(serializer) = self.tool_serializer.as_mut() {
+            let Some(kept) = serializer.filter(event) else {
+                return true;
+            };
+            event = kept;
         }
         match self.stop_guard.as_mut() {
             Some(guard) => self.ready.extend(guard.filter(event)),

--- a/exp/runtime/gateway/native/src/tool_serialization.rs
+++ b/exp/runtime/gateway/native/src/tool_serialization.rs
@@ -1,0 +1,221 @@
+//! Gateway-emulated `parallel_tool_calls: false`.
+//!
+//! A caller who sends `parallel_tool_calls: false` asks for at most one tool
+//! call per assistant turn. Providers whose wire has no such control (Gemini,
+//! Bedrock, and OpenAI-compatible servers that accept but ignore the field)
+//! may still emit several calls in one turn. Rather than refuse the request,
+//! the route entry marks the rung and this filter serializes the turn: the
+//! first tool call streams through untouched and every later call in the same
+//! turn is dropped (its start, argument deltas, completion, and its
+//! provider-owned Responses item lifecycle). The model sees one result on the
+//! next turn and re-issues the remaining calls then, which is exactly the
+//! sequential behaviour the caller asked for. Provider-executed server tools
+//! and hosted tools are never touched. Nothing here logs request text.
+
+use std::collections::BTreeSet;
+
+use crate::events::{Event, ProviderOutputItemKind};
+
+/// Stateful one-call-per-turn filter for one upstream relay.
+#[derive(Debug, Default)]
+pub struct ToolCallSerializer {
+    /// The one tool-call index this turn keeps.
+    kept: Option<u32>,
+    /// Indexes of calls dropped after the kept one opened.
+    dropped: BTreeSet<u32>,
+}
+
+impl ToolCallSerializer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the index belongs to the call this turn keeps; a new index
+    /// becomes the kept call when none is open yet, otherwise it is dropped.
+    fn admit(&mut self, index: u32) -> bool {
+        match self.kept {
+            None => {
+                self.kept = Some(index);
+                true
+            }
+            Some(kept) if kept == index => true,
+            Some(_) => {
+                self.dropped.insert(index);
+                false
+            }
+        }
+    }
+
+    /// Filter one decoded event: `Some(event)` passes, `None` drops it.
+    pub fn filter(&mut self, event: Event) -> Option<Event> {
+        match &event {
+            Event::ToolCallStarted { index, .. } => self.admit(*index).then_some(event),
+            Event::ToolArgumentsDelta { index, .. } | Event::ToolCallCompleted { index, .. } => {
+                (!self.dropped.contains(index)).then_some(event)
+            }
+            // A Responses function/custom tool item opens BEFORE its
+            // ToolCallStarted and shares its output index, so the item start
+            // is where a later call is first seen and dropped.
+            Event::ProviderOutputItemStarted {
+                output_index, kind, ..
+            } if is_tool_item(*kind) => self.admit(*output_index).then_some(event),
+            Event::ProviderOutputItemCompleted {
+                output_index, kind, ..
+            } if is_tool_item(*kind) => (!self.dropped.contains(output_index)).then_some(event),
+            _ => Some(event),
+        }
+    }
+}
+
+fn is_tool_item(kind: ProviderOutputItemKind) -> bool {
+    matches!(
+        kind,
+        ProviderOutputItemKind::FunctionCall | ProviderOutputItemKind::CustomToolCall
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::CompletedToolCall;
+
+    fn started(index: u32) -> Event {
+        Event::ToolCallStarted {
+            index,
+            call_id: format!("call_{index}"),
+            name: "lookup".to_string(),
+            namespace: None,
+            caller: None,
+        }
+    }
+
+    fn completed(index: u32) -> Event {
+        Event::ToolCallCompleted {
+            index,
+            call: CompletedToolCall {
+                call_id: format!("call_{index}"),
+                name: "lookup".to_string(),
+                namespace: None,
+                caller: None,
+                provider_item_id: None,
+                provider_status: None,
+                raw_arguments: "{}".to_string(),
+                custom: false,
+            },
+        }
+    }
+
+    fn kinds(events: &[Option<Event>]) -> Vec<String> {
+        events
+            .iter()
+            .map(|event| match event {
+                None => "dropped".to_string(),
+                Some(Event::ToolCallStarted { index, .. }) => format!("start:{index}"),
+                Some(Event::ToolArgumentsDelta { index, .. }) => format!("args:{index}"),
+                Some(Event::ToolCallCompleted { index, .. }) => format!("done:{index}"),
+                Some(Event::TextDelta(_)) => "text".to_string(),
+                Some(Event::Completed) => "completed".to_string(),
+                Some(other) => format!("{other:?}")
+                    .split(' ')
+                    .next()
+                    .unwrap_or("")
+                    .to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_first_call_streams_and_every_later_call_in_the_turn_is_dropped() {
+        let mut serializer = ToolCallSerializer::new();
+        let out: Vec<Option<Event>> = vec![
+            serializer.filter(Event::TextDelta("thinking".into())),
+            serializer.filter(started(0)),
+            serializer.filter(Event::ToolArgumentsDelta {
+                index: 0,
+                delta: "{\"city\":\"Paris\"}".into(),
+            }),
+            serializer.filter(started(1)),
+            serializer.filter(Event::ToolArgumentsDelta {
+                index: 1,
+                delta: "{\"city\":\"Rome\"}".into(),
+            }),
+            serializer.filter(completed(1)),
+            serializer.filter(completed(0)),
+            serializer.filter(Event::Completed),
+        ];
+        assert_eq!(
+            kinds(&out),
+            vec![
+                "text",
+                "start:0",
+                "args:0",
+                "dropped",
+                "dropped",
+                "dropped",
+                "done:0",
+                "completed"
+            ]
+        );
+    }
+
+    #[test]
+    fn responses_items_are_admitted_at_their_item_start_and_share_the_index_space() {
+        let mut serializer = ToolCallSerializer::new();
+        let item =
+            |output_index: u32, kind: ProviderOutputItemKind| Event::ProviderOutputItemStarted {
+                output_index,
+                item_id: Some(format!("fc_{output_index}")),
+                kind,
+                status: None,
+                phase: None,
+            };
+        // A reasoning item never counts as a call.
+        assert!(serializer
+            .filter(item(0, ProviderOutputItemKind::Reasoning))
+            .is_some());
+        assert!(serializer
+            .filter(item(1, ProviderOutputItemKind::FunctionCall))
+            .is_some());
+        assert!(serializer.filter(started(1)).is_some());
+        // The second function item in the same turn is dropped end to end.
+        assert!(serializer
+            .filter(item(2, ProviderOutputItemKind::FunctionCall))
+            .is_none());
+        assert!(serializer.filter(started(2)).is_none());
+        assert!(serializer.filter(completed(2)).is_none());
+        assert!(serializer
+            .filter(Event::ProviderOutputItemCompleted {
+                output_index: 2,
+                item_id: Some("fc_2".into()),
+                kind: ProviderOutputItemKind::FunctionCall,
+                status: None,
+                phase: None,
+            })
+            .is_none());
+        // The kept item's completion and the message item pass.
+        assert!(serializer.filter(completed(1)).is_some());
+        assert!(serializer
+            .filter(Event::ProviderOutputItemCompleted {
+                output_index: 3,
+                item_id: None,
+                kind: ProviderOutputItemKind::Message,
+                status: None,
+                phase: None,
+            })
+            .is_some());
+    }
+
+    #[test]
+    fn a_single_call_turn_is_untouched() {
+        let mut serializer = ToolCallSerializer::new();
+        assert!(serializer.filter(started(4)).is_some());
+        assert!(serializer
+            .filter(Event::ToolArgumentsDelta {
+                index: 4,
+                delta: "{}".into(),
+            })
+            .is_some());
+        assert!(serializer.filter(completed(4)).is_some());
+        assert!(serializer.filter(Event::Completed).is_some());
+    }
+}

--- a/exp/runtime/gateway/native/src/tool_serialization.rs
+++ b/exp/runtime/gateway/native/src/tool_serialization.rs
@@ -11,6 +11,11 @@
 //! next turn and re-issues the remaining calls then, which is exactly the
 //! sequential behaviour the caller asked for. Provider-executed server tools
 //! and hosted tools are never touched. Nothing here logs request text.
+//!
+//! Lifetime: one serializer per `UpstreamRelay`, and the waterfall builds a
+//! fresh relay for every upstream response, so the kept/dropped state spans
+//! exactly one assistant turn. A failover attempt or a Responses continuation
+//! is a new relay; state never carries across turns and needs no reset.
 
 use std::collections::BTreeSet;
 

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -95,6 +95,10 @@ pub struct DeploymentWire {
     /// `Event::StoppedAtSequence`. Empty when the payload carries `stop`.
     #[serde(default)]
     pub stop_sequences: Vec<String>,
+    /// The caller sent `parallel_tool_calls: false` and this rung's wire has
+    /// no such control: the relay serializes the turn to one tool call.
+    #[serde(default)]
+    pub serialize_tool_calls: bool,
     pub idempotency_key: String,
     /// Deployment override for the flat first-byte allowance; the serving
     /// configuration's default applies when absent.
@@ -582,6 +586,7 @@ async fn run_attempt(
         None => UpstreamRelay::new(response, dialect, first_byte_deadline),
     };
     relay.set_stop_sequences(wire.stop_sequences.iter().cloned());
+    relay.set_serialize_tool_calls(wire.serialize_tool_calls);
     if !wire.model_id.is_empty() {
         relay.set_request_words([wire.model_id.clone()]);
     }
@@ -768,6 +773,7 @@ mod tests {
             hunyuan_reasoning_route_sha256: None,
             reasoning_output_exposed: false,
             stop_sequences: Vec::new(),
+            serialize_tool_calls: false,
             model_id: String::new(),
             billing_customer_managed: false,
             idempotency_key: "op".to_string(),

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 
+from exp.common.models.catalog import GatewayDeploymentCapabilities
 from exp.runtime.gateway.contracts import AuthorizationSnapshot, DirectTarget, GatewayRequest
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_components import NativeGatewayComponents
@@ -205,6 +206,20 @@ def admitted_route_requests(
                 provider_request,
                 public_stream=public_request.stream,
             )
+    if not protocol_indexes and provider_request.parallel_tool_calls is not None:
+        # LAST resort for parallel_tool_calls: no rung honours the control
+        # natively (and no other coercion freed one), so admit the rungs whose
+        # only objection is that control. The data plane then drops `true`
+        # (the provider's default) or serializes `false` per rung, disclosed
+        # (native_bridge's per-rung shaping). A native rung is always
+        # preferred, which is why this pass runs after everything else.
+        protocol_indexes, protocol_errors = protocol_compatible_indexes(
+            route,
+            resolved_wires,
+            provider_request,
+            public_stream=public_request.stream,
+            emulate_parallel_tool_calls=True,
+        )
     if not protocol_indexes:
         if not protocol_errors:
             raise GatewayRoutingError("authorized route has no compatible deployment")
@@ -396,6 +411,7 @@ def protocol_compatible_indexes(
     provider_request: GatewayRequest,
     *,
     public_stream: bool | None,
+    emulate_parallel_tool_calls: bool = False,
 ) -> tuple[tuple[int, ...], tuple[ProviderParameterError | ProviderCapabilityError, ...]]:
     """Select rungs that pass capability preflight and payload build.
 
@@ -422,7 +438,9 @@ def protocol_compatible_indexes(
                 model_capabilities=deployment.capabilities,
                 public_stream=public_stream,
                 route_provider=deployment.provider,
-                emulated_capabilities=emulated_gateway_capabilities(profile.dialect),
+                emulated_capabilities=emulated_gateway_capabilities(
+                    profile.dialect, emulate_parallel_tool_calls=emulate_parallel_tool_calls
+                ),
             )
             dialect_stream_payload(profile, provider_request)
         except (ProviderParameterError, ProviderCapabilityError) as exc:
@@ -430,6 +448,71 @@ def protocol_compatible_indexes(
             continue
         indexes.append(index)
     return tuple(indexes), tuple(errors)
+
+
+def shape_parallel_tool_calls(
+    request: GatewayRequest,
+    capabilities: GatewayDeploymentCapabilities,
+) -> tuple[GatewayRequest, str | None]:
+    """Shape ``parallel_tool_calls`` for one rung that may lack the control.
+
+    A rung whose wire carries the control forwards it verbatim. One that does
+    not gets ``true`` dropped (parallel calls are the provider's own default)
+    or ``false`` emulated: the data plane serializes that rung's stream to one
+    tool call per turn (``serialize_tool_calls``). Either way the caller reads
+    the disclosure in ``ignored_parameters``.
+
+    Args:
+        request: The streaming-forced provider request.
+        capabilities: The rung's deployment capability declaration.
+
+    Returns:
+        The request to build this rung's payload from, and the disclosure to
+        publish (``None`` when nothing changed).
+    """
+    if request.parallel_tool_calls is None or capabilities.supports_parallel_tool_calls:
+        return request, None
+    if request.parallel_tool_calls:
+        return (
+            request.model_copy(update={"parallel_tool_calls": None}),
+            "parallel_tool_calls->dropped(provider_default)",
+        )
+    return (
+        request.model_copy(update={"parallel_tool_calls": None, "serialize_tool_calls": True}),
+        "parallel_tool_calls->emulated(serialized_by_gateway)",
+    )
+
+
+def fold_parallel_tool_call_disclosures(
+    public_request: GatewayRequest,
+    disclosures: set[str],
+    *,
+    accounting: NativeAttemptAccounting,
+    authorization: AuthorizationSnapshot,
+) -> GatewayRequest:
+    """Publish per-rung parallel-tool shaping like any other admission coercion.
+
+    Args:
+        public_request: The public request the admission answer carries.
+        disclosures: Distinct disclosures the per-rung shaping produced.
+        accounting: Shared accounting owning the coercion counter.
+        authorization: Frozen authority for the accepted request.
+
+    Returns:
+        The public request with the disclosures folded into
+        ``ignored_parameters`` (unchanged when there are none).
+    """
+    if not disclosures:
+        return public_request
+    ordered = tuple(sorted(disclosures))
+    record_admission_coercions(accounting, authorization, ordered)
+    return public_request.model_copy(
+        update={
+            "ignored_parameters": tuple(
+                dict.fromkeys((*public_request.ignored_parameters, *ordered))
+            )
+        }
+    )
 
 
 def record_admission_coercions(

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -37,6 +37,7 @@ from exp.runtime.gateway.native_admission import (
     admitted_route_requests,
     protocol_compatible_indexes,
     route_rejection,
+    shape_parallel_tool_calls,
 )
 from exp.runtime.gateway.native_dispatch import NativeWireClient
 from exp.runtime.gateway.prompt_size import MAXIMUM_BYTES_PER_TOKEN
@@ -1253,3 +1254,32 @@ def test_a_prompt_certain_to_overflow_the_route_is_refused_before_shaping() -> N
     assert caught.value.param == "messages"
     assert "at least 201 tokens" in str(caught.value)
     assert "200 tokens" in str(caught.value)
+
+
+def test_parallel_tool_calls_shape_per_rung_capability() -> None:
+    """A rung with the control forwards it; one without drops `true` or serializes `false`."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        parallel_tool_calls=False,
+    )
+    carried = GatewayDeploymentCapabilities(supports_parallel_tool_calls=True)
+    missing = GatewayDeploymentCapabilities(supports_parallel_tool_calls=False)
+
+    shaped, disclosure = shape_parallel_tool_calls(request, carried)
+    assert shaped is request and disclosure is None
+
+    shaped, disclosure = shape_parallel_tool_calls(request, missing)
+    assert shaped.parallel_tool_calls is None and shaped.serialize_tool_calls is True
+    assert disclosure == "parallel_tool_calls->emulated(serialized_by_gateway)"
+
+    shaped, disclosure = shape_parallel_tool_calls(
+        request.model_copy(update={"parallel_tool_calls": True}), missing
+    )
+    assert shaped.parallel_tool_calls is None and shaped.serialize_tool_calls is False
+    assert disclosure == "parallel_tool_calls->dropped(provider_default)"
+
+    untouched, disclosure = shape_parallel_tool_calls(
+        request.model_copy(update={"parallel_tool_calls": None}), missing
+    )
+    assert untouched.parallel_tool_calls is None and disclosure is None

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -52,7 +52,11 @@ from exp.runtime.gateway.native_accounting import (
 from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
 )
-from exp.runtime.gateway.native_admission import admitted_route_requests, resolve_admission_route
+from exp.runtime.gateway.native_admission import (
+    admitted_route_requests,
+    fold_parallel_tool_call_disclosures,
+    resolve_admission_route,
+)
 from exp.runtime.gateway.native_batches import NativeBatchRelayMixin
 from exp.runtime.gateway.native_bridge_errors import (
     escalation as _escalation,
@@ -77,7 +81,7 @@ from exp.runtime.gateway.native_continuation import (
     select_bound_continuation_route as _select_bound_continuation_route,
 )
 from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_body
-from exp.runtime.gateway.native_dispatch import dispatch_signature_headers, frozen_dispatch
+from exp.runtime.gateway.native_dispatch import dispatch_signature_headers
 from exp.runtime.gateway.native_embeddings import NativeEmbeddingsMixin
 from exp.runtime.gateway.native_execution import (
     MAXIMUM_SAME_DEPLOYMENT_ATTEMPTS,
@@ -85,7 +89,6 @@ from exp.runtime.gateway.native_execution import (
     FrozenDispatchBinding,
     InflightRequest,
     NativeDialectUnavailableError,
-    deployment_wire_entry,
     dispatchable_route_profiles,
     resolve_route_profiles,
     select_route_deployments,
@@ -105,21 +108,14 @@ from exp.runtime.gateway.native_responses import (
     continued_request,
     responses_envelope,
 )
+from exp.runtime.gateway.native_rungs import build_rung_dispatch
 from exp.runtime.gateway.native_settlement import (
     optional_text,
 )
 from exp.runtime.gateway.reasoning_carrier import (
     ReasoningCarrierAuthority,
-    reasoning_carrier_authority,
-    scheme_for_profile,
 )
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
-from exp.runtime.models.providers import (
-    emulated_gateway_capabilities,
-    emulated_stop_sequences,
-    preflight_gateway_request,
-    require_gateway_provider,
-)
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
@@ -127,8 +123,6 @@ from exp.runtime.models.providers.errors import (
     normalized_provider_failure,
 )
 from exp.runtime.models.providers.protocol import GatewayDispatchSigner, NativeWireClient
-from exp.runtime.models.providers.streaming_requests import dialect_stream_payload
-from exp.runtime.models.providers.wire_messages import anthropic_request_headers
 from exp.runtime.openai_protocol.errors import (
     OpenAIProtocolError,
     invalid_field,
@@ -524,61 +518,34 @@ class NativeControlPlane(
                 authorization=authorization,
             )
             wire_route: list[JsonObject] = []
+            parallel_disclosures: set[str] = set()
             signers: list[GatewayDispatchSigner | None] = []
             dispatch_bindings: list[FrozenDispatchBinding | None] = []
             carrier_authorities: list[ReasoningCarrierAuthority | None] = []
             for deployment, (profile, client) in zip(
                 route.deployments, resolved_wires, strict=True
             ):
-                require_gateway_provider(deployment.provider)
-                preflight_gateway_request(
-                    provider_request,
-                    deployment.gateway.capabilities,
-                    model_capabilities=deployment.capabilities,
-                    public_stream=public_request.stream,
-                    route_provider=deployment.provider,
-                    emulated_capabilities=emulated_gateway_capabilities(profile.dialect),
+                dispatch = build_rung_dispatch(
+                    route,
+                    deployment,
+                    profile,
+                    client,
+                    provider_request=provider_request,
+                    public_request=public_request,
+                    authorization=authorization,
                 )
-                upstream_payload = dialect_stream_payload(profile, provider_request)
-                upstream_body, dispatch_signer = frozen_dispatch(profile, client, upstream_payload)
-                request_headers = (
-                    anthropic_request_headers(dict(profile.headers), provider_request)
-                    if profile.dialect == "anthropic_messages"
-                    else None
-                )
-                wire_route.append(
-                    deployment_wire_entry(
-                        route,
-                        deployment,
-                        profile,
-                        upstream_payload,
-                        upstream_body,
-                        headers=request_headers,
-                        stop_sequences=emulated_stop_sequences(profile.dialect, provider_request),
-                    )
-                )
-                signers.append(dispatch_signer)
-                dispatch_bindings.append(
-                    None
-                    if dispatch_signer is None or upstream_body is None
-                    else FrozenDispatchBinding(
-                        url=profile.url,
-                        body_sha256=sha256_bytes(upstream_body.encode("utf-8")),
-                    )
-                )
-                carrier_scheme = scheme_for_profile(profile)
-                carrier_authorities.append(
-                    None
-                    if carrier_scheme is None
-                    else reasoning_carrier_authority(
-                        authorization=authorization,
-                        exact_model_id=route.snapshot.exact_model_id,
-                        pool_id=route.snapshot.pool_id,
-                        deployment=deployment,
-                        profile=profile,
-                        scheme=carrier_scheme,
-                    )
-                )
+                if dispatch.parallel_disclosure is not None:
+                    parallel_disclosures.add(dispatch.parallel_disclosure)
+                wire_route.append(dispatch.wire_entry)
+                signers.append(dispatch.signer)
+                dispatch_bindings.append(dispatch.binding)
+                carrier_authorities.append(dispatch.carrier_authority)
+            public_request = fold_parallel_tool_call_disclosures(
+                public_request,
+                parallel_disclosures,
+                accounting=self._accounting,
+                authorization=authorization,
+            )
             if continuation_context is not None:
                 continuation_context.route_bindings = tuple(
                     continuation_route_binding(deployment, profile)

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -546,6 +546,7 @@ def deployment_wire_entry(
     upstream_body: str | None = None,
     headers: dict[str, str] | None = None,
     stop_sequences: Sequence[str] = (),
+    serialize_tool_calls: bool = False,
 ) -> JsonObject:
     """Build one deployment's wire configuration for the admitted route.
 
@@ -566,6 +567,9 @@ def deployment_wire_entry(
         stop_sequences: Caller stop sequences the data plane must enforce on
             this rung's stream because the provider wire has no stop field
             (OpenAI Responses). Empty when the provider honours them itself.
+        serialize_tool_calls: The caller sent ``parallel_tool_calls: false``
+            and this rung's wire has no such control, so the data plane keeps
+            one tool call per turn on its stream.
 
     Returns:
         The JSON-compatible wire entry consumed by the data plane.
@@ -592,6 +596,7 @@ def deployment_wire_entry(
         # match and terminates with a stop-sequence reason. Empty for rungs
         # whose payload already carries the caller's stop field.
         "stop_sequences": list(stop_sequences),
+        "serialize_tool_calls": serialize_tool_calls,
         "idempotency_key": deployment_operation_key(route, deployment),
         # First-byte allowance overrides; the data plane falls back to its
         # serving defaults when a deployment declares nothing.

--- a/exp/runtime/gateway/native_execution_test.py
+++ b/exp/runtime/gateway/native_execution_test.py
@@ -633,3 +633,13 @@ def test_wire_entry_names_customer_managed_billing_for_the_data_plane() -> None:
     house = GatewayWireProfile(dialect="openai_responses", url="https://provider.test")
     assert deployment_wire_entry(route, route.deployment, byok, {})["billing_customer_managed"]
     assert not deployment_wire_entry(route, route.deployment, house, {})["billing_customer_managed"]
+
+
+def test_wire_entry_carries_the_tool_call_serialization_flag() -> None:
+    """A rung emulating parallel_tool_calls=false tells the data plane to serialize."""
+    route = _route()
+    profile = GatewayWireProfile(dialect="gemini_generate_content", url="https://provider.test")
+    assert deployment_wire_entry(route, route.deployment, profile, {}, serialize_tool_calls=True)[
+        "serialize_tool_calls"
+    ]
+    assert not deployment_wire_entry(route, route.deployment, profile, {})["serialize_tool_calls"]

--- a/exp/runtime/gateway/native_rungs.py
+++ b/exp/runtime/gateway/native_rungs.py
@@ -1,0 +1,119 @@
+"""Per-rung dispatch construction for the native bridge.
+
+Admission hands the bridge an ordered route; this module turns one rung of
+it into everything the data plane needs for that deployment: the frozen wire
+entry, the dispatch signer, the frozen-body binding and the reasoning-carrier
+authority. Rungs are shaped independently so a control (``parallel_tool_calls``
+today) can be honored natively on one rung and emulated on the next without
+the route-level request changing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from exp.common.core.artifacts import JsonObject, sha256_bytes
+from exp.common.models.gateway_catalog import ExactModelDeployment
+from exp.runtime.gateway.contracts import AuthorizationSnapshot, GatewayRequest
+from exp.runtime.gateway.native_admission import shape_parallel_tool_calls
+from exp.runtime.gateway.native_dispatch import frozen_dispatch
+from exp.runtime.gateway.native_execution import FrozenDispatchBinding, deployment_wire_entry
+from exp.runtime.gateway.reasoning_carrier import (
+    ReasoningCarrierAuthority,
+    reasoning_carrier_authority,
+    scheme_for_profile,
+)
+from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.models.providers import (
+    emulated_gateway_capabilities,
+    emulated_stop_sequences,
+    preflight_gateway_request,
+    require_gateway_provider,
+)
+from exp.runtime.models.providers.base import GatewayWireProfile
+from exp.runtime.models.providers.protocol import GatewayDispatchSigner, NativeWireClient
+from exp.runtime.models.providers.streaming_requests import dialect_stream_payload
+from exp.runtime.models.providers.wire_messages import anthropic_request_headers
+
+
+@dataclass(frozen=True, slots=True)
+class RungDispatch:
+    """One deployment's frozen dispatch material plus its shaping disclosure."""
+
+    wire_entry: JsonObject
+    signer: GatewayDispatchSigner | None
+    binding: FrozenDispatchBinding | None
+    carrier_authority: ReasoningCarrierAuthority | None
+    parallel_disclosure: str | None
+
+
+def build_rung_dispatch(
+    route: GatewayRoute,
+    deployment: ExactModelDeployment,
+    profile: GatewayWireProfile,
+    client: NativeWireClient,
+    *,
+    provider_request: GatewayRequest,
+    public_request: GatewayRequest,
+    authorization: AuthorizationSnapshot,
+) -> RungDispatch:
+    """Preflight, shape and freeze ``provider_request`` for one route rung."""
+    require_gateway_provider(deployment.provider)
+    preflight_gateway_request(
+        provider_request,
+        deployment.gateway.capabilities,
+        model_capabilities=deployment.capabilities,
+        public_stream=public_request.stream,
+        route_provider=deployment.provider,
+        emulated_capabilities=emulated_gateway_capabilities(
+            profile.dialect, emulate_parallel_tool_calls=True
+        ),
+    )
+    rung_request, parallel_disclosure = shape_parallel_tool_calls(
+        provider_request, deployment.gateway.capabilities
+    )
+    upstream_payload = dialect_stream_payload(profile, rung_request)
+    upstream_body, signer = frozen_dispatch(profile, client, upstream_payload)
+    request_headers = (
+        anthropic_request_headers(dict(profile.headers), rung_request)
+        if profile.dialect == "anthropic_messages"
+        else None
+    )
+    wire_entry = deployment_wire_entry(
+        route,
+        deployment,
+        profile,
+        upstream_payload,
+        upstream_body,
+        headers=request_headers,
+        stop_sequences=emulated_stop_sequences(profile.dialect, rung_request),
+        serialize_tool_calls=rung_request.serialize_tool_calls,
+    )
+    binding = (
+        None
+        if signer is None or upstream_body is None
+        else FrozenDispatchBinding(
+            url=profile.url,
+            body_sha256=sha256_bytes(upstream_body.encode("utf-8")),
+        )
+    )
+    carrier_scheme = scheme_for_profile(profile)
+    carrier_authority = (
+        None
+        if carrier_scheme is None
+        else reasoning_carrier_authority(
+            authorization=authorization,
+            exact_model_id=route.snapshot.exact_model_id,
+            pool_id=route.snapshot.pool_id,
+            deployment=deployment,
+            profile=profile,
+            scheme=carrier_scheme,
+        )
+    )
+    return RungDispatch(
+        wire_entry=wire_entry,
+        signer=signer,
+        binding=binding,
+        carrier_authority=carrier_authority,
+        parallel_disclosure=parallel_disclosure,
+    )

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -97,10 +97,11 @@ def test_effort_snaps_to_the_nearest_route_level_with_disclosure() -> None:
     assert coercion.disclosures == ("reasoning_effort->high",)
 
 
-def test_effort_snap_skips_levels_that_admit_no_rung() -> None:
-    """The snap is the nearest level that actually serves, not the nearest
-    level on paper: a rung carrying the closer effort may reject another
-    requested control, and the coercion must not dead-end there."""
+def test_effort_snap_lands_on_the_nearer_rung_and_drops_what_it_cannot_carry() -> None:
+    """The snap is the nearest level that actually serves. A rung carrying the
+    closer effort no longer dead-ends on a sampling control it cannot carry:
+    since 2026-09-06 an unsupported temperature is dropped with disclosure
+    rather than refused, so the nearer rung admits the request."""
     xhigh_only_no_temperature = GatewayWireProfile(
         dialect="openai_compatible",
         url="https://a.test",
@@ -115,10 +116,10 @@ def test_effort_snap_skips_levels_that_admit_no_rung() -> None:
         request,
     )
     assert coercion is not None
-    # xhigh is nearer to ultra but only the temperature-rejecting rung has
-    # it; high is the closest level that admits a serving rung.
-    assert coercion.request.reasoning_effort == "high"
-    assert coercion.disclosures == ("reasoning_effort->high",)
+    # xhigh is nearer to ultra; the rung that carries it serves once the
+    # temperature it rejects is dropped (disclosed downstream, not refused).
+    assert coercion.request.reasoning_effort == "xhigh"
+    assert coercion.disclosures == ("reasoning_effort->xhigh",)
 
 
 def test_any_effort_drops_on_a_route_with_no_reasoning_at_all() -> None:

--- a/exp/runtime/models/providers/protocol.py
+++ b/exp/runtime/models/providers/protocol.py
@@ -189,19 +189,30 @@ class GatewayDispatchSigner(Protocol):
 STOP_SEQUENCE_EMULATED_DIALECTS: frozenset[str] = frozenset({"openai_responses"})
 
 
-def emulated_gateway_capabilities(dialect: str) -> frozenset[str]:
+def emulated_gateway_capabilities(
+    dialect: str, *, emulate_parallel_tool_calls: bool = False
+) -> frozenset[str]:
     """Name the capabilities the data plane emulates for one wire dialect.
 
     Args:
         dialect: The rung's wire dialect (``GatewayWireProfile.dialect``).
+        emulate_parallel_tool_calls: Admit ``parallel_tool_calls`` on a rung
+            whose wire lacks the control (``true`` dropped as the provider's
+            default, ``false`` serialized by the data plane, both disclosed).
+            Admission turns this on only as the LAST resort, after no rung
+            honouring the control natively could serve, so a native rung is
+            always preferred over emulation.
 
     Returns:
         Capability labels admission treats as satisfied without a catalog
         declaration; empty for dialects with nothing emulated.
     """
+    emulated: set[str] = set()
     if dialect in STOP_SEQUENCE_EMULATED_DIALECTS:
-        return frozenset({"stop_sequences"})
-    return frozenset()
+        emulated.add("stop_sequences")
+    if emulate_parallel_tool_calls:
+        emulated.add("parallel_tool_calls")
+    return frozenset(emulated)
 
 
 def emulated_stop_sequences(dialect: str, request: GatewayRequest) -> tuple[str, ...]:

--- a/exp/runtime/models/providers/protocol_test.py
+++ b/exp/runtime/models/providers/protocol_test.py
@@ -276,6 +276,10 @@ def test_preflight_admits_an_undeclared_stop_when_the_data_plane_emulates_it() -
 
     assert emulated_gateway_capabilities("openai_responses") == frozenset({"stop_sequences"})
     assert emulated_gateway_capabilities("openai_compatible") == frozenset()
+    # parallel_tool_calls emulation is opt-in: admission's last resort on any wire.
+    assert emulated_gateway_capabilities(
+        "openai_compatible", emulate_parallel_tool_calls=True
+    ) == frozenset({"parallel_tool_calls"})
     preflight_gateway_request(
         request,
         undeclared,

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -263,9 +263,17 @@ def route_generation_parameter_requests(
             sampling_supported(profile, top_p=top_p) for profile in profiles
         )
 
+    # Sampling controls a rung cannot carry at all (a reasoning model whose
+    # provider rejects temperature outright) are DROPPED with disclosure, not
+    # refused: the model still answers, with its own default. The 400 stays
+    # only for a value outside a supporting route's declared range, which is
+    # a genuine caller error. (2026-09-06: 1,483 rejections in six hours across
+    # 289 orgs on one alias for a field OpenAI itself simply refuses.)
     if request.temperature is not None:
         if srn_only_block():
             ignore("temperature", "temperature->dropped(set_reasoning_effort_none)")
+        elif not all(sampling_supported(profile) for profile in profiles):
+            ignore("temperature", "temperature->dropped(unsupported_by_provider)")
         else:
             _require_route_numeric_parameter(
                 profiles,
@@ -278,6 +286,8 @@ def route_generation_parameter_requests(
     if request.top_p is not None:
         if srn_only_block(top_p=True):
             ignore("top_p", "top_p->dropped(set_reasoning_effort_none)")
+        elif not all(sampling_supported(profile, top_p=True) for profile in profiles):
+            ignore("top_p", "top_p->dropped(unsupported_by_provider)")
         else:
             _require_route_numeric_parameter(
                 profiles,
@@ -943,15 +953,17 @@ def route_generation_parameter_requests(
     elif request.parallel_tool_calls is not None and any(
         profile.dialect in _NO_PARALLEL_TOOL_CONTROL_DIALECTS for profile in profiles
     ):
-        raise ProviderParameterError(
-            message=(
-                "The parameter 'parallel_tool_calls' is not supported by this model route. "
-                "Remove the field or choose a provider route with an explicit parallel-tool "
-                "control."
-            ),
-            param="parallel_tool_calls",
-            code="unsupported_parameter",
-        )
+        # A wire with no parallel-tool control: `true` is the provider's own
+        # default and is dropped; `false` is honoured by the data plane, which
+        # serializes each turn to its first tool call. Both are disclosed.
+        if request.parallel_tool_calls:
+            ignore("parallel_tool_calls", "parallel_tool_calls->dropped(provider_default)")
+        else:
+            ignore(
+                "parallel_tool_calls",
+                "parallel_tool_calls->emulated(serialized_by_gateway)",
+            )
+            provider_updates["serialize_tool_calls"] = True
 
     # A true logprob request changes the requested result. Until the normalized
     # response can return those arrays, reject it rather than pretending it ran.

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -950,12 +950,15 @@ def route_generation_parameter_requests(
         )
     elif request.tool_choice == "none" and request.parallel_tool_calls is not None:
         ignore("parallel_tool_calls")
-    elif request.parallel_tool_calls is not None and any(
+    elif request.parallel_tool_calls is not None and all(
         profile.dialect in _NO_PARALLEL_TOOL_CONTROL_DIALECTS for profile in profiles
     ):
-        # A wire with no parallel-tool control: `true` is the provider's own
+        # No rung carries a parallel-tool control: `true` is the provider's own
         # default and is dropped; `false` is honoured by the data plane, which
-        # serializes each turn to its first tool call. Both are disclosed.
+        # serializes each turn to its first tool call. Both are disclosed. A
+        # mixed route keeps the field so rungs that carry the control forward
+        # it natively; only the toggle-less rungs are shaped per rung at
+        # dispatch (native_admission.shape_parallel_tool_calls).
         if request.parallel_tool_calls:
             ignore("parallel_tool_calls", "parallel_tool_calls->dropped(provider_default)")
         else:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -954,11 +954,8 @@ def route_generation_parameter_requests(
         profile.dialect in _NO_PARALLEL_TOOL_CONTROL_DIALECTS for profile in profiles
     ):
         # No rung carries a parallel-tool control: `true` is the provider's own
-        # default and is dropped; `false` is honoured by the data plane, which
-        # serializes each turn to its first tool call. Both are disclosed. A
-        # mixed route keeps the field so rungs that carry the control forward
-        # it natively; only the toggle-less rungs are shaped per rung at
-        # dispatch (native_admission.shape_parallel_tool_calls).
+        # default (dropped); `false` is serialized by the data plane. A mixed
+        # route keeps the field; toggle-less rungs are shaped per rung at dispatch.
         if request.parallel_tool_calls:
             ignore("parallel_tool_calls", "parallel_tool_calls->dropped(provider_default)")
         else:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -712,11 +712,12 @@ def test_reasoning_summary_narrows_a_mixed_claude_waterfall() -> None:
 def test_route_generation_controls_use_the_whole_waterfall_intersection(
     field: str, value: float | int
 ) -> None:
-    """One incompatible fallback rejects an explicit semantic control before dispatch.
+    """One incompatible fallback drops an explicit sampling control with disclosure.
 
-    temperature/top_p are genuinely unsupported on the fallback (declared False),
-    so they still hard-reject; top_k is a droppable sampling preference and is
-    covered separately.
+    temperature/top_p are genuinely unsupported on the fallback (declared False):
+    the control is dropped route-wide and disclosed, never a 400 (the model
+    still answers with its own default). A value outside a SUPPORTING route's
+    range still rejects (covered separately).
     """
     request = _chat_request().model_copy(update={field: value})
     profiles = (
@@ -742,11 +743,10 @@ def test_route_generation_controls_use_the_whole_waterfall_intersection(
         ),
     )
 
-    with pytest.raises(ProviderParameterError) as raised:
-        route_generation_parameter_requests(profiles, request)
+    public_request, provider_request = route_generation_parameter_requests(profiles, request)
 
-    assert raised.value.code == "unsupported_parameter"
-    assert raised.value.param == field
+    assert getattr(provider_request, field) is None
+    assert f"{field}->dropped(unsupported_by_provider)" in public_request.ignored_parameters
 
 
 def test_top_k_narrows_to_a_supporting_rung_then_drops_when_none_support() -> None:
@@ -1254,23 +1254,29 @@ def test_route_shaping_omits_parallel_control_when_tool_choice_disables_tools() 
     "dialect",
     ("gemini_generate_content", "bedrock_converse_stream"),
 )
-def test_route_rejects_parallel_control_when_the_dialect_has_no_toggle(dialect: str) -> None:
-    """A semantic parallel-tool control never disappears on native provider wires."""
-    request = _chat_request().model_copy(
-        update={
-            "tools": (GatewayToolDefinition(name="search", parameters={"type": "object"}),),
-            "parallel_tool_calls": False,
-        }
+def test_route_emulates_parallel_control_when_the_dialect_has_no_toggle(dialect: str) -> None:
+    """A wire without a parallel-tool control never loses the caller's semantics.
+
+    `false` is honoured by the data plane (one tool call per turn) and
+    disclosed; `true` is the provider's own default and is dropped with its
+    own disclosure. Neither is a 400 any more.
+    """
+    tools = (GatewayToolDefinition(name="search", parameters={"type": "object"}),)
+    profiles = (GatewayWireProfile(dialect=dialect, url="https://provider.test"),)
+
+    sequential = _chat_request().model_copy(update={"tools": tools, "parallel_tool_calls": False})
+    public_request, provider_request = route_generation_parameter_requests(profiles, sequential)
+    assert provider_request.parallel_tool_calls is None
+    assert provider_request.serialize_tool_calls is True
+    assert (
+        "parallel_tool_calls->emulated(serialized_by_gateway)" in public_request.ignored_parameters
     )
 
-    with pytest.raises(ProviderParameterError) as raised:
-        route_generation_parameter_requests(
-            (GatewayWireProfile(dialect=dialect, url="https://provider.test"),),
-            request,
-        )
-
-    assert raised.value.code == "unsupported_parameter"
-    assert raised.value.param == "parallel_tool_calls"
+    parallel = _chat_request().model_copy(update={"tools": tools, "parallel_tool_calls": True})
+    public_request, provider_request = route_generation_parameter_requests(profiles, parallel)
+    assert provider_request.parallel_tool_calls is None
+    assert provider_request.serialize_tool_calls is False
+    assert "parallel_tool_calls->dropped(provider_default)" in public_request.ignored_parameters
 
 
 def test_route_rejects_non_strict_schema_on_a_strict_only_provider() -> None:
@@ -1435,20 +1441,25 @@ def test_temperature_narrows_to_a_honoring_rung_over_an_srn_rung() -> None:
     assert compatible_generation_parameter_profile_indexes((srn_rung, plain_rung), request) == (1,)
 
 
-def test_genuinely_unsupported_sampling_still_hard_rejects() -> None:
-    """A route that never declares temperature (Anthropic constrained [1,1]) still
-    rejects — there is nothing to honor at any effort, so it is not srn-droppable."""
+def test_genuinely_unsupported_sampling_drops_with_its_own_disclosure() -> None:
+    """A route that never declares temperature (Anthropic constrained [1,1]) drops it
+    and says so — there is nothing to honor at any effort, so the disclosure names
+    the provider, not a reasoning-effort remedy, and the model still answers."""
     profile = GatewayWireProfile(
         dialect="anthropic_messages",
         url="https://provider.test",
         model_id="claude-constrained",
         supports_temperature=False,
     )
-    with pytest.raises(ProviderParameterError) as raised:
-        route_generation_parameter_requests((profile,), _chat_request(temperature=0.2))
+    public_request, provider_request = route_generation_parameter_requests(
+        (profile,), _chat_request(temperature=0.2)
+    )
 
-    assert raised.value.code == "unsupported_parameter"
-    assert raised.value.param == "temperature"
+    assert provider_request.temperature is None
+    assert "temperature->dropped(unsupported_by_provider)" in public_request.ignored_parameters
+    assert "temperature->dropped(set_reasoning_effort_none)" not in (
+        public_request.ignored_parameters
+    )
 
 
 def test_thinking_default_enable_resolves_the_required_default_effort() -> None:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1279,6 +1279,26 @@ def test_route_emulates_parallel_control_when_the_dialect_has_no_toggle(dialect:
     assert "parallel_tool_calls->dropped(provider_default)" in public_request.ignored_parameters
 
 
+def test_mixed_route_keeps_parallel_control_for_the_rungs_that_carry_it() -> None:
+    """Route-wide shaping only fires when NO rung has the control.
+
+    With one native rung and one toggle-less rung the field stays on the
+    provider request: the native rung forwards it verbatim and the toggle-less
+    rung is shaped per rung at dispatch, so a capable deployment never loses
+    the caller's native control to another rung's limitation.
+    """
+    tools = (GatewayToolDefinition(name="search", parameters={"type": "object"}),)
+    profiles = (
+        GatewayWireProfile(dialect="openai_compatible", url="https://native.test"),
+        GatewayWireProfile(dialect="openai_responses", url="https://toggle-less.test"),
+    )
+    sequential = _chat_request().model_copy(update={"tools": tools, "parallel_tool_calls": False})
+    public_request, provider_request = route_generation_parameter_requests(profiles, sequential)
+    assert provider_request.parallel_tool_calls is False
+    assert provider_request.serialize_tool_calls is False
+    assert not any("parallel_tool_calls" in note for note in public_request.ignored_parameters)
+
+
 def test_route_rejects_non_strict_schema_on_a_strict_only_provider() -> None:
     """Constrained decoding cannot silently strengthen a non-strict request."""
     request = _chat_request().model_copy(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.39,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.40,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.39"
+version = "0.3.40"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

Third batch of the 2026-09-05/06 alerts-channel error review. Two request-shaping rejections were client 400s for fields the caller cannot reasonably know per model, and both were high-volume on the OpenAI reasoning aliases:

- `temperature` / `top_p` on a rung whose provider refuses the field outright (gpt-6-astra rejects `temperature` at every effort and has no `reasoning_effort: none`): 1,483 rejections in six hours across 289 orgs on one alias. The model serves fine with its own default.
- `parallel_tool_calls` on dialects with no wire toggle (openai_responses, anthropic_messages, …): rejected with `unsupported_parameter` even though the caller's intent is satisfiable.

## What

**Sampling controls a rung cannot carry are dropped with disclosure, not refused.** `temperature`/`top_p` now flow through `ignore(...)` as `temperature->dropped(unsupported_by_provider)` in `ignored_parameters`. A value outside a *supporting* route's declared range still 400s (a genuine caller error). The existing `set_reasoning_effort_none` hatch is unchanged and still preferred where the provider has it.

**`parallel_tool_calls` becomes a warning, per rung.**
- `true` on a wire with no toggle is the provider's own default: dropped as `parallel_tool_calls->dropped(provider_default)`.
- `false` is honoured by the data plane: `parallel_tool_calls->emulated(serialized_by_gateway)`. New `ToolCallSerializer` (Rust) keeps the first tool call of each turn and drops later calls' start/args/completion/item lifecycle events. `DeploymentWire.serialize_tool_calls` carries the flag per rung.
- Shaping is per rung (`shape_parallel_tool_calls`) so a route can honour the field natively on one deployment and emulate it on the next; the union of disclosures is folded into the public request (`fold_parallel_tool_call_disclosures`). Route admission does a last-resort pass with `emulate_parallel_tool_calls=True` so a request is never refused solely for this field.

**Bridge trimmed under the 999-line budget** by extracting per-rung dispatch construction into `native_rungs.py::build_rung_dispatch` (behaviour-preserving move).

`exp-gateway-native` 0.3.40. No release cut in this PR; batching with #833 (0.3.39) per the ongoing alerts review.

## Verification

- Rust: `cargo fmt --check`, `cargo clippy --no-default-features -D warnings`, `cargo test --no-default-features` (239 tests, 3 new for the serializer).
- Python: `ruff check`, `ruff format --check`, `ty check`, full `pytest -q` on the committed tree — green. Suites updated: `streaming_requests_test`, `protocol_test`, `native_admission_test`, `native_execution_test`, `capability_policy_test` (effort snap now lands on the nearer rung since the temperature it rejects is dropped rather than refused).
- Live: OpenAI gpt-6-astra rejects `temperature` and `reasoning.effort: none` (probed 2026-09-06), so the drop is the only non-refusing path for that lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)