### PR TITLE
release: v0.7.50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.49"
+version = "0.7.50"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.49"
+version = "0.7.50"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only (pyproject + uv.lock): experiential 0.7.49 → 0.7.50, shipping native exp-gateway-native 0.3.44 with the trusted-hop client IP on AuthorizationSnapshot for per-key IP enforcement (#847). The release tag fires python-package.yml to publish both wheels.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>