### PR TITLE
native: cyber_policy refusal, routing-gate 403 not auth, lane-limitation 400s fail over (native 0.3.41)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.40"
+version = "0.3.41"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.40"
+version = "0.3.41"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.40"
+version = "0.3.41"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -81,31 +81,66 @@ const LANE_LIMITATION_PHRASES: &[&str] = &[
     "only the first message can be a system message",
 ];
 
-/// Whether a 4xx body describes a limitation of the lane rather than of the
-/// caller's request (see [`LANE_LIMITATION_PHRASES`]).
-pub fn rejected_by_lane_limitation(body: &str) -> bool {
-    let lowered = body.to_ascii_lowercase();
-    LANE_LIMITATION_PHRASES
-        .iter()
-        .any(|phrase| lowered.contains(phrase))
+/// The provider's own error sentence from one client-error body, read only
+/// from the dialect's documented message field (never from echoed request
+/// data or unrelated metadata).
+fn error_message_field(dialect: Dialect, value: &Value) -> Option<&str> {
+    match dialect {
+        Dialect::OpenAiResponses
+        | Dialect::OpenAiCompatible
+        | Dialect::AnthropicMessages
+        | Dialect::GeminiGenerateContent => value.get("error")?.get("message")?.as_str(),
+        // Bedrock reports a modeling error as a bare top-level `message`.
+        Dialect::BedrockConverseStream => value.get("message")?.as_str(),
+    }
 }
 
-/// Whether a 403 body is an aggregator ROUTING gate rather than a credential
-/// verdict: OpenRouter answers `metadata.failed_routing_step` (its free
-/// endpoints gated to allow-listed apps, 2026-09-06) with an otherwise valid
-/// key. The lane cannot serve this model for the gateway's account, so it takes
-/// the not-found policy and the ladder advances instead of blaming the key.
-pub fn rejected_by_routing_gate(body: &str) -> bool {
+/// Whether a 4xx body's error SENTENCE describes a limitation of the lane
+/// rather than of the caller's request (see [`LANE_LIMITATION_PHRASES`]). Only
+/// the dialect's message field is read, so request text echoed elsewhere in
+/// the body cannot change routing.
+pub fn rejected_by_lane_limitation(dialect: Dialect, body: &str) -> bool {
     let value: Value = match serde_json::from_str(body) {
         Ok(value) => value,
         Err(_) => return false,
     };
-    value
-        .get("error")
-        .and_then(|error| error.get("metadata"))
-        .and_then(|metadata| metadata.get("failed_routing_step"))
+    error_message_field(dialect, &value).is_some_and(|message| {
+        let lowered = message.to_ascii_lowercase();
+        LANE_LIMITATION_PHRASES
+            .iter()
+            .any(|phrase| lowered.contains(phrase))
+    })
+}
+
+/// Whether a 403 body is an aggregator ROUTING verdict rather than a
+/// credential one. OpenRouter runs its routing funnel only AFTER the key has
+/// authenticated, and reports the funnel it walked (`metadata.routing_funnel`)
+/// plus the step that refused (`metadata.failed_routing_step`; "Gate Free
+/// Endpoints by Agentic Harness" on its app-allow-listed free endpoints,
+/// 2026-09-06). Both fields together mean the key is fine and this lane will
+/// not serve this model for the gateway's account, so it takes the not-found
+/// policy and the ladder advances. Only the OpenAI-compatible wire OpenRouter
+/// speaks is read; other dialects keep the credential verdict.
+pub fn rejected_by_routing_gate(dialect: Dialect, body: &str) -> bool {
+    if dialect != Dialect::OpenAiCompatible {
+        return false;
+    }
+    let value: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let Some(metadata) = value.get("error").and_then(|error| error.get("metadata")) else {
+        return false;
+    };
+    let walked_funnel = metadata
+        .get("routing_funnel")
+        .and_then(Value::as_array)
+        .is_some_and(|steps| !steps.is_empty());
+    let failed_step = metadata
+        .get("failed_routing_step")
         .and_then(Value::as_str)
-        .is_some_and(|step| !step.is_empty())
+        .is_some_and(|step| !step.trim().is_empty());
+    walked_funnel && failed_step
 }
 
 /// Whether one client-error body reports that the dispatched model does not exist.
@@ -160,14 +195,7 @@ pub fn rejected_model_not_found(dialect: Dialect, body: &str) -> bool {
 /// generic 400 for a client-side fix (2026-09-04 ledger).
 pub fn rejected_detail(dialect: Dialect, body: &str, request_words: &[&str]) -> Option<String> {
     let value: Value = serde_json::from_str(body).ok()?;
-    let message = match dialect {
-        Dialect::OpenAiResponses
-        | Dialect::OpenAiCompatible
-        | Dialect::AnthropicMessages
-        | Dialect::GeminiGenerateContent => value.get("error")?.get("message")?.as_str()?,
-        // Bedrock reports a modeling error as a bare top-level `message`.
-        Dialect::BedrockConverseStream => value.get("message")?.as_str()?,
-    };
+    let message = error_message_field(dialect, &value)?;
     sanitized_detail(message, request_words)
 }
 

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -70,6 +70,44 @@ pub fn rejected_parameter(dialect: Dialect, body: &str) -> Option<String> {
 /// OpenAI-family `error.code` naming a deployment model the provider cannot serve.
 const MODEL_NOT_FOUND_CODE: &str = "model_not_found";
 
+/// Sentences a provider answers with a 400 for a request shape the OpenAI
+/// contract allows but THIS lane's serving stack cannot carry (a chat
+/// template that only accepts a leading system turn). They are lane
+/// limitations, not caller errors: the request fails over to the next rung and
+/// only a route with no other rung surfaces the sentence.
+const LANE_LIMITATION_PHRASES: &[&str] = &[
+    "system message must be at the beginning",
+    "system message should be at the beginning",
+    "only the first message can be a system message",
+];
+
+/// Whether a 4xx body describes a limitation of the lane rather than of the
+/// caller's request (see [`LANE_LIMITATION_PHRASES`]).
+pub fn rejected_by_lane_limitation(body: &str) -> bool {
+    let lowered = body.to_ascii_lowercase();
+    LANE_LIMITATION_PHRASES
+        .iter()
+        .any(|phrase| lowered.contains(phrase))
+}
+
+/// Whether a 403 body is an aggregator ROUTING gate rather than a credential
+/// verdict: OpenRouter answers `metadata.failed_routing_step` (its free
+/// endpoints gated to allow-listed apps, 2026-09-06) with an otherwise valid
+/// key. The lane cannot serve this model for the gateway's account, so it takes
+/// the not-found policy and the ladder advances instead of blaming the key.
+pub fn rejected_by_routing_gate(body: &str) -> bool {
+    let value: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    value
+        .get("error")
+        .and_then(|error| error.get("metadata"))
+        .and_then(|metadata| metadata.get("failed_routing_step"))
+        .and_then(Value::as_str)
+        .is_some_and(|step| !step.is_empty())
+}
+
 /// Whether one client-error body reports that the dispatched model does not exist.
 ///
 /// The OpenAI Responses surface answers an unknown model with HTTP 400 and

--- a/exp/runtime/gateway/native/src/stream_errors.rs
+++ b/exp/runtime/gateway/native/src/stream_errors.rs
@@ -68,6 +68,9 @@ const REFUSAL_CODES: &[&str] = &[
     "spii",
     "moderation_blocked",
     "refusal",
+    // OpenAI's cyber-safety policy verdict (gpt-6-astra, 2026-09-06): a model
+    // decision on the content, filed as a refusal, never a provider failure.
+    "cyber_policy",
 ];
 const THROTTLED_CODES: &[&str] = &[
     "rate_limit_exceeded",
@@ -329,6 +332,10 @@ mod tests {
                 Some("data_inspection_failed"),
                 Some("Output data may contain inappropriate content.")
             ),
+            StreamErrorKind::Refusal
+        );
+        assert_eq!(
+            classify_stream_error(Some("cyber_policy"), None),
             StreamErrorKind::Refusal
         );
     }

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -8,8 +8,8 @@ use serde_json::Value;
 use crate::dialects::Dialect;
 use crate::errors::{Failure, FailureClass};
 use crate::param_attribution::{
-    generic_error_code, rejected_code, rejected_detail, rejected_model_not_found,
-    rejected_parameter,
+    generic_error_code, rejected_by_lane_limitation, rejected_by_routing_gate, rejected_code,
+    rejected_detail, rejected_model_not_found, rejected_parameter,
 };
 
 /// Build the shared pooled upstream client, mirroring the pooling constants in
@@ -172,8 +172,9 @@ pub async fn open_stream(
         // Only the generic client-error class may carry attribution: the body
         // is read bounded, and the relayable facts are a validated parameter
         // path plus the provider's own bounded explanation of what the caller
-        // got wrong; every other class stays content-free.
-        if failure.failure_class != FailureClass::InvalidRequest {
+        // got wrong; every other class stays content-free. A 403 is read too,
+        // only to tell an aggregator routing gate from a credential verdict.
+        if failure.failure_class != FailureClass::InvalidRequest && status != 403 {
             return Err(failure);
         }
         let body = match tokio::time::timeout(ERROR_BODY_READ_TIMEOUT, bounded_error_body(response))
@@ -182,6 +183,17 @@ pub async fn open_stream(
             Ok(Some(body)) => Some(body),
             _ => None,
         };
+        if status == 403 {
+            if body.as_deref().is_some_and(rejected_by_routing_gate) {
+                return Err(Failure::new(
+                    FailureClass::ProviderNotFound,
+                    "provider does not route this model for the gateway's account; ask \
+                     the gateway operator to change or disable the lane",
+                )
+                .with_retry(false, true));
+            }
+            return Err(failure);
+        }
         // A client-error status whose body names a missing model is the
         // catalog's fault, not the caller's: it takes the 404 policy so the
         // ladder advances instead of surfacing one dead rung as a 400.
@@ -224,7 +236,14 @@ pub async fn open_stream(
                     .with_provider_detail(detail),
             );
         }
+        // A sentence naming a limitation of THIS lane's serving stack (a chat
+        // template that rejects a mid-conversation system turn the OpenAI
+        // contract allows) keeps the caller's class and detail but fails over:
+        // another rung serves the same request, and only a route with no other
+        // rung surfaces the 400.
+        let lane_limitation = body.as_deref().is_some_and(rejected_by_lane_limitation);
         return Err(failure
+            .with_retry(false, lane_limitation)
             .with_rejected_parameter(parameter)
             .with_provider_detail(detail));
     }
@@ -424,6 +443,68 @@ mod tests {
             failure.public_error().message,
             "provider refused the request"
         );
+    }
+
+    #[tokio::test]
+    async fn an_aggregator_routing_gate_403_is_not_a_credential_failure() {
+        let failure = open_against_body(
+            "403 Forbidden",
+            "{\"error\":{\"message\":\"thinkingmachines/inkling:free is only available \
+             on agentic harnesses.\",\"code\":403,\"metadata\":{\"failed_routing_step\":\
+             \"Gate Free Endpoints by Agentic Harness\"}}}",
+            "thinkingmachines/inkling:free",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::ProviderNotFound);
+        assert!(failure.failover_eligible);
+        assert!(!failure.retryable_same_deployment);
+        assert!(failure.provider_detail.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_plain_403_stays_a_credential_failure() {
+        let failure = open_against_body(
+            "403 Forbidden",
+            "{\"error\":{\"message\":\"Forbidden\",\"code\":403}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::ProviderAuthentication);
+        assert!(failure.failover_eligible);
+    }
+
+    #[tokio::test]
+    async fn a_lane_limitation_400_keeps_the_class_but_fails_over() {
+        let failure = open_against_body(
+            "400 Bad Request",
+            "{\"error\":{\"message\":\"System message must be at the beginning.\",\
+             \"type\":\"invalid_request_error\"}}",
+            "qwen3.8-27b",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
+        assert!(
+            failure.failover_eligible,
+            "another rung can carry the request"
+        );
+        assert!(!failure.retryable_same_deployment);
+        assert!(failure
+            .provider_detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("System message must be at the beginning")));
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_400_does_not_fail_over() {
+        let failure = open_against_body(
+            "400 Bad Request",
+            "{\"error\":{\"message\":\"Invalid value for temperature.\",\
+             \"type\":\"invalid_request_error\"}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
+        assert!(!failure.failover_eligible);
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -1,7 +1,7 @@
 //! Upstream provider HTTP transport over one shared pooled client.
 
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
@@ -156,6 +156,7 @@ pub async fn open_stream(
         Some(body) => request.body(body.to_string()).send(),
         None => request.json(payload).send(),
     };
+    let phase_started = Instant::now();
     let response = match tokio::time::timeout(phase_timeout, send).await {
         Ok(Ok(response)) => response,
         Ok(Err(error)) => {
@@ -177,14 +178,21 @@ pub async fn open_stream(
         if failure.failure_class != FailureClass::InvalidRequest && status != 403 {
             return Err(failure);
         }
-        let body = match tokio::time::timeout(ERROR_BODY_READ_TIMEOUT, bounded_error_body(response))
-            .await
-        {
+        // The attribution read never outlives the rung's own header-phase
+        // budget: a provider that answers its status and then stalls the body
+        // costs at most what was left of that window, never a further two
+        // seconds past the caller's deadline.
+        let body_budget =
+            ERROR_BODY_READ_TIMEOUT.min(phase_timeout.saturating_sub(phase_started.elapsed()));
+        let body = match tokio::time::timeout(body_budget, bounded_error_body(response)).await {
             Ok(Some(body)) => Some(body),
             _ => None,
         };
         if status == 403 {
-            if body.as_deref().is_some_and(rejected_by_routing_gate) {
+            if body
+                .as_deref()
+                .is_some_and(|body| rejected_by_routing_gate(dialect, body))
+            {
                 return Err(Failure::new(
                     FailureClass::ProviderNotFound,
                     "provider does not route this model for the gateway's account; ask \
@@ -241,7 +249,9 @@ pub async fn open_stream(
         // contract allows) keeps the caller's class and detail but fails over:
         // another rung serves the same request, and only a route with no other
         // rung surfaces the 400.
-        let lane_limitation = body.as_deref().is_some_and(rejected_by_lane_limitation);
+        let lane_limitation = body
+            .as_deref()
+            .is_some_and(|body| rejected_by_lane_limitation(dialect, body));
         return Err(failure
             .with_retry(false, lane_limitation)
             .with_rejected_parameter(parameter)
@@ -450,8 +460,9 @@ mod tests {
         let failure = open_against_body(
             "403 Forbidden",
             "{\"error\":{\"message\":\"thinkingmachines/inkling:free is only available \
-             on agentic harnesses.\",\"code\":403,\"metadata\":{\"failed_routing_step\":\
-             \"Gate Free Endpoints by Agentic Harness\"}}}",
+             on agentic harnesses.\",\"code\":403,\"metadata\":{\"routing_funnel\":\
+             [{\"step\":\"Initial Endpoints\",\"endpoint_count\":1}],\
+             \"failed_routing_step\":\"Gate Free Endpoints by Agentic Harness\"}}}",
             "thinkingmachines/inkling:free",
         )
         .await;
@@ -492,6 +503,32 @@ mod tests {
             .provider_detail
             .as_deref()
             .is_some_and(|detail| detail.contains("System message must be at the beginning")));
+    }
+
+    #[tokio::test]
+    async fn a_lane_limitation_phrase_echoed_outside_the_message_does_not_fail_over() {
+        let failure = open_against_body(
+            "400 Bad Request",
+            "{\"error\":{\"message\":\"Invalid value for temperature.\",\
+             \"type\":\"invalid_request_error\",\"param\":\"temperature\",\
+             \"echo\":\"System message must be at the beginning\"}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
+        assert!(!failure.failover_eligible);
+    }
+
+    #[tokio::test]
+    async fn a_403_naming_a_step_without_a_walked_funnel_stays_a_credential_failure() {
+        let failure = open_against_body(
+            "403 Forbidden",
+            "{\"error\":{\"message\":\"Forbidden\",\"code\":403,\
+             \"metadata\":{\"failed_routing_step\":\"Authenticate\"}}}",
+            "m",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::ProviderAuthentication);
     }
 
     #[tokio::test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.40,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.41,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.40"
+version = "0.3.41"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

Fourth batch of the alerts-channel error review (2026-09-06 evening paste). Three misfiled provider answers:

- **`cyber_policy`** (OpenAI's cyber-safety verdict on gpt-6-astra) was not in the refusal code list, so it filed as `provider_internal`, retried across rungs, and read as a provider failure. 35 in 45 minutes.
- **OpenRouter routing gate 403.** `thinkingmachines/inkling:free` answers 403 with `metadata.failed_routing_step: "Gate Free Endpoints by Agentic Harness"` on a healthy key. Every 401/403 mapped to `provider_authentication`, so 2,600 attempts in 48h blamed the house credential.
- **"System message must be at the beginning."** The Experiential Cloud qwen3.8-27b chat template rejects a mid-conversation system turn the OpenAI contract allows. The 400 was terminal even though the cerebras, fireworks and openrouter rungs carry the request: 5,064 terminal 400s across 73 orgs in 48h, all at attempt ordinal 0.

## What

- `stream_errors.rs`: `cyber_policy` joins `REFUSAL_CODES` (covers both the mid-stream and the pre-stream 4xx paths).
- `upstream.rs`: a 403 body is now read (bounded, content-free) only to detect a routing gate; `rejected_by_routing_gate` (`error.metadata.failed_routing_step`) → `ProviderNotFound`, failover-eligible, no detail. A plain 403 is unchanged.
- `upstream.rs`: a 4xx whose sentence matches `LANE_LIMITATION_PHRASES` keeps `InvalidRequest` + the relayed sentence but becomes failover-eligible. Only a route with no other rung surfaces the 400. An ordinary 400 still does not fail over.
- native 0.3.41.

## Verification

`cargo fmt --check`, `clippy -D warnings`, `cargo test --no-default-features` (243 tests; 4 new upstream tests against a loopback server + 1 refusal-code assertion). Ledger evidence above from prod read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)