### PR TITLE
release: bump experiential to 0.7.46 (native 0.3.42)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.45"
+version = "0.7.46"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.45"
+version = "0.7.46"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the v0.7.46 release (v0.7.45 shipped fair-share rung admission from #838 before these landed). Ships the two merged, unreleased batches:

- #839 (native 0.3.42): OpenRouter's upstream sentence relayed behind its generic "Provider returned error" (pre-stream and in-stream); Anthropic assistant prefill refused pre-dispatch on the 4.6+/5 releases that 400 it; replayed Responses input messages drop the output-only `status`; the forced `tool_choice` refusal says to send `auto`.
- #840 (Python only): interleaved-thinking assistant turns replay in the caller's block order (with cache markers preserved), so Anthropic no longer refuses the latest assistant message as modified; Anthropic-invalid tool names are refused before dispatch.

Publishing: merge, then `gh release create v0.7.46 --target <merge sha>`, then the platform repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)