### PR TITLE
release: bump experiential to 0.7.49 (native 0.3.43: refusal_reason category on public errors and settlement, #843)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.48"
+version = "0.7.49"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.48"
+version = "0.7.49"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only: `pyproject.toml` `version = "0.7.49"` and the matching `uv.lock` line.

Ships #843 (native crate 0.3.43): a provider refusal names its bounded category to the caller. A `refusal` answer stays a 400 `refusal` / `invalid_request_error` and adds one additive machine-readable `refusal_reason` field (`cyber_policy` | `cbrn` | `content_policy` | `recitation` | `data_inspection` | `unspecified`) on the OpenAI and Anthropic envelopes, plus `refusal_reason` beside `provider_detail` on the settlement argument and `GatewayFailure.refusal_reason` on the Python contract. The message is the fixed sentence plus the category's fixed phrase, never provider prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)