### PR TITLE
fix(gateway): preserve empty reasoning_content replay (0.7.48)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -430,18 +430,17 @@ exceeds the largest declared context window on the route. Anything under the bou
 and is left to the provider's precise count; output budgets are never refused here, a too-small
 ceiling is an `incomplete` answer.
 
-Exposure-gated reasoning rungs (Tencent Hunyuan, DeepSeek — rows the catalog stamps
-`reasoning_output_exposed`) return the model's plaintext `reasoning_content` on every non-tool
-Chat turn, and the caller may echo that text back verbatim on later assistant turns: the
-decoder carries it as an `exposed_reasoning_content` block, route narrowing forwards it only to
-rungs that expose their reasoning (a route with no exposing rung rejects it by name as
-`messages.reasoning_content`; a mixed waterfall prefers the exposing rung and discloses the drop
-on the others), and the payload builder writes it back onto the wire unchanged. The provider's
-own API accepts and does not validate that text, so it is ordinary caller-owned history, exactly
-like a prior assistant `content`. A TOOL turn's reasoning still round-trips only as the sealed,
-rung-pinned carrier (`x-experiential-hunyuan-reasoning-v1:`), which the same decoder recognizes
-by prefix. This is what lets a Terminus-style loop (commands parsed from assistant text, output
-fed back as user messages) and Harbor's interleaved-thinking replay both preserve thinking.
+Exposure-gated reasoning rungs (Tencent Hunyuan and DeepSeek, rows stamped
+`reasoning_output_exposed`) accept caller-owned plaintext `reasoning_content` on assistant
+history, including tool-call turns. The decoder preserves the text verbatim, including an
+explicitly empty string: a provider can require the field even when the turn performed no
+reasoning. Missing or null values remain absent. Plaintext is bounded to 8,388,608 characters;
+values exceeding that limit receive a named error with the limit and a retry instruction.
+Route narrowing prefers exposing rungs and discloses
+`messages.reasoning_content->dropped(unsupported_by_provider)` when a rung cannot replay it,
+including routes with no exposing rung. Gateway-issued carriers are recognized by their
+scheme prefix and retain strict parsing, authentication, and route binding; malformed carriers
+never become plaintext history.
 
 Route admission preserves caller capabilities in three verbatim-preference layers before any
 coercion: operationally dead rungs are skipped (`dispatchable_route_profiles`), generation

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -628,7 +628,11 @@ def test_hunyuan_tool_turn_reasoning_round_trips_as_a_sealed_carrier(
     assert json.loads(modified.value.public_error_json)["param"] == "messages.reasoning_content"
 
 
-def test_hunyuan_plain_turn_plaintext_reasoning_replays_verbatim(tmp_path: Path) -> None:
+@pytest.mark.parametrize("thinking", ["", "The user wants a directory listing; ls is the command."])
+def test_hunyuan_plain_turn_plaintext_reasoning_replays_verbatim(
+    tmp_path: Path,
+    thinking: str,
+) -> None:
     """A Terminus-shaped loop round-trips the plaintext the rung itself returned.
 
     Terminus-2 parses commands out of assistant TEXT and feeds the output back
@@ -646,7 +650,6 @@ def test_hunyuan_plain_turn_plaintext_reasoning_replays_verbatim(tmp_path: Path)
     control = NativeControlPlane(
         load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
     )
-    thinking = "The user wants a directory listing; ls is the command."
     body = json.dumps(
         {
             "model": "coding",
@@ -751,7 +754,11 @@ def test_hunyuan_mixed_carrier_and_plaintext_history_round_trips(tmp_path: Path)
     assert messages[3]["reasoning_content"] == plain
 
 
-def test_plaintext_reasoning_degrades_on_a_route_without_exposure(tmp_path: Path) -> None:
+@pytest.mark.parametrize("reasoning", ["", "private"])
+def test_plaintext_reasoning_degrades_on_a_route_without_exposure(
+    tmp_path: Path,
+    reasoning: str,
+) -> None:
     """A rung that cannot replay plaintext reasoning drops it with disclosure.
 
     The block is baked into the caller's transcript (an earlier exposed-rung
@@ -767,7 +774,7 @@ def test_plaintext_reasoning_degrades_on_a_route_without_exposure(tmp_path: Path
             "model": "coding",
             "messages": [
                 {"role": "user", "content": "hi"},
-                {"role": "assistant", "content": "x", "reasoning_content": "private"},
+                {"role": "assistant", "content": "x", "reasoning_content": reasoning},
                 {"role": "user", "content": "again"},
             ],
         }

--- a/exp/runtime/gateway/reasoning_blocks.py
+++ b/exp/runtime/gateway/reasoning_blocks.py
@@ -80,17 +80,16 @@ class ExposedReasoningContentBlock(ContractModel):
     """Caller-replayed plaintext reasoning for an exposure-gated rung.
 
     A rung stamped ``reasoning_output_exposed`` (Tencent Hunyuan, DeepSeek)
-    returns the model's reasoning as plaintext ``reasoning_content`` on every
-    non-tool turn; the provider's own wire accepts that text back verbatim on
-    later assistant turns and validates nothing about it. The caller echoing
-    it is therefore ordinary conversation history — no different from prior
-    assistant ``content`` — so it is carried as this block and forwarded only
-    to rungs that expose their reasoning. Tool turns keep the sealed carrier
-    (``SealedReasoningContentBlock``), which additionally pins the issuing rung.
+    accepts caller-owned ``reasoning_content`` on assistant history, including
+    tool-call turns. Preserve an explicitly empty string: providers can require
+    the field's presence even when that turn performed no reasoning. Missing
+    or null fields produce no block, and unsupported rungs omit exposed blocks
+    with a disclosure. Gateway-issued sealed carriers retain their separate
+    authenticated contract.
     """
 
     kind: Literal["exposed_reasoning_content"] = "exposed_reasoning_content"
-    content: str = Field(min_length=1, max_length=8 * 1024 * 1024)
+    content: str = Field(max_length=8 * 1024 * 1024)
 
 
 ProviderReasoningBlock = Annotated[

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -703,7 +703,7 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
             # The scheme is fixed by the carrier's own opaque prefix. A known
             # prefix MUST parse as that provider's carrier. Text under no known
             # prefix is the plaintext an exposure-gated rung itself returned on
-            # a non-tool turn (Tencent/DeepSeek): it decodes as caller-owned
+            # an assistant turn (Tencent/DeepSeek): it decodes as caller-owned
             # history and route admission decides which rungs may carry it.
             scheme = scheme_for_carrier(message.reasoning_content)
             if scheme is None:
@@ -723,8 +723,8 @@ def _messages(messages: tuple[_Message, ...], prefix: str) -> tuple[GatewayMessa
                 except ValidationError as exc:
                     raise invalid_field(
                         param,
-                        f"'{param}' must be non-empty plaintext reasoning within the size bound "
-                        "or a gateway-issued carrier.",
+                        f"'{param}' plaintext reasoning exceeds 8,388,608 characters. "
+                        "Shorten the replayed reasoning_content and retry.",
                     ) from exc
             else:
                 try:

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -534,15 +534,6 @@ def test_chat_decoder_accepts_plaintext_reasoning_as_exposed_history() -> None:
     tool_turn_message = tool_turn.request.messages[1]
     assert tool_turn_message.provider_reasoning[0].kind == "exposed_reasoning_content"
     assert tool_turn_message.tool_calls[0].name == "lookup"
-    # An empty string is not reasoning; it names its field.
-    with pytest.raises(OpenAIProtocolError) as raised:
-        decode_chat(
-            {
-                "model": "coding",
-                "messages": [{"role": "assistant", "content": "x", "reasoning_content": ""}],
-            }
-        )
-    assert raised.value.detail.param == "messages.0.reasoning_content"
 
 
 @pytest.mark.parametrize(
@@ -3562,7 +3553,10 @@ def test_a_name_on_a_non_tool_message_stays_a_named_400() -> None:
     assert "name is valid only for tool messages" in str(error.value.detail.message)
 
 
-def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sessions() -> None:
+@pytest.mark.parametrize("reasoning", ["", " \n\t", "The user wants the time; call get_time."])
+def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sessions(
+    reasoning: str,
+) -> None:
     """The prod OpenCode + gpt-6-astra wedge: rc in history serves everywhere.
 
     A session that touched a reasoning-exposed rung (or whose AI-SDK client
@@ -3604,7 +3598,7 @@ def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sess
                 {"role": "user", "content": "what time is it"},
                 {
                     "role": "assistant",
-                    "reasoning_content": "The user wants the time; call get_time.",
+                    "reasoning_content": reasoning,
                     "tool_calls": [
                         {
                             "id": "call_rc1",
@@ -3648,7 +3642,7 @@ def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sess
         exposed, provider_exposed.model_copy(update={"stream": True})
     )
     exposed_messages = cast(list[JsonObject], exposed_payload["messages"])
-    assert exposed_messages[1]["reasoning_content"] == "The user wants the time; call get_time."
+    assert exposed_messages[1]["reasoning_content"] == reasoning
     assert exposed_messages[1]["tool_calls"]
 
     # Repro B: rc on a plain assistant turn, non-exposed route.
@@ -3657,7 +3651,7 @@ def test_replayed_reasoning_content_degrades_instead_of_wedging_cross_model_sess
             "model": "coding",
             "messages": [
                 {"role": "user", "content": "hi"},
-                {"role": "assistant", "content": "A", "reasoning_content": "thinking..."},
+                {"role": "assistant", "content": "A", "reasoning_content": reasoning},
                 {"role": "user", "content": "again"},
             ],
         }
@@ -3909,3 +3903,39 @@ def test_structured_format_description_bounds_are_uniform_and_named() -> None:
         )
     assert responses_over.value.detail.param == "text.format.description"
     assert "at most 65,536 characters" in str(responses_over.value.detail.message)
+
+
+@pytest.mark.parametrize("reasoning", ["", " \n\t", None])
+def test_reasoning_echo_keeps_empty_distinct_from_null(reasoning: str | None) -> None:
+    """An empty field creates a replay block; null stays absent."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "assistant", "content": "done", "reasoning_content": reasoning}],
+        }
+    )
+    blocks = decoded.request.messages[0].provider_reasoning
+    if reasoning is None:
+        assert blocks == ()
+    else:
+        assert len(blocks) == 1
+        assert blocks[0].kind == "exposed_reasoning_content"
+        assert blocks[0].content == reasoning
+
+
+def test_oversized_plaintext_reasoning_names_limit_and_remedy() -> None:
+    """Admit the exact plaintext limit and reject its first excess character."""
+    limit = 8 * 1024 * 1024
+    body: JsonObject = {
+        "model": "coding",
+        "messages": [{"role": "assistant", "content": "done", "reasoning_content": "x" * limit}],
+    }
+    assert decode_chat(body).request.messages[0].provider_reasoning
+    body["messages"] = [
+        {"role": "assistant", "content": "done", "reasoning_content": "x" * (limit + 1)}
+    ]
+    with pytest.raises(OpenAIProtocolError) as error:
+        decode_chat(body)
+    assert error.value.detail.param == "messages.0.reasoning_content"
+    assert "8,388,608 characters" in error.value.detail.message
+    assert "Shorten" in error.value.detail.message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.47"
+version = "0.7.48"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.47"
+version = "0.7.48"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
An assistant history message containing `reasoning_content: ""` still returned HTTP 400 with `must be non-empty plaintext reasoning within the size bound or a gateway-issued carrier`, including DeepSeek Flash v4 tool continuations. #815 fixed populated plaintext on tool turns and unsupported routes, but the internal exposed-reasoning block still rejected empty strings.

Preserve explicitly empty plaintext reasoning as caller-owned history. Exposing rungs forward the empty field verbatim; unsupported rungs omit it with the existing disclosure. Missing/null values remain absent. Carrier-prefixed values retain strict parsing and authentication. The existing 8,388,608-character plaintext limit remains enforced, and its error now states the limit and how to retry.

Validation:
- Reproduced the exact reported error with a failing regression before the fix.
- 472 focused protocol, native admission, carrier, and provider tests passed; full-repository Ruff checks, format checks, and ty passed.
- Eight real native HTTP gateway cases passed against a capturing loopback provider: exposing/unsupported routes, streaming/non-streaming, plain/tool-call assistant turns. The smoke uses the real Tencent profile with only its destination URL redirected to localhost; it does not establish live DeepSeek or production deployment health.
- Greptile: **5/5** on version-bump head `41f28f63`; security scan passed.
- Hosted CI: **all checks passing** on `41f28f63`, including the full test gate, Darwin evidence, CodeQL, latency, all five native wheel builds, and installed-wheel release evidence. Publishing is correctly skipped for the PR.
- Full local non-live suite: **3,877 passed, 1 skipped**, Python 3.12 with `TERM=xterm-256color` and `--dist loadfile`. Separate router, simulation, and installed-wheel release evidence: **3 passed**. An initial Python 3.13/worksteal run exposed terminal-mode assumptions, a test Thread._handle collision, and a module-fixture test split across workers; the corrected local environment/scheduling passes without unrelated source changes.

Bumps `experiential` from **0.7.47 to 0.7.48**, with the lockfile synchronized. Python-only change; native remains **0.3.42**. Platform delegates decoding to this package and currently pins a released engine. This fix must be merged and published before a Platform exact-PyPI-pin update can pass its dependency guards. No production deployment is included.
