### PR TITLE
gateway: relay OpenRouter's upstream sentence, refuse Anthropic assistant prefill pre-dispatch, drop replayed input-message status, name the way out of a forced tool_choice (native 0.3.42)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.41"
+version = "0.3.42"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.41"
+version = "0.3.42"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.41"
+version = "0.3.42"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
@@ -56,10 +56,15 @@ impl Normalizer {
                             .map(str::to_string)
                             .or_else(|| value.as_i64().map(|numeric| numeric.to_string()))
                     }),
-                    error
-                        .get("message")
-                        .and_then(Value::as_str)
-                        .map(str::to_string),
+                    error.get("message").and_then(Value::as_str).map(|message| {
+                        // An aggregator's generic sentence yields to the
+                        // upstream provider's own (OpenRouter metadata.raw).
+                        crate::param_attribution::upstream_relayed_message(
+                            &Value::Object(error.clone()),
+                            message,
+                        )
+                        .unwrap_or_else(|| message.to_string())
+                    }),
                 ),
                 None => (None, None),
             };

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -196,7 +196,82 @@ pub fn rejected_model_not_found(dialect: Dialect, body: &str) -> bool {
 pub fn rejected_detail(dialect: Dialect, body: &str, request_words: &[&str]) -> Option<String> {
     let value: Value = serde_json::from_str(body).ok()?;
     let message = error_message_field(dialect, &value)?;
+    if dialect == Dialect::OpenAiCompatible {
+        if let Some(relayed) = value
+            .get("error")
+            .and_then(|error| upstream_relayed_message(error, message))
+        {
+            return sanitized_detail(&relayed, request_words);
+        }
+    }
     sanitized_detail(message, request_words)
+}
+
+/// Aggregator sentences that say nothing about what was refused.
+const GENERIC_AGGREGATOR_MESSAGES: &[&str] = &["provider returned error", "provider error"];
+
+/// The upstream provider's own sentence behind an aggregator's generic one.
+///
+/// OpenRouter answers a rejected relay with "Provider returned error" and
+/// puts the upstream body in `error.metadata.raw` (a JSON document or plain
+/// text) plus the upstream's name in `error.metadata.provider_name`. The
+/// generic sentence leaves the caller nothing to act on (673 such 400s across
+/// 137 orgs in the 24h to 2026-09-07 00:20 UTC), so when the aggregator's
+/// message is generic the upstream sentence is read instead, prefixed with
+/// the provider's name. Only the message field of a JSON `raw` is used; a
+/// plain-text `raw` is taken whole. The result still passes the same
+/// identifier screen and length bound as any relayed sentence.
+pub fn upstream_relayed_message(error: &Value, message: &str) -> Option<String> {
+    let lowered = message.trim().trim_end_matches('.').to_ascii_lowercase();
+    if !GENERIC_AGGREGATOR_MESSAGES.contains(&lowered.as_str()) {
+        return None;
+    }
+    let metadata = error.get("metadata")?;
+    let raw = metadata.get("raw")?;
+    let upstream = match raw {
+        Value::String(text) => match serde_json::from_str::<Value>(text) {
+            Ok(document) => json_error_sentence(&document)?,
+            Err(_) => text.trim().to_string(),
+        },
+        Value::Object(_) => json_error_sentence(raw)?,
+        _ => return None,
+    };
+    if upstream.is_empty() {
+        return None;
+    }
+    let provider = metadata
+        .get("provider_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| {
+            !name.is_empty()
+                && name.chars().all(|c| {
+                    c.is_ascii_alphanumeric() || c == ' ' || c == '-' || c == '_' || c == '.'
+                })
+        });
+    Some(match provider {
+        Some(name) => format!("{name}: {upstream}"),
+        None => upstream,
+    })
+}
+
+/// The human sentence of one upstream error document, whichever documented
+/// spelling it uses (`error.message`, `message`, `detail`, or a bare string
+/// `error`).
+fn json_error_sentence(document: &Value) -> Option<String> {
+    let error = document.get("error");
+    let candidates = [
+        error.and_then(|error| error.get("message")),
+        document.get("message"),
+        document.get("detail"),
+        error.filter(|value| value.is_string()),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find_map(|value| value.as_str())
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
 }
 
 /// The provider's own error code or type from one client-error body, as a
@@ -504,6 +579,36 @@ mod tests {
         // Any other message keeps the content-free failure.
         let other = r#"{"error": {"message": "This model is not available to your account."}}"#;
         assert_eq!(rejected_parameter(Dialect::OpenAiCompatible, other), None);
+    }
+
+    #[test]
+    fn an_aggregators_generic_sentence_yields_to_the_upstream_message() {
+        let body = r#"{"error":{"message":"Provider returned error","code":400,
+            "metadata":{"raw":"{\"error\":{\"message\":\"Input exceeds the maximum context window.\",\"type\":\"invalid_request_error\"}}",
+            "provider_name":"Relace"}}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, body, &[]).as_deref(),
+            Some("Relace: Input exceeds the maximum context window.")
+        );
+        // A plain-text raw is relayed whole; a specific aggregator sentence is kept.
+        let plain = r#"{"error":{"message":"Provider returned error","code":400,
+            "metadata":{"raw":"model is overloaded, try again","provider_name":"Fugu"}}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, plain, &[]).as_deref(),
+            Some("Fugu: model is overloaded, try again")
+        );
+        let specific = r#"{"error":{"message":"temperature must be <= 1","code":400,
+            "metadata":{"raw":"{\"error\":{\"message\":\"ignored\"}}"}}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, specific, &[]).as_deref(),
+            Some("temperature must be <= 1")
+        );
+        // Without metadata the generic sentence stays what it was.
+        let bare = r#"{"error":{"message":"Provider returned error","code":400}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, bare, &[]).as_deref(),
+            Some("Provider returned error")
+        );
     }
 
     #[test]

--- a/exp/runtime/gateway/native_bridge_errors.py
+++ b/exp/runtime/gateway/native_bridge_errors.py
@@ -116,6 +116,11 @@ _ATTACHMENT_CAPABILITY_MESSAGES = {
         "selected model route. Send the media inline or choose a model alias "
         "served by the provider that holds the upload."
     ),
+    "forced_tool_choice": (
+        "The selected model rejects a forced tool_choice ('required' or a named tool), "
+        "and the gateway will not silently weaken it to 'auto'. Send tool_choice 'auto' "
+        "(the model may still call the tool) or choose a different model alias."
+    ),
 }
 """Why an attachment was refused, since the field itself is the caller's message.
 

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -227,6 +227,28 @@ def test_audio_capability_error_explains_the_refusal(
     assert "audio_input" not in error.detail.message
 
 
+def test_forced_tool_choice_refusal_tells_the_caller_what_to_send_instead() -> None:
+    """The forced-choice refusal names the field AND the way out ('auto'), on
+    every surface: the generic "remove the unsupported field" wording left 64
+    callers in two hours (2026-09-06) with nothing actionable."""
+    for surface in (
+        GatewayApiSurface.CHAT_COMPLETIONS,
+        GatewayApiSurface.RESPONSES,
+        GatewayApiSurface.MESSAGES,
+    ):
+        error = _public_capability_error(
+            ProviderCapabilityError(capability="forced_tool_choice"),
+            surface,
+            public_stream=True,
+            public_tools=True,
+        )
+        assert error.status_code == 400
+        assert error.detail.param == "tool_choice"
+        assert error.detail.code == "unsupported_capability"
+        assert "tool_choice 'auto'" in error.detail.message
+        assert "forced_tool_choice" not in error.detail.message
+
+
 def test_public_capability_error_never_exposes_internal_labels() -> None:
     """Internal route requirements fail against model without leaking their names."""
     error = _public_capability_error(

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -11,6 +11,7 @@ call the provider is known to 400.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator, Mapping
 
 from pydantic import JsonValue
@@ -51,6 +52,47 @@ def anthropic_rejects_forced_tool_choice(model_id: str) -> bool:
     return any(
         normalized == release or normalized.startswith(f"{release}-")
         for release in _ANTHROPIC_FORCED_TOOL_CHOICE_REJECTING_RELEASES
+    )
+
+
+_ANTHROPIC_PREFILL_REJECTING_RELEASES = (
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+    "claude-sonnet-5",
+    "claude-opus-5",
+    "claude-fable-5",
+    "claude-fable-5-1",
+)
+"""Exact releases that answer a trailing assistant turn with a 400 by name.
+
+"This model does not support assistant message prefill. The conversation
+must end with a user message." Live-verified with the house key on
+2026-09-07: every release above rejects a two-turn user/assistant prefill,
+while claude-sonnet-4-5 and claude-haiku-4-5 answer it. Entries are exact
+RELEASES matched as a whole id segment (so a dated snapshot and a Bedrock
+``anthropic.claude-opus-5-v1:0`` spelling inherit their release's rule) and
+never generation prefixes: a new point release must be probed and added
+deliberately. The ledger for the 48h to 2026-09-07 00:30 UTC carried 128
+such provider 400s across 64 orgs, each dispatched before the caller learned
+the conversation shape was the problem."""
+
+
+def anthropic_rejects_assistant_prefill(model_id: str) -> bool:
+    """Return whether one Anthropic model refuses an assistant message as the final turn.
+
+    Args:
+        model_id: Exact provider model identifier, in any of the Anthropic,
+            Bedrock, or Vertex spellings.
+
+    Returns:
+        ``True`` when the model answers assistant prefill with a 400.
+    """
+    normalized = model_id.lower().replace(".", "-").replace("_", "-")
+    return any(
+        re.search(rf"(^|[^a-z0-9]){re.escape(release)}([^a-z0-9]|$)", normalized) is not None
+        for release in _ANTHROPIC_PREFILL_REJECTING_RELEASES
     )
 
 

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -90,8 +90,16 @@ def anthropic_rejects_assistant_prefill(model_id: str) -> bool:
         ``True`` when the model answers assistant prefill with a 400.
     """
     normalized = model_id.lower().replace(".", "-").replace("_", "-")
+    # A listed release matches as a whole segment: what follows may be the
+    # end, a non-alphanumeric separator, a dated snapshot (8+ digits), or a
+    # provider suffix (``-v1:0``), but never a SHORT digit group, which is a
+    # different point release (``claude-opus-5-1`` is not ``claude-opus-5``).
     return any(
-        re.search(rf"(^|[^a-z0-9]){re.escape(release)}([^a-z0-9]|$)", normalized) is not None
+        re.search(
+            rf"(?:^|[^a-z0-9]){re.escape(release)}(?![a-z0-9])(?!-\d{{1,7}}(?![0-9]))",
+            normalized,
+        )
+        is not None
         for release in _ANTHROPIC_PREFILL_REJECTING_RELEASES
     )
 

--- a/exp/runtime/models/providers/generation_parameter_validation.py
+++ b/exp/runtime/models/providers/generation_parameter_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 
 from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.models.providers.anthropic_tool_compat import anthropic_rejects_assistant_prefill
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderParameterError
 from exp.runtime.models.providers.reasoning_compat import supported_reasoning_efforts
@@ -106,6 +107,41 @@ def anthropic_reasoning_disengaged(request: GatewayRequest) -> bool:
     thinking_on = config is not None and config.get("type") in {"enabled", "adaptive"}
     effort_on = request.reasoning_effort is not None and request.reasoning_effort != "none"
     return not thinking_on and not effort_on
+
+
+def require_assistant_prefill_supported(
+    profiles: Sequence[GatewayWireProfile], request: GatewayRequest
+) -> None:
+    """Refuse a trailing assistant turn before dispatch on rungs whose model rejects it.
+
+    Anthropic's 4.6+ and 5-generation releases answer assistant prefill with a
+    400 after the request was dispatched and billed for admission. The rungs
+    that carry such a model narrow out here with the same fact stated for the
+    caller; a route with no other rung surfaces it as the request's 400.
+
+    Raises:
+        ProviderParameterError: The final message is an assistant turn and a
+            profile's model refuses prefill.
+    """
+    if not request.messages or request.messages[-1].role != "assistant":
+        return
+    if request.messages[-1].provider_native_item is not None:
+        return
+    for profile in profiles:
+        if profile.dialect not in {
+            "anthropic_messages",
+            "bedrock_converse_stream",
+        } or not anthropic_rejects_assistant_prefill(profile.model_id):
+            continue
+        raise ProviderParameterError(
+            message=(
+                f"{profile.model_id} does not accept an assistant message as the final "
+                "turn (assistant prefill). End the conversation with a user message, or "
+                "choose a model alias that supports prefill."
+            ),
+            param="messages",
+            code="unsupported_parameter",
+        )
 
 
 def mid_conversation_system_present(request: GatewayRequest) -> bool:

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -25,6 +25,19 @@ from exp.runtime.models.providers.wire_messages import (
     responses_items,
 )
 
+_INPUT_MESSAGE_ROLES = frozenset({"user", "system", "developer"})
+
+
+def _without_input_message_status(item: JsonObject) -> JsonObject:
+    """Drop ``status`` from a replayed input message; every other item is verbatim."""
+    if (
+        "status" in item
+        and item.get("type") in (None, "message")
+        and item.get("role") in _INPUT_MESSAGE_ROLES
+    ):
+        return {key: value for key, value in item.items() if key != "status"}
+    return item
+
 
 def openai_responses_stream_payload(
     model_id: str,
@@ -64,9 +77,14 @@ def openai_responses_stream_payload(
     for message in request.messages:
         if message.provider_native_item is not None:
             # Codex-native input items (tool namespaces, freeform tool
-            # history) re-emit byte-for-byte at their position; route
-            # admission already required every rung to speak this wire.
-            items.append(message.provider_native_item)
+            # history, hosted tool echoes) re-emit byte-for-byte at their
+            # position; route admission already required every rung to speak
+            # this wire. The one exception is an input MESSAGE carrying the
+            # output-only ``status`` a client copied from a prior response:
+            # the input-message schema has no such field and OpenAI answers
+            # 400 "Unknown parameter: 'input[N].status'". Hosted tool items
+            # keep theirs (their schema defines it).
+            items.append(_without_input_message_status(message.provider_native_item))
         elif message.role in {"system", "developer"}:
             if message.content is None:
                 raise ProviderResponseError("instruction messages require text")

--- a/exp/runtime/models/providers/openai_payloads_test.py
+++ b/exp/runtime/models/providers/openai_payloads_test.py
@@ -3,6 +3,7 @@ are exercised in streaming_requests_test.py."""
 
 from __future__ import annotations
 
+from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
 from exp.runtime.models.providers.openai_payloads import (
     openai_compatible_stream_payload,
@@ -61,3 +62,38 @@ def test_responses_wire_keeps_the_developer_role_it_defines() -> None:
     items = payload["input"]
     assert isinstance(items, list)
     assert {"role": "developer", "content": "Now be terse."} in items
+
+
+def test_replayed_responses_items_drop_the_output_only_status_field() -> None:
+    """A replayed input MESSAGE loses the output-only ``status`` a client copied
+    from a prior response (OpenAI: "Unknown parameter: 'input[N].status'");
+    every other item, hosted tool echoes included, re-emits verbatim."""
+    replayed: JsonObject = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "run it again"}],
+        "status": "completed",
+    }
+    hosted: JsonObject = {"type": "web_search_call", "id": "ws_1", "status": "completed"}
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="user", content="run it"),
+            GatewayMessage(role="user", provider_native_item=replayed),
+            GatewayMessage(role="assistant", provider_native_item=hosted),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = openai_responses_stream_payload("gpt-6-astra", request, supports_temperature=False)
+    items = payload["input"]
+    assert isinstance(items, list)
+    assert {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "run it again"}],
+    } in items
+    # A hosted tool echo keeps its status: that schema defines the field.
+    assert hosted in items
+    # The caller's own item object is left untouched.
+    assert replayed["status"] == "completed"

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -39,6 +39,7 @@ from exp.runtime.models.providers.fireworks import (
 from exp.runtime.models.providers.generation_parameter_validation import (
     anthropic_reasoning_disengaged,
     mid_conversation_system_present,
+    require_assistant_prefill_supported,
     serves_reasoning_summary,
 )
 from exp.runtime.models.providers.generation_parameter_validation import (
@@ -263,12 +264,9 @@ def route_generation_parameter_requests(
             sampling_supported(profile, top_p=top_p) for profile in profiles
         )
 
-    # Sampling controls a rung cannot carry at all (a reasoning model whose
-    # provider rejects temperature outright) are DROPPED with disclosure, not
-    # refused: the model still answers, with its own default. The 400 stays
-    # only for a value outside a supporting route's declared range, which is
-    # a genuine caller error. (2026-09-06: 1,483 rejections in six hours across
-    # 289 orgs on one alias for a field OpenAI itself simply refuses.)
+    # Sampling a rung cannot carry is DROPPED with disclosure, not refused; the
+    # 400 stays only for a value outside a supporting route's declared range
+    # (2026-09-06: 1,483 rejections / 289 orgs on one alias OpenAI itself refuses).
     if request.temperature is not None:
         if srn_only_block():
             ignore("temperature", "temperature->dropped(set_reasoning_effort_none)")
@@ -864,6 +862,8 @@ def route_generation_parameter_requests(
             param="messages",
             code="invalid_parameter",
         )
+
+    require_assistant_prefill_supported(profiles, request)
 
     # A system turn after conversation began has positional semantics that
     # instruction-hoisting wires cannot preserve; those rungs narrow out.

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2607,6 +2607,45 @@ def test_context_management_forwards_on_anthropic_and_discloses_elsewhere() -> N
     assert provider.context_management is None
 
 
+def test_assistant_prefill_narrows_out_rungs_whose_model_rejects_it() -> None:
+    """A trailing assistant turn is refused BEFORE dispatch on the Anthropic
+    releases that 400 it (live 2026-09-07: 4.6+ and every 5-generation
+    release), in any id spelling, and passes everywhere else."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="Say a colour."),
+            GatewayMessage(role="assistant", content="The colour is"),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    rejecting = GatewayWireProfile(
+        dialect="anthropic_messages", url="https://anthropic.test", model_id="claude-opus-5"
+    )
+    bedrock = GatewayWireProfile(
+        dialect="bedrock_converse_stream",
+        url="https://bedrock.test",
+        model_id="anthropic.claude-fable-5-1-20260901-v1:0",
+    )
+    accepting = GatewayWireProfile(
+        dialect="anthropic_messages", url="https://anthropic.test", model_id="claude-sonnet-4-5"
+    )
+    for profile in (rejecting, bedrock):
+        with pytest.raises(ProviderParameterError) as prefill:
+            route_generation_parameter_requests((profile,), request)
+        assert prefill.value.param == "messages"
+        assert "assistant prefill" in str(prefill.value)
+        assert profile.model_id in str(prefill.value)
+    public, _provider = route_generation_parameter_requests((accepting,), request)
+    assert public.ignored_parameters == ()
+    # The same conversation ending in a user turn passes on the rejecting rung.
+    user_last = request.model_copy(
+        update={"messages": (*request.messages, GatewayMessage(role="user", content="go on"))}
+    )
+    route_generation_parameter_requests((rejecting,), user_last)
+
+
 def test_mid_conversation_system_stays_positional_on_capable_wires() -> None:
     """A system turn after conversation start keeps its position on the
     Anthropic and OpenAI wires and narrows out instruction-hoisting rungs

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -25,6 +25,9 @@ from exp.runtime.gateway.contracts import (
     StructuredTextFormat,
     ThinkingBlock,
 )
+from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_rejects_assistant_prefill,
+)
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.bedrock_requests import converse_body
 from exp.runtime.models.providers.errors import (
@@ -2639,6 +2642,13 @@ def test_assistant_prefill_narrows_out_rungs_whose_model_rejects_it() -> None:
         assert profile.model_id in str(prefill.value)
     public, _provider = route_generation_parameter_requests((accepting,), request)
     assert public.ignored_parameters == ()
+    # Exact releases only: a later point release is NOT assumed from its
+    # generation, while a dated snapshot and a Bedrock suffix inherit.
+    assert anthropic_rejects_assistant_prefill("claude-opus-5-20260901")
+    assert anthropic_rejects_assistant_prefill("anthropic.claude-sonnet-4-6-v1:0")
+    assert not anthropic_rejects_assistant_prefill("claude-opus-5-1")
+    assert not anthropic_rejects_assistant_prefill("claude-sonnet-5-2")
+    assert not anthropic_rejects_assistant_prefill("claude-sonnet-4-5")
     # The same conversation ending in a user turn passes on the rejecting rung.
     user_last = request.model_copy(
         update={"messages": (*request.messages, GatewayMessage(role="user", content="go on"))}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.41,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.42,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.41"
+version = "0.3.42"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

Fifth batch of the alerts-channel error review (items 2, 3 and 6 of the 2026-09-07 triage).

- **OpenRouter opaque 400s.** 673 requests across 137 orgs in 24h ended with `provider rejected the request: Provider returned error` (relace-apply-3, fugu-ultra, kat-coder-pro and others). OpenRouter carries the upstream provider's own sentence in `error.metadata.raw` and the provider's name in `error.metadata.provider_name`; the engine never read them.
- **Anthropic assistant prefill.** 128 requests across 64 orgs in 48h were dispatched and then answered "This model does not support assistant message prefill." Live probe with the house key (2026-09-07): opus-4-6, opus-4-7, opus-4-8, sonnet-4-6, sonnet-5, opus-5, fable-5, fable-5-1 reject it; sonnet-4-5 and haiku-4-5 accept it.
- **`input[N].status`.** Clients that copy a prior response's items back into `input` include the output-only `status` on an input message; OpenAI 400s it as an unknown parameter (24 in 24h).
- **Forced `tool_choice` on claude-fable-5.1.** The refusal only said "remove the unsupported field (field: tool_choice)"; 64 rejections in two hours from one org with nothing actionable.

## What

- `param_attribution.rs`: `upstream_relayed_message` reads `metadata.raw` (JSON `error.message` / `message` / `detail` / string `error`, or plain text) only when the aggregator's own message is generic, prefixed `"<provider_name>: "`; used by `rejected_detail` (pre-stream, OpenAI-compatible dialect only) and by the OpenAI-compatible in-stream error frame. The relayed sentence still passes the same identifier screen and length bound.
- `anthropic_tool_compat.py`: `_ANTHROPIC_PREFILL_REJECTING_RELEASES` (exact releases, matched as a whole id segment so dated snapshots and Bedrock spellings inherit). `require_assistant_prefill_supported` in route admission narrows those rungs out with a caller-facing sentence; a route with no other rung surfaces it as the 400, before dispatch.
- `openai_payloads.py`: a replayed input **message** (role user/system/developer) loses `status`; every other item, hosted tool echoes included, re-emits verbatim.
- `native_bridge_errors.py`: the forced tool choice refusal now says to send `tool_choice: 'auto'` or choose another alias.
- native 0.3.42.

## Verification

`cargo fmt --check`, `clippy -D warnings`, `cargo test --no-default-features` (246; one new param_attribution test covering JSON raw, plain-text raw, a specific aggregator sentence kept, and no metadata). `ruff`, `ty`, affected pytest suites green with three new tests (prefill narrowing on Anthropic and Bedrock spellings, status stripping with a hosted echo kept verbatim, the forced tool choice message on all three surfaces). Full pytest running.

Also done outside this PR: the zai `glm-ocr` chat lane (z.ai serves OCR on `layout_parsing`, and its chat endpoint rejects SSE, so the lane could never serve) is disabled via a catalog draft; the model is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)