### PR TITLE
gateway: carry the caller's trusted-hop client IP onto AuthorizationSnapshot

### DIFF
--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -901,6 +901,12 @@ class AuthorizationSnapshot(ContractModel):
     attribution_label: str | None = Field(default=None, max_length=1024)
     """End-user attribution from the OpenAI ``safety_identifier`` (or deprecated
     ``user``) request field: content-free and never a credential."""
+    client_ip: str | None = Field(default=None, max_length=45)
+    """Caller IP from the TRUSTED proxy hop (``X-Real-IP``, else the RIGHTMOST
+    ``X-Forwarded-For`` entry; never the leftmost, which is client-forgeable),
+    for per-key IP allow/deny enforcement by the hosted authority. Content-free
+    and never a credential; ``None`` when no trusted hop yields an address (an
+    allowlist then fails closed, a denylist open). 45 chars fits any IPv6 form."""
     fair_share_weight: int = Field(default=1, ge=1, le=1_000_000)
     """Relative weight of this organization for fair-share rung admission.
 

--- a/exp/runtime/gateway/contracts_test.py
+++ b/exp/runtime/gateway/contracts_test.py
@@ -120,6 +120,33 @@ def test_targets_and_compatibility_manifest_are_closed_and_deterministic() -> No
         )
 
 
+def test_authorization_snapshot_carries_the_trusted_client_ip() -> None:
+    """The optional trusted-hop client IP round-trips and defaults to None."""
+    without_ip = AuthorizationSnapshot(
+        request_id="request-1",
+        organization_id="organization-1",
+        identity_id="identity-1",
+        virtual_key_id="key-1",
+        alias="coding",
+        alias_revision_id="alias-revision-1",
+        target=ProjectTarget(
+            project_ref="support-agent",
+            activation_ref="activation-1",
+            catalog_sha256="a" * 64,
+        ),
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        catalog_sha256="a" * 64,
+        canonical_request_sha256="b" * 64,
+        deadline_monotonic=10.0,
+    )
+    assert without_ip.client_ip is None
+
+    with_ip = without_ip.model_copy(update={"client_ip": "198.51.100.9"})
+    assert with_ip.client_ip == "198.51.100.9"
+    restored = AuthorizationSnapshot.model_validate_json(with_ip.model_dump_json())
+    assert restored.client_ip == "198.51.100.9"
+
+
 def test_project_authorization_precedes_route_bound_execution() -> None:
     """Authorization can freeze a target before learned selection supplies route identity."""
     authorization = AuthorizationSnapshot(

--- a/exp/runtime/gateway/interfaces.py
+++ b/exp/runtime/gateway/interfaces.py
@@ -40,11 +40,15 @@ class GatewayControlStore(Protocol):
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,
+        client_ip: str | None = None,
     ) -> AuthorizationSnapshot:
         """Authenticate, authorize, and freeze authority before route selection.
 
         ``app_referer`` and ``app_title`` carry the caller's OpenRouter-style app identity
         (the ``HTTP-Referer`` and ``X-Title`` request headers) for content-free attribution.
+        ``client_ip`` is the caller IP from the TRUSTED proxy hop (``X-Real-IP``, else the
+        rightmost ``X-Forwarded-For`` entry), frozen onto the snapshot for the hosted
+        authority's per-key IP allow/deny enforcement; ``None`` when unavailable.
         """
         ...
 

--- a/exp/runtime/gateway/lifecycle.py
+++ b/exp/runtime/gateway/lifecycle.py
@@ -354,12 +354,11 @@ class _ReadyControlStore:
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,
+        client_ip: str | None = None,
     ) -> AuthorizationSnapshot:
         """Authorize only an alias revision this process can serve, reloading once on drift.
 
-        A revision retired by a concurrent activation stays authorized while its retained
-        catalogs can still serve it, so a request whose SQLite authority was minted an instant
-        before the swap is pinned to its revision instead of being rejected at the swap boundary.
+        An authority minted just before an activation swap is pinned to its revision, not rejected.
         """
         authorization = self.store.authorize_request(
             raw_key=raw_key,
@@ -368,6 +367,7 @@ class _ReadyControlStore:
             deadline_monotonic=deadline_monotonic,
             app_referer=app_referer,
             app_title=app_title,
+            client_ip=client_ip,
         )
         served = _serve_or_fallback(self.reloader.state, authorization)
         if served is not None:

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.43"
+version = "0.3.44"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.43"
+version = "0.3.44"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.43"
+version = "0.3.44"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/respond.rs
+++ b/exp/runtime/gateway/native/src/respond.rs
@@ -98,6 +98,28 @@ pub(crate) fn bearer_key(headers: &HeaderMap) -> Result<String, PublicError> {
     Ok(trimmed.to_string())
 }
 
+/// Resolve the caller IP from the TRUSTED proxy hop for per-key IP enforcement:
+/// `X-Real-IP` when present, else the RIGHTMOST `X-Forwarded-For` entry. The
+/// leftmost XFF token is client-forgeable per request, so it is never trusted;
+/// the rightmost entry is the one our own ingress appended. Content-free (an
+/// address), decoded latin-1 like every other header. `None` when no trusted hop
+/// yields a non-empty address — the hosted authority then treats the IP as
+/// unknown (an allowlist fails closed, a denylist open).
+pub(crate) fn client_ip(headers: &HeaderMap) -> Option<String> {
+    if let Some(real) = latin1_header(headers, "x-real-ip") {
+        let trimmed = real.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    let forwarded = latin1_header_list(headers, "x-forwarded-for")?;
+    forwarded
+        .rsplit(',')
+        .map(str::trim)
+        .find(|token| !token.is_empty())
+        .map(str::to_string)
+}
+
 /// Read one request body under the shared explicit cap.
 pub(crate) async fn read_body(body: Body) -> Result<Bytes, PublicError> {
     axum::body::to_bytes(body, MAXIMUM_REQUEST_BODY_BYTES)
@@ -356,5 +378,45 @@ mod tests {
             latin1_header_list(&headers, "anthropic-beta").as_deref(),
             Some("context-1m-2025-08-07")
         );
+    }
+
+    #[test]
+    fn client_ip_prefers_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-real-ip", "203.0.113.7".parse().unwrap());
+        headers.append("x-forwarded-for", "10.0.0.1, 198.51.100.9".parse().unwrap());
+        assert_eq!(client_ip(&headers).as_deref(), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn client_ip_takes_the_rightmost_forwarded_entry() {
+        // The leftmost token is client-forgeable; the rightmost is our ingress's.
+        let mut headers = HeaderMap::new();
+        headers.append(
+            "x-forwarded-for",
+            "1.2.3.4, 10.0.0.1, 198.51.100.9".parse().unwrap(),
+        );
+        assert_eq!(client_ip(&headers).as_deref(), Some("198.51.100.9"));
+    }
+
+    #[test]
+    fn client_ip_takes_the_rightmost_across_repeated_lines() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        headers.append("x-forwarded-for", "198.51.100.9".parse().unwrap());
+        assert_eq!(client_ip(&headers).as_deref(), Some("198.51.100.9"));
+    }
+
+    #[test]
+    fn client_ip_is_none_without_a_trusted_hop() {
+        assert_eq!(client_ip(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn client_ip_skips_a_blank_real_ip_and_trailing_forwarded_commas() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-real-ip", "   ".parse().unwrap());
+        headers.append("x-forwarded-for", "203.0.113.7, ".parse().unwrap());
+        assert_eq!(client_ip(&headers).as_deref(), Some("203.0.113.7"));
     }
 }

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -28,9 +28,9 @@ use crate::metrics::{classify_escalation, METRICS};
 use crate::relay::{collect_committed, collection_public_error, track_event};
 use crate::replay::{CachedResponse, Claim, OwnerLease, ReplayKey};
 use crate::respond::{
-    bearer_key, cached_response, capture_frame, complete_visible_refusal, error_response,
-    escalation_error, finish_stream_terminal, json_response, latin1_header, read_body,
-    send_bounded, settle_stream_end, sse_body_response,
+    bearer_key, cached_response, capture_frame, client_ip, complete_visible_refusal,
+    error_response, escalation_error, finish_stream_terminal, json_response, latin1_header,
+    read_body, send_bounded, settle_stream_end, sse_body_response,
 };
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
@@ -121,6 +121,7 @@ pub(crate) async fn chat(
         "body": body_text,
         "idempotency_key": idempotency_key,
         "client_request_id": client_request_id,
+        "client_ip": client_ip(&headers),
     }));
     let admission_text = match state.bridge.call("admit", admit_argument).await {
         Ok(text) => text,

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -29,8 +29,8 @@ use crate::events::{Event, Usage};
 use crate::metrics::{classify_escalation, METRICS};
 use crate::relay::{collect_committed, collection_public_error, track_event};
 use crate::respond::{
-    bearer_key, complete_visible_refusal, escalation_error, json_response, latin1_header_list,
-    read_body, send_bounded, settle_stream_end, sse_body_response,
+    bearer_key, client_ip, complete_visible_refusal, escalation_error, json_response,
+    latin1_header_list, read_body, send_bounded, settle_stream_end, sse_body_response,
 };
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
@@ -128,6 +128,7 @@ pub(crate) async fn messages(
         "body": body_text,
         "surface": "messages",
         "anthropic_beta": anthropic_beta,
+        "client_ip": client_ip(&headers),
     }));
     let admission_text = match state.bridge.call("admit", admit_argument).await {
         Ok(text) => text,

--- a/exp/runtime/gateway/native/src/route_responses.rs
+++ b/exp/runtime/gateway/native/src/route_responses.rs
@@ -29,9 +29,9 @@ use crate::metrics::{classify_escalation, METRICS};
 use crate::relay::{collect_committed, collection_public_error, track_event};
 use crate::replay::{CachedResponse, Claim, OwnerLease, ReplayKey};
 use crate::respond::{
-    bearer_key, cached_response, capture_frame, complete_visible_refusal, error_response,
-    escalation_error, finish_stream_terminal, json_response, latin1_header, read_body,
-    send_bounded, settle_stream_end, sse_body_response,
+    bearer_key, cached_response, capture_frame, client_ip, complete_visible_refusal,
+    error_response, escalation_error, finish_stream_terminal, json_response, latin1_header,
+    read_body, send_bounded, settle_stream_end, sse_body_response,
 };
 use crate::responses_retention::{remember_argument, remember_continuation, ResponsesRetention};
 use crate::route_chat::{seal_reasoning_candidate, seal_reasoning_events};
@@ -125,6 +125,7 @@ pub(crate) async fn responses(
         "surface": "responses",
         "idempotency_key": idempotency_key,
         "client_request_id": client_request_id,
+        "client_ip": client_ip(&headers),
     }));
     let admission_text = match state.bridge.call("admit", admit_argument).await {
         Ok(text) => text,

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -315,7 +315,9 @@ class NativeControlPlane(
         try:
             # ``app_referer``/``app_title`` are forwarded when the native engine includes the
             # caller HTTP-Referer/X-Title in its admit payload; absent them app attribution
-            # stays null on the default path until the Rust engine populates them.
+            # stays null on the default path until the Rust engine populates them. ``client_ip``
+            # rides the same seam: the Rust engine resolves the trusted proxy hop and includes
+            # it so the hosted store can freeze it onto the snapshot for per-key IP enforcement.
             authorization = self._components.store.authorize_request(
                 raw_key=data["raw_key"],
                 alias=decoded.alias,
@@ -323,6 +325,7 @@ class NativeControlPlane(
                 deadline_monotonic=deadline,
                 app_referer=optional_text(data.get("app_referer")),
                 app_title=optional_text(data.get("app_title")),
+                client_ip=optional_text(data.get("client_ip")),
             )
         except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
             mapped = _authority_error(exc)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -2881,6 +2881,7 @@ def test_admission_authorized_at_the_swap_instant_stays_pinned_to_its_revision(
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,
+        client_ip: str | None = None,
     ) -> AuthorizationSnapshot:
         """Mint the authorization, then stall until the activation swap lands."""
         authorization = original(
@@ -2890,6 +2891,7 @@ def test_admission_authorized_at_the_swap_instant_stays_pinned_to_its_revision(
             deadline_monotonic=deadline_monotonic,
             app_referer=app_referer,
             app_title=app_title,
+            client_ip=client_ip,
         )
         minted.set()
         assert swapped.wait(timeout=10)

--- a/exp/runtime/gateway/sqlite/store.py
+++ b/exp/runtime/gateway/sqlite/store.py
@@ -650,6 +650,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
         deadline_monotonic: float,
         app_referer: str | None = None,
         app_title: str | None = None,
+        client_ip: str | None = None,
     ) -> AuthorizationSnapshot:
         """Authenticate and authorize before any model or provider work.
 
@@ -659,6 +660,9 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             request: Canonical content-bearing request used only for its digest.
             deadline_monotonic: Absolute request-wide monotonic deadline.
             app_referer: Caller ``HTTP-Referer`` and ``app_title`` its ``X-Title`` app identity.
+            client_ip: Caller IP from the trusted proxy hop, frozen onto the snapshot
+                for the hosted authority's per-key IP enforcement; local SQLite serving
+                has no proxy, so it is simply carried through (usually ``None``).
 
         Returns:
             Immutable content-free authority snapshot.
@@ -729,6 +733,7 @@ class SQLiteGatewayStore(ProviderConnectionStoreMixin):
             refusal_failover=bool(row["refusal_failover"]),
             app_referer=app_referer,
             app_title=app_title,
+            client_ip=client_ip,
         )
 
     def authenticate_key(self, *, raw_key: str) -> None:

--- a/exp/runtime/gateway/sqlite/store_test.py
+++ b/exp/runtime/gateway/sqlite/store_test.py
@@ -139,6 +139,29 @@ def test_authorization_freezes_revision_scoped_refusal_policy(
     assert snapshot.refusal_failover is refusal_failover
 
 
+def test_authorization_freezes_the_trusted_client_ip(tmp_path: Path) -> None:
+    """The caller IP the native engine resolved from the trusted proxy hop rides
+    onto the frozen snapshot for per-key IP enforcement; absent it, it is None."""
+    store, clock, raw_key = _configured_store(tmp_path)
+
+    with_ip = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request(),
+        deadline_monotonic=clock.monotonic() + 30,
+        client_ip="203.0.113.7",
+    )
+    assert with_ip.client_ip == "203.0.113.7"
+
+    without_ip = store.authorize_request(
+        raw_key=raw_key,
+        alias="coding",
+        request=_request(),
+        deadline_monotonic=clock.monotonic() + 30,
+    )
+    assert without_ip.client_ip is None
+
+
 def test_key_derived_authority_is_deny_by_default_and_revocation_is_immediate(
     tmp_path: Path,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.43,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.44,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.43"
+version = "0.3.44"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Summary
Surfaces the caller's **client IP** onto `AuthorizationSnapshot` so the hosted authority can enforce **per-key IP allow/deny** lists (the platform half stores the rules and the enforcement predicate `gateway_key_ip_allowed`; this is the engine half that gives it the IP to check).

The IP is taken from the **trusted proxy hop** — `X-Real-IP`, else the **rightmost** `X-Forwarded-For` entry. The leftmost XFF token is client-forgeable per request, so it is never trusted.

## Changes
- **`contracts.py`**: `AuthorizationSnapshot.client_ip: str | None = None` (content-free, `max_length=45` for any IPv6 form; never a credential).
- **Rust (`native/`)**: `respond.rs::client_ip(headers)` trusted-hop helper (with 5 unit tests); the three serving surfaces — `route_chat`, `route_messages`, `route_responses` — add `"client_ip"` to their `admit` JSON. The snapshot is built in Python, so Rust only adds one JSON key; nothing crosses back.
- **`native_bridge.admit`** forwards `client_ip` to `authorize_request`; the interface (`interfaces.py`) and both impls (`sqlite/store.py` local store, and the hosted store on the platform side) thread it and freeze it on the snapshot.

## Safety
Purely additive: `client_ip` defaults `None`, so every existing snapshot construction and every caller is byte-identical until a consumer reads the field. `None` (no trusted hop) is treated by the hosted authority as an unknown IP — an allowlist fails **closed**, a denylist **open**.

## Validation
- Rust: `cargo check` clean; `cargo test --no-default-features respond::tests::client_ip` → 5/5.
- Python: `ruff check` / `ruff format --check` / `ty check` clean; targeted `pytest` green — `contracts_test`, `sqlite/store_test`, `native_bridge_test` (161), `lifecycle_test`, `native_admission/accounting/execution_test`, `platform_test`, `ledger_test`.

## Follow-up
A release cut (version bump + PyPI publish) is needed before the platform can bump its pin and wire enforcement (`gateway_key_ip_allowed` in the bridge's `apply_accept_request`). Platform PR: experientiallabs/platform#1479.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
