### PR TITLE
release: bump experiential to 0.7.44 (native 0.3.41)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.43"
+version = "0.7.44"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.43"
+version = "0.7.44"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the v0.7.44 release. Ships the three merged, unreleased engine batches:

- #833 (native 0.3.39): Anthropic/Bedrock tool calls truncated at max_tokens settle `incomplete`; pre-stream 4xx relays the provider code token; authoritative content-filter codes file as refusal.
- #834 (native 0.3.40): unsupported `temperature`/`top_p` dropped with disclosure instead of a 400; `parallel_tool_calls` becomes a warning, `false` emulated by the data plane's tool-call serializer per rung.
- #836 (native 0.3.41): `cyber_policy` is a refusal; OpenRouter routing-gate 403 is not a credential failure; lane-limitation 400s ("System message must be at the beginning") fail over.

Publishing follows the usual path: merge, then `gh release create v0.7.44 --target <merge sha>` triggers `python-package.yml`, then the platform repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)