### PR TITLE
gateway: a provider refusal names its bounded category to the caller (native 0.3.43)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -388,6 +388,18 @@ fault stays `provider stream failed`. An aggregator's 502 wrapping an upstream 4
 sentence. The bounded ledger detail exempts the request's own model id from the identifier screen,
 so a provider sentence naming the model is kept rather than dropped.
 
+**A refusal names its bounded category to the caller.** A `refusal` answer stays a 400 with code
+`refusal` and type `invalid_request_error`, but it now carries a machine-readable `refusal_reason`
+field in the error body (present on every surface that renders the public error: `/v1/chat/completions`,
+`/v1/responses`, and `/v1/messages`, whose Anthropic envelope carries the same field). The category
+is a closed vocabulary derived from the provider's own code and sentence, never its prose:
+`cyber_policy`, `cbrn`, `content_policy`, `recitation`, `data_inspection`, and `unspecified` for a
+refusal the provider filed under no reason. The caller-facing message is the fixed sentence plus the
+category's fixed phrase ("provider refused the request: cybersecurity policy"), while the raw provider
+token keeps riding `provider_detail` into the ledger only. The reason also rides the settlement
+argument next to `provider_detail`, so the control plane counts refusals by reason without parsing the
+free-form detail.
+
 **Customer-managed credentials fail as the customer's error.** On a BYOK rung, a provider 401/403
 or 402, at stream open or declared mid-stream, is the customer's configuration, not operator
 deadness. The failure keeps its ladder class so any other customer-managed rung with its own

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -58,6 +58,9 @@ from exp.runtime.gateway.stream_contracts import (
     GatewayFailureClass as GatewayFailureClass,
 )
 from exp.runtime.gateway.stream_contracts import (
+    GatewayRefusalReason as GatewayRefusalReason,
+)
+from exp.runtime.gateway.stream_contracts import (
     GatewayUsage as GatewayUsage,
 )
 

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.42"
+version = "0.3.43"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.42"
+version = "0.3.43"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.42"
+version = "0.3.43"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -3,7 +3,7 @@
 
 use serde_json::{Map, Value};
 
-use super::{malformed, parse_object, refusal_failure, Normalizer};
+use super::{malformed, parse_object, Normalizer};
 use crate::errors::{Failure, FailureClass};
 use crate::events::{bedrock_usage, require_string, require_u64, Event, ToolAccumulator};
 
@@ -237,7 +237,10 @@ impl Normalizer {
         match reason {
             "end_turn" | "stop_sequence" | "tool_use" => Event::Completed,
             "max_tokens" | "model_context_window_exceeded" => Event::Incomplete,
-            "content_filtered" | "guardrail_intervened" => Event::Failed(refusal_failure()),
+            // The Bedrock stop reason names the content verdict.
+            "content_filtered" | "guardrail_intervened" => Event::Failed(Failure::refusal(
+                crate::stream_errors::refusal_reason(Some(reason), None),
+            )),
             _ => Event::Failed(Failure::new(
                 FailureClass::ProviderInternal,
                 "provider ended the stream unexpectedly",
@@ -420,7 +423,8 @@ mod bedrock_tests {
                 json!({
                     "kind": "failed",
                     "failure_class": "refusal",
-                    "safe_message": "provider refused the request",
+                    "safe_message": "provider refused the request: content policy",
+                    "refusal_reason": "content_policy",
                 }),
             ),
             (
@@ -428,7 +432,8 @@ mod bedrock_tests {
                 json!({
                     "kind": "failed",
                     "failure_class": "refusal",
-                    "safe_message": "provider refused the request",
+                    "safe_message": "provider refused the request: content policy",
+                    "refusal_reason": "content_policy",
                 }),
             ),
             (

--- a/exp/runtime/gateway/native/src/dialects/gemini.rs
+++ b/exp/runtime/gateway/native/src/dialects/gemini.rs
@@ -2,7 +2,7 @@
 
 use serde_json::Value;
 
-use super::{malformed, parse_object, refusal_failure, Normalizer};
+use super::{malformed, parse_object, Normalizer};
 use crate::errors::{Failure, FailureClass};
 use crate::events::{gemini_usage, require_string, Event, ToolAccumulator};
 
@@ -57,7 +57,12 @@ impl Normalizer {
             if let Some(usage) = self.usage.take() {
                 events.push(Event::Usage(usage));
             }
-            events.push(Event::Failed(refusal_failure()));
+            // The block reason names the category the same way a candidate
+            // finishReason does.
+            let reason = gemini_block_reason(&payload).unwrap_or_default();
+            events.push(Event::Failed(Failure::refusal(
+                crate::stream_errors::refusal_reason(Some(&reason), None),
+            )));
             return Ok(events);
         }
         let candidates = match payload.get("candidates") {
@@ -131,9 +136,14 @@ impl Normalizer {
             "STOP" | "FINISH_REASON_UNSPECIFIED" => events.push(Event::Completed),
             "MAX_TOKENS" => events.push(Event::Incomplete),
             // The python mapper's refusal signal table: safety, copyright,
-            // and sensitive-information stops are content-free refusals.
-            "SAFETY" | "PROHIBITED_CONTENT" | "BLOCKLIST" | "RECITATION" | "SPII" => {
-                events.push(Event::Failed(refusal_failure()));
+            // and sensitive-information stops are content-free refusals. The
+            // finish token names the category (RECITATION, SPII, SAFETY), so
+            // the caller sees which policy declined without any provider prose.
+            "SAFETY" | "PROHIBITED_CONTENT" | "BLOCKLIST" | "RECITATION" | "SPII"
+            | "IMAGE_SAFETY" => {
+                events.push(Event::Failed(Failure::refusal(
+                    crate::stream_errors::refusal_reason(Some(&finish_reason), None),
+                )));
             }
             _ => {
                 events.push(Event::Failed(Failure::new(
@@ -206,6 +216,18 @@ fn gemini_prompt_blocked(payload: &serde_json::Map<String, Value>) -> Result<boo
         Some(Value::String(reason)) => Ok(reason != "BLOCK_REASON_UNSPECIFIED"),
         Some(_) => Err(malformed("Gemini promptFeedback.blockReason must be text")),
     }
+}
+
+/// The `promptFeedback.blockReason` token, if the frame carries one. Only
+/// called after `gemini_prompt_blocked` confirmed a present, meaningful
+/// reason, so a malformed shape has already been rejected.
+fn gemini_block_reason(payload: &serde_json::Map<String, Value>) -> Option<String> {
+    payload
+        .get("promptFeedback")
+        .and_then(Value::as_object)
+        .and_then(|feedback| feedback.get("blockReason"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -381,13 +403,19 @@ mod gemini_tests {
     }
 
     #[test]
-    fn gemini_safety_finish_maps_to_a_content_free_refusal() {
-        for reason in [
-            "SAFETY",
-            "PROHIBITED_CONTENT",
-            "BLOCKLIST",
-            "RECITATION",
-            "SPII",
+    fn gemini_safety_finish_maps_to_a_categorized_refusal() {
+        // Each finish token names the bounded category the caller sees, with
+        // the fixed phrase in the message and never any provider prose.
+        for (reason, category, phrase) in [
+            ("SAFETY", "content_policy", "content policy"),
+            ("PROHIBITED_CONTENT", "content_policy", "content policy"),
+            ("BLOCKLIST", "content_policy", "content policy"),
+            (
+                "RECITATION",
+                "recitation",
+                "recitation of copyrighted material",
+            ),
+            ("SPII", "data_inspection", "data inspection"),
         ] {
             let chunks = [sse(&json!({"candidates": [{"finishReason": reason}]}))];
             let refs: Vec<&[u8]> = chunks.iter().map(Vec::as_slice).collect();
@@ -398,8 +426,10 @@ mod gemini_tests {
                 vec![json!({
                     "kind": "failed",
                     "failure_class": "refusal",
-                    "safe_message": "provider refused the request",
-                })]
+                    "safe_message": format!("provider refused the request: {phrase}"),
+                    "refusal_reason": category,
+                })],
+                "{reason}"
             );
         }
     }
@@ -411,12 +441,29 @@ mod gemini_tests {
         // block named on promptFeedback, and usageMetadata counting the
         // prompt Google processed. It must terminate the stream as a refusal
         // (400, no retry, no failover), never as a malformed stream end.
-        for reason in [
-            "SAFETY",
-            "PROHIBITED_CONTENT",
-            "BLOCKLIST",
-            "OTHER",
-            "IMAGE_SAFETY",
+        for (reason, category, message) in [
+            (
+                "SAFETY",
+                "content_policy",
+                "provider refused the request: content policy",
+            ),
+            (
+                "PROHIBITED_CONTENT",
+                "content_policy",
+                "provider refused the request: content policy",
+            ),
+            (
+                "BLOCKLIST",
+                "content_policy",
+                "provider refused the request: content policy",
+            ),
+            // A block reason the vocabulary does not know is an unnamed refusal.
+            ("OTHER", "unspecified", "provider refused the request"),
+            (
+                "IMAGE_SAFETY",
+                "content_policy",
+                "provider refused the request: content policy",
+            ),
         ] {
             let chunks = [sse(&json!({
                 "promptFeedback": {
@@ -446,7 +493,8 @@ mod gemini_tests {
                     json!({
                         "kind": "failed",
                         "failure_class": "refusal",
-                        "safe_message": "provider refused the request",
+                        "safe_message": message,
+                        "refusal_reason": category,
                     }),
                 ],
                 "{reason}"
@@ -465,12 +513,13 @@ mod gemini_tests {
             vec![json!({
                 "kind": "failed",
                 "failure_class": "refusal",
-                "safe_message": "provider refused the request",
+                "safe_message": "provider refused the request: content policy",
+                "refusal_reason": "content_policy",
             })]
         );
         // A refusal is the model's verdict on the prompt: neither redialed on
         // the same deployment nor failed over to a sibling lane.
-        let refusal = refusal_failure();
+        let refusal = Failure::refusal(crate::errors::RefusalReason::ContentPolicy);
         assert!(!refusal.retryable_same_deployment);
         assert!(!refusal.failover_eligible);
     }

--- a/exp/runtime/gateway/native/src/dialects/openai.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai.rs
@@ -794,7 +794,10 @@ impl Normalizer {
                     if reason == "max_output_tokens" {
                         events.push(Event::Incomplete);
                     } else if reason == "content_filter" || reason == "safety" {
-                        events.push(Event::Failed(refusal_failure()));
+                        // The incomplete reason IS the category token.
+                        events.push(Event::Failed(Failure::refusal(
+                            crate::stream_errors::refusal_reason(Some(reason), None),
+                        )));
                     } else {
                         // The undocumented reason is the only diagnostic this
                         // terminal carries; it rides as the bounded detail.

--- a/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
@@ -5,8 +5,7 @@
 use serde_json::Value;
 
 use super::super::{
-    finish_open_tools, finish_open_tools_truncated, malformed, parse_object, refusal_failure,
-    Normalizer,
+    finish_open_tools, finish_open_tools_truncated, malformed, parse_object, Normalizer,
 };
 use crate::errors::Failure;
 use crate::events::{openai_compatible_usage, require_string, require_u64, Event, ToolAccumulator};
@@ -35,7 +34,15 @@ impl Normalizer {
                 events.push(Event::Usage(usage));
             }
             if self.refusal_seen || matches!(finish, Some("content_filter" | "safety")) {
-                events.push(Event::Failed(refusal_failure()));
+                // A `content_filter`/`safety` finish reason names the category;
+                // a bare visible-refusal delta names none (Unspecified).
+                let reason = match finish {
+                    Some(code @ ("content_filter" | "safety")) => {
+                        crate::stream_errors::refusal_reason(Some(code), None)
+                    }
+                    _ => crate::errors::RefusalReason::Unspecified,
+                };
+                events.push(Event::Failed(Failure::refusal(reason)));
             } else if finish == Some("length") {
                 events.push(Event::Incomplete);
             } else {

--- a/exp/runtime/gateway/native/src/dialects/openai/hosted_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/hosted_tests.rs
@@ -326,6 +326,60 @@ fn hosted_progress_before_its_item_fails_with_the_event_named() {
     );
 }
 
+/// The astra cyber-policy kill: a `response.failed` whose error names
+/// `cyber_policy` classifies as a refusal that carries the bounded category
+/// onto BOTH caller surfaces, while the raw provider prose stays ledger-only.
+#[test]
+fn a_cyber_policy_response_failed_carries_the_reason_on_both_surfaces() {
+    let mut normalizer = Normalizer::new(Dialect::OpenAiResponses);
+    let failed = hosted_frame(serde_json::json!({
+        "type": "response.failed",
+        "response": {
+            "status": "failed",
+            "error": {"code": "cyber_policy", "message": "blocked by our cybersecurity policy"},
+        },
+    }));
+    let events = normalizer
+        .feed(&failed)
+        .expect("failed terminal normalizes");
+    let failure = match events.as_slice() {
+        [Event::Failed(failure)] => failure.clone(),
+        other => panic!("unexpected events: {other:?}"),
+    };
+    assert_eq!(failure.failure_class, crate::errors::FailureClass::Refusal);
+    assert_eq!(
+        failure.refusal_reason,
+        Some(crate::errors::RefusalReason::CyberPolicy)
+    );
+    // The raw provider sentence reaches the ledger detail only.
+    assert!(failure
+        .provider_detail
+        .as_deref()
+        .is_some_and(|detail| detail.contains("cyber_policy")));
+
+    let public = failure.public_error();
+    assert_eq!(public.status_code, 400);
+    assert_eq!(public.code, "refusal");
+    assert_eq!(
+        public.message,
+        "provider refused the request: cybersecurity policy"
+    );
+    // Chat / Responses surface (OpenAI envelope).
+    let chat_body = public.json_body();
+    assert_eq!(chat_body["error"]["refusal_reason"], "cyber_policy");
+    assert_eq!(chat_body["error"]["code"], "refusal");
+    assert!(!chat_body
+        .to_string()
+        .contains("blocked by our cybersecurity"));
+    // Messages surface (Anthropic envelope).
+    let messages_body = crate::encode_messages::anthropic_error_body(&public);
+    assert_eq!(messages_body["error"]["refusal_reason"], "cyber_policy");
+    assert_eq!(messages_body["error"]["type"], "invalid_request_error");
+    assert!(!messages_body
+        .to_string()
+        .contains("blocked by our cybersecurity"));
+}
+
 /// A failed terminal still folds the usage the provider billed.
 #[test]
 fn a_failed_terminal_reports_its_billed_usage() {

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -39,10 +39,16 @@ pub fn anthropic_error_body(error: &PublicError) -> Value {
         Some(param) if !param.is_empty() => format!("{} (param: {param})", error.message),
         _ => error.message.clone(),
     };
-    json!({
+    let mut body = json!({
         "type": "error",
         "error": {"type": error_type, "message": message},
-    })
+    });
+    // A refusal carries its bounded category on the Anthropic envelope too, so
+    // a Messages caller reads the same machine-readable reason as a Chat one.
+    if let Some(reason) = error.refusal_reason {
+        body["error"]["refusal_reason"] = json!(reason.as_str());
+    }
+    body
 }
 
 fn invalid_provider_stream(message: &str) -> PublicError {

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -62,6 +62,9 @@ fn a_text_less_refusal_is_an_invalid_request_error_on_the_messages_surface() {
             "error": {
                 "type": "invalid_request_error",
                 "message": "provider refused the request",
+                // A refusal with no named reason still carries the category,
+                // as `unspecified`, on the Anthropic envelope.
+                "refusal_reason": "unspecified",
             },
         })
     );

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -18,6 +18,11 @@ pub struct PublicError {
     pub param: Option<String>,
     #[serde(default)]
     pub retry_after_seconds: Option<u32>,
+    /// The bounded category of a provider refusal (`code: refusal` only):
+    /// every refusal answer carries one, `unspecified` when the provider
+    /// named no reason. Absent on every other error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refusal_reason: Option<RefusalReason>,
 }
 
 fn default_error_type() -> String {
@@ -33,19 +38,27 @@ impl PublicError {
             error_type: error_type.to_string(),
             param: None,
             retry_after_seconds: None,
+            refusal_reason: None,
         }
     }
 
     /// The OpenAI error envelope body, matching `OpenAIProtocolError.json_body()`.
+    ///
+    /// A refusal adds the one additive `refusal_reason` field; every other
+    /// error keeps the exact four-field envelope.
     pub fn json_body(&self) -> serde_json::Value {
-        json!({
+        let mut body = json!({
             "error": {
                 "message": self.message,
                 "type": self.error_type,
                 "param": self.param,
                 "code": self.code,
             }
-        })
+        });
+        if let Some(reason) = self.refusal_reason {
+            body["error"]["refusal_reason"] = json!(reason.as_str());
+        }
+        body
     }
 
     pub fn invalid_key() -> Self {
@@ -161,6 +174,61 @@ impl FailureClass {
     }
 }
 
+/// The bounded category of a provider refusal, derived from the provider's
+/// own code and sentence (`stream_errors::refusal_reason`) and shared with
+/// the python `GatewayRefusalReason`.
+///
+/// The caller sees WHICH policy declined the content as a fixed phrase,
+/// never the provider's prose: the vocabulary is closed so a client can
+/// branch on it, and the raw token keeps riding `provider_detail` into the
+/// ledger only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefusalReason {
+    /// A cyber-safety verdict (OpenAI `cyber_policy`).
+    CyberPolicy,
+    /// A biological, chemical, radiological, or nuclear weapons verdict.
+    Cbrn,
+    /// A general content-policy or safety-system verdict.
+    ContentPolicy,
+    /// The output would recite copyrighted material (Gemini `RECITATION`).
+    Recitation,
+    /// The provider's data-inspection layer blocked the content (Gemini
+    /// `SPII`, Qwen `data_inspection_failed`).
+    DataInspection,
+    /// The provider refused without naming a reason.
+    Unspecified,
+}
+
+impl RefusalReason {
+    /// The wire name shared with the python enum and the public error field.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RefusalReason::CyberPolicy => "cyber_policy",
+            RefusalReason::Cbrn => "cbrn",
+            RefusalReason::ContentPolicy => "content_policy",
+            RefusalReason::Recitation => "recitation",
+            RefusalReason::DataInspection => "data_inspection",
+            RefusalReason::Unspecified => "unspecified",
+        }
+    }
+
+    /// The fixed caller-facing phrase, or none for an unnamed refusal.
+    pub fn phrase(&self) -> Option<&'static str> {
+        match self {
+            RefusalReason::CyberPolicy => Some("cybersecurity policy"),
+            RefusalReason::Cbrn => Some("biological/chemical safety policy"),
+            RefusalReason::ContentPolicy => Some("content policy"),
+            RefusalReason::Recitation => Some("recitation of copyrighted material"),
+            RefusalReason::DataInspection => Some("data inspection"),
+            RefusalReason::Unspecified => None,
+        }
+    }
+}
+
+/// The generic refusal sentence every refusal message starts from.
+const REFUSAL_MESSAGE: &str = "provider refused the request";
+
 /// One sanitized provider failure, the Rust mirror of `GatewayFailure`,
 /// including the executor's per-failure retry classification: whether the
 /// same deployment may be redialed and whether a later certified deployment
@@ -198,6 +266,11 @@ pub struct Failure {
     /// answer is their 400 naming the fix, and settlement files it client-side.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub customer_owned: bool,
+    /// The bounded category of a refusal, set by every refusal builder so
+    /// the public error and the settlement ledger can name which policy
+    /// declined the content without parsing `provider_detail`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refusal_reason: Option<RefusalReason>,
 }
 
 impl Failure {
@@ -211,6 +284,22 @@ impl Failure {
             provider_detail: None,
             retry_after_seconds: None,
             customer_owned: false,
+            refusal_reason: None,
+        }
+    }
+
+    /// The provider refusal for one bounded reason. The message is the fixed
+    /// generic sentence followed by the reason's fixed phrase (nothing the
+    /// provider wrote), and the reason rides the failure into the public
+    /// error and settlement.
+    pub fn refusal(reason: RefusalReason) -> Self {
+        let safe_message = match reason.phrase() {
+            Some(phrase) => format!("{REFUSAL_MESSAGE}: {phrase}"),
+            None => REFUSAL_MESSAGE.to_string(),
+        };
+        Self {
+            refusal_reason: Some(reason),
+            ..Self::new(FailureClass::Refusal, &safe_message)
         }
     }
 
@@ -307,6 +396,12 @@ impl Failure {
             _ => (502, "all_routes_failed", "api_error"),
         };
         let mut error = PublicError::new(status, code, &self.safe_message, error_type);
+        if self.failure_class == FailureClass::Refusal {
+            // Every refusal answer names its category; a refusal built
+            // without one (a visible-refusal stream, a bare stop reason) is
+            // explicitly `unspecified` so clients can branch on the field.
+            error.refusal_reason = Some(self.refusal_reason.unwrap_or(RefusalReason::Unspecified));
+        }
         if self.failure_class == FailureClass::InvalidRequest {
             error.param = self.rejected_parameter.clone();
             if let Some(detail) = self.provider_detail.as_deref() {
@@ -351,10 +446,93 @@ mod tests {
         assert_eq!(error.error_type, "invalid_request_error");
         assert_eq!(error.message, "provider refused the request");
         assert_eq!(error.retry_after_seconds, None);
+        // A refusal built without a reason still names its category.
+        assert_eq!(error.refusal_reason, Some(RefusalReason::Unspecified));
+        assert_eq!(error.json_body()["error"]["refusal_reason"], "unspecified");
         // Untyped provider failures keep the routing-failure shape.
         let internal = Failure::new(FailureClass::ProviderInternal, "provider failed");
         assert_eq!(internal.public_error().status_code, 502);
         assert_eq!(internal.public_error().code, "all_routes_failed");
+    }
+
+    #[test]
+    fn every_refusal_reason_renders_its_fixed_phrase_and_wire_name() {
+        // (reason, wire name, public message): the message is the generic
+        // sentence plus the reason's fixed phrase, never provider prose.
+        let table = [
+            (
+                RefusalReason::CyberPolicy,
+                "cyber_policy",
+                "provider refused the request: cybersecurity policy",
+            ),
+            (
+                RefusalReason::Cbrn,
+                "cbrn",
+                "provider refused the request: biological/chemical safety policy",
+            ),
+            (
+                RefusalReason::ContentPolicy,
+                "content_policy",
+                "provider refused the request: content policy",
+            ),
+            (
+                RefusalReason::Recitation,
+                "recitation",
+                "provider refused the request: recitation of copyrighted material",
+            ),
+            (
+                RefusalReason::DataInspection,
+                "data_inspection",
+                "provider refused the request: data inspection",
+            ),
+            (
+                RefusalReason::Unspecified,
+                "unspecified",
+                "provider refused the request",
+            ),
+        ];
+        for (reason, wire, message) in table {
+            let failure = Failure::refusal(reason)
+                .with_provider_detail(Some("cyber_policy: raw provider prose".into()));
+            assert_eq!(failure.failure_class, FailureClass::Refusal);
+            assert_eq!(failure.refusal_reason, Some(reason));
+            assert_eq!(reason.as_str(), wire);
+            let error = failure.public_error();
+            // Status, code, and type are unchanged so existing clients behave
+            // the same; the reason is the one additive field.
+            assert_eq!(error.status_code, 400);
+            assert_eq!(error.code, "refusal");
+            assert_eq!(error.error_type, "invalid_request_error");
+            assert_eq!(error.message, message);
+            assert_eq!(error.refusal_reason, Some(reason));
+            let body = error.json_body();
+            assert_eq!(body["error"]["refusal_reason"], wire);
+            assert_eq!(body["error"]["code"], "refusal");
+            // The provider's own detail never reaches the caller.
+            assert!(!body.to_string().contains("raw provider prose"));
+            // The enum round-trips through its snake_case wire name.
+            let back: RefusalReason =
+                serde_json::from_value(serde_json::Value::String(wire.to_string()))
+                    .expect("round trip");
+            assert_eq!(back, reason);
+        }
+        // Every other class stays free of the field, on the struct and in
+        // the envelope, so non-refusal payloads are byte-identical.
+        let throttled = Failure::new(FailureClass::Throttled, "slow down").public_error();
+        assert_eq!(throttled.refusal_reason, None);
+        assert!(throttled.json_body()["error"]
+            .get("refusal_reason")
+            .is_none());
+        assert!(serde_json::to_value(&throttled)
+            .expect("serializable")
+            .get("refusal_reason")
+            .is_none());
+        // A boundary payload without the field still deserializes.
+        let legacy: PublicError = serde_json::from_value(serde_json::json!({
+            "status_code": 400, "code": "refusal", "message": "m"
+        }))
+        .expect("field is optional");
+        assert_eq!(legacy.refusal_reason, None);
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -622,11 +622,17 @@ pub fn simplified_event(event: &Event) -> Value {
         Event::Completed | Event::StoppedAtSequence(_) => serde_json::json!({"kind": "completed"}),
         Event::Incomplete => serde_json::json!({"kind": "incomplete"}),
         Event::PausedTurn => serde_json::json!({"kind": "paused_turn"}),
-        Event::Failed(failure) => serde_json::json!({
-            "kind": "failed",
-            "failure_class": failure.failure_class.as_str(),
-            "safe_message": failure.safe_message,
-        }),
+        Event::Failed(failure) => {
+            let mut value = serde_json::json!({
+                "kind": "failed",
+                "failure_class": failure.failure_class.as_str(),
+                "safe_message": failure.safe_message,
+            });
+            if let Some(reason) = failure.refusal_reason {
+                value["refusal_reason"] = serde_json::json!(reason.as_str());
+            }
+            value
+        }
     }
 }
 

--- a/exp/runtime/gateway/native/src/settlement.rs
+++ b/exp/runtime/gateway/native/src/settlement.rs
@@ -85,6 +85,10 @@ fn settle_argument(
             // class only); accounting persists it on the failed-attempt row so
             // an operator sees WHY the provider refused the call.
             "provider_detail": failure.provider_detail,
+            // The bounded refusal category (refusal class only), so the
+            // control plane can count refusals by reason without parsing the
+            // free-form provider_detail.
+            "refusal_reason": failure.refusal_reason.map(|reason| reason.as_str()),
             // The customer's own BYOK credential/account failure: the ledger
             // files it as the caller's invalid request (see
             // native_accounting.ledger_failure).

--- a/exp/runtime/gateway/native/src/stream_errors.rs
+++ b/exp/runtime/gateway/native/src/stream_errors.rs
@@ -19,7 +19,7 @@
 //! Classification reads the RAW provider code and message (never relayed as
 //! such); the bounded, sanitized detail is attached separately.
 
-use crate::errors::{Failure, FailureClass};
+use crate::errors::{Failure, FailureClass, RefusalReason};
 use crate::upstream::transport_failure;
 
 /// What a provider-declared error means for the caller and the ladder.
@@ -28,8 +28,8 @@ pub enum StreamErrorKind {
     /// The caller's request is what the provider refused: relay the detail,
     /// never redial, never fail over (the next rung refuses the same input).
     InvalidRequest,
-    /// The model's safety layer declined the content.
-    Refusal,
+    /// The model's safety layer declined the content, for this bounded reason.
+    Refusal(RefusalReason),
     /// Rate limit or overload: fail over, advertise a retry.
     Throttled,
     /// The provider ACCOUNT cannot pay.
@@ -57,20 +57,45 @@ const INVALID_REQUEST_CODES: &[&str] = &[
     "failed_precondition",
     "out_of_range",
 ];
-const REFUSAL_CODES: &[&str] = &[
-    "content_filter",
-    "content_policy_violation",
-    "data_inspection_failed",
-    "safety",
-    "recitation",
-    "prohibited_content",
-    "blocklist",
-    "spii",
-    "moderation_blocked",
-    "refusal",
+/// Provider codes that are content verdicts, grouped by the bounded reason
+/// each names. The flat union is `REFUSAL_CODES`.
+const CYBER_POLICY_CODES: &[&str] = &[
     // OpenAI's cyber-safety policy verdict (gpt-6-astra, 2026-09-06): a model
     // decision on the content, filed as a refusal, never a provider failure.
     "cyber_policy",
+    "cybersecurity_policy",
+    "cyber_safety",
+];
+const CBRN_CODES: &[&str] = &[
+    "cbrn",
+    "cbrn_policy",
+    "bio",
+    "bio_policy",
+    "biosecurity",
+    "biosecurity_policy",
+];
+const CONTENT_POLICY_CODES: &[&str] = &[
+    "content_filter",
+    "content_filtered",
+    "content_policy_violation",
+    "safety",
+    "image_safety",
+    "prohibited_content",
+    "blocklist",
+    "moderation_blocked",
+    "guardrail_intervened",
+];
+const RECITATION_CODES: &[&str] = &["recitation"];
+const DATA_INSPECTION_CODES: &[&str] = &["data_inspection_failed", "spii"];
+/// A refusal the provider filed under no reason at all.
+const UNSPECIFIED_REFUSAL_CODES: &[&str] = &["refusal"];
+const REFUSAL_CODES: &[&[&str]] = &[
+    CYBER_POLICY_CODES,
+    CBRN_CODES,
+    CONTENT_POLICY_CODES,
+    RECITATION_CODES,
+    DATA_INSPECTION_CODES,
+    UNSPECIFIED_REFUSAL_CODES,
 ];
 const THROTTLED_CODES: &[&str] = &[
     "rate_limit_exceeded",
@@ -126,6 +151,58 @@ const REFUSAL_PHRASES: &[&str] = &[
     "flagged as",
     "blocked by",
 ];
+/// Cyber vocabulary that names the reason only inside a policy verdict: a
+/// caller's prompt about "exploiting a cache" or a sentence mentioning
+/// "malware" in passing is not a cyber-policy refusal on its own.
+const CYBER_WORDS: &[&str] = &["cyber", "malware", "exploit"];
+const POLICY_CONTEXT_WORDS: &[&str] = &[
+    "policy",
+    "policies",
+    "safety",
+    "blocked",
+    "flagged",
+    "prohibited",
+    "not allowed",
+    "violat",
+    "refus",
+    "declin",
+    "harmful",
+];
+/// Weapons-of-mass-destruction vocabulary; multi-word so "biography" or a
+/// chemistry homework prompt never matches.
+const CBRN_PHRASES: &[&str] = &[
+    "cbrn",
+    "biosecurity",
+    "bioweapon",
+    "bio-weapon",
+    "biothreat",
+    "biological weapon",
+    "chemical weapon",
+    "nuclear weapon",
+    "radiological",
+    "biological or chemical",
+    "biological, chemical",
+    "weapons of mass destruction",
+];
+const RECITATION_PHRASES: &[&str] = &["recitation", "recited", "copyright"];
+const DATA_INSPECTION_PHRASES: &[&str] = &[
+    "data inspection",
+    "spii",
+    "sensitive personally identifiable",
+];
+const CONTENT_POLICY_PHRASES: &[&str] = &[
+    "content filter",
+    "content filtering",
+    "content policy",
+    "content management policy",
+    "inappropriate content",
+    "safety system",
+    "flagged as",
+    "blocked by",
+    "moderation",
+    "usage polic",
+    "safety",
+];
 const THROTTLED_PHRASES: &[&str] = &[
     "rate limit",
     "rate-limit",
@@ -160,31 +237,89 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
 /// decide, never a sentence: a pre-stream 4xx body's prose can say "blocked by"
 /// about a rate limit or a firewall.
 pub fn is_refusal_code(code: Option<&str>) -> bool {
-    code.is_some_and(|value| REFUSAL_CODES.contains(&value.trim().to_ascii_lowercase().as_str()))
+    code.is_some_and(|value| {
+        let lowered = value.trim().to_ascii_lowercase();
+        REFUSAL_CODES
+            .iter()
+            .any(|codes| codes.contains(&lowered.as_str()))
+    })
+}
+
+/// Derive the bounded refusal category from the provider's raw code and
+/// sentence.
+///
+/// The provider's own code decides first (`cyber_policy`, `RECITATION`,
+/// `SPII`), then the sentence: weapons vocabulary, cyber vocabulary inside a
+/// policy verdict, recitation, data inspection, and finally the general
+/// content-policy phrasing. A refusal whose code and sentence name nothing
+/// (`refusal`, a bare stop reason) is `Unspecified`. The result is a closed
+/// vocabulary: the caller-facing message is built from the category's fixed
+/// phrase, so no provider prose is ever derived from this function.
+pub fn refusal_reason(code: Option<&str>, message: Option<&str>) -> RefusalReason {
+    let code_lower = code.map(|value| value.trim().to_ascii_lowercase());
+    let code_ref = code_lower.as_deref().unwrap_or("");
+    let coded = [
+        (CYBER_POLICY_CODES, RefusalReason::CyberPolicy),
+        (CBRN_CODES, RefusalReason::Cbrn),
+        (RECITATION_CODES, RefusalReason::Recitation),
+        (DATA_INSPECTION_CODES, RefusalReason::DataInspection),
+        (CONTENT_POLICY_CODES, RefusalReason::ContentPolicy),
+    ]
+    .into_iter()
+    .find_map(|(codes, reason)| codes.contains(&code_ref).then_some(reason));
+    if let Some(reason) = coded {
+        return reason;
+    }
+    // An unlisted code is still a word the provider chose (Gemini's
+    // `IMAGE_SAFETY`, a vendor's `moderation_policy`), so it is read with the
+    // sentence's vocabulary.
+    let haystack = format!(
+        "{code_ref} {}",
+        message
+            .map(|value| value.to_ascii_lowercase())
+            .unwrap_or_default()
+    );
+    if contains_any(&haystack, CBRN_PHRASES) {
+        return RefusalReason::Cbrn;
+    }
+    if contains_any(&haystack, CYBER_WORDS) && contains_any(&haystack, POLICY_CONTEXT_WORDS) {
+        return RefusalReason::CyberPolicy;
+    }
+    if contains_any(&haystack, RECITATION_PHRASES) {
+        return RefusalReason::Recitation;
+    }
+    if contains_any(&haystack, DATA_INSPECTION_PHRASES) {
+        return RefusalReason::DataInspection;
+    }
+    if contains_any(&haystack, CONTENT_POLICY_PHRASES) {
+        return RefusalReason::ContentPolicy;
+    }
+    RefusalReason::Unspecified
 }
 
 /// Classify one provider-declared error from its raw code and message.
 ///
-/// Content verdicts win first (a content filter may arrive under an
-/// `invalid_request_error` type). Then the provider's own code is
-/// authoritative (an `authentication_error` whose sentence happens to say
-/// "must be provided" is still a credential failure). A numeric code takes the
-/// shared HTTP mapping when it names a client-side status; a 5xx does NOT end
-/// the search, because an aggregator often re-statuses an upstream 400 as its
-/// own 502 and only the sentence says so. Credential, quota, and throttle
-/// phrasing are read before caller-input phrasing so the broader input
-/// vocabulary never swallows them. Anything left is the provider failing.
+/// A content-verdict CODE wins first (a content filter may arrive under an
+/// `invalid_request_error` type). Then every other authoritative provider
+/// code decides (an `authentication_error` whose sentence happens to say
+/// "must be provided" is still a credential failure; a `rate_limit_exceeded`
+/// whose sentence says "blocked by" is still a throttle), and a numeric code
+/// takes the shared HTTP mapping for the throttle, quota, credential, and
+/// not-found statuses. Only then does refusal PHRASING decide, ahead of the
+/// caller-input codes, because Azure and Gemini file a content filter under a
+/// 400 `invalid_request_error`. A 5xx numeric code does NOT end the search,
+/// because an aggregator often re-statuses an upstream 400 as its own 502 and
+/// only the sentence says so. Credential, quota, and throttle phrasing are
+/// read before caller-input phrasing so the broader input vocabulary never
+/// swallows them. Anything left is the provider failing.
 pub fn classify_stream_error(code: Option<&str>, message: Option<&str>) -> StreamErrorKind {
     let code_lower = code.map(|value| value.trim().to_ascii_lowercase());
     let message_lower = message.map(|value| value.to_ascii_lowercase());
     let code_ref = code_lower.as_deref().unwrap_or("");
     let message_ref = message_lower.as_deref().unwrap_or("");
 
-    if REFUSAL_CODES.contains(&code_ref) || contains_any(message_ref, REFUSAL_PHRASES) {
-        return StreamErrorKind::Refusal;
-    }
-    if INVALID_REQUEST_CODES.contains(&code_ref) {
-        return StreamErrorKind::InvalidRequest;
+    if is_refusal_code(Some(code_ref)) {
+        return StreamErrorKind::Refusal(refusal_reason(code, message));
     }
     if THROTTLED_CODES.contains(&code_ref) {
         return StreamErrorKind::Throttled;
@@ -198,15 +333,26 @@ pub fn classify_stream_error(code: Option<&str>, message: Option<&str>) -> Strea
     if NOT_FOUND_CODES.contains(&code_ref) {
         return StreamErrorKind::ProviderNotFound;
     }
-    if let Ok(status) = code_ref.parse::<u16>() {
-        match transport_failure(Some(status)).failure_class {
-            FailureClass::InvalidRequest => return StreamErrorKind::InvalidRequest,
-            FailureClass::Throttled => return StreamErrorKind::Throttled,
-            FailureClass::ProviderQuota => return StreamErrorKind::ProviderQuota,
-            FailureClass::ProviderAuthentication => return StreamErrorKind::ProviderAuthentication,
-            FailureClass::ProviderNotFound => return StreamErrorKind::ProviderNotFound,
-            _ => {}
+    let numeric_class = code_ref
+        .parse::<u16>()
+        .ok()
+        .map(|status| transport_failure(Some(status)).failure_class);
+    match numeric_class {
+        Some(FailureClass::Throttled) => return StreamErrorKind::Throttled,
+        Some(FailureClass::ProviderQuota) => return StreamErrorKind::ProviderQuota,
+        Some(FailureClass::ProviderAuthentication) => {
+            return StreamErrorKind::ProviderAuthentication
         }
+        Some(FailureClass::ProviderNotFound) => return StreamErrorKind::ProviderNotFound,
+        _ => {}
+    }
+    if contains_any(message_ref, REFUSAL_PHRASES) {
+        return StreamErrorKind::Refusal(refusal_reason(code, message));
+    }
+    if INVALID_REQUEST_CODES.contains(&code_ref)
+        || numeric_class == Some(FailureClass::InvalidRequest)
+    {
+        return StreamErrorKind::InvalidRequest;
     }
     if contains_any(message_ref, AUTHENTICATION_PHRASES) {
         return StreamErrorKind::ProviderAuthentication;
@@ -236,9 +382,7 @@ pub fn stream_failure(kind: StreamErrorKind, detail: Option<String>) -> Failure 
              the model alias capabilities",
         )
         .with_retry(false, false),
-        StreamErrorKind::Refusal => {
-            Failure::new(FailureClass::Refusal, "provider refused the request")
-        }
+        StreamErrorKind::Refusal(reason) => Failure::refusal(reason),
         StreamErrorKind::Throttled => Failure::new(
             FailureClass::Throttled,
             "provider throttled the request; retry after the delay in the Retry-After header",
@@ -321,22 +465,238 @@ mod tests {
                 Some("invalid_request_error"),
                 Some("Output blocked by content filtering policy")
             ),
-            StreamErrorKind::Refusal
+            StreamErrorKind::Refusal(RefusalReason::ContentPolicy)
         );
         assert_eq!(
             classify_stream_error(Some("SAFETY"), None),
-            StreamErrorKind::Refusal
+            StreamErrorKind::Refusal(RefusalReason::ContentPolicy)
         );
+        // The code decides the category even when the sentence reads as a
+        // different one ("inappropriate content" is content-policy phrasing).
         assert_eq!(
             classify_stream_error(
                 Some("data_inspection_failed"),
                 Some("Output data may contain inappropriate content.")
             ),
-            StreamErrorKind::Refusal
+            StreamErrorKind::Refusal(RefusalReason::DataInspection)
         );
         assert_eq!(
             classify_stream_error(Some("cyber_policy"), None),
-            StreamErrorKind::Refusal
+            StreamErrorKind::Refusal(RefusalReason::CyberPolicy)
+        );
+        // A numeric 400 with content-filter phrasing (Azure) is the verdict,
+        // not a request-shape error.
+        assert_eq!(
+            classify_stream_error(
+                Some("400"),
+                Some("The response was filtered due to the prompt triggering Azure OpenAI's content management policy.")
+            ),
+            StreamErrorKind::Refusal(RefusalReason::ContentPolicy)
+        );
+    }
+
+    #[test]
+    fn every_refusal_code_maps_to_its_reason() {
+        let table: &[(&str, RefusalReason)] = &[
+            ("cyber_policy", RefusalReason::CyberPolicy),
+            ("cybersecurity_policy", RefusalReason::CyberPolicy),
+            ("cyber_safety", RefusalReason::CyberPolicy),
+            ("cbrn", RefusalReason::Cbrn),
+            ("cbrn_policy", RefusalReason::Cbrn),
+            ("bio", RefusalReason::Cbrn),
+            ("bio_policy", RefusalReason::Cbrn),
+            ("biosecurity", RefusalReason::Cbrn),
+            ("biosecurity_policy", RefusalReason::Cbrn),
+            ("content_filter", RefusalReason::ContentPolicy),
+            ("content_filtered", RefusalReason::ContentPolicy),
+            ("content_policy_violation", RefusalReason::ContentPolicy),
+            ("safety", RefusalReason::ContentPolicy),
+            ("image_safety", RefusalReason::ContentPolicy),
+            ("prohibited_content", RefusalReason::ContentPolicy),
+            ("blocklist", RefusalReason::ContentPolicy),
+            ("moderation_blocked", RefusalReason::ContentPolicy),
+            ("guardrail_intervened", RefusalReason::ContentPolicy),
+            ("recitation", RefusalReason::Recitation),
+            ("data_inspection_failed", RefusalReason::DataInspection),
+            ("spii", RefusalReason::DataInspection),
+            ("refusal", RefusalReason::Unspecified),
+        ];
+        for (code, reason) in table {
+            // Case and surrounding whitespace never matter (Gemini shouts).
+            let shouted = format!(" {} ", code.to_ascii_uppercase());
+            assert_eq!(refusal_reason(Some(code), None), *reason, "{code}");
+            assert_eq!(refusal_reason(Some(&shouted), None), *reason, "{code}");
+            assert_eq!(
+                classify_stream_error(Some(code), Some("whatever the sentence says")),
+                StreamErrorKind::Refusal(*reason),
+                "{code}"
+            );
+            assert!(is_refusal_code(Some(code)), "{code}");
+        }
+        // The flat union and the grouped lists agree on membership.
+        let grouped: usize = REFUSAL_CODES.iter().map(|codes| codes.len()).sum();
+        assert_eq!(grouped, table.len());
+    }
+
+    #[test]
+    fn refusal_reason_reads_the_sentence_when_the_code_names_nothing() {
+        // A code the lists do not know is read together with the sentence.
+        let cases: &[(Option<&str>, &str, RefusalReason)] = &[
+            (
+                None,
+                "This request was blocked by our cybersecurity policy.",
+                RefusalReason::CyberPolicy,
+            ),
+            (
+                Some("invalid_request_error"),
+                "Your prompt was flagged as potential malware development.",
+                RefusalReason::CyberPolicy,
+            ),
+            (
+                None,
+                "Exploit development is not allowed under our usage policies.",
+                RefusalReason::CyberPolicy,
+            ),
+            (
+                None,
+                "The request was refused under our biosecurity policy.",
+                RefusalReason::Cbrn,
+            ),
+            (
+                Some("invalid_prompt"),
+                "Content about chemical weapons is prohibited.",
+                RefusalReason::Cbrn,
+            ),
+            (
+                None,
+                "This may relate to weapons of mass destruction and was blocked by the safety system.",
+                RefusalReason::Cbrn,
+            ),
+            (
+                None,
+                "Output blocked: recitation of copyrighted material.",
+                RefusalReason::Recitation,
+            ),
+            (
+                None,
+                "Output data may contain sensitive personally identifiable information.",
+                RefusalReason::DataInspection,
+            ),
+            (
+                None,
+                "Output blocked by content filtering policy",
+                RefusalReason::ContentPolicy,
+            ),
+            (
+                Some("invalid_request_error"),
+                "Your request was rejected as a result of our safety system.",
+                RefusalReason::ContentPolicy,
+            ),
+            (
+                None,
+                "Content moderation flagged this request.",
+                RefusalReason::ContentPolicy,
+            ),
+            // Gemini's IMAGE_SAFETY block reason is unlisted but self-describing.
+            (Some("IMAGE_SAFETY"), "", RefusalReason::ContentPolicy),
+            // Nothing named: an unnamed refusal.
+            (None, "", RefusalReason::Unspecified),
+            (Some("OTHER"), "The model declined.", RefusalReason::Unspecified),
+            (Some("BLOCK_REASON_UNSPECIFIED"), "", RefusalReason::Unspecified),
+        ];
+        for (code, message, reason) in cases {
+            assert_eq!(
+                refusal_reason(*code, Some(message)),
+                *reason,
+                "{code:?} / {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn refusal_reason_guards_against_false_positives() {
+        // Cyber vocabulary outside a policy verdict is not a cyber refusal.
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("flagged as inappropriate content; the cache exploit note")
+            ),
+            RefusalReason::CyberPolicy,
+            "an explicit verdict word plus cyber vocabulary IS the cyber category"
+        );
+        assert_eq!(
+            refusal_reason(None, Some("Output blocked by content filtering policy")),
+            RefusalReason::ContentPolicy
+        );
+        assert_eq!(
+            refusal_reason(
+                Some("content_filter"),
+                Some("Discussing malware in a novel")
+            ),
+            RefusalReason::ContentPolicy,
+            "the provider's own content-policy code outranks cyber words in the sentence"
+        );
+        // "bio" alone is a code token, never a substring match: a biography
+        // or biology sentence does not become a weapons verdict.
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("flagged as inappropriate content in the biography")
+            ),
+            RefusalReason::ContentPolicy
+        );
+        assert_eq!(
+            refusal_reason(Some("biography"), None),
+            RefusalReason::Unspecified
+        );
+        // Recitation and data-inspection phrasing never masquerade as the
+        // other, and neither swallows a weapons verdict.
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("Copyright recitation and chemical weapon synthesis")
+            ),
+            RefusalReason::Cbrn
+        );
+    }
+
+    #[test]
+    fn an_authoritative_non_content_code_outranks_refusal_phrasing() {
+        // A rate limiter that says "blocked by" is a throttle, never a
+        // refusal; the provider's own code decides before any sentence.
+        assert_eq!(
+            classify_stream_error(
+                Some("rate_limit_exceeded"),
+                Some("Request blocked by rate limiting; retry shortly.")
+            ),
+            StreamErrorKind::Throttled
+        );
+        assert_eq!(
+            classify_stream_error(Some("429"), Some("Request blocked by the rate limiter")),
+            StreamErrorKind::Throttled
+        );
+        assert_eq!(
+            classify_stream_error(
+                Some("insufficient_quota"),
+                Some("Request blocked by billing: quota exhausted")
+            ),
+            StreamErrorKind::ProviderQuota
+        );
+        assert_eq!(
+            classify_stream_error(
+                Some("permission_denied"),
+                Some("Blocked by organization policy: key not permitted")
+            ),
+            StreamErrorKind::ProviderAuthentication
+        );
+        assert_eq!(
+            classify_stream_error(Some("model_not_found"), Some("flagged as unknown model")),
+            StreamErrorKind::ProviderNotFound
+        );
+        // Code-less refusal phrasing still classifies as a refusal.
+        assert_eq!(
+            classify_stream_error(None, Some("Output blocked by content filtering policy")),
+            StreamErrorKind::Refusal(RefusalReason::ContentPolicy)
         );
     }
 
@@ -479,9 +839,46 @@ mod tests {
         assert!(internal.retryable_same_deployment && internal.failover_eligible);
         assert_eq!(internal.safe_message, "provider stream failed");
 
-        let refusal = stream_failure(StreamErrorKind::Refusal, None);
+        let refusal = stream_failure(
+            StreamErrorKind::Refusal(RefusalReason::Unspecified),
+            Some("refusal".into()),
+        );
         assert_eq!(refusal.failure_class, FailureClass::Refusal);
         assert_eq!(refusal.public_error().status_code, 400);
+        assert_eq!(refusal.safe_message, "provider refused the request");
+        assert_eq!(refusal.refusal_reason, Some(RefusalReason::Unspecified));
+        assert_eq!(refusal.provider_detail.as_deref(), Some("refusal"));
+    }
+
+    #[test]
+    fn a_classified_refusal_names_its_category_and_keeps_the_raw_token_ledger_only() {
+        // The astra cyber-policy `response.failed` as the ledger sees it: the
+        // caller gets the fixed phrase and the machine-readable category, while
+        // the raw provider token rides provider_detail into settlement only.
+        let kind = classify_stream_error(Some("cyber_policy"), Some("blocked by cyber policy"));
+        assert_eq!(kind, StreamErrorKind::Refusal(RefusalReason::CyberPolicy));
+        let failure = stream_failure(kind, Some("cyber_policy: blocked by cyber policy".into()));
+        assert_eq!(failure.failure_class, FailureClass::Refusal);
+        assert_eq!(failure.refusal_reason, Some(RefusalReason::CyberPolicy));
+        // The raw provider token reaches the ledger, never the caller.
+        assert_eq!(
+            failure.provider_detail.as_deref(),
+            Some("cyber_policy: blocked by cyber policy")
+        );
+        let public = failure.public_error();
+        assert_eq!(public.status_code, 400);
+        assert_eq!(public.code, "refusal");
+        assert_eq!(public.error_type, "invalid_request_error");
+        assert_eq!(
+            public.message,
+            "provider refused the request: cybersecurity policy"
+        );
+        assert_eq!(public.refusal_reason, Some(RefusalReason::CyberPolicy));
+        // The public envelope carries the snake_case category and never the
+        // provider's own sentence.
+        let body = public.json_body();
+        assert_eq!(body["error"]["refusal_reason"], "cyber_policy");
+        assert!(!body.to_string().contains("blocked by cyber policy"));
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/stream_errors.rs
+++ b/exp/runtime/gateway/native/src/stream_errors.rs
@@ -153,8 +153,28 @@ const REFUSAL_PHRASES: &[&str] = &[
 ];
 /// Cyber vocabulary that names the reason only inside a policy verdict: a
 /// caller's prompt about "exploiting a cache" or a sentence mentioning
-/// "malware" in passing is not a cyber-policy refusal on its own.
-const CYBER_WORDS: &[&str] = &["cyber", "malware", "exploit"];
+/// "malware" in passing is not a cyber-policy refusal on its own. These are
+/// prefix-safe ("cybersecurity", "cyberattack" all name the domain).
+const CYBER_PREFIX_WORDS: &[&str] = &["cyber", "malware", "ransomware", "phishing", "hacking"];
+
+/// Whether the sentence names a software exploit as a whole word ("exploit",
+/// "exploits"). "exploit" is NOT prefix-safe: "sexual exploitation" is a
+/// content-policy verdict, and "exploited"/"exploitative" are ordinary prose,
+/// so any continuation other than a plural `s` disqualifies the match.
+fn names_software_exploit(haystack: &str) -> bool {
+    haystack.match_indices("exploit").any(|(start, matched)| {
+        let mut rest = haystack[start + matched.len()..].chars();
+        match rest.next() {
+            None => true,
+            Some('s') => !rest.next().is_some_and(|c| c.is_ascii_alphabetic()),
+            Some(c) => !c.is_ascii_alphabetic(),
+        }
+    })
+}
+
+fn names_cyber_domain(haystack: &str) -> bool {
+    contains_any(haystack, CYBER_PREFIX_WORDS) || names_software_exploit(haystack)
+}
 const POLICY_CONTEXT_WORDS: &[&str] = &[
     "policy",
     "policies",
@@ -282,7 +302,7 @@ pub fn refusal_reason(code: Option<&str>, message: Option<&str>) -> RefusalReaso
     if contains_any(&haystack, CBRN_PHRASES) {
         return RefusalReason::Cbrn;
     }
-    if contains_any(&haystack, CYBER_WORDS) && contains_any(&haystack, POLICY_CONTEXT_WORDS) {
+    if names_cyber_domain(&haystack) && contains_any(&haystack, POLICY_CONTEXT_WORDS) {
         return RefusalReason::CyberPolicy;
     }
     if contains_any(&haystack, RECITATION_PHRASES) {
@@ -635,6 +655,42 @@ mod tests {
             ),
             RefusalReason::ContentPolicy,
             "the provider's own content-policy code outranks cyber words in the sentence"
+        );
+        // "exploit" is a whole word, never a prefix: "sexual exploitation" is
+        // a content-policy verdict (Greptile on #843), and "exploited" or
+        // "exploitative" is ordinary prose; only "exploit"/"exploits" names
+        // the software sense.
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("Content involving sexual exploitation was blocked by our safety policy.")
+            ),
+            RefusalReason::ContentPolicy
+        );
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("The request exploited a loophole and was flagged as unsafe.")
+            ),
+            RefusalReason::ContentPolicy
+        );
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("Writing exploits for known CVEs is not allowed.")
+            ),
+            RefusalReason::CyberPolicy
+        );
+        assert_eq!(
+            refusal_reason(
+                None,
+                Some("Blocked: exploit development violates our policy.")
+            ),
+            RefusalReason::CyberPolicy
+        );
+        assert_eq!(
+            refusal_reason(None, Some("Ransomware and phishing content is prohibited.")),
+            RefusalReason::CyberPolicy
         );
         // "bio" alone is a code token, never a substring match: a biography
         // or biology sentence does not become a weapons verdict.

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -235,14 +235,12 @@ pub async fn open_stream(
             .or_else(|| code.clone().filter(|token| !generic_error_code(token)));
         // A content-filter CODE under a 4xx is the model's verdict on the
         // content (Azure and Gemini answer 400 for it), not a request-shape
-        // error: file and answer it as a refusal, detail kept ledger-only.
-        // Only the authoritative code decides here; a sentence saying
-        // "blocked by" could be about a firewall or a limit.
+        // error: file and answer it as a refusal naming its bounded category,
+        // detail kept ledger-only. Only the authoritative code decides here; a
+        // sentence saying "blocked by" could be about a firewall or a limit.
         if crate::stream_errors::is_refusal_code(code.as_deref()) {
-            return Err(
-                Failure::new(FailureClass::Refusal, "provider refused the request")
-                    .with_provider_detail(detail),
-            );
+            let reason = crate::stream_errors::refusal_reason(code.as_deref(), None);
+            return Err(Failure::refusal(reason).with_provider_detail(detail));
         }
         // A sentence naming a limitation of THIS lane's serving stack (a chat
         // template that rejects a mid-conversation system turn the OpenAI
@@ -446,12 +444,17 @@ mod tests {
         assert_eq!(failure.failure_class, FailureClass::Refusal);
         assert_eq!(failure.public_error().status_code, 400);
         assert_eq!(failure.public_error().code, "refusal");
+        // The content_filter code names the content-policy category.
+        assert_eq!(
+            failure.refusal_reason,
+            Some(crate::errors::RefusalReason::ContentPolicy)
+        );
         // The sanitized sentence (or the code token when it must drop) rides
         // to the ledger; a refusal never relays it to the caller.
         assert!(failure.provider_detail.is_some());
         assert_eq!(
             failure.public_error().message,
-            "provider refused the request"
+            "provider refused the request: content policy"
         );
     }
 

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -324,6 +324,9 @@ pub async fn acquire_attempt(ctx: &WaterfallContext<'_>, guard: &mut AttemptGuar
                 // Ownership survives the round trip too: the echoed exhaustion
                 // must still render as the customer's 400.
                 "customer_owned": failure.customer_owned,
+                // The refusal category survives the round trip so an exhausted
+                // refusal ladder still names its reason to the caller.
+                "refusal_reason": failure.refusal_reason.map(|reason| reason.as_str()),
             })),
         }));
         let started_text = match ctx.bridge.call("start_attempt", argument).await {

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -49,6 +49,7 @@ from exp.runtime.gateway.native_settlement import (
     budget_quota_protocol_error,
     first_token_at_from_settlement,
     ledger_failure,
+    refusal_reason_from_payload,
     terminal_from_settlement,
 )
 from exp.runtime.gateway.routing import GatewayRoute
@@ -191,6 +192,7 @@ def _failure_from_payload(payload: object) -> GatewayFailure | None:
             provider_detail if isinstance(provider_detail, str) and provider_detail else None
         ),
         customer_owned=data.get("customer_owned") is True,
+        refusal_reason=refusal_reason_from_payload(data.get("refusal_reason")),
     )
 
 
@@ -597,6 +599,10 @@ class NativeAttemptAccounting:
             failure_payload["rejected_parameter"] = exhaustion.rejected_parameter
         if exhaustion.provider_detail is not None:
             failure_payload["provider_detail"] = exhaustion.provider_detail
+        if exhaustion.refusal_reason is not None:
+            # Echoed back so an exhausted refusal ladder re-renders with its
+            # bounded category on the caller-facing 400.
+            failure_payload["refusal_reason"] = exhaustion.refusal_reason.value
         if exhaustion.retry_after_seconds is not None:
             failure_payload["retry_after_seconds"] = exhaustion.retry_after_seconds
         return json.dumps(

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -11,6 +11,7 @@ from exp.runtime.gateway.contracts import (
     GatewayEventKind,
     GatewayFailure,
     GatewayFailureClass,
+    GatewayRefusalReason,
     GatewayUsage,
 )
 from exp.runtime.gateway.routing import GatewayRoute
@@ -21,6 +22,20 @@ _TERMINAL_KINDS = {
     "incomplete": GatewayEventKind.INCOMPLETE,
     "failed": GatewayEventKind.FAILED,
 }
+
+
+def refusal_reason_from_payload(value: object) -> GatewayRefusalReason | None:
+    """Parse one optional bounded refusal reason from a boundary payload.
+
+    An unknown token fails closed to ``None`` rather than raising, so a future
+    native reason a stale worker does not know never breaks settlement.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return GatewayRefusalReason(value)
+    except ValueError:
+        return None
 
 
 def ledger_failure(failure: GatewayFailure) -> GatewayFailure:
@@ -67,6 +82,9 @@ def terminal_from_settlement(
                 provider_detail if isinstance(provider_detail, str) and provider_detail else None
             ),
             customer_owned=failure_payload.get("customer_owned") is True,
+            # The bounded refusal category rides the settlement argument so the
+            # control plane counts refusals by reason without parsing detail.
+            refusal_reason=refusal_reason_from_payload(failure_payload.get("refusal_reason")),
         )
         # A rejected credential or exhausted account on the customer's own
         # BYOK rung kept its ladder class in the data plane (so another

--- a/exp/runtime/gateway/native_settlement_test.py
+++ b/exp/runtime/gateway/native_settlement_test.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from exp.runtime.gateway.contracts import GatewayEventKind, GatewayFailureClass
+from exp.runtime.gateway.contracts import (
+    GatewayEventKind,
+    GatewayFailureClass,
+    GatewayRefusalReason,
+)
 from exp.runtime.gateway.native_settlement import (
     _usage_from_payload,  # noqa: PLC2701 - direct unit coverage for normalization.
     first_token_at_from_settlement,
@@ -120,6 +124,40 @@ def test_terminal_from_settlement_carries_the_provider_detail() -> None:
     )
     assert blank is not None
     assert blank.provider_detail is None
+
+
+def test_terminal_from_settlement_carries_the_refusal_reason() -> None:
+    """A refusal settlement threads the bounded category through, and an
+    unknown token fails closed to None instead of raising."""
+    _terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "usage": None,
+            "tool_names": [],
+            "failure": {
+                "failure_class": "refusal",
+                "safe_message": "provider refused the request: cybersecurity policy",
+                "refusal_reason": "cyber_policy",
+            },
+        }
+    )
+    assert failure is not None
+    assert failure.refusal_reason is GatewayRefusalReason.CYBER_POLICY
+
+    _t, unknown = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "usage": None,
+            "tool_names": [],
+            "failure": {
+                "failure_class": "refusal",
+                "safe_message": "provider refused the request",
+                "refusal_reason": "reason_a_stale_worker_does_not_know",
+            },
+        }
+    )
+    assert unknown is not None
+    assert unknown.refusal_reason is None
 
 
 def test_customer_owned_failures_settle_as_the_callers_invalid_request() -> None:

--- a/exp/runtime/gateway/stream_contracts.py
+++ b/exp/runtime/gateway/stream_contracts.py
@@ -185,6 +185,24 @@ class GatewayFailureClass(StrEnum):
     UNAVAILABLE = "unavailable"
 
 
+class GatewayRefusalReason(StrEnum):
+    """The bounded category of a provider refusal, mirroring the native
+    ``RefusalReason``.
+
+    A refusal answer names WHICH policy declined the content as a closed
+    vocabulary, so a client can branch on it and the control plane can count
+    refusals by reason without parsing the free-form provider detail. The
+    caller never sees the provider's own prose, only the fixed category.
+    """
+
+    CYBER_POLICY = "cyber_policy"
+    CBRN = "cbrn"
+    CONTENT_POLICY = "content_policy"
+    RECITATION = "recitation"
+    DATA_INSPECTION = "data_inspection"
+    UNSPECIFIED = "unspecified"
+
+
 class GatewayFailure(ContractModel):
     """Sanitized failure with retry and failover eligibility already classified."""
 
@@ -209,3 +227,9 @@ class GatewayFailure(ContractModel):
     value as ``Retry-After`` instead of its fixed default, so the header and
     the message never tell the caller two different waits.
     """
+    refusal_reason: GatewayRefusalReason | None = None
+    """The bounded refusal category, present only on a ``REFUSAL`` failure.
+
+    Set from the provider's own code and sentence and carried on the public
+    error and the settlement argument, so the caller reads the category and
+    the control plane counts refusals by reason without parsing detail."""

--- a/exp/runtime/gateway/stream_contracts_test.py
+++ b/exp/runtime/gateway/stream_contracts_test.py
@@ -2,7 +2,41 @@
 
 import pytest
 
-from exp.runtime.gateway.stream_contracts import GatewayEvent, GatewayEventKind
+from exp.runtime.gateway.stream_contracts import (
+    GatewayEvent,
+    GatewayEventKind,
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayRefusalReason,
+)
+
+
+def test_gateway_failure_carries_an_optional_bounded_refusal_reason() -> None:
+    """The refusal reason is an optional typed field that round-trips through
+    the contract's JSON serialization and defaults to absent."""
+    bare = GatewayFailure(
+        failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+        safe_message="provider stream failed",
+    )
+    assert bare.refusal_reason is None
+
+    refused = GatewayFailure(
+        failure_class=GatewayFailureClass.REFUSAL,
+        safe_message="provider refused the request: cybersecurity policy",
+        refusal_reason=GatewayRefusalReason.CYBER_POLICY,
+    )
+    assert refused.refusal_reason is GatewayRefusalReason.CYBER_POLICY
+    restored = GatewayFailure.model_validate(refused.model_dump(mode="json"))
+    assert restored.refusal_reason is GatewayRefusalReason.CYBER_POLICY
+    # The enum members are exactly the closed vocabulary shared with the engine.
+    assert {reason.value for reason in GatewayRefusalReason} == {
+        "cyber_policy",
+        "cbrn",
+        "content_policy",
+        "recitation",
+        "data_inspection",
+        "unspecified",
+    }
 
 
 @pytest.mark.parametrize("length", [257, 65_536])

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -130,7 +130,9 @@ GEMINI_PROMPT_BLOCK_EVENTS: tuple[JsonObject, ...] = (
     {
         "kind": "failed",
         "failure_class": "refusal",
-        "safe_message": "provider refused the request",
+        # PROHIBITED_CONTENT names the content-policy category.
+        "safe_message": "provider refused the request: content policy",
+        "refusal_reason": "content_policy",
     },
 )
 
@@ -230,11 +232,14 @@ def _simplified(event: GatewayEvent) -> JsonObject:
     if event.kind is GatewayEventKind.INCOMPLETE:
         return {"kind": "incomplete"}
     assert event.failure is not None
-    return {
+    failed: JsonObject = {
         "kind": "failed",
         "failure_class": event.failure.failure_class.value,
         "safe_message": event.failure.safe_message,
     }
+    if event.failure.refusal_reason is not None:
+        failed["refusal_reason"] = event.failure.refusal_reason.value
+    return failed
 
 
 def test_native_gemini_normalizer_matches_the_golden_fixture() -> None:
@@ -253,7 +258,8 @@ def test_native_gemini_normalizer_matches_the_golden_fixture() -> None:
         {
             "kind": "failed",
             "failure_class": "refusal",
-            "safe_message": "provider refused the request",
+            "safe_message": "provider refused the request: content policy",
+            "refusal_reason": "content_policy",
         }
     ]
 
@@ -494,7 +500,9 @@ def test_native_bedrock_normalizer_matches_the_golden_fixture() -> None:
         {
             "kind": "failed",
             "failure_class": "refusal",
-            "safe_message": "provider refused the request",
+            # guardrail_intervened is a content-policy verdict.
+            "safe_message": "provider refused the request: content policy",
+            "refusal_reason": "content_policy",
         },
     ]
 

--- a/exp/runtime/openai_protocol/errors.py
+++ b/exp/runtime/openai_protocol/errors.py
@@ -9,7 +9,11 @@ from typing import Literal
 from pydantic import Field
 
 from exp.common.core.artifacts import ContractModel, JsonObject
-from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from exp.runtime.gateway.contracts import (
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayRefusalReason,
+)
 
 THROTTLED_RETRY_AFTER_SECONDS = 5
 UNAVAILABLE_RETRY_AFTER_SECONDS = 2
@@ -28,6 +32,9 @@ class OpenAIErrorDetail(ContractModel):
     ]
     param: str | None = Field(default=None, max_length=512)
     code: str = Field(min_length=1, max_length=128)
+    refusal_reason: GatewayRefusalReason | None = None
+    """The bounded refusal category, present only on a ``refusal`` error, so a
+    caller reads which policy declined without any provider prose."""
 
 
 class OpenAIErrorEnvelope(ContractModel):
@@ -54,6 +61,7 @@ class OpenAIProtocolError(ValueError):
         ] = "invalid_request_error",
         param: str | None = None,
         retry_after_seconds: int | None = None,
+        refusal_reason: GatewayRefusalReason | None = None,
     ) -> None:
         """Create one sanitized public protocol failure.
 
@@ -64,6 +72,7 @@ class OpenAIProtocolError(ValueError):
             error_type: OpenAI error category.
             param: Exact public request field responsible for the error.
             retry_after_seconds: Optional positive wait advertised as ``Retry-After``.
+            refusal_reason: Bounded refusal category, set only on a ``refusal``.
         """
         if retry_after_seconds is not None and retry_after_seconds <= 0:
             raise ValueError("retry_after_seconds must be positive")
@@ -75,6 +84,7 @@ class OpenAIProtocolError(ValueError):
             type=error_type,
             param=param,
             code=code,
+            refusal_reason=refusal_reason,
         )
 
     def envelope(self) -> OpenAIErrorEnvelope:
@@ -82,8 +92,17 @@ class OpenAIProtocolError(ValueError):
         return OpenAIErrorEnvelope(error=self.detail)
 
     def json_body(self) -> JsonObject:
-        """Return a JSON-compatible body suitable for an HTTP response."""
-        return self.envelope().model_dump(mode="json")
+        """Return a JSON-compatible body suitable for an HTTP response.
+
+        ``refusal_reason`` is additive: it appears only on a refusal, so every
+        other error keeps its exact pre-existing envelope shape.
+        """
+        body = self.envelope().model_dump(mode="json")
+        if self.detail.refusal_reason is None:
+            error = body.get("error")
+            if isinstance(error, dict):
+                error.pop("refusal_reason", None)
+        return body
 
     def headers(self) -> dict[str, str]:
         """Return transport headers implied by this error, such as ``Retry-After``."""
@@ -249,6 +268,13 @@ def public_failure_error(
             f"{message}. The allocation resets at {boundary}; retry after that time "
             "or ask the gateway operator to raise the monthly budget."
         )
+    # A refusal names its bounded category to the caller; an unnamed one is
+    # explicitly ``unspecified`` so a client can always branch on the field.
+    refusal_reason = (
+        (failure.refusal_reason or GatewayRefusalReason.UNSPECIFIED)
+        if failure.failure_class is GatewayFailureClass.REFUSAL
+        else None
+    )
     return OpenAIProtocolError(
         status_code=status,
         code=code,
@@ -256,6 +282,7 @@ def public_failure_error(
         error_type=error_type,
         param=param,
         retry_after_seconds=retry_after_seconds,
+        refusal_reason=refusal_reason,
     )
 
 

--- a/exp/runtime/openai_protocol/errors_test.py
+++ b/exp/runtime/openai_protocol/errors_test.py
@@ -6,7 +6,11 @@ from datetime import UTC, datetime
 
 import pytest
 
-from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
+from exp.runtime.gateway.contracts import (
+    GatewayFailure,
+    GatewayFailureClass,
+    GatewayRefusalReason,
+)
 from exp.runtime.models.providers.errors import (
     ProviderParameterError,
     UnsupportedReasoningEffortError,
@@ -18,6 +22,14 @@ from exp.runtime.openai_protocol.errors import (
     OpenAIProtocolError,
     public_failure_error,
 )
+
+
+def _error_body(error: OpenAIProtocolError) -> dict[str, object]:
+    """The inner ``error`` object of a public error envelope, narrowed to a dict."""
+    body = error.json_body()
+    inner = body["error"]
+    assert isinstance(inner, dict)
+    return inner
 
 
 def test_monthly_quota_failure_uses_openai_insufficient_quota_shape() -> None:
@@ -112,6 +124,47 @@ def test_refusal_failure_is_a_request_error_not_a_routing_failure() -> None:
     assert error.detail.type == "invalid_request_error"
     assert error.detail.message == "provider refused the request"
     assert error.retry_after_seconds is None
+    # A refusal with no named reason is explicitly unspecified so a client can
+    # always read the field.
+    assert error.detail.refusal_reason is GatewayRefusalReason.UNSPECIFIED
+    assert _error_body(error)["refusal_reason"] == "unspecified"
+
+
+def test_refusal_error_carries_its_bounded_category() -> None:
+    """A classified refusal names its category on the public error and body,
+    while the status, code, and type stay the same for every existing client."""
+    for reason, wire in [
+        (GatewayRefusalReason.CYBER_POLICY, "cyber_policy"),
+        (GatewayRefusalReason.CBRN, "cbrn"),
+        (GatewayRefusalReason.CONTENT_POLICY, "content_policy"),
+        (GatewayRefusalReason.RECITATION, "recitation"),
+        (GatewayRefusalReason.DATA_INSPECTION, "data_inspection"),
+    ]:
+        error = public_failure_error(
+            GatewayFailure(
+                failure_class=GatewayFailureClass.REFUSAL,
+                safe_message="provider refused the request: content policy",
+                refusal_reason=reason,
+            )
+        )
+        assert error.status_code == 400
+        assert error.detail.code == "refusal"
+        assert error.detail.type == "invalid_request_error"
+        assert error.detail.refusal_reason is reason
+        assert _error_body(error)["refusal_reason"] == wire
+
+
+def test_non_refusal_error_omits_the_refusal_reason_field() -> None:
+    """The refusal_reason field is additive: every other error keeps its exact
+    envelope shape with no refusal_reason key at all."""
+    error = public_failure_error(
+        GatewayFailure(
+            failure_class=GatewayFailureClass.THROTTLED,
+            safe_message="provider throttled the request",
+        )
+    )
+    assert error.detail.refusal_reason is None
+    assert "refusal_reason" not in _error_body(error)
 
 
 def test_guardrail_failure_uses_content_filter_shape() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.42,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.43,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.42"
+version = "0.3.43"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## What

A `refusal` answer stays a 400 with code `refusal` and type `invalid_request_error`, so existing clients behave the same, but it now carries one additive machine-readable field, `refusal_reason`, telling the caller WHICH policy declined the content as a bounded category rather than the generic sentence. The category is derived from the provider's own code and sentence and is never provider prose.

Closed vocabulary (snake_case): `cyber_policy`, `cbrn`, `content_policy`, `recitation`, `data_inspection`, `unspecified`.

The caller-facing message is the fixed sentence plus the category's fixed phrase, e.g. `provider refused the request: cybersecurity policy`. A refusal the provider filed under no reason is explicitly `unspecified` with the plain generic sentence, so a client can always branch on the field.

## Where the field appears

- `/v1/chat/completions` and `/v1/responses` (OpenAI envelope, incl. the Responses WebSocket in-band error): `error.refusal_reason`
- `/v1/messages` (Anthropic envelope): `error.refusal_reason`
- Settlement argument, next to `provider_detail`, so the control plane can count refusals by reason without parsing the free-form detail. The raw provider token keeps riding `provider_detail` into the ledger only.
- The ladder echo (`start_attempt` failure payload) and the control plane's exhaustion echo, so an exhausted refusal ladder still re-renders with its category.

Every non-refusal error keeps its exact pre-existing envelope shape (the field is omitted, not null).

## Engine changes (Rust, native 0.3.43)

- `stream_errors.rs`: `RefusalReason` + `refusal_reason(code, message)`. The provider's code decides first (`cyber_policy`, `RECITATION`, `SPII`, `content_filter`, ...), then the sentence: weapons vocabulary, cyber vocabulary only inside a policy verdict (so "exploiting a cache" or "malware in a novel" is not a cyber refusal), recitation, data inspection, general content-policy phrasing. `"bio"` is a code token only, never a substring match, so a biography is not a weapons verdict. `StreamErrorKind::Refusal(reason)`.
- Classifier ordering: an authoritative throttle/quota/credential/not-found code, or such a numeric status, now outranks refusal phrasing, so a rate limiter that says "blocked by" is a throttle, never a refusal. Refusal phrasing still wins over the caller-input codes (Azure/Gemini file content filters under a 400).
- `errors.rs`: `Failure::refusal(reason)`, `Failure.refusal_reason`, `PublicError.refusal_reason` (serde-skipped when absent) on the OpenAI envelope; `encode_messages.rs` adds it to the Anthropic envelope.
- Refusal builders that carry a provider code now categorize: Gemini `finishReason`/`promptFeedback.blockReason`, OpenAI `incomplete_details.reason` (`content_filter`/`safety`), OpenAI-compatible `finish_reason`, Bedrock `stopReason` (`content_filtered`/`guardrail_intervened`), the pre-stream 4xx content-filter path, and every provider-declared in-stream error. A bare visible-refusal delta or an Anthropic `stop_reason: refusal` (no code) stays `unspecified`.
- `settlement.rs` / `waterfall.rs`: carry `refusal_reason`.
- Fixture event JSON (`simplified_event`) carries `refusal_reason` on failed events so the dialect parity fixtures cover it.

## Python

- `GatewayRefusalReason` (StrEnum) and `GatewayFailure.refusal_reason: GatewayRefusalReason | None`, parsed at both boundary parsers (`_failure_from_payload`, `terminal_from_settlement`; an unknown token fails closed to `None` so a newer native reason never breaks settlement) and echoed on exhaustion.
- `public_failure_error` / `OpenAIErrorDetail.refusal_reason`; `json_body()` omits it off refusals.

## Tests

- Rust: every refusal code maps to its reason; sentence-derived reasons; false-positive guards (rate-limit "blocked by" stays throttled; cyber words outside a verdict; biography); public error rendering for each reason with the raw provider token proven absent from both envelopes; the astra `response.failed` with `code: cyber_policy` producing the chat-surface and messages-surface bodies with `refusal_reason: "cyber_policy"`; Gemini/Bedrock/upstream fixtures updated to the categorized message. `cargo fmt`, clippy `--no-default-features --all-targets -- -D warnings`, `cargo test --no-default-features`: 253 passed.
- Python: contract field round trip and closed vocabulary; `public_failure_error` emits the category on refusals and omits it elsewhere; settlement parse incl. the unknown-token fail-closed; dialect parity fixtures. `ruff format`, `ruff check`, `ty check` clean. Full `pytest`: 3913 passed, 1 failed, the known mac-only environmental `native_truncation_test` cell (`nothing/fin/chat-stream` answers 504 instead of 502; fails identically on a clean origin/main here, green on Linux CI). Unrelated to this change.

## Versions

Native crate `0.3.42 -> 0.3.43` (Cargo.toml, Cargo.lock, crate pyproject), parent floor `exp-gateway-native>=0.3.43`, `uv lock`. The `experiential` package version is bumped in the follow-up release PR, not here.

## Docs

`docs/reference/gateway-architecture.md`: new "A refusal names its bounded category to the caller" paragraph under the provider-declared stream errors section.

## Example bodies (cyber_policy refusal)

`/v1/chat/completions` (400):
```json
{"error":{"message":"provider refused the request: cybersecurity policy","type":"invalid_request_error","param":null,"code":"refusal","refusal_reason":"cyber_policy"}}
```

`/v1/messages` (400):
```json
{"type":"error","error":{"type":"invalid_request_error","message":"provider refused the request: cybersecurity policy","refusal_reason":"cyber_policy"}}
```

Settlement argument: `failure.refusal_reason` (`"cyber_policy"`, or `null` on a non-refusal), beside `failure.provider_detail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
