### PR TITLE
gateway: replay interleaved-thinking turns in the caller's block order; refuse Anthropic-invalid tool names before dispatch

### DIFF
--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -745,9 +745,9 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
     content_parts: list[MessageContentPart] = []
     tool_calls: list[ToolCall] = []
     reasoning: list[ProviderReasoningBlock] = []
-    # The segment's blocks as the caller sent them (empty text dropped, as the
-    # wire rejects it): an assistant turn carrying thinking replays in this
-    # order on the Anthropic wire so its signatures still verify.
+    # The segment's blocks as the caller sent them: an assistant turn carrying
+    # thinking replays in this order on the Anthropic wire so its signatures
+    # still verify (empty text drops at emission, its cache marker migrated).
     ordered_blocks: list[JsonObject] = []
 
     def flush() -> None:
@@ -805,6 +805,10 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
             # rejects a standalone empty block, so it never becomes a part.
             if block.text:
                 content_parts.append(TextContentPart(text=block.text))
+            # The ordered replay keeps an empty text block only for the cache
+            # marker it may carry; emission drops the block and migrates the
+            # marker (``ordered_blocks_with_markers``).
+            if block.text or block.cache_control is not None:
                 ordered_blocks.append(
                     block.model_dump(mode="json", exclude_none=True, exclude={"citations"})
                 )

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -745,12 +745,17 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
     content_parts: list[MessageContentPart] = []
     tool_calls: list[ToolCall] = []
     reasoning: list[ProviderReasoningBlock] = []
+    # The segment's blocks as the caller sent them (empty text dropped, as the
+    # wire rejects it): an assistant turn carrying thinking replays in this
+    # order on the Anthropic wire so its signatures still verify.
+    ordered_blocks: list[JsonObject] = []
 
     def flush() -> None:
         """Emit the pending content, tool calls, and reasoning as one message."""
         content = "".join(part.text for part in text_parts) if text_parts else None
         attachments = any(part.kind != "text" for part in content_parts)
         if content is None and not tool_calls and not reasoning and not attachments:
+            ordered_blocks.clear()
             return
         out.append(
             GatewayMessage(
@@ -763,12 +768,14 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                 # blocks are the same text in the same order, so a multimodal
                 # turn keeps its cache markers when it re-emits.
                 provider_text_blocks=_marked_text_blocks(tuple(text_parts)),
+                provider_anthropic_blocks=tuple(ordered_blocks) if reasoning else None,
             )
         )
         text_parts.clear()
         content_parts.clear()
         tool_calls.clear()
         reasoning.clear()
+        ordered_blocks.clear()
 
     for block_index, block in enumerate(message.content):
         if isinstance(block, _TextBlock):
@@ -798,6 +805,9 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
             # rejects a standalone empty block, so it never becomes a part.
             if block.text:
                 content_parts.append(TextContentPart(text=block.text))
+                ordered_blocks.append(
+                    block.model_dump(mode="json", exclude_none=True, exclude={"citations"})
+                )
         elif isinstance(block, ImageBlock):
             if message.role != "user":
                 raise invalid_field(
@@ -823,6 +833,7 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                 if isinstance(block, _ThinkingBlock)
                 else RedactedThinkingBlock(data=block.data)
             )
+            ordered_blocks.append(block.model_dump(mode="json", exclude_none=True))
         elif isinstance(block, _ToolUseBlock):
             if message.role != "assistant":
                 raise invalid_field(
@@ -844,6 +855,7 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                     ),
                 )
             )
+            ordered_blocks.append(block.model_dump(mode="json", exclude_none=True))
         elif isinstance(block, (_ServerToolUseBlock, _WebSearchToolResultBlock)):
             if message.role != "assistant":
                 raise invalid_field(

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -199,6 +199,30 @@ def test_interleaved_thinking_turn_keeps_its_block_order_for_replay() -> None:
     assert role == "assistant"
     assert wire == blocks
 
+    # An empty text block carrying Claude Code's cache marker drops (the wire
+    # rejects it) and its breakpoint lands on the closest prior block that can
+    # carry one, skipping the signed thinking block.
+    marked = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        *blocks[:3],
+                        {"type": "text", "text": "", "cache_control": {"type": "ephemeral"}},
+                        *blocks[3:],
+                    ],
+                },
+            ]
+        )
+    )
+    _role, migrated = anthropic_blocks(marked.request.messages[1])
+    assert len(migrated) == len(blocks)
+    assert migrated[1] == {**blocks[1], "cache_control": {"type": "ephemeral"}}
+    assert migrated[2] == blocks[2]
+    assert [block["type"] for block in migrated] == [block["type"] for block in blocks]
+
     # A turn without thinking has no signatures to protect and stays flattened.
     plain = decode_messages(
         _body(

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -174,6 +174,49 @@ def test_thinking_config_is_carried_verbatim() -> None:
         decode_messages(_body(thinking={"type": "adaptive", "budget_tokens": 64}))
 
 
+def test_interleaved_thinking_turn_keeps_its_block_order_for_replay() -> None:
+    """A thinking turn carries its blocks in the caller's order alongside the
+    flattened fields, so the Anthropic wire can replay it byte-for-byte:
+    interleaved thinking puts thinking between tool_use blocks, and the
+    provider refuses a reordered latest assistant message."""
+    blocks: list[JsonObject] = [
+        {"type": "thinking", "thinking": "plan", "signature": "sig-a"},
+        {"type": "tool_use", "id": "call-1", "name": "read", "input": {"path": "a"}},
+        {"type": "thinking", "thinking": "next", "signature": "sig-b"},
+        {"type": "text", "text": "reading"},
+        {"type": "tool_use", "id": "call-2", "name": "read", "input": {"path": "b"}},
+    ]
+    decoded = decode_messages(
+        _body(
+            messages=[{"role": "user", "content": "go"}, {"role": "assistant", "content": blocks}]
+        )
+    )
+    assistant = decoded.request.messages[1]
+    assert assistant.provider_anthropic_blocks == tuple(blocks)
+    assert [block.kind for block in assistant.provider_reasoning] == ["thinking", "thinking"]
+    assert [call.call_id for call in assistant.tool_calls] == ["call-1", "call-2"]
+    role, wire = anthropic_blocks(assistant)
+    assert role == "assistant"
+    assert wire == blocks
+
+    # A turn without thinking has no signatures to protect and stays flattened.
+    plain = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {"role": "assistant", "content": [{"type": "text", "text": "ok"}, blocks[1]]},
+            ]
+        )
+    )
+    assert plain.request.messages[1].provider_anthropic_blocks is None
+
+    # Reasoning narrowed away (nothing left to verify) falls back to the
+    # flattened emission rather than replaying thinking the rung dropped.
+    stripped = assistant.model_copy(update={"provider_reasoning": ()})
+    _role, fallback = anthropic_blocks(stripped)
+    assert [block["type"] for block in fallback] == ["text", "tool_use", "tool_use"]
+
+
 def test_thinking_history_blocks_ride_the_opaque_carrier_in_order() -> None:
     """Assistant reasoning history translates losslessly with byte-exact signatures."""
     decoded = decode_messages(

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -287,6 +287,23 @@ class GatewayMessage(ContractModel):
     like the other carriers so item-free digests are unperturbed; a present
     item joins replay identity through :func:`canonical_request_sha256`.
     """
+    provider_anthropic_blocks: tuple[JsonObject, ...] | None = Field(default=None, exclude=True)
+    """The caller's assistant content blocks in their ORIGINAL order, when a
+    thinking block is among them.
+
+    The flattened fields (``content``, ``tool_calls``, ``provider_reasoning``)
+    lose the order of blocks within one assistant turn; the Anthropic wire
+    re-emits them as thinking, then text, then tool_use. With interleaved
+    thinking a turn is [thinking, tool_use, thinking, text, tool_use ...], and
+    Anthropic verifies the LATEST assistant message byte-for-byte against the
+    signatures it issued: a reordered turn is refused as "thinking or
+    redacted_thinking blocks in the latest assistant message cannot be
+    modified" (134 requests / 48h on one Messages-surface client,
+    2026-09-07). The Anthropic wire replays these verbatim when they are
+    present and the flattened reasoning was not narrowed; every other wire
+    keeps reading the flattened fields. Excluded from serialization like the
+    other carriers.
+    """
     provider_anthropic_block: JsonObject | None = Field(default=None, exclude=True)
     """One verbatim Anthropic content block the gateway carries opaquely.
 

--- a/exp/runtime/models/providers/generation_parameter_validation.py
+++ b/exp/runtime/models/providers/generation_parameter_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable, Sequence
 
 from exp.runtime.gateway.contracts import GatewayRequest
@@ -142,6 +143,43 @@ def require_assistant_prefill_supported(
             param="messages",
             code="unsupported_parameter",
         )
+
+
+_ANTHROPIC_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+_ANTHROPIC_TOOL_NAME_DIALECTS = frozenset({"anthropic_messages", "bedrock_converse_stream"})
+
+
+def require_tool_names_supported(
+    profiles: Sequence[GatewayWireProfile], request: GatewayRequest
+) -> None:
+    """Refuse a tool name the Anthropic wire will 400 by name, before dispatch.
+
+    Anthropic (and Bedrock, which relays the same rule) accepts tool names
+    matching ``^[a-zA-Z0-9_-]{1,128}$``; a client sending dots, spaces, or
+    a longer name learned that only from the provider's 400 after dispatch
+    ("tools.0.custom.name: String should match pattern"). The rung narrows
+    out with the index named; the name itself is caller content and stays
+    out of the message.
+
+    Raises:
+        ProviderParameterError: A profile speaks an Anthropic wire and a tool
+            name does not match.
+    """
+    if not request.tools or not any(
+        profile.dialect in _ANTHROPIC_TOOL_NAME_DIALECTS for profile in profiles
+    ):
+        return
+    for index, tool in enumerate(request.tools):
+        if _ANTHROPIC_TOOL_NAME.fullmatch(tool.name) is None:
+            raise ProviderParameterError(
+                message=(
+                    f"tools[{index}].name is not accepted by this model route: tool names "
+                    "must match ^[a-zA-Z0-9_-]{1,128} (letters, digits, underscore, "
+                    "hyphen). Rename the tool or choose a different model alias."
+                ),
+                param=f"tools[{index}].name",
+                code="invalid_parameter",
+            )
 
 
 def mid_conversation_system_present(request: GatewayRequest) -> bool:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -40,6 +40,7 @@ from exp.runtime.models.providers.generation_parameter_validation import (
     anthropic_reasoning_disengaged,
     mid_conversation_system_present,
     require_assistant_prefill_supported,
+    require_tool_names_supported,
     serves_reasoning_summary,
 )
 from exp.runtime.models.providers.generation_parameter_validation import (
@@ -864,9 +865,8 @@ def route_generation_parameter_requests(
         )
 
     require_assistant_prefill_supported(profiles, request)
-
-    # A system turn after conversation began has positional semantics that
-    # instruction-hoisting wires cannot preserve; those rungs narrow out.
+    require_tool_names_supported(profiles, request)
+    # A mid-conversation system turn narrows out instruction-hoisting wires.
     if mid_conversation_system_present(request) and any(
         profile.dialect in {"gemini_generate_content", "bedrock_converse_stream"}
         for profile in profiles
@@ -953,9 +953,8 @@ def route_generation_parameter_requests(
     elif request.parallel_tool_calls is not None and all(
         profile.dialect in _NO_PARALLEL_TOOL_CONTROL_DIALECTS for profile in profiles
     ):
-        # No rung carries a parallel-tool control: `true` is the provider's own
-        # default (dropped); `false` is serialized by the data plane. A mixed
-        # route keeps the field; toggle-less rungs are shaped per rung at dispatch.
+        # No rung carries a parallel-tool control: `true` drops (provider default),
+        # `false` is serialized by the data plane; mixed routes shape per rung.
         if request.parallel_tool_calls:
             ignore("parallel_tool_calls", "parallel_tool_calls->dropped(provider_default)")
         else:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2610,6 +2610,36 @@ def test_context_management_forwards_on_anthropic_and_discloses_elsewhere() -> N
     assert provider.context_management is None
 
 
+def test_tool_names_the_anthropic_wire_rejects_narrow_out_before_dispatch() -> None:
+    """A dotted tool name is refused by name on Anthropic and Bedrock rungs
+    (the provider's own 400 named tools.0.custom.name after dispatch, one
+    org, 2026-09-07) and passes untouched on wires that accept it."""
+    request = _chat_request().model_copy(
+        update={
+            "tools": (
+                GatewayToolDefinition(name="search", parameters={"type": "object"}),
+                GatewayToolDefinition(name="web.search", parameters={"type": "object"}),
+            )
+        }
+    )
+    anthropic = GatewayWireProfile(
+        dialect="anthropic_messages", url="https://anthropic.test", model_id="claude-sonnet-4-5"
+    )
+    bedrock = GatewayWireProfile(
+        dialect="bedrock_converse_stream",
+        url="https://bedrock.test",
+        model_id="anthropic.claude-sonnet-4-5-v1:0",
+    )
+    for profile in (anthropic, bedrock):
+        with pytest.raises(ProviderParameterError) as rejected:
+            route_generation_parameter_requests((profile,), request)
+        assert rejected.value.param == "tools[1].name"
+        assert "web.search" not in str(rejected.value)
+    compatible = GatewayWireProfile(dialect="openai_compatible", url="https://fw.test")
+    public, _provider = route_generation_parameter_requests((compatible,), request)
+    assert public.ignored_parameters == ()
+
+
 def test_assistant_prefill_narrows_out_rungs_whose_model_rejects_it() -> None:
     """A trailing assistant turn is refused BEFORE dispatch on the Anthropic
     releases that 400 it (live 2026-09-07: 4.6+ and every 5-generation

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -256,6 +256,25 @@ def _anthropic_multimodal_blocks(message: GatewayMessage) -> list[JsonObject]:
     return blocks
 
 
+def _reasoning_intact(message: GatewayMessage) -> bool:
+    """Whether the flattened reasoning still holds every thinking block the caller sent.
+
+    Admission may strip or narrow reasoning blocks for a rung; the verbatim
+    order is only replayed when it would say exactly what the flattened
+    fields say.
+    """
+    assert message.provider_anthropic_blocks is not None
+    sent = sum(
+        1
+        for block in message.provider_anthropic_blocks
+        if block.get("type") in {"thinking", "redacted_thinking"}
+    )
+    kept = sum(
+        1 for block in message.provider_reasoning if block.kind in {"thinking", "redacted_thinking"}
+    )
+    return sent == kept and sent > 0
+
+
 def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
     """Translate one non-instruction gateway message to Anthropic content blocks."""
     if message.role == "tool":
@@ -309,6 +328,12 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         # An echoed server-tool block re-emits byte-for-byte at its position;
         # route admission guarantees this dispatch is an Anthropic rung.
         return "assistant", [message.provider_anthropic_block]
+    if message.provider_anthropic_blocks is not None and _reasoning_intact(message):
+        # A thinking turn replays in the caller's own block order: Anthropic
+        # verifies the latest assistant message against its signatures, and
+        # interleaved thinking puts thinking between tool_use blocks, an
+        # order the flattened fields below cannot express.
+        return "assistant", [dict(block) for block in message.provider_anthropic_blocks]
     blocks: list[JsonObject] = []
     for reasoning in message.provider_reasoning:
         if reasoning.kind == "exposed_reasoning_content":

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -256,6 +256,47 @@ def _anthropic_multimodal_blocks(message: GatewayMessage) -> list[JsonObject]:
     return blocks
 
 
+_UNMARKABLE_REPLAY_BLOCKS = frozenset({"thinking", "redacted_thinking"})
+
+
+def ordered_blocks_with_markers(blocks: tuple[JsonObject, ...]) -> list[JsonObject]:
+    """Replay an ordered turn: empty text drops, its cache marker survives.
+
+    Same rule as :func:`retained_cache_marked_blocks`, extended to a turn that
+    mixes block kinds: a displaced marker lands on the closest retained block
+    before it that can carry one (text or tool_use; the wire refuses markers
+    on thinking blocks), else on the first such block after it. Signed
+    blocks themselves are never touched.
+    """
+    retained: list[JsonObject] = []
+    displaced: object | None = None
+
+    def markable(block: JsonObject) -> bool:
+        return block.get("type") not in _UNMARKABLE_REPLAY_BLOCKS
+
+    for block in blocks:
+        if block.get("type") == "text" and not block.get("text"):
+            marker = block.get("cache_control")
+            if marker is None:
+                continue
+            carrier = next(
+                (index for index in range(len(retained) - 1, -1, -1) if markable(retained[index])),
+                None,
+            )
+            if carrier is not None:
+                if "cache_control" not in retained[carrier]:
+                    retained[carrier] = {**retained[carrier], "cache_control": marker}
+            else:
+                displaced = marker
+            continue
+        kept = dict(block)
+        if displaced is not None and markable(kept) and "cache_control" not in kept:
+            kept["cache_control"] = displaced
+            displaced = None
+        retained.append(kept)
+    return retained
+
+
 def _reasoning_intact(message: GatewayMessage) -> bool:
     """Whether the flattened reasoning still holds every thinking block the caller sent.
 
@@ -333,7 +374,7 @@ def anthropic_blocks(message: GatewayMessage) -> tuple[str, list[JsonObject]]:
         # verifies the latest assistant message against its signatures, and
         # interleaved thinking puts thinking between tool_use blocks, an
         # order the flattened fields below cannot express.
-        return "assistant", [dict(block) for block in message.provider_anthropic_blocks]
+        return "assistant", ordered_blocks_with_markers(message.provider_anthropic_blocks)
     blocks: list[JsonObject] = []
     for reasoning in message.provider_reasoning:
         if reasoning.kind == "exposed_reasoning_content":


### PR DESCRIPTION
## Why

Two lines from the 2026-09-07 alerts paste:

- **"thinking or redacted_thinking blocks in the latest assistant message cannot be modified"** on claude-fable-5.1 and claude-opus-5: 134 requests in 48h from one Messages-surface client, always at a deep block index (`messages.7.content.16`). Root cause is ours: the Messages decoder flattens an assistant turn into `content` + `tool_calls` + `provider_reasoning`, and the Anthropic wire re-emits thinking, then text, then tool_use. With interleaved thinking a turn is `[thinking, tool_use, thinking, text, tool_use, ...]`; Anthropic verifies the latest assistant message against the signatures it issued, so the reordered turn is refused.
- **`tools.0.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'`** on claude-fable-5 / sonnet-4-6: a dotted or otherwise invalid tool name was dispatched and billed before the caller learned the rule.

## What

- `GatewayMessage.provider_anthropic_blocks`: the caller's assistant blocks in original order, set by the Messages decoder only when the turn carries thinking (empty text dropped as the wire requires). Excluded from serialization like the other carriers.
- `wire_messages.anthropic_blocks` replays those blocks verbatim when the flattened reasoning still holds every thinking block the caller sent (`_reasoning_intact`); if admission narrowed the reasoning away, the flattened emission is used as before. Other wires keep reading the flattened fields.
- `require_tool_names_supported`: on anthropic_messages / bedrock_converse_stream rungs a tool name outside `^[a-zA-Z0-9_-]{1,128}$` narrows the rung out pre-dispatch with `param: tools[i].name`; the name itself is caller content and stays out of the message. Other dialects are untouched (permissive OpenAI-compatible servers exist).

Python only; native stays 0.3.42.

## Verification

`ruff`, `ty`, anthropic_protocol + streaming_requests + contracts suites green with two new tests: an interleaved turn decodes with its order kept and re-emits byte-for-byte, a plain turn stays flattened, a reasoning-stripped turn falls back; a dotted tool name narrows out anthropic and bedrock rungs by index and passes on an OpenAI-compatible rung. Full pytest running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)