### PR TITLE
release: bump experiential to 0.7.47 (native unchanged at 0.3.42: in-flight worst-case token reservation for platform token caps)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.46"
+version = "0.7.47"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.46"
+version = "0.7.47"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Releases #832: per-attempt worst-case token reservation (`worst_case_attempt_tokens`, threaded through the ledger `start_attempt` protocols) so the platform's token windows can bind on the in-flight burst — the promo free-tier caps (strict) and the org token rate limits (soft). Inert until the platform ledger reads the reservation.

Python-only; native unchanged at 0.3.42. pyproject + uv.lock version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)