### PR TITLE
release: bump experiential to 0.7.45 (fair-share/spill/affinity; native unchanged at 0.3.41)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.44"
+version = "0.7.45"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.44"
+version = "0.7.45"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only: pyproject.toml 0.7.44 -> 0.7.45 plus the one-line uv.lock update (uv lock --python 3.13). No crate change in #785, so exp-gateway-native stays pinned at >=0.3.41,<0.4.

Ships #785: flag-gated fair-share rung admission, bounded-queue spill, deterministic weighted-rendezvous cache-affinity routing, and the per-attempt cost-optimality disclosures (SQLite migration v17). Everything defaults off; the platform pin bump plus catalog opt-in (deepseek-v4-flash pilot) follow per the rollout ordering documented on the FailoverMode docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)