### PR TITLE
gateway: adaptive rate limits, passive throttle calibration, cache-priority fair share, and sticky spill affinity (0.7.53, native 0.3.46)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -222,12 +222,18 @@ claimable rung (spill in seconds) instead of queueing at the deployment until th
 deadline. `requests_per_minute` and `tokens_per_minute` (each usable without the bound) cap the
 rung's sliding 60-second dispatch window the same way, shedding a reservation the window cannot
 absorb sideways as `rate_limit` BEFORE the provider answers 429; token accounting counts each
-dispatch's conservative worst-case reserved input plus output tokens at reservation. The working
+dispatch's conservative worst-case reserved input plus output tokens at reservation, with a
+burst allowance admitting a single over-cap reservation into an EMPTY window (a prompt whose
+worst case exceeds the whole per-worker cap must stay admissible, then blocks the window until
+it slides out). The working
 request ceiling is additionally calibrated passively per worker: a provider throttle settlement
 clamps a learned ceiling to ninety percent of the rate observed in the window at that moment,
 every unthrottled recovery minute creeps it back up by five percent (at least one request, capped
 at the authored rate when one exists; each creep step is the probe that rediscovers headroom, so
-no synthetic traffic is ever sent), and a ceiling unthrottled for six hours is forgotten. With
+no synthetic traffic is ever sent), and a ceiling unthrottled for six hours is forgotten. The
+learned ceiling is a float and may sit below one request per minute: per-worker ceilings
+multiply across the fleet, and some provider accounts allow less than one request per worker
+per minute. With
 `fair_share: true` (which requires the bound), a contended rung additionally
 limits each organization to its weighted max-min share of the bound; weights arrive per request
 on `AuthorizationSnapshot.fair_share_weight` (default 1) from the hosted store, capacity below
@@ -256,15 +262,25 @@ rungs that author none of this keep byte-identical behavior and null disclosure 
 
 Under `maximize_cache_affinity`, two further per-rung fields keep provider prompt caches warm
 across spills. `sticky_spill_seconds` gives each dispatch a worker-local
-fingerprint-to-deployment binding with that lifetime (refreshed per hit): the binding is honored
+fingerprint-to-deployment binding with that lifetime (refreshed per hit, but capped at four
+lifetimes of total age from creation so continuous hits cannot pin a long-running session to a
+pricier spill rung forever): the binding is honored
 ahead of rendezvous order on later requests, so a spilled conversation keeps serving off the rung
 holding its warm cache instead of bouncing back the moment the preferred rung stops shedding, and
 a binding whose rung is throttled or circuit-open is cleared rather than followed. The binding is
 deliberately worker-local (the serving edge's keep-alives pin a client to one worker; the
-cross-worker miss costs one cold dispatch). `fresh_session_spill_fraction` reserves the top slice
+cross-worker miss costs one cold dispatch). The binding keys on the affinity fingerprint (the
+session identity rendezvous already uses), never on a derived provider cache key: on
+OpenAI-compatible shim lanes (including Experiential Cloud's vLLM boxes) no `prompt_cache_key` is
+forwarded and the box's prefix cache is content-addressed, so gateway-side session-to-rung
+consistency is the entire cache-preservation mechanism there. `fresh_session_spill_fraction`
+reserves the top slice
 of a bounded rung for warm sessions: a request whose fingerprint holds no live binding on the
 rung sheds sideways once in-flight dispatches reach `bound * fraction` (`fresh_session_spill`),
-while warm sessions ride to the hard bound.
+while warm sessions ride to the hard bound (it requires `sticky_spill_seconds`, because warm
+standing IS a live binding). A hosted composition may also exclude individual attempts from the
+cache-priority EWMA through the accounting's `cache_sample_gate` (promotion-funded replay must
+not buy fair-share weight with prefixes the promotion already made costless).
 
 A deployment's price schedule may declare a long-context tier: a whole-request premium applied
 once provider-reported input tokens reach its threshold, matching both published tier schedules

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -219,19 +219,52 @@ A rung may author a `GatewayRungDispatchPolicy` on its gateway metadata (all fie
 default). Its `concurrency_bound` is a per-worker in-flight cap enforced by pure in-process
 counters at the same pre-dispatch point: a rung at its bound is bypassed sideways to the next
 claimable rung (spill in seconds) instead of queueing at the deployment until the request
-deadline. With `fair_share: true` (which requires the bound), a contended rung additionally
+deadline. `requests_per_minute` and `tokens_per_minute` (each usable without the bound) cap the
+rung's sliding 60-second dispatch window the same way, shedding a reservation the window cannot
+absorb sideways as `rate_limit` BEFORE the provider answers 429; token accounting counts each
+dispatch's conservative worst-case reserved input plus output tokens at reservation. The working
+request ceiling is additionally calibrated passively per worker: a provider throttle settlement
+clamps a learned ceiling to ninety percent of the rate observed in the window at that moment,
+every unthrottled recovery minute creeps it back up by five percent (at least one request, capped
+at the authored rate when one exists; each creep step is the probe that rediscovers headroom, so
+no synthetic traffic is ever sent), and a ceiling unthrottled for six hours is forgotten. With
+`fair_share: true` (which requires the bound), a contended rung additionally
 limits each organization to its weighted max-min share of the bound; weights arrive per request
 on `AuthorizationSnapshot.fair_share_weight` (default 1) from the hosted store, capacity below
 the bound is always borrowable (a lone organization uses the whole rung), freed slots are
 reserved for recently active under-share organizations, and running dispatches are never
-preempted. A ladder whose every remaining rung was bypassed only by these policies force-admits
-past the bound rather than manufacturing a failure unbounded admission would not have had.
+preempted. With `cache_priority_alpha` authored on a fair-share rung, each organization's
+effective weight becomes `weight * (1 + alpha * congestion * cached_fraction)`, where congestion
+is the rung's in-flight total over its bound and the cached fraction is the worker's time-decayed
+EWMA (half-life roughly ten minutes) of the organization's settled cached-token share on that
+rung, so at the contended margin traffic that reuses warm provider cache is admitted ahead of
+equal-weight cold traffic. A ladder whose every remaining rung was bypassed only by these
+policies force-admits past the bound rather than manufacturing a failure unbounded admission
+would not have had.
 Every policy-routed dispatch is disclosed on its attempt row: `dispatch_reason` (`affinity`,
-`fair_share_shed`, `queue_bound`, `rung_dead`, `saturated_overflow`), the bypassed
+`affinity_sticky`, `fair_share_shed`, `queue_bound`, `rate_limit`, `fresh_session_spill`,
+`rung_dead`, `saturated_overflow`), the bypassed
 `preferred_deployment_id` with its frozen base token rates, and at settle a
 `counterfactual_cost_micro_usd` pricing the same observed usage at those preferred rates, so
-cost optimality is measurable from the ledger alone. Pools and rungs that author none of this
-keep byte-identical behavior and null disclosure columns.
+cost optimality is measurable from the ledger alone. Settlement also persists the provider's own
+rate-limit response headers per attempt when the data plane harvests them (`retry-after` plus the
+OpenAI `x-ratelimit-*` and Anthropic `anthropic-ratelimit-*` families, normalized to integers),
+and a throttled settlement carrying a parseable `Retry-After` (seconds or HTTP-date) sizes that
+deployment's throttle window from it, clamped to [5s, 6h], instead of the fixed default, so a
+daily-quota reset actually suppresses the rung for the wait the provider asked for. Pools and
+rungs that author none of this keep byte-identical behavior and null disclosure columns.
+
+Under `maximize_cache_affinity`, two further per-rung fields keep provider prompt caches warm
+across spills. `sticky_spill_seconds` gives each dispatch a worker-local
+fingerprint-to-deployment binding with that lifetime (refreshed per hit): the binding is honored
+ahead of rendezvous order on later requests, so a spilled conversation keeps serving off the rung
+holding its warm cache instead of bouncing back the moment the preferred rung stops shedding, and
+a binding whose rung is throttled or circuit-open is cleared rather than followed. The binding is
+deliberately worker-local (the serving edge's keep-alives pin a client to one worker; the
+cross-worker miss costs one cold dispatch). `fresh_session_spill_fraction` reserves the top slice
+of a bounded rung for warm sessions: a request whose fingerprint holds no live binding on the
+rung sheds sideways once in-flight dispatches reach `bound * fraction` (`fresh_session_spill`),
+while warm sessions ride to the hard bound.
 
 A deployment's price schedule may declare a long-context tier: a whole-request premium applied
 once provider-reported input tokens reach its threshold, matching both published tier schedules

--- a/exp/common/models/dispatch_policy.py
+++ b/exp/common/models/dispatch_policy.py
@@ -125,7 +125,10 @@ class GatewayRungDispatchPolicy(ContractModel):
     in-flight dispatches reach ``concurrency_bound * fraction``
     (``fresh_session_spill``), reserving the top slice of the bound for warm
     sessions, which shed only at the hard bound. ``None`` disables the early
-    threshold. Requires ``concurrency_bound``.
+    threshold. Requires ``concurrency_bound`` AND ``sticky_spill_seconds``:
+    warm standing IS a live sticky binding, so without a binding lifetime
+    every session would stay fresh forever and the reserved top slice would be
+    reachable only through force admission.
     """
     sticky_spill_seconds: int | None = Field(default=None, ge=1)
     """How long one conversation stays bound to the rung that served it.
@@ -152,6 +155,13 @@ class GatewayRungDispatchPolicy(ContractModel):
             raise ValueError("fair_share requires a concurrency_bound to share")
         if self.cache_priority_alpha is not None and not self.fair_share:
             raise ValueError("cache_priority_alpha requires fair_share to weight")
-        if self.fresh_session_spill_fraction is not None and self.concurrency_bound is None:
-            raise ValueError("fresh_session_spill_fraction requires a concurrency_bound")
+        if self.fresh_session_spill_fraction is not None:
+            if self.concurrency_bound is None:
+                raise ValueError("fresh_session_spill_fraction requires a concurrency_bound")
+            if self.sticky_spill_seconds is None:
+                raise ValueError(
+                    "fresh_session_spill_fraction requires sticky_spill_seconds: warm "
+                    "standing is a live sticky binding, so without one every session "
+                    "stays fresh and the reserved slice is unreachable"
+                )
         return self

--- a/exp/common/models/dispatch_policy.py
+++ b/exp/common/models/dispatch_policy.py
@@ -1,4 +1,4 @@
-"""Authored per-rung dispatch policy: admission bounds and affinity weight.
+"""Authored per-rung dispatch policy: bounds, rate windows, and affinity.
 
 One nested, fully defaulted model hung off ``GatewayDeploymentMetadata``. It
 is additive-defaulted on purpose: an unauthored rung contributes zero identity
@@ -47,12 +47,14 @@ fleet-wide pin bump, then the catalog opt-in.
 
 
 class GatewayRungDispatchPolicy(ContractModel):
-    """Authored per-rung dispatch controls: admission bounds and affinity weight.
+    """Authored per-rung dispatch controls: admission bounds, rates, and affinity.
 
     Every field defaults to inert so an unauthored rung behaves exactly as
-    today: unbounded admission, no fairness accounting, rendezvous weight 1.
-    The bound and fairness apply on any pool; the affinity weight is read only
-    under a pool's ``maximize_cache_affinity`` policy.
+    today: unbounded admission, no rate windows, no fairness accounting,
+    rendezvous weight 1, no session stickiness. The bound, rate caps, and
+    fairness apply on any pool; the affinity weight, fresh-session threshold,
+    and sticky binding are read only under a pool's
+    ``maximize_cache_affinity`` policy.
     """
 
     concurrency_bound: int | None = Field(default=None, ge=1)
@@ -81,10 +83,75 @@ class GatewayRungDispatchPolicy(ContractModel):
     a heavy house rung and a moderate cheap-cached-input rung makes the house
     box the warm home and the cheap rung the stable spill target.
     """
+    requests_per_minute: int | None = Field(default=None, ge=1)
+    """Sliding-window dispatch rate cap for this rung, per gateway worker process.
+
+    A reservation past the 60-second window's cap sheds sideways to the next
+    rung (``rate_limit``) BEFORE the provider answers 429, so the pre-emptive
+    spill preserves the request instead of burning a provider attempt. Like
+    ``concurrency_bound`` the value is authored per worker process (fleet rate
+    divided by serving replicas). Usable without a ``concurrency_bound``. The
+    worker additionally learns a lower working ceiling from observed provider
+    throttles and re-discovers headroom by letting a little more through over
+    time, so the authored value is a cap, never a promise the provider honors
+    it.
+    """
+    tokens_per_minute: int | None = Field(default=None, ge=1)
+    """Sliding-window token rate cap for this rung, per gateway worker process.
+
+    Counted from each dispatch's worst-case reserved input plus output tokens
+    at reservation time (the same conservative bound the platform's token
+    windows count), so a concurrent burst binds instead of leaking past the
+    cap. Over-window reservations shed sideways as ``rate_limit`` exactly like
+    ``requests_per_minute``. Usable without a ``concurrency_bound``.
+    """
+    cache_priority_alpha: float | None = Field(default=None, ge=0, allow_inf_nan=False)
+    """Congestion-dependent boost for cache-heavy organizations under fairness.
+
+    When set on a ``fair_share`` rung, each organization's effective admission
+    weight becomes ``weight * (1 + alpha * congestion * cached_fraction)``
+    where ``congestion`` is the rung's in-flight total over its bound and
+    ``cached_fraction`` is the worker's EWMA of that organization's settled
+    cached-token fraction on this rung. At the contended margin the
+    organization whose traffic reuses warm provider cache is admitted ahead of
+    an equal-weight organization running cold, exactly when cache is most
+    valuable. ``None`` disables the term. Requires ``fair_share``.
+    """
+    fresh_session_spill_fraction: float | None = Field(default=None, gt=0, lt=1)
+    """Fraction of the bound where sessions with no warm standing shed early.
+
+    Under a pool's ``maximize_cache_affinity`` policy, a request whose affinity
+    fingerprint holds no live sticky binding on this rung sheds sideways once
+    in-flight dispatches reach ``concurrency_bound * fraction``
+    (``fresh_session_spill``), reserving the top slice of the bound for warm
+    sessions, which shed only at the hard bound. ``None`` disables the early
+    threshold. Requires ``concurrency_bound``.
+    """
+    sticky_spill_seconds: int | None = Field(default=None, ge=1)
+    """How long one conversation stays bound to the rung that served it.
+
+    Under ``maximize_cache_affinity`` each dispatch records a worker-local
+    fingerprint-to-deployment binding with this time-to-live, refreshed on
+    every hit; the binding is honored ahead of rendezvous order on subsequent
+    requests, so a spilled conversation does not bounce back to the
+    higher-ranked rung the moment it stops shedding (its warm cache now lives
+    on the spill target). Author roughly the provider's prompt-cache lifetime.
+    ``None`` records no binding for dispatches landing on this rung.
+    """
 
     @model_validator(mode="after")
-    def _require_bound_for_fair_share(self) -> GatewayRungDispatchPolicy:
-        """Reject fairness without a capacity: shares need a bound to divide."""
+    def _require_coherent_authoring(self) -> GatewayRungDispatchPolicy:
+        """Reject values whose prerequisite lever is not authored.
+
+        Fairness and the fresh-session threshold divide a capacity, so both
+        need the bound; the cache-priority term scales fairness weights, so it
+        needs fairness. Failing closed here keeps an inert combination from
+        being authored and silently doing nothing.
+        """
         if self.fair_share and self.concurrency_bound is None:
             raise ValueError("fair_share requires a concurrency_bound to share")
+        if self.cache_priority_alpha is not None and not self.fair_share:
+            raise ValueError("cache_priority_alpha requires fair_share to weight")
+        if self.fresh_session_spill_fraction is not None and self.concurrency_bound is None:
+            raise ValueError("fresh_session_spill_fraction requires a concurrency_bound")
         return self

--- a/exp/common/models/dispatch_policy_test.py
+++ b/exp/common/models/dispatch_policy_test.py
@@ -19,12 +19,46 @@ def test_rung_dispatch_policy_rejects_incoherent_authoring() -> None:
         GatewayRungDispatchPolicy(affinity_weight=float("inf"))
 
 
+def test_rate_and_cache_fields_validate_their_prerequisites() -> None:
+    """Rates stand alone; the cache term needs fairness; the threshold needs a bound."""
+    standalone = GatewayRungDispatchPolicy(requests_per_minute=90, tokens_per_minute=1_000_000)
+    assert standalone.concurrency_bound is None
+    with pytest.raises(ValueError):
+        GatewayRungDispatchPolicy(requests_per_minute=0)
+    with pytest.raises(ValueError):
+        GatewayRungDispatchPolicy(tokens_per_minute=0)
+    with pytest.raises(ValueError, match="fair_share"):
+        GatewayRungDispatchPolicy(concurrency_bound=8, cache_priority_alpha=2.0)
+    with pytest.raises(ValueError):
+        GatewayRungDispatchPolicy(
+            concurrency_bound=8, fair_share=True, cache_priority_alpha=float("nan")
+        )
+    with pytest.raises(ValueError, match="concurrency_bound"):
+        GatewayRungDispatchPolicy(fresh_session_spill_fraction=0.85)
+    for fraction in (0.0, 1.0):
+        with pytest.raises(ValueError):
+            GatewayRungDispatchPolicy(concurrency_bound=8, fresh_session_spill_fraction=fraction)
+    with pytest.raises(ValueError):
+        GatewayRungDispatchPolicy(sticky_spill_seconds=0)
+    full = GatewayRungDispatchPolicy(
+        concurrency_bound=8,
+        fair_share=True,
+        requests_per_minute=90,
+        tokens_per_minute=1_000_000,
+        cache_priority_alpha=2.0,
+        fresh_session_spill_fraction=0.85,
+        sticky_spill_seconds=600,
+    )
+    assert full.cache_priority_alpha == 2.0
+
+
 def test_default_policy_contributes_zero_identity_bytes() -> None:
     """An all-default policy dumps empty under exclude-defaults.
 
     This is what keeps the catalog's pinned identity digest stable when the
-    field exists but nothing is authored; the full catalog-level proof lives
-    in ``gateway_catalog_test.py``.
+    fields exist (including the rate, cache-priority, and stickiness fields)
+    but nothing is authored; the full catalog-level proof lives in
+    ``gateway_catalog_test.py``.
     """
     assert (
         GatewayRungDispatchPolicy().model_dump(mode="json", by_alias=True, exclude_defaults=True)

--- a/exp/common/models/dispatch_policy_test.py
+++ b/exp/common/models/dispatch_policy_test.py
@@ -35,6 +35,10 @@ def test_rate_and_cache_fields_validate_their_prerequisites() -> None:
         )
     with pytest.raises(ValueError, match="concurrency_bound"):
         GatewayRungDispatchPolicy(fresh_session_spill_fraction=0.85)
+    # Warm standing IS a live sticky binding, so the early threshold without a
+    # binding lifetime would class every session fresh forever.
+    with pytest.raises(ValueError, match="sticky_spill_seconds"):
+        GatewayRungDispatchPolicy(concurrency_bound=8, fresh_session_spill_fraction=0.85)
     for fraction in (0.0, 1.0):
         with pytest.raises(ValueError):
             GatewayRungDispatchPolicy(concurrency_bound=8, fresh_session_spill_fraction=fraction)

--- a/exp/runtime/gateway/attempt_tokens.py
+++ b/exp/runtime/gateway/attempt_tokens.py
@@ -33,17 +33,41 @@ def worst_case_attempt_tokens(
     their byte-bounded input and zero output; a completion reserves its
     byte-bounded input (plus replayed-carrier bytes) and its clamped max output.
     """
+    return worst_case_input_tokens(request), worst_case_output_tokens(request, deployment)
+
+
+def worst_case_input_tokens(request: ServingRequest) -> int:
+    """Byte-bounded worst-case input tokens for one request.
+
+    Deployment-independent, and the only expensive half of the estimate (it
+    serializes the whole request), so a ladder walk computes it once and pairs
+    it with each candidate's cheap output clamp.
+    """
+    input_tokens = len(canonical_json_bytes(request))
     match request:
         case EmbeddingsRequest() | ImagesRequest():
-            return len(canonical_json_bytes(request)), 0
+            return input_tokens
         case GatewayRequest():
-            input_tokens = len(canonical_json_bytes(request))
             # Excluded provider carriers (replayed reasoning, native items,
             # verbatim configs) are provider-read input the plain serialization
             # misses; their envelope bytes keep the bound an upper bound.
             replay_envelope = provider_replay_authority(request)
             if replay_envelope is not None:
                 input_tokens += len(canonical_json_bytes(replay_envelope))
+            return input_tokens
+        case _:  # pragma: no cover - exhaustive over the ServingRequest union.
+            assert_never(request)
+
+
+def worst_case_output_tokens(
+    request: ServingRequest,
+    deployment: ExactModelDeployment,
+) -> int:
+    """Worst-case output tokens one deployment could emit for this request."""
+    match request:
+        case EmbeddingsRequest() | ImagesRequest():
+            return 0
+        case GatewayRequest():
             output_tokens = request.maximum_output_tokens
             deployment_ceiling = (
                 deployment.capabilities.maximum_output_tokens
@@ -70,6 +94,6 @@ def worst_case_attempt_tokens(
                     if context_window is not None
                     else DEFAULT_RESERVATION_OUTPUT_TOKENS
                 )
-            return input_tokens, output_tokens
+            return output_tokens
         case _:  # pragma: no cover - exhaustive over the ServingRequest union.
             assert_never(request)

--- a/exp/runtime/gateway/group_commit.py
+++ b/exp/runtime/gateway/group_commit.py
@@ -220,6 +220,11 @@ class GroupCommitAttemptLedger:
         failure: GatewayFailure | None,
         finalize_request: bool = True,
         first_token_at: datetime | None = None,
+        retry_after_seconds: int | None = None,
+        ratelimit_limit_requests: int | None = None,
+        ratelimit_remaining_requests: int | None = None,
+        ratelimit_limit_tokens: int | None = None,
+        ratelimit_remaining_tokens: int | None = None,
     ) -> None:
         """Durably settle one attempt with normalized content-free fields.
 
@@ -229,6 +234,11 @@ class GroupCommitAttemptLedger:
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
             first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
+            retry_after_seconds: Provider-stated wait from ``Retry-After``.
+            ratelimit_limit_requests: Provider-stated request-rate ceiling.
+            ratelimit_remaining_requests: Provider-stated requests remaining.
+            ratelimit_limit_tokens: Provider-stated token-rate ceiling.
+            ratelimit_remaining_tokens: Provider-stated tokens remaining.
         """
         await self._submit(
             lambda connection: self.core.apply_finish_attempt(
@@ -238,6 +248,11 @@ class GroupCommitAttemptLedger:
                 failure=failure,
                 finalize_request=finalize_request,
                 first_token_at=first_token_at,
+                retry_after_seconds=retry_after_seconds,
+                ratelimit_limit_requests=ratelimit_limit_requests,
+                ratelimit_remaining_requests=ratelimit_remaining_requests,
+                ratelimit_limit_tokens=ratelimit_limit_tokens,
+                ratelimit_remaining_tokens=ratelimit_remaining_tokens,
             )
         )
 
@@ -548,6 +563,11 @@ class SyncGroupCommitLedger:
         failure: GatewayFailure | None,
         finalize_request: bool = True,
         first_token_at: datetime | None = None,
+        retry_after_seconds: int | None = None,
+        ratelimit_limit_requests: int | None = None,
+        ratelimit_remaining_requests: int | None = None,
+        ratelimit_limit_tokens: int | None = None,
+        ratelimit_remaining_tokens: int | None = None,
     ) -> None:
         """Durably settle one attempt with normalized content-free fields.
 
@@ -557,6 +577,11 @@ class SyncGroupCommitLedger:
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
             first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
+            retry_after_seconds: Provider-stated wait from ``Retry-After``.
+            ratelimit_limit_requests: Provider-stated request-rate ceiling.
+            ratelimit_remaining_requests: Provider-stated requests remaining.
+            ratelimit_limit_tokens: Provider-stated token-rate ceiling.
+            ratelimit_remaining_tokens: Provider-stated tokens remaining.
         """
         self._writer.submit_blocking(
             lambda connection: self._writer.core.apply_finish_attempt(
@@ -566,6 +591,11 @@ class SyncGroupCommitLedger:
                 failure=failure,
                 finalize_request=finalize_request,
                 first_token_at=first_token_at,
+                retry_after_seconds=retry_after_seconds,
+                ratelimit_limit_requests=ratelimit_limit_requests,
+                ratelimit_remaining_requests=ratelimit_remaining_requests,
+                ratelimit_limit_tokens=ratelimit_limit_tokens,
+                ratelimit_remaining_tokens=ratelimit_remaining_tokens,
             )
         )
 

--- a/exp/runtime/gateway/health.py
+++ b/exp/runtime/gateway/health.py
@@ -27,6 +27,14 @@ _OPERATIONAL_FAILURES = {
     GatewayFailureClass.PROVIDER_INTERNAL,
 }
 
+# Clamp on a provider-stated Retry-After when it sizes a throttle window. The
+# floor keeps a degenerate "0"/"1" from thrashing the rung; the ceiling keeps
+# one absurd header from suppressing a lane for days while still letting a
+# daily-quota reset (hours) mark the rung dead-for-hours so the waterfall
+# skips it for the whole window.
+RETRY_AFTER_WINDOW_MINIMUM_SECONDS = 5.0
+RETRY_AFTER_WINDOW_MAXIMUM_SECONDS = 6.0 * 3_600.0
+
 
 @dataclass
 class _DeploymentHealth:
@@ -188,7 +196,7 @@ class DeploymentHealthRegistry:
             if failure.failure_class == GatewayFailureClass.THROTTLED:
                 state.throttle_until = max(
                     state.throttle_until,
-                    now + self._throttle_seconds,
+                    now + self._throttle_window_seconds(failure),
                 )
                 return
             if failure.failure_class == GatewayFailureClass.REFUSAL:
@@ -202,6 +210,48 @@ class DeploymentHealthRegistry:
                 state.consecutive_failures += 1
                 if state.consecutive_failures >= self._failure_threshold:
                     state.open_until = now + self._open_seconds
+
+    def _throttle_window_seconds(self, failure: GatewayFailure) -> float:
+        """Size one throttle window from the provider's own stated wait.
+
+        A throttled failure carrying a parsed ``Retry-After`` sizes the window
+        from it, clamped to the bounded range, so a long provider backoff (an
+        exhausted daily quota) actually suppresses the rung for the wait the
+        provider asked for instead of re-attempting every fixed default. An
+        absent or unparseable wait keeps the fixed default window.
+
+        Args:
+            failure: Sanitized throttled failure.
+
+        Returns:
+            The window length in seconds.
+        """
+        if failure.retry_after_seconds is None:
+            return self._throttle_seconds
+        return min(
+            max(float(failure.retry_after_seconds), RETRY_AFTER_WINDOW_MINIMUM_SECONDS),
+            RETRY_AFTER_WINDOW_MAXIMUM_SECONDS,
+        )
+
+    def suppressed(self, key: DeploymentHealthKey) -> bool:
+        """Whether one deployment currently sits inside any suppression window.
+
+        A read-only probe (unlike :meth:`claim` it never reserves a half-open
+        slot), used by sticky-affinity admission to bypass and clear a binding
+        whose rung is throttled or circuit-open right now.
+
+        Args:
+            key: Catalog, deployment, and connection identity tuple.
+
+        Returns:
+            Whether the deployment is throttle- or circuit-suppressed.
+        """
+        now = self._clock()
+        with self._lock:
+            state = self._states.get(key)
+            if state is None:
+                return False
+            return state.throttle_until > now or state.open_until > now
 
     def throttled_remaining_seconds(self, keys: tuple[DeploymentHealthKey, ...]) -> float | None:
         """Return the longest remaining throttle window when EVERY key is inside one.

--- a/exp/runtime/gateway/health_test.py
+++ b/exp/runtime/gateway/health_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from exp.runtime.gateway.contracts import GatewayFailure, GatewayFailureClass
 from exp.runtime.gateway.health import DeploymentHealthKey, DeploymentHealthRegistry
 
@@ -115,6 +117,72 @@ def test_forced_claim_still_respects_the_throttle_window() -> None:
     assert not registry.claim_forced(_KEY)
     now[0] += 31
     assert registry.claim_forced(_KEY)
+
+
+@pytest.mark.parametrize(
+    ("retry_after", "expected_window"),
+    [(2, 5.0), (7_200, 7_200.0), (999_999, 21_600.0)],
+)
+def test_retry_after_sizes_the_throttle_window_clamped(
+    retry_after: int, expected_window: float
+) -> None:
+    """A provider-stated wait sizes the window inside the [5s, 6h] clamp.
+
+    A short or degenerate wait floors at five seconds, an in-range wait (an
+    hourly quota reset) suppresses for exactly what the provider asked, and an
+    absurd wait ceilings at six hours; a throttle carrying no wait keeps the
+    fixed default window.
+    """
+    now = [100.0]
+    registry = DeploymentHealthRegistry(throttle_seconds=30.0, clock=lambda: now[0])
+    registry.failed(
+        _KEY,
+        GatewayFailure(
+            failure_class=GatewayFailureClass.THROTTLED,
+            safe_message="scripted throttle",
+            retry_after_seconds=retry_after,
+        ),
+    )
+    now[0] = 100.0 + expected_window - 0.5
+    assert not registry.claim(_KEY)
+    now[0] = 100.0 + expected_window + 0.5
+    assert registry.claim(_KEY)
+
+
+def test_throttle_without_retry_after_keeps_the_default_window() -> None:
+    """An absent wait falls back to the registry's fixed throttle window."""
+    now = [100.0]
+    registry = DeploymentHealthRegistry(throttle_seconds=30.0, clock=lambda: now[0])
+    registry.failed(_KEY, _failure(GatewayFailureClass.THROTTLED))
+    now[0] = 129.0
+    assert not registry.claim(_KEY)
+    now[0] = 131.0
+    assert registry.claim(_KEY)
+
+
+def test_suppressed_is_a_read_only_probe() -> None:
+    """``suppressed`` reports throttle and circuit windows without claiming.
+
+    Unlike ``claim`` it must not consume the half-open probe: a sticky-affinity
+    lookup that peeked would otherwise steal the one probe real dispatch needs.
+    """
+    now = [100.0]
+    registry = DeploymentHealthRegistry(
+        failure_threshold=1, open_seconds=30.0, throttle_seconds=30.0, clock=lambda: now[0]
+    )
+    assert not registry.suppressed(_KEY)
+    registry.failed(_KEY, _failure(GatewayFailureClass.THROTTLED))
+    assert registry.suppressed(_KEY)
+    now[0] = 131.0
+    assert not registry.suppressed(_KEY)
+    registry.failed(_KEY, _failure(GatewayFailureClass.TRANSPORT))
+    assert registry.suppressed(_KEY)
+    for _ in range(3):
+        assert registry.suppressed(_KEY)
+    now[0] = 162.0
+    assert not registry.suppressed(_KEY)
+    # The half-open probe is still available to the first real claim.
+    assert registry.claim(_KEY)
 
 
 def test_throttled_remaining_seconds_names_a_fully_throttled_route() -> None:

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -459,6 +459,11 @@ class SQLiteAttemptLedger:
         failure: GatewayFailure | None,
         finalize_request: bool = True,
         first_token_at: datetime | None = None,
+        retry_after_seconds: int | None = None,
+        ratelimit_limit_requests: int | None = None,
+        ratelimit_remaining_requests: int | None = None,
+        ratelimit_limit_tokens: int | None = None,
+        ratelimit_remaining_tokens: int | None = None,
     ) -> None:
         """Idempotently settle one attempt with normalized content-free fields.
 
@@ -468,6 +473,12 @@ class SQLiteAttemptLedger:
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
             first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
+            retry_after_seconds: Provider-stated wait from the response's
+                ``Retry-After`` header, when one was harvested.
+            ratelimit_limit_requests: Provider-stated request-rate ceiling.
+            ratelimit_remaining_requests: Provider-stated requests remaining.
+            ratelimit_limit_tokens: Provider-stated token-rate ceiling.
+            ratelimit_remaining_tokens: Provider-stated tokens remaining.
         """
         with self._transaction() as connection:
             self.apply_finish_attempt(
@@ -477,6 +488,11 @@ class SQLiteAttemptLedger:
                 failure=failure,
                 finalize_request=finalize_request,
                 first_token_at=first_token_at,
+                retry_after_seconds=retry_after_seconds,
+                ratelimit_limit_requests=ratelimit_limit_requests,
+                ratelimit_remaining_requests=ratelimit_remaining_requests,
+                ratelimit_limit_tokens=ratelimit_limit_tokens,
+                ratelimit_remaining_tokens=ratelimit_remaining_tokens,
             )
 
     def apply_finish_attempt(
@@ -488,6 +504,11 @@ class SQLiteAttemptLedger:
         failure: GatewayFailure | None,
         finalize_request: bool = True,
         first_token_at: datetime | None = None,
+        retry_after_seconds: int | None = None,
+        ratelimit_limit_requests: int | None = None,
+        ratelimit_remaining_requests: int | None = None,
+        ratelimit_limit_tokens: int | None = None,
+        ratelimit_remaining_tokens: int | None = None,
     ) -> None:
         """Run the attempt settlement inside the caller's open write transaction.
 
@@ -498,6 +519,12 @@ class SQLiteAttemptLedger:
             failure: Sanitized failure when no successful terminal event exists.
             finalize_request: Whether this attempt is the final route for its parent request.
             first_token_at: Wall-clock time the attempt streamed its first token, or ``None``.
+            retry_after_seconds: Provider-stated wait from the response's
+                ``Retry-After`` header, when one was harvested.
+            ratelimit_limit_requests: Provider-stated request-rate ceiling.
+            ratelimit_remaining_requests: Provider-stated requests remaining.
+            ratelimit_limit_tokens: Provider-stated token-rate ceiling.
+            ratelimit_remaining_tokens: Provider-stated tokens remaining.
         """
         state, normalized_failure, failure_message, usage = _terminal_values(
             terminal_event, failure
@@ -570,7 +597,10 @@ class SQLiteAttemptLedger:
                 input_tokens = ?, cached_input_tokens = ?, output_tokens = ?,
                 reasoning_tokens = ?, usage_source = ?, estimated_cost_micro_usd = ?,
                 counterfactual_cost_micro_usd = ?,
-                budget_settled_micro_usd = ?
+                budget_settled_micro_usd = ?,
+                retry_after_seconds = ?, ratelimit_limit_requests = ?,
+                ratelimit_remaining_requests = ?, ratelimit_limit_tokens = ?,
+                ratelimit_remaining_tokens = ?
             WHERE attempt_id = ? AND state = 'dispatched'
             """,
             (
@@ -587,6 +617,11 @@ class SQLiteAttemptLedger:
                 cost,
                 counterfactual_cost,
                 budget_settlement,
+                retry_after_seconds,
+                ratelimit_limit_requests,
+                ratelimit_remaining_requests,
+                ratelimit_limit_tokens,
+                ratelimit_remaining_tokens,
                 attempt_id,
             ),
         )

--- a/exp/runtime/gateway/ledger_test.py
+++ b/exp/runtime/gateway/ledger_test.py
@@ -1302,6 +1302,56 @@ def test_dispatch_disclosure_persists_and_prices_the_counterfactual(tmp_path: Pa
     assert row["estimated_cost_micro_usd"] == 195
 
 
+def test_finish_attempt_persists_harvested_rate_limit_observations(tmp_path: Path) -> None:
+    """The provider's rate-limit headers land as nullable integer columns."""
+    clock = FakeLedgerClock()
+    ledger, snapshot, chosen, _preferred = _spill_fixture(tmp_path, clock)
+    attempt_id = ledger.start_attempt(
+        snapshot=snapshot,
+        deployment=chosen,
+        attempt_ordinal=0,
+        route_depth=1,
+    )
+    ledger.finish_attempt(
+        attempt_id=attempt_id,
+        terminal_event=GatewayEvent(
+            kind=GatewayEventKind.COMPLETED,
+            sequence_number=1,
+            usage=GatewayUsage(input_tokens=10, output_tokens=5),
+        ),
+        failure=None,
+        finalize_request=False,
+        retry_after_seconds=30,
+        ratelimit_limit_requests=10_000,
+        ratelimit_remaining_requests=9_999,
+        ratelimit_limit_tokens=180_000_000,
+        ratelimit_remaining_tokens=179_000_000,
+    )
+    row = _attempt_row(tmp_path, attempt_id)
+    assert row["retry_after_seconds"] == 30
+    assert row["ratelimit_limit_requests"] == 10_000
+    assert row["ratelimit_remaining_requests"] == 9_999
+    assert row["ratelimit_limit_tokens"] == 180_000_000
+    assert row["ratelimit_remaining_tokens"] == 179_000_000
+
+    # A settlement without observations keeps every column NULL.
+    second = ledger.start_attempt(
+        snapshot=snapshot,
+        deployment=chosen,
+        attempt_ordinal=1,
+        route_depth=1,
+    )
+    ledger.finish_attempt(
+        attempt_id=second,
+        terminal_event=GatewayEvent(kind=GatewayEventKind.COMPLETED, sequence_number=1),
+        failure=None,
+    )
+    bare = _attempt_row(tmp_path, second)
+    assert bare["retry_after_seconds"] is None
+    assert bare["ratelimit_limit_requests"] is None
+    assert bare["ratelimit_remaining_tokens"] is None
+
+
 def test_counterfactual_stays_null_when_a_preferred_rate_is_unknown(tmp_path: Path) -> None:
     """An unpriced preferred rung never guesses a counterfactual cost."""
     clock = FakeLedgerClock()

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.45"
+version = "0.3.46"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.45"
+version = "0.3.46"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.45"
+version = "0.3.46"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -271,6 +271,13 @@ pub struct Failure {
     /// declined the content without parsing `provider_detail`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refusal_reason: Option<RefusalReason>,
+    /// Allowlisted rate-limit headers harvested from the provider response
+    /// that produced this failure (a non-2xx open carries the interesting
+    /// ones: a 429's `retry-after` and remaining-quota counts). Settlement
+    /// hoists them into the payload's `rate_limit_headers` map; they never
+    /// reach the caller.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit_headers: Option<Box<serde_json::Map<String, serde_json::Value>>>,
 }
 
 impl Failure {
@@ -285,6 +292,7 @@ impl Failure {
             retry_after_seconds: None,
             customer_owned: false,
             refusal_reason: None,
+            rate_limit_headers: None,
         }
     }
 
@@ -319,6 +327,21 @@ impl Failure {
     pub fn with_retry(mut self, retryable_same_deployment: bool, failover_eligible: bool) -> Self {
         self.retryable_same_deployment = retryable_same_deployment;
         self.failover_eligible = failover_eligible;
+        self
+    }
+
+    /// Attach the allowlisted rate-limit headers of the producing response,
+    /// and, on a throttled failure, the provider's own integer `Retry-After`
+    /// so the control plane sizes the throttle window from it.
+    pub fn with_rate_limit_facts(
+        mut self,
+        headers: Option<serde_json::Map<String, serde_json::Value>>,
+        retry_after_seconds: Option<u32>,
+    ) -> Self {
+        self.rate_limit_headers = headers.map(Box::new);
+        if self.failure_class == FailureClass::Throttled && self.retry_after_seconds.is_none() {
+            self.retry_after_seconds = retry_after_seconds;
+        }
         self
     }
 

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -18,6 +18,7 @@ mod guardrails;
 mod memory;
 mod metrics;
 mod param_attribution;
+mod rate_limit_headers;
 mod rejection_shapes;
 mod relay;
 mod replay;

--- a/exp/runtime/gateway/native/src/rate_limit_headers.rs
+++ b/exp/runtime/gateway/native/src/rate_limit_headers.rs
@@ -1,0 +1,121 @@
+//! Allowlisted provider rate-limit response headers for settlement.
+//!
+//! Providers describe their rate limiting in a small set of response headers
+//! (`retry-after` plus the OpenAI `x-ratelimit-*` and Anthropic
+//! `anthropic-ratelimit-*` families). Settlement forwards exactly that
+//! allowlist to the control plane as the optional `rate_limit_headers` map,
+//! on successes and failures alike, where the python side normalizes the raw
+//! strings into typed integers for the ledger and sizes throttle windows from
+//! the provider's own stated wait. The allowlist is deliberately closed:
+//! arbitrary provider headers are never forwarded, because exotic providers
+//! put account identifiers and other non-content-free material in theirs.
+
+use reqwest::header::HeaderMap;
+use serde_json::{Map, Value};
+
+/// The closed set of forwarded rate-limit headers, lowercased.
+const ALLOWLISTED_HEADERS: [&str; 9] = [
+    "retry-after",
+    "x-ratelimit-limit-requests",
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-limit-tokens",
+    "x-ratelimit-remaining-tokens",
+    "anthropic-ratelimit-requests-limit",
+    "anthropic-ratelimit-requests-remaining",
+    "anthropic-ratelimit-tokens-limit",
+    "anthropic-ratelimit-tokens-remaining",
+];
+
+/// Collect the allowlisted rate-limit headers from one provider response.
+///
+/// Returns `None` when the response carries none of them, so settlement can
+/// omit the field entirely; header values that are not visible ASCII are
+/// skipped rather than lossily decoded.
+pub fn harvest_rate_limit_headers(headers: &HeaderMap) -> Option<Map<String, Value>> {
+    let mut harvested = Map::new();
+    for name in ALLOWLISTED_HEADERS {
+        if let Some(value) = headers.get(name).and_then(|value| value.to_str().ok()) {
+            harvested.insert(name.to_string(), Value::String(value.to_string()));
+        }
+    }
+    if harvested.is_empty() {
+        None
+    } else {
+        Some(harvested)
+    }
+}
+
+/// Parse one `Retry-After` header as whole seconds.
+///
+/// Only the integer-seconds form parses here; the HTTP-date form still rides
+/// the harvested map verbatim, where the control plane's fuller parser
+/// handles it. Anything unparseable yields `None` rather than a guess.
+pub fn retry_after_seconds(headers: &HeaderMap) -> Option<u32> {
+    headers
+        .get("retry-after")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u32>().ok())
+        .filter(|seconds| *seconds > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::{HeaderName, HeaderValue};
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                name.parse::<HeaderName>().unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn harvest_keeps_only_the_allowlist() {
+        let harvested = harvest_rate_limit_headers(&headers(&[
+            ("retry-after", "30"),
+            ("x-ratelimit-remaining-requests", "9999"),
+            ("anthropic-ratelimit-tokens-limit", "12000000"),
+            ("content-type", "application/json"),
+            ("x-request-id", "req_secretive"),
+        ]))
+        .unwrap();
+        assert_eq!(harvested.len(), 3);
+        assert_eq!(harvested["retry-after"], "30");
+        assert_eq!(harvested["x-ratelimit-remaining-requests"], "9999");
+        assert_eq!(harvested["anthropic-ratelimit-tokens-limit"], "12000000");
+    }
+
+    #[test]
+    fn harvest_is_none_without_rate_limit_headers() {
+        assert!(
+            harvest_rate_limit_headers(&headers(&[("content-type", "text/event-stream")]))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn retry_after_parses_only_positive_integer_seconds() {
+        assert_eq!(
+            retry_after_seconds(&headers(&[("retry-after", "3600")])),
+            Some(3600)
+        );
+        assert_eq!(
+            retry_after_seconds(&headers(&[("retry-after", " 7 ")])),
+            Some(7)
+        );
+        assert_eq!(retry_after_seconds(&headers(&[("retry-after", "0")])), None);
+        assert_eq!(
+            retry_after_seconds(&headers(&[(
+                "retry-after",
+                "Mon, 07 Sep 2026 12:00:00 GMT"
+            )])),
+            None
+        );
+        assert_eq!(retry_after_seconds(&HeaderMap::new()), None);
+    }
+}

--- a/exp/runtime/gateway/native/src/settlement.rs
+++ b/exp/runtime/gateway/native/src/settlement.rs
@@ -66,6 +66,7 @@ fn settle_argument(
     finalize: bool,
     opened: bool,
     first_token_at: Option<SystemTime>,
+    rate_limit_headers: Option<&serde_json::Map<String, Value>>,
 ) -> String {
     compact_json(&json!({
         "request_id": request_id,
@@ -93,10 +94,18 @@ fn settle_argument(
             // files it as the caller's invalid request (see
             // native_accounting.ledger_failure).
             "customer_owned": failure.customer_owned,
+            // The provider's own stated wait (a throttled open's integer
+            // Retry-After), so the control plane sizes the deployment's
+            // throttle window from it instead of the fixed default.
+            "retry_after_seconds": failure.retry_after_seconds,
         })),
         "finalize": finalize,
         "opened": opened,
         "first_token_at": first_token_at.map(system_time_to_rfc3339),
+        // Allowlisted rate-limit headers of the attempt's provider response
+        // (successes and failures alike, absent when none were present); the
+        // control plane normalizes and persists them per attempt.
+        "rate_limit_headers": rate_limit_headers,
     }))
 }
 
@@ -162,6 +171,11 @@ pub struct AttemptGuard {
     /// reported in the finalizing settlement so the control plane can derive
     /// time-to-first-token. `None` until an attempt observes a first token.
     first_token_at: Option<SystemTime>,
+    /// Allowlisted rate-limit headers of the active attempt's OPENED provider
+    /// response, recorded once per attempt at open and settled alongside the
+    /// outcome. An attempt that failed at open instead carries them on its
+    /// `Failure`, which settlement hoists into the same payload field.
+    rate_limit_headers: Option<serde_json::Map<String, Value>>,
 }
 
 /// Holds one unit of the shutdown drain counter for a detached stream task,
@@ -207,6 +221,7 @@ impl AttemptGuard {
             decided_settlement: None,
             started,
             first_token_at: None,
+            rate_limit_headers: None,
         }
     }
 
@@ -216,8 +231,10 @@ impl AttemptGuard {
         self.opened = false;
         self.decided_settlement = None;
         // Each physical attempt observes its own first token; a prior failed
-        // attempt's timing never carries into its successor.
+        // attempt's timing never carries into its successor. The same holds
+        // for its provider response's rate-limit headers.
         self.first_token_at = None;
+        self.rate_limit_headers = None;
     }
 
     /// Record the wall-clock time the active attempt streamed its first output
@@ -232,6 +249,12 @@ impl AttemptGuard {
     /// Record that the active attempt's provider dispatch opened.
     pub fn mark_opened(&mut self) {
         self.opened = true;
+    }
+
+    /// Record the allowlisted rate-limit headers of the active attempt's
+    /// opened provider response, for settlement.
+    pub fn record_rate_limit_headers(&mut self, headers: Option<serde_json::Map<String, Value>>) {
+        self.rate_limit_headers = headers;
     }
 
     /// Record this request's terminal outcome and duration exactly once, at
@@ -265,6 +288,12 @@ impl AttemptGuard {
             // path owns request-only terminalization.
             return true;
         };
+        // An opened attempt's headers live on the guard; an attempt that
+        // failed at open carries them on its failure instead.
+        let rate_limit_headers = self
+            .rate_limit_headers
+            .as_ref()
+            .or_else(|| failure.and_then(|failure| failure.rate_limit_headers.as_deref()));
         let argument = settle_argument(
             &self.request_id,
             &attempt_id,
@@ -275,6 +304,7 @@ impl AttemptGuard {
             finalize,
             self.opened,
             self.first_token_at,
+            rate_limit_headers,
         );
         if finalize {
             let cancelled = failure.map(|failure| failure.failure_class == FailureClass::Cancelled)
@@ -382,6 +412,7 @@ impl Drop for AttemptGuard {
                             true,
                             self.opened,
                             self.first_token_at,
+                            self.rate_limit_headers.as_ref(),
                         ),
                     )
                 }
@@ -448,6 +479,7 @@ mod tests {
             true,
             true,
             Some(observed),
+            None,
         );
         let parsed: Value = serde_json::from_str(&with_token).expect("valid json");
         assert_eq!(
@@ -456,7 +488,18 @@ mod tests {
         );
         // A non-streaming attempt observes no first token: the field is null,
         // matching the control plane's backward-compatible parse.
-        let without = settle_argument("req", "att", "completed", None, &[], None, true, true, None);
+        let without = settle_argument(
+            "req",
+            "att",
+            "completed",
+            None,
+            &[],
+            None,
+            true,
+            true,
+            None,
+            None,
+        );
         let parsed: Value = serde_json::from_str(&without).expect("valid json");
         assert_eq!(parsed["first_token_at"], Value::Null);
     }
@@ -476,6 +519,7 @@ mod tests {
             Some(&failure),
             true,
             true,
+            None,
             None,
         );
         let parsed: Value = serde_json::from_str(&argument).expect("valid json");
@@ -499,6 +543,7 @@ mod tests {
             true,
             true,
             None,
+            None,
         );
         let parsed: Value = serde_json::from_str(&owned_argument).expect("valid json");
         assert_eq!(
@@ -519,8 +564,90 @@ mod tests {
             true,
             true,
             None,
+            None,
         );
         let parsed: Value = serde_json::from_str(&bare_argument).expect("valid json");
         assert_eq!(parsed["failure"]["provider_detail"], Value::Null);
+    }
+
+    #[test]
+    fn settle_argument_carries_rate_limit_facts_when_harvested() {
+        // A throttled open: the failure carries the harvested headers and the
+        // integer Retry-After, both settled for the control plane.
+        let mut headers = serde_json::Map::new();
+        headers.insert("retry-after".to_string(), Value::String("3600".to_string()));
+        headers.insert(
+            "x-ratelimit-remaining-requests".to_string(),
+            Value::String("0".to_string()),
+        );
+        let throttled = crate::upstream::transport_failure(Some(429))
+            .with_rate_limit_facts(Some(headers.clone()), Some(3_600));
+        let argument = settle_argument(
+            "req",
+            "att",
+            "failed",
+            None,
+            &[],
+            Some(&throttled),
+            true,
+            false,
+            None,
+            throttled.rate_limit_headers.as_deref(),
+        );
+        let parsed: Value = serde_json::from_str(&argument).expect("valid json");
+        assert_eq!(parsed["failure"]["retry_after_seconds"], 3_600);
+        assert_eq!(parsed["rate_limit_headers"]["retry-after"], "3600");
+        assert_eq!(
+            parsed["rate_limit_headers"]["x-ratelimit-remaining-requests"],
+            "0"
+        );
+        // A successful attempt settles the opened response's headers; absent
+        // headers settle an explicit null the control plane treats as absent.
+        let success = settle_argument(
+            "req",
+            "att",
+            "completed",
+            None,
+            &[],
+            None,
+            true,
+            true,
+            None,
+            Some(&headers),
+        );
+        let parsed: Value = serde_json::from_str(&success).expect("valid json");
+        assert_eq!(parsed["rate_limit_headers"]["retry-after"], "3600");
+        let bare = settle_argument(
+            "req",
+            "att",
+            "completed",
+            None,
+            &[],
+            None,
+            true,
+            true,
+            None,
+            None,
+        );
+        let parsed: Value = serde_json::from_str(&bare).expect("valid json");
+        assert_eq!(parsed["rate_limit_headers"], Value::Null);
+    }
+
+    #[test]
+    fn retry_after_fills_only_throttled_failures_and_never_overwrites() {
+        let throttled =
+            crate::upstream::transport_failure(Some(429)).with_rate_limit_facts(None, Some(30));
+        assert_eq!(throttled.retry_after_seconds, Some(30));
+        let already = Failure::new(FailureClass::Throttled, "throttled")
+            .with_rate_limit_facts(None, Some(30));
+        let kept = Failure {
+            retry_after_seconds: Some(7),
+            ..already
+        }
+        .with_rate_limit_facts(None, Some(30));
+        assert_eq!(kept.retry_after_seconds, Some(7));
+        let internal =
+            crate::upstream::transport_failure(Some(500)).with_rate_limit_facts(None, Some(30));
+        assert_eq!(internal.retry_after_seconds, None);
     }
 }

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -226,7 +226,8 @@ pub async fn open_stream(
                 )
                 .with_retry(false, false)
                 .with_rejected_parameter(parameter)
-                .with_provider_detail(detail));
+                .with_provider_detail(detail)
+                .with_rate_limit_facts(rate_limit.clone(), retry_after));
             }
             return Err(failure);
         }

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -12,6 +12,7 @@ use crate::param_attribution::{
     rejected_caller_reference_not_found, rejected_code, rejected_detail, rejected_model_not_found,
     rejected_parameter,
 };
+use crate::rate_limit_headers::{harvest_rate_limit_headers, retry_after_seconds};
 
 /// Build the shared pooled upstream client, mirroring the pooling constants in
 /// `providers.async_transport` (64 keep-alive) and its no-redirect policy so a
@@ -170,7 +171,14 @@ pub async fn open_stream(
     };
     let status = response.status().as_u16();
     if !(200..300).contains(&status) {
-        let failure = transport_failure(Some(status));
+        // Rate-limit facts are read off the headers before anything consumes
+        // the response: a 429's `retry-after` and remaining-quota counts ride
+        // the failure into settlement (never to the caller), where the
+        // control plane sizes throttle windows and persists them per attempt.
+        let rate_limit = harvest_rate_limit_headers(response.headers());
+        let retry_after = retry_after_seconds(response.headers());
+        let failure =
+            transport_failure(Some(status)).with_rate_limit_facts(rate_limit.clone(), retry_after);
         // Only the generic client-error class may carry attribution: the body
         // is read bounded, and the relayable facts are a validated parameter
         // path plus the provider's own bounded explanation of what the caller
@@ -232,7 +240,8 @@ pub async fn open_stream(
                     "provider does not route this model for the gateway's account; ask \
                      the gateway operator to change or disable the lane",
                 )
-                .with_retry(false, true));
+                .with_retry(false, true)
+                .with_rate_limit_facts(rate_limit.clone(), retry_after));
             }
             return Err(failure);
         }
@@ -243,7 +252,9 @@ pub async fn open_stream(
             .as_deref()
             .is_some_and(|body| rejected_model_not_found(dialect, body))
         {
-            return Err(transport_failure(Some(404)));
+            return Err(
+                transport_failure(Some(404)).with_rate_limit_facts(rate_limit.clone(), retry_after)
+            );
         }
         let parameter = body
             .as_deref()
@@ -274,7 +285,9 @@ pub async fn open_stream(
         // sentence saying "blocked by" could be about a firewall or a limit.
         if crate::stream_errors::is_refusal_code(code.as_deref()) {
             let reason = crate::stream_errors::refusal_reason(code.as_deref(), None);
-            return Err(Failure::refusal(reason).with_provider_detail(detail));
+            return Err(Failure::refusal(reason)
+                .with_provider_detail(detail)
+                .with_rate_limit_facts(rate_limit.clone(), retry_after));
         }
         // A sentence naming a limitation of THIS lane's serving stack (a chat
         // template that rejects a mid-conversation system turn the OpenAI

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -31,6 +31,7 @@ use crate::encode::compact_json;
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 use crate::metrics::METRICS;
+use crate::rate_limit_headers::harvest_rate_limit_headers;
 use crate::relay::{
     collection_public_error, ended_without_terminal, remaining, track_event, UpstreamRelay,
 };
@@ -575,6 +576,10 @@ async fn run_attempt(
         }
     };
     guard.mark_opened();
+    // The opened response's allowlisted rate-limit headers settle with this
+    // attempt whatever its terminal outcome; a failed OPEN instead carries
+    // them on its failure (attached in `open_stream`).
+    guard.record_rate_limit_headers(harvest_rate_limit_headers(response.headers()));
     let mut relay = match wire
         .fireworks_reasoning_route_sha256
         .clone()

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -132,6 +132,7 @@ class NativeAttemptAccounting:
         write_ledger: SyncWriteLedger,
         *,
         budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
+        cache_sample_gate: Callable[[str], bool] | None = None,
     ) -> None:
         """Bind the durable ledger and start the settlement sweep.
 
@@ -139,9 +140,18 @@ class NativeAttemptAccounting:
             write_ledger: Blocking durable request and attempt ledger.
             budget_error_factory: Optional hosted mapping for a rejected
                 reservation.
+            cache_sample_gate: Optional hosted predicate deciding whether one
+                settled attempt (by attempt id) may feed the cache-priority
+                EWMA. The hosted store knows which attempts are promo-funded;
+                admitting those samples would let free-tier replay traffic
+                (whose cached prefixes are costless under a promotion) buy
+                fair-share weight with the very replay the promotion already
+                subsidizes. ``None`` admits every sample; a raising gate
+                skips the sample (fails closed).
         """
         self._write_ledger = write_ledger
         self._budget_error_factory = budget_error_factory
+        self._cache_sample_gate = cache_sample_gate
         # The native waterfall's deployment-health circuits, revision-scoped
         # to the traffic this plane serves.
         self._health = DeploymentHealthRegistry()
@@ -812,6 +822,15 @@ class NativeAttemptAccounting:
         depth = entry.attempt_depths.get(attempt_id)
         if depth is None:
             return
+        if self._cache_sample_gate is not None:
+            # Promo-funded (or otherwise excluded) attempts must not buy
+            # fair-share weight; an erroring gate skips the sample rather
+            # than admit one the host meant to exclude.
+            try:
+                if not self._cache_sample_gate(attempt_id):
+                    return
+            except Exception:  # noqa: BLE001 - the sample is telemetry, never worth failing settle.
+                return
         with self._lock:
             if attempt_id in entry.cache_recorded_attempts:
                 return

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -932,6 +932,10 @@ class NativeAttemptAccounting:
             self._accounting_healthy = False
             return False
         self._record_health(entry, attempt_id, opened=False, failure=failure)
+        # A retained settlement that finally lands through the sweep carries
+        # the same observed usage as the direct path, so the cache-priority
+        # EWMA must not depend on WHICH recovery path succeeded.
+        self._record_cache_fraction(entry, attempt_id, terminal.usage)
         with self._lock:
             if finalize:
                 self._inflight.pop(request_id, None)

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.gateway_catalog import ExactModelDeployment
-from exp.runtime.gateway.attempt_tokens import worst_case_attempt_tokens
+from exp.runtime.gateway.attempt_tokens import worst_case_input_tokens, worst_case_output_tokens
 from exp.runtime.gateway.boundary import boundary_protocol_error
 from exp.runtime.gateway.budgets import (
     BudgetReservationRejected,
@@ -427,6 +427,9 @@ class NativeAttemptAccounting:
         # manufacture a failure unbounded admission would not have had.
         policy_sheds: list[tuple[int, str]] = []
         forced_overflow = False
+        # The input half of the worst-case reservation serializes the whole
+        # request, so it is computed once per ladder walk, never per candidate.
+        reserved_input_tokens = worst_case_input_tokens(entry.request)
         while True:
             if candidate is None:
                 if policy_sheds and last_failure is None and not forced_overflow:
@@ -447,9 +450,7 @@ class NativeAttemptAccounting:
             # rate limits, soft) count these dispatched reservations, and the
             # rung's own authored token window counts the same conservative
             # bound, so a concurrent burst binds instead of leaking past caps.
-            reserved_input_tokens, reserved_output_tokens = worst_case_attempt_tokens(
-                entry.request, deployment
-            )
+            reserved_output_tokens = worst_case_output_tokens(entry.request, deployment)
             ticket = self._reserve_rung_slot(
                 entry,
                 deployment,

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -797,7 +797,10 @@ class NativeAttemptAccounting:
         Feeds the congestion-dependent cache-priority term: the registry keeps
         a per-(organization, rung) EWMA of the settled cached fraction, so
         fairness can favor the organization whose traffic actually reuses warm
-        provider cache. Attempts without observed token usage record nothing.
+        provider cache. Attempts without observed token usage record nothing,
+        and one attempt folds at most once: a settlement can reach the ledger
+        through both the direct path and the retained-settlement sweep (each
+        idempotent there), and a duplicate fold would skew the estimate.
 
         Args:
             entry: The owning in-flight request.
@@ -809,6 +812,10 @@ class NativeAttemptAccounting:
         depth = entry.attempt_depths.get(attempt_id)
         if depth is None:
             return
+        with self._lock:
+            if attempt_id in entry.cache_recorded_attempts:
+                return
+            entry.cache_recorded_attempts.add(attempt_id)
         cached = usage.cached_input_tokens
         self._loads.record_settle(
             rung_load_key(entry.route.deployments[depth]),

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -14,11 +14,9 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import threading
 import time
 from collections.abc import Callable
-from typing import cast
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.gateway_catalog import ExactModelDeployment
@@ -35,6 +33,7 @@ from exp.runtime.gateway.contracts import (
     GatewayEventKind,
     GatewayFailure,
     GatewayFailureClass,
+    GatewayUsage,
 )
 from exp.runtime.gateway.health import DeploymentHealthRegistry
 from exp.runtime.gateway.native_components import SyncWriteLedger
@@ -43,19 +42,26 @@ from exp.runtime.gateway.native_execution import (
     InflightRequest,
     claim_route_from,
     deployment_health_key,
+    deployment_priced_for_service_tier,
+    dispatch_disclosure,
     next_route_candidate,
+    rung_load_key,
 )
 from exp.runtime.gateway.native_settlement import (
+    all_routes_throttled_failure,
+    all_routes_unavailable_failure,
+    budget_quota_failure,
     budget_quota_protocol_error,
+    failure_from_boundary_payload,
     first_token_at_from_settlement,
     ledger_failure,
-    refusal_reason_from_payload,
+    settlement_rate_limit,
     terminal_from_settlement,
 )
-from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.gateway.rate_limit_headers import RateLimitObservation
 from exp.runtime.gateway.rung_admission import RungLoadRegistry, RungShed
+from exp.runtime.gateway.sticky_affinity import StickySpillRegistry
 from exp.runtime.openai_protocol.errors import (
-    THROTTLED_RETRY_AFTER_SECONDS,
     OpenAIProtocolError,
     public_failure_error,
 )
@@ -111,121 +117,6 @@ def internal_protocol_error() -> OpenAIProtocolError:
     )
 
 
-def budget_quota_failure() -> GatewayFailure:
-    """Return the sanitized quota failure after no route can reserve its cost."""
-    return GatewayFailure(
-        failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
-        safe_message="monthly gateway allocation is exhausted",
-    )
-
-
-def all_routes_unavailable_failure() -> GatewayFailure:
-    """Return the sanitized terminal failure for an exhausted certified pool."""
-    return GatewayFailure(
-        failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
-        safe_message="all exact-model deployments are unavailable",
-    )
-
-
-def all_routes_throttled_failure(remaining_seconds: float) -> GatewayFailure:
-    """Return the throttle-window failure for a route the provider backed off.
-
-    Every deployment sitting inside a provider throttle window is caller-facing
-    rate limiting (the provider answered 429 and asked for backoff), not
-    platform deadness: classing it provider_internal misfiled 429 storms as
-    outages and paged operators for caller-driven load (2026-09-04 ledger,
-    deepseek-v4-flash-vision-exp). One computed wait (the remaining window,
-    floored at the default throttle backoff) rides both the message and
-    ``retry_after_seconds`` so the Retry-After header a client honors never
-    disagrees with the sentence it reads.
-
-    Args:
-        remaining_seconds: Longest remaining throttle window across the route.
-
-    Returns:
-        Sanitized throttled failure naming the retry window.
-    """
-    seconds = max(THROTTLED_RETRY_AFTER_SECONDS, math.ceil(remaining_seconds))
-    return GatewayFailure(
-        failure_class=GatewayFailureClass.THROTTLED,
-        safe_message=(
-            "all exact-model deployments are inside a provider throttle window; "
-            f"retry in {seconds}s"
-        ),
-        retry_after_seconds=seconds,
-    )
-
-
-def gateway_updating_failure() -> GatewayFailure:
-    """Return the sanitized retryable failure for a transient roll condition.
-
-    A pod that cannot build the authorized catalog revision during a rolling
-    deploy (a snapshot authored by another engine version it cannot reconcile)
-    surfaces this instead of a closed INTERNAL: the condition clears on its own
-    once the roll settles, so the honest answer is a retryable 503, never a bug
-    signal that pages or opens a deployment circuit.
-    """
-    return GatewayFailure(
-        failure_class=GatewayFailureClass.UNAVAILABLE,
-        safe_message="the gateway is updating; retry the request",
-    )
-
-
-def _failure_from_payload(payload: object) -> GatewayFailure | None:
-    """Parse one optional classified failure from a boundary payload."""
-    if not isinstance(payload, dict):
-        return None
-    data = cast("JsonObject", payload)
-    rejected_parameter = data.get("rejected_parameter")
-    provider_detail = data.get("provider_detail")
-    return GatewayFailure(
-        failure_class=GatewayFailureClass(str(data["failure_class"])),
-        safe_message=str(data["safe_message"]),
-        retryable_same_deployment=bool(data.get("retryable_same_deployment", False)),
-        failover_eligible=bool(data.get("failover_eligible", False)),
-        rejected_parameter=(
-            rejected_parameter
-            if isinstance(rejected_parameter, str) and rejected_parameter
-            else None
-        ),
-        provider_detail=(
-            provider_detail if isinstance(provider_detail, str) and provider_detail else None
-        ),
-        customer_owned=data.get("customer_owned") is True,
-        refusal_reason=refusal_reason_from_payload(data.get("refusal_reason")),
-    )
-
-
-def _deployment_priced_for_service_tier(
-    deployment: ExactModelDeployment,
-    service_tier: str | None,
-    *,
-    forwards_tier: bool,
-) -> ExactModelDeployment:
-    """Reprice one deployment for a requested flex/priority processing tier.
-
-    v1 bills the REQUESTED tier: when the SELECTED candidate actually FORWARDS
-    the tier to its provider and carries a pass-through card for it, the card's
-    rates replace the base schedule on a copy used only for THIS reservation, so
-    the ceiling, the stored per-token rates, and settlement all bill the tier
-    transparently. ``forwards_tier`` is the admission-time forwarding decision
-    for this exact depth (``GatewayWireProfile.forwards_tier``); gating on it
-    keeps FORWARD and BILL consistent even if a card ever sits on a lane whose
-    wire would strip the tier (non-tier dialect, tier disabled) — such a depth
-    runs the provider's base schedule, so it must bill the base schedule too. No
-    tier, no forwarding, or no card returns the deployment unchanged. The copy
-    stays Python-side and never crosses the native boundary.
-    """
-    if not forwards_tier:
-        return deployment
-    effective = deployment.gateway.prices.for_service_tier(service_tier)
-    if effective is deployment.gateway.prices:
-        return deployment
-    return deployment.model_copy(
-        update={"gateway": deployment.gateway.model_copy(update={"prices": effective})}
-    )
-
-
 class NativeAttemptAccounting:
     """Registry of admitted requests and their durable attempt settlements.
 
@@ -254,10 +145,15 @@ class NativeAttemptAccounting:
         # The native waterfall's deployment-health circuits, revision-scoped
         # to the traffic this plane serves.
         self._health = DeploymentHealthRegistry()
-        # Per-worker in-flight counters for rungs that author a dispatch
-        # policy (concurrency bound, weighted fair share); pure in-memory
-        # arithmetic, physical-lane scoped so counters survive catalog rolls.
+        # Per-worker in-flight counters and rate windows for rungs that author
+        # a dispatch policy (concurrency bound, rate caps, weighted fair
+        # share); pure in-memory arithmetic, physical-lane scoped so counters
+        # survive catalog rolls.
         self._loads = RungLoadRegistry()
+        # Worker-local conversation-to-rung bindings under
+        # maximize_cache_affinity, so a spilled conversation keeps serving off
+        # the rung holding its warm cache instead of bouncing back.
+        self._sticky = StickySpillRegistry()
         self._inflight: dict[str, InflightRequest] = {}
         self._lock = threading.Lock()
         self._accounting_healthy = True
@@ -269,11 +165,14 @@ class NativeAttemptAccounting:
         self._admission_dead_rungs_skipped = 0
         self._admission_parameter_coercions = 0
         self._admission_lead_rungs_skipped = 0
-        # Dispatch-policy outcomes: rungs bypassed at their bound or their
-        # organization's fair share, and dispatches forced past a bound
-        # because no other rung could serve.
+        # Dispatch-policy outcomes: rungs bypassed at their bound, rate
+        # window, fresh-session threshold, or their organization's fair
+        # share, and dispatches forced past a bound because no other rung
+        # could serve. The per-reason counters split the aggregate.
         self._rung_admission_sheds = 0
         self._rung_saturated_overflows = 0
+        self._rung_rate_limit_sheds = 0
+        self._rung_fresh_session_spills = 0
         # The sweep also runs on a timer so retained settlements and abandoned
         # attempts are recovered even when no further requests arrive.
         self._sweeper = threading.Thread(
@@ -298,11 +197,17 @@ class NativeAttemptAccounting:
         """Return the per-worker rung in-flight registry for bounded admission."""
         return self._loads
 
+    @property
+    def sticky(self) -> StickySpillRegistry:
+        """Return the worker-local sticky conversation-to-rung bindings."""
+        return self._sticky
+
     def _reserve_rung_slot(
         self,
         entry: InflightRequest,
         deployment: ExactModelDeployment,
         *,
+        reserved_tokens: int,
         force: bool,
     ) -> str | RungShed | None:
         """Reserve one policy-bounded slot on a rung, or report the shed.
@@ -310,32 +215,78 @@ class NativeAttemptAccounting:
         Args:
             entry: The owning in-flight request (organization and weight).
             deployment: The claimed rung about to dispatch.
-            force: Admit past the bound because no other rung can serve.
+            reserved_tokens: Worst-case tokens this dispatch reserves, counted
+                against the rung's token window when one is authored.
+            force: Admit past every policy limit because no other rung can
+                serve.
 
         Returns:
             An opaque reservation ticket, the shed disclosure, or ``None``
-            when the rung authors no dispatch policy (the untouched default).
+            when the rung authors no admission policy (the untouched default).
         """
         policy = deployment.gateway.dispatch
-        if policy is None or policy.concurrency_bound is None:
+        if policy is None or (
+            policy.concurrency_bound is None
+            and policy.requests_per_minute is None
+            and policy.tokens_per_minute is None
+        ):
             return None
+        # Warm standing: the request's affinity fingerprint holds a live
+        # sticky binding on THIS rung, so its provider cache lives here and
+        # the fresh-session early threshold does not apply to it. The early
+        # threshold only exists on affinity pools AND for requests that carry
+        # a fingerprint (chat/Responses admission): a surface with no session
+        # concept (embeddings, images) must never be classed fresh wholesale.
+        fresh_fraction = (
+            policy.fresh_session_spill_fraction
+            if entry.route.snapshot.failover_mode == "maximize_cache_affinity"
+            and entry.affinity_fingerprint is not None
+            else None
+        )
+        warm_session = True
+        if fresh_fraction is not None and entry.affinity_fingerprint is not None:
+            warm_session = (
+                self._sticky.bound_deployment(entry.affinity_fingerprint)
+                == deployment.deployment_id
+            )
         result = self._loads.reserve(
             (deployment.deployment_id, deployment.connection_sha256),
             organization_id=entry.authorization.organization_id,
             weight=entry.authorization.fair_share_weight,
             bound=policy.concurrency_bound,
             fair_share=policy.fair_share,
+            requests_per_minute=policy.requests_per_minute,
+            tokens_per_minute=policy.tokens_per_minute,
+            cache_priority_alpha=policy.cache_priority_alpha,
+            reserved_tokens=reserved_tokens if policy.tokens_per_minute is not None else 0,
+            warm_session=warm_session,
+            fresh_spill_fraction=fresh_fraction,
             force=force,
         )
         if isinstance(result, RungShed):
             with self._lock:
                 self._rung_admission_sheds += 1
+                if result.reason == "rate_limit":
+                    self._rung_rate_limit_sheds += 1
+                elif result.reason == "fresh_session_spill":
+                    self._rung_fresh_session_spills += 1
+            if result.reason == "rate_limit":
+                _logger.debug(
+                    "gateway rate-limit shed on deployment %r (learned ceiling %s/min)",
+                    deployment.deployment_id,
+                    result.learned_requests_per_minute,
+                )
         return result
 
     def rung_admission_counters(self) -> tuple[int, int]:
         """Return ``(sheds, saturated_overflows)`` for the metrics snapshot."""
         with self._lock:
             return (self._rung_admission_sheds, self._rung_saturated_overflows)
+
+    def rung_rate_counters(self) -> tuple[int, int]:
+        """Return ``(rate_limit_sheds, fresh_session_spills)`` for metrics."""
+        with self._lock:
+            return (self._rung_rate_limit_sheds, self._rung_fresh_session_spills)
 
     def mark_unhealthy(self) -> None:
         """Latch an unhealthy state after a lost terminal accounting write."""
@@ -441,7 +392,7 @@ class NativeAttemptAccounting:
             with self._lock:
                 self._inflight.pop(request_id, None)
             raise NativeBridgeError(public_failure_error(failure))
-        failure = _failure_from_payload(data.get("failure"))
+        failure = failure_from_boundary_payload(data.get("failure"))
         current_depth = data.get("current_depth")
         if failure is not None and isinstance(current_depth, int):
             candidate = next_route_candidate(
@@ -473,7 +424,7 @@ class NativeAttemptAccounting:
                     candidate = policy_sheds[0][0]
                 else:
                     break
-            deployment = _deployment_priced_for_service_tier(
+            deployment = deployment_priced_for_service_tier(
                 route.deployments[candidate],
                 getattr(entry.request, "service_tier", None),
                 forwards_tier=(
@@ -481,24 +432,31 @@ class NativeAttemptAccounting:
                     and entry.tier_forwarded_by_depth[candidate]
                 ),
             )
-            ticket = self._reserve_rung_slot(entry, deployment, force=forced_overflow)
+            # Reserve the worst-case in-flight tokens alongside the worst-case
+            # cost. The platform's token windows (promo free-tier, strict; org
+            # rate limits, soft) count these dispatched reservations, and the
+            # rung's own authored token window counts the same conservative
+            # bound, so a concurrent burst binds instead of leaking past caps.
+            reserved_input_tokens, reserved_output_tokens = worst_case_attempt_tokens(
+                entry.request, deployment
+            )
+            ticket = self._reserve_rung_slot(
+                entry,
+                deployment,
+                reserved_tokens=reserved_input_tokens + reserved_output_tokens,
+                force=forced_overflow,
+            )
             if isinstance(ticket, RungShed):
                 policy_sheds.append((candidate, ticket.reason))
                 self._health.release_probe(keys[candidate])
                 candidate = claim_route_from(self._health, keys, candidate + 1)
                 continue
-            dispatch_reason, preferred_deployment = _dispatch_disclosure(
+            dispatch_reason, preferred_deployment = dispatch_disclosure(
                 route,
                 candidate,
                 policy_sheds=policy_sheds,
                 forced_overflow=forced_overflow,
-            )
-            # Reserve the worst-case in-flight tokens alongside the worst-case
-            # cost. The platform's token windows (promo free-tier, strict; org
-            # rate limits, soft) count these dispatched reservations, so a
-            # concurrent burst binds instead of leaking past the cap.
-            reserved_input_tokens, reserved_output_tokens = worst_case_attempt_tokens(
-                entry.request, deployment
+                sticky_preferred=entry.sticky_preferred,
             )
             try:
                 attempt_id = self._write_ledger.start_attempt(
@@ -564,6 +522,7 @@ class NativeAttemptAccounting:
             if forced_overflow:
                 with self._lock:
                     self._rung_saturated_overflows += 1
+            self._bind_sticky_dispatch(entry, deployment)
             with self._lock:
                 entry.attempt_counts[candidate] += 1
                 entry.total_attempts += 1
@@ -610,6 +569,38 @@ class NativeAttemptAccounting:
             separators=(",", ":"),
         )
 
+    def _bind_sticky_dispatch(
+        self,
+        entry: InflightRequest,
+        deployment: ExactModelDeployment,
+    ) -> None:
+        """Record or refresh the conversation's binding to its serving rung.
+
+        Every dispatch on a ``maximize_cache_affinity`` pool records where the
+        conversation's provider cache is being built, with the serving rung's
+        authored ``sticky_spill_seconds`` as the lifetime: a spilled
+        conversation thereby stays on its spill target instead of bouncing
+        back to the higher-ranked rung the moment it stops shedding, and a
+        conversation on its preferred rung simply refreshes a no-op binding.
+        A rung authoring no lifetime records nothing.
+
+        Args:
+            entry: The owning in-flight request.
+            deployment: The rung about to receive the dispatch.
+        """
+        if entry.affinity_fingerprint is None:
+            return
+        if entry.route.snapshot.failover_mode != "maximize_cache_affinity":
+            return
+        policy = deployment.gateway.dispatch
+        if policy is None or policy.sticky_spill_seconds is None:
+            return
+        self._sticky.bind(
+            entry.affinity_fingerprint,
+            deployment.deployment_id,
+            ttl_seconds=float(policy.sticky_spill_seconds),
+        )
+
     def settle(self, argument: str) -> str:
         """Durably settle one previously reserved attempt exactly once.
 
@@ -644,6 +635,7 @@ class NativeAttemptAccounting:
         opened = bool(data.get("opened", False))
         terminal, failure = terminal_from_settlement(data)
         first_token_at = first_token_at_from_settlement(data)
+        rate_limit = settlement_rate_limit(data)
         try:
             self._write_ledger.finish_attempt(
                 attempt_id=attempt_id,
@@ -651,6 +643,11 @@ class NativeAttemptAccounting:
                 failure=failure,
                 finalize_request=finalize,
                 first_token_at=first_token_at,
+                retry_after_seconds=rate_limit.retry_after_seconds,
+                ratelimit_limit_requests=rate_limit.limit_requests,
+                ratelimit_remaining_requests=rate_limit.remaining_requests,
+                ratelimit_limit_tokens=rate_limit.limit_tokens,
+                ratelimit_remaining_tokens=rate_limit.remaining_tokens,
             )
         except Exception as exc:  # noqa: BLE001 - the data plane retries.
             # The exact settlement is retained so a retry (from the data
@@ -660,6 +657,7 @@ class NativeAttemptAccounting:
                 entry.pending_settlement = data
             raise authority_error(exc) from exc
         self._record_health(entry, attempt_id, opened=opened, failure=failure)
+        self._record_cache_fraction(entry, attempt_id, terminal.usage)
         with self._lock:
             if finalize:
                 self._inflight.pop(request_id, None)
@@ -693,7 +691,7 @@ class NativeAttemptAccounting:
             entry = self._inflight.get(request_id)
         if entry is None:
             return "{}"
-        failure = _failure_from_payload(data.get("failure")) or GatewayFailure(
+        failure = failure_from_boundary_payload(data.get("failure")) or GatewayFailure(
             failure_class=GatewayFailureClass.CANCELLED,
             safe_message="gateway request was cancelled",
         )
@@ -762,13 +760,62 @@ class NativeAttemptAccounting:
         depth = entry.attempt_depths.get(attempt_id)
         if depth is None:
             return
-        key = deployment_health_key(entry.authorization, entry.route.deployments[depth])
+        deployment = entry.route.deployments[depth]
+        key = deployment_health_key(entry.authorization, deployment)
         if opened:
             self._health.dispatch_opened(key)
         if failure is not None:
+            policy = deployment.gateway.dispatch
+            if failure.failure_class == GatewayFailureClass.THROTTLED and (
+                policy is not None
+                and (
+                    policy.concurrency_bound is not None
+                    or policy.requests_per_minute is not None
+                    or policy.tokens_per_minute is not None
+                )
+            ):
+                # Passive-adaptive calibration: the provider just proved the
+                # observed dispatch rate is too high for this physical lane,
+                # so the rung's learned ceiling clamps to it. Recovery creep
+                # rediscovers headroom without synthetic probes. Gated on an
+                # admission-participating policy: only such rungs reserve
+                # through the registry, so only they carry a real observed
+                # window (and only they would ever enforce the ceiling).
+                self._loads.record_throttle(rung_load_key(deployment))
             self._health.failed(key, failure)
         else:
             self._health.succeeded(key)
+
+    def _record_cache_fraction(
+        self,
+        entry: InflightRequest,
+        attempt_id: str,
+        usage: GatewayUsage | None,
+    ) -> None:
+        """Fold one settled attempt's cached-token fraction into the registry.
+
+        Feeds the congestion-dependent cache-priority term: the registry keeps
+        a per-(organization, rung) EWMA of the settled cached fraction, so
+        fairness can favor the organization whose traffic actually reuses warm
+        provider cache. Attempts without observed token usage record nothing.
+
+        Args:
+            entry: The owning in-flight request.
+            attempt_id: The settled attempt.
+            usage: The terminal event's usage, if any.
+        """
+        if usage is None or usage.input_tokens is None:
+            return
+        depth = entry.attempt_depths.get(attempt_id)
+        if depth is None:
+            return
+        cached = usage.cached_input_tokens
+        self._loads.record_settle(
+            rung_load_key(entry.route.deployments[depth]),
+            entry.authorization.organization_id,
+            cached_tokens=0 if cached is None else cached,
+            input_tokens=usage.input_tokens,
+        )
 
     def _sweep_loop(self) -> None:
         """Run the settlement sweep on a timer for the process lifetime."""
@@ -813,6 +860,7 @@ class NativeAttemptAccounting:
                 terminal=terminal,
                 failure=failure,
                 finalize=bool(settlement.get("finalize", True)),
+                rate_limit=settlement_rate_limit(settlement),
             ):
                 with self._lock:
                     entry.pending_settlement = None
@@ -860,18 +908,25 @@ class NativeAttemptAccounting:
         terminal: GatewayEvent,
         failure: GatewayFailure | None,
         finalize: bool,
+        rate_limit: RateLimitObservation | None = None,
     ) -> bool:
         """Land one swept settlement; keep the entry for retry on failure.
 
         Returns:
             Whether the swept terminal write reached the ledger.
         """
+        observation = RateLimitObservation() if rate_limit is None else rate_limit
         try:
             self._write_ledger.finish_attempt(
                 attempt_id=attempt_id,
                 terminal_event=terminal,
                 failure=failure,
                 finalize_request=finalize,
+                retry_after_seconds=observation.retry_after_seconds,
+                ratelimit_limit_requests=observation.limit_requests,
+                ratelimit_remaining_requests=observation.remaining_requests,
+                ratelimit_limit_tokens=observation.limit_tokens,
+                ratelimit_remaining_tokens=observation.remaining_tokens,
             )
         except Exception:  # noqa: BLE001 - keep the entry; the sweep retries.
             self._accounting_healthy = False
@@ -883,57 +938,6 @@ class NativeAttemptAccounting:
             elif entry.active_attempt_id == attempt_id:
                 entry.active_attempt_id = None
         return True
-
-
-def _dispatch_disclosure(
-    route: GatewayRoute,
-    candidate: int,
-    *,
-    policy_sheds: list[tuple[int, str]],
-    forced_overflow: bool,
-) -> tuple[str | None, ExactModelDeployment | None]:
-    """Name why the chosen rung serves and the bypassed preferred rung, if any.
-
-    Emission is gated so an alias the platform never opted in keeps byte-null
-    disclosure columns. On a ``maximize_cache_affinity`` pool every attempt
-    discloses against the rendezvous-preferred depth-0 rung: ``affinity`` on
-    the happy path, the shed reason when depth 0 was policy-shed in this
-    reservation, ``rung_dead`` when it was bypassed by health or an earlier
-    failure, ``saturated_overflow`` when the ladder force-admitted past a
-    bound. On any other pool a disclosure appears only when a dispatch policy
-    actually shed a rung in this reservation, and the preferred rung is the
-    shed rung itself (the counterfactual the shed is measured against).
-
-    Args:
-        route: Frozen ordered route for this request.
-        candidate: The route depth about to dispatch.
-        policy_sheds: ``(depth, reason)`` for every policy shed this
-            reservation, in ladder order.
-        forced_overflow: Whether this dispatch was forced past a bound.
-
-    Returns:
-        ``(dispatch_reason, preferred_deployment)``; the deployment is
-        ``None`` whenever the chosen rung IS the disclosure's preferred rung.
-    """
-    if route.snapshot.failover_mode == "maximize_cache_affinity":
-        target_depth = 0
-        if forced_overflow:
-            reason = "saturated_overflow"
-        elif candidate == 0:
-            reason = "affinity"
-        else:
-            lead_shed = next((shed for depth, shed in policy_sheds if depth == 0), None)
-            reason = lead_shed or "rung_dead"
-    elif forced_overflow:
-        target_depth = policy_sheds[0][0]
-        reason = "saturated_overflow"
-    elif policy_sheds:
-        target_depth, reason = policy_sheds[0]
-    else:
-        return None, None
-    if target_depth == candidate:
-        return reason, None
-    return reason, route.deployments[target_depth]
 
 
 def record_dead_admission_rungs(

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -125,6 +125,7 @@ class _RecordingLedger:
         self.rate_limit_settlements: list[JsonObject] = []
         self.finished_requests: list[GatewayFailure] = []
         self.budget_rejections: dict[str, BudgetScopeKind] = {}
+        self.fail_finishes = 0
         self._counter = 0
 
     def accept_request(self, *, authorization: AuthorizationSnapshot) -> None:
@@ -185,6 +186,9 @@ class _RecordingLedger:
     ) -> None:
         """Record one settled attempt, tracking harvested rate-limit values apart."""
         del terminal_event, first_token_at
+        if self.fail_finishes > 0:
+            self.fail_finishes -= 1
+            raise RuntimeError("scripted terminal-write failure")
         self.finished.append(
             {
                 "attempt_id": attempt_id,
@@ -1229,7 +1233,7 @@ class TestRateLimitSettlement:
                     "attempt_id": str(started["attempt_id"]),
                     "outcome": "completed",
                     "usage": {
-                        "input_tokens": 200,
+                        "input_tokens": 1_000,
                         "cached_input_tokens": 800,
                         "output_tokens": 5,
                     },
@@ -1240,7 +1244,61 @@ class TestRateLimitSettlement:
                 }
             )
         )
-        assert recorded == [(("deployment-a", "b" * 64), "organization-one", 800, 200)]
+        assert recorded == [(("deployment-a", "b" * 64), "organization-one", 800, 1_000)]
+
+    def test_swept_retained_settlement_still_records_the_cache_fraction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A settlement recovered by the sweep feeds the EWMA like a direct one."""
+        recorded: list[tuple[tuple[str, str], str, int, int]] = []
+        registry, ledger, _entry = _registry()
+
+        def _record(
+            key: tuple[str, str],
+            organization_id: str,
+            *,
+            cached_tokens: int,
+            input_tokens: int,
+        ) -> None:
+            """Record one EWMA sample instead of folding it."""
+            recorded.append((key, organization_id, cached_tokens, input_tokens))
+
+        monkeypatch.setattr(registry.loads, "record_settle", _record)
+        started = _start(registry, ordinal=0)
+        ledger.fail_finishes = 1
+        settlement = json.dumps(
+            {
+                "request_id": "request-one",
+                "attempt_id": str(started["attempt_id"]),
+                "outcome": "completed",
+                "usage": {
+                    "input_tokens": 1_000,
+                    "cached_input_tokens": 800,
+                    "output_tokens": 5,
+                },
+                "tool_names": [],
+                "failure": None,
+                "finalize": True,
+                "opened": True,
+                "rate_limit_headers": {"x-ratelimit-remaining-requests": "9999"},
+            }
+        )
+        with pytest.raises(NativeBridgeError):
+            registry.settle(settlement)
+        assert recorded == []
+        registry.sweep_expired()
+        assert recorded == [(("deployment-a", "b" * 64), "organization-one", 800, 1_000)]
+        # The harvested rate-limit values ride the swept write too.
+        assert ledger.rate_limit_settlements == [
+            {
+                "attempt_id": str(started["attempt_id"]),
+                "retry_after_seconds": None,
+                "ratelimit_limit_requests": None,
+                "ratelimit_remaining_requests": 9_999,
+                "ratelimit_limit_tokens": None,
+                "ratelimit_remaining_tokens": None,
+            }
+        ]
 
 
 class TestStickySpillBindings:

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -1065,14 +1065,22 @@ class TestRateLimitSheds:
         assert registry.rung_rate_counters() == (1, 0)
 
     def test_token_rate_counts_the_worst_case_reservation(self) -> None:
-        """A token cap below one request's worst case spills every dispatch."""
+        """An over-cap request bursts into an empty window; the next one spills.
+
+        The burst allowance keeps a token cap below one request's worst case
+        from becoming a permanent shed loop: the first dispatch lands on the
+        rung and occupies the window, and the follow-up spills as a normal
+        ``rate_limit`` shed until the window slides.
+        """
         ledger = _RecordingLedger()
         registry = NativeAttemptAccounting(ledger)
         deployments = _rated_pair(tokens_per_minute=1)
         _admit(registry, deployments, request_id="request-1")
-        spilled = _start(registry, ordinal=0, request_id="request-1")
+        _admit(registry, deployments, request_id="request-2")
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        spilled = _start(registry, ordinal=0, request_id="request-2")
         assert spilled["route_depth"] == 1
-        assert ledger.started[0]["dispatch_reason"] == "rate_limit"
+        assert ledger.started[1]["dispatch_reason"] == "rate_limit"
 
     def test_whole_ladder_rate_limited_still_force_admits(self) -> None:
         """A single rate-capped rung never manufactures a failure."""
@@ -1093,6 +1101,48 @@ class TestRateLimitSheds:
         assert ledger.started[1]["dispatch_reason"] == "saturated_overflow"
         assert registry.rung_admission_counters() == (1, 1)
 
+    def test_whole_ladder_fresh_spill_limited_still_force_admits(self) -> None:
+        """A narrow ladder blocked only by the fresh threshold never mints a 429.
+
+        Production showed one org taking hard 429s while its only eligible
+        rung sat healthy; both new shed reasons (rate_limit above,
+        fresh_session_spill here) must participate in the saturated-overflow
+        force-admit so policy sheds can never manufacture a caller failure.
+        """
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        only = (
+            _deployment(
+                "deployment-a",
+                connection_sha256="b" * 64,
+                dispatch=GatewayRungDispatchPolicy(
+                    concurrency_bound=2,
+                    fresh_session_spill_fraction=0.5,
+                    sticky_spill_seconds=600,
+                ),
+            ),
+        )
+        _admit(
+            registry,
+            only,
+            request_id="request-1",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-1",
+        )
+        _admit(
+            registry,
+            only,
+            request_id="request-2",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-2",
+        )
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        overflow = _start(registry, ordinal=0, request_id="request-2")
+        assert overflow["route_depth"] == 0
+        assert ledger.started[1]["dispatch_reason"] == "saturated_overflow"
+        assert registry.rung_admission_counters() == (1, 1)
+        assert registry.rung_rate_counters() == (0, 1)
+
     def test_throttled_settle_teaches_the_rungs_learned_ceiling(self) -> None:
         """A provider 429 clamps the physical lane's learned request ceiling."""
         ledger = _RecordingLedger()
@@ -1112,8 +1162,9 @@ class TestRateLimitSheds:
             },
             request_id="request-1",
         )
-        # One dispatch observed in the window: learned = max(1, 1 * 0.9) = 1.
-        assert registry.loads.learned_ceilings() == {"deployment-a:bbbbbbbb": 1}
+        # One dispatch observed in the window: learned = 1 * 0.9 (a float; the
+        # ceiling may sit below one per minute so fleet totals can undershoot).
+        assert registry.loads.learned_ceilings() == {"deployment-a:bbbbbbbb": 0.9}
 
     def test_bound_only_rungs_calibrate_and_unpolicied_rungs_do_not(self) -> None:
         """A bound-only rung learns from its real window; unpolicied lanes never do."""
@@ -1137,7 +1188,7 @@ class TestRateLimitSheds:
             failure=throttle,
             request_id="request-1",
         )
-        assert registry.loads.learned_ceilings() == {"deployment-a:bbbbbbbb": 1}
+        assert registry.loads.learned_ceilings() == {"deployment-a:bbbbbbbb": 0.9}
         # Unpolicied: a throttle teaches nothing (nothing would enforce it and
         # the window never observed the lane's rate).
         bare_ledger = _RecordingLedger()
@@ -1247,6 +1298,67 @@ class TestRateLimitSettlement:
         # fold the same attempt's sample into the EWMA a second time.
         registry.settle(settlement)
         assert recorded == [(("deployment-a", "b" * 64), "organization-one", 800, 1_000)]
+
+    def test_cache_sample_gate_excludes_promo_funded_attempts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A hosted gate can veto samples so promo replay cannot buy weight.
+
+        A gate answering False (the host marked the attempt promo-funded) and
+        a raising gate both skip the fold; only an admitted attempt records.
+        """
+        for verdict, folds in (("deny", 0), ("raise", 0), ("admit", 1)):
+            recorded: list[str] = []
+            ledger = _RecordingLedger()
+
+            def _gate(attempt_id: str, verdict: str = verdict) -> bool:
+                """Answer the scripted verdict for every attempt."""
+                del attempt_id
+                if verdict == "raise":
+                    raise RuntimeError("scripted gate failure")
+                return verdict == "admit"
+
+            registry = NativeAttemptAccounting(ledger, cache_sample_gate=_gate)
+            deployments = (
+                _deployment("deployment-a", connection_sha256="b" * 64),
+                _deployment("deployment-b", connection_sha256="c" * 64),
+            )
+            entry = _admit(registry, deployments, request_id="request-1")
+            del entry
+
+            def _record(
+                key: tuple[str, str],
+                organization_id: str,
+                *,
+                cached_tokens: int,
+                input_tokens: int,
+                folds: list[str] = recorded,
+            ) -> None:
+                """Record the fold instead of applying it."""
+                del key, organization_id, cached_tokens, input_tokens
+                folds.append("fold")
+
+            monkeypatch.setattr(registry.loads, "record_settle", _record)
+            started = _start(registry, ordinal=0, request_id="request-1")
+            registry.settle(
+                json.dumps(
+                    {
+                        "request_id": "request-1",
+                        "attempt_id": str(started["attempt_id"]),
+                        "outcome": "completed",
+                        "usage": {
+                            "input_tokens": 1_000,
+                            "cached_input_tokens": 800,
+                            "output_tokens": 5,
+                        },
+                        "tool_names": [],
+                        "failure": None,
+                        "finalize": True,
+                        "opened": True,
+                    }
+                )
+            )
+            assert len(recorded) == folds, verdict
 
     def test_swept_retained_settlement_still_records_the_cache_fraction(
         self, monkeypatch: pytest.MonkeyPatch

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -30,10 +30,9 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
-    _failure_from_payload,
 )
 from exp.runtime.gateway.native_execution import InflightRequest, deployment_health_key
-from exp.runtime.gateway.native_settlement import ledger_failure
+from exp.runtime.gateway.native_settlement import failure_from_boundary_payload, ledger_failure
 from exp.runtime.gateway.routing import GatewayRoute
 from exp.runtime.openai_protocol.errors import (
     THROTTLED_RETRY_AFTER_SECONDS,
@@ -123,6 +122,7 @@ class _RecordingLedger:
         """Start with empty write logs and no scripted rejections."""
         self.started: list[JsonObject] = []
         self.finished: list[JsonObject] = []
+        self.rate_limit_settlements: list[JsonObject] = []
         self.finished_requests: list[GatewayFailure] = []
         self.budget_rejections: dict[str, BudgetScopeKind] = {}
         self._counter = 0
@@ -177,8 +177,13 @@ class _RecordingLedger:
         failure: GatewayFailure | None,
         finalize_request: bool = True,
         first_token_at: datetime | None = None,
+        retry_after_seconds: int | None = None,
+        ratelimit_limit_requests: int | None = None,
+        ratelimit_remaining_requests: int | None = None,
+        ratelimit_limit_tokens: int | None = None,
+        ratelimit_remaining_tokens: int | None = None,
     ) -> None:
-        """Record one settled attempt."""
+        """Record one settled attempt, tracking harvested rate-limit values apart."""
         del terminal_event, first_token_at
         self.finished.append(
             {
@@ -187,6 +192,26 @@ class _RecordingLedger:
                 "finalize": finalize_request,
             }
         )
+        if any(
+            value is not None
+            for value in (
+                retry_after_seconds,
+                ratelimit_limit_requests,
+                ratelimit_remaining_requests,
+                ratelimit_limit_tokens,
+                ratelimit_remaining_tokens,
+            )
+        ):
+            self.rate_limit_settlements.append(
+                {
+                    "attempt_id": attempt_id,
+                    "retry_after_seconds": retry_after_seconds,
+                    "ratelimit_limit_requests": ratelimit_limit_requests,
+                    "ratelimit_remaining_requests": ratelimit_remaining_requests,
+                    "ratelimit_limit_tokens": ratelimit_limit_tokens,
+                    "ratelimit_remaining_tokens": ratelimit_remaining_tokens,
+                }
+            )
 
     def finish_request(
         self,
@@ -502,11 +527,11 @@ def test_rejected_parameter_crosses_the_boundary_only_as_a_string() -> None:
     assert isinstance(failure_payload, dict)
     assert failure_payload["rejected_parameter"] == "input[1].status"
     # Non-string or empty payload values decode to None, never a coerced str.
-    numeric = _failure_from_payload(
+    numeric = failure_from_boundary_payload(
         {"failure_class": "invalid_request", "safe_message": "x", "rejected_parameter": 7}
     )
     assert numeric is not None and numeric.rejected_parameter is None
-    empty = _failure_from_payload(
+    empty = failure_from_boundary_payload(
         {"failure_class": "invalid_request", "safe_message": "x", "rejected_parameter": ""}
     )
     assert empty is not None and empty.rejected_parameter is None
@@ -520,6 +545,8 @@ def _admit(
     organization_id: str = "organization-one",
     weight: int = 1,
     failover_mode: FailoverMode = "maximize_availability",
+    affinity_fingerprint: bytes | None = None,
+    sticky_preferred: bool = False,
 ) -> InflightRequest:
     """Register one admitted request over the given rung ladder."""
     authorization = _authorization(_DIGEST).model_copy(
@@ -547,6 +574,8 @@ def _admit(
         route=route,
         request=_request(),
         deadline_monotonic=time.monotonic() + 30,
+        affinity_fingerprint=affinity_fingerprint,
+        sticky_preferred=sticky_preferred,
     )
     registry.register(entry)
     return entry
@@ -792,11 +821,11 @@ def test_provider_detail_crosses_the_boundary_only_as_a_string() -> None:
     failure_payload = exhausted["failure"]
     assert isinstance(failure_payload, dict)
     assert failure_payload["provider_detail"] == "`top_p` is deprecated for this model."
-    numeric = _failure_from_payload(
+    numeric = failure_from_boundary_payload(
         {"failure_class": "invalid_request", "safe_message": "x", "provider_detail": 7}
     )
     assert numeric is not None and numeric.provider_detail is None
-    empty_detail = _failure_from_payload(
+    empty_detail = failure_from_boundary_payload(
         {"failure_class": "invalid_request", "safe_message": "x", "provider_detail": ""}
     )
     assert empty_detail is not None and empty_detail.provider_detail is None
@@ -811,7 +840,7 @@ def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() 
         GatewayTokenPrices,
     )
     from exp.common.models.gateway_catalog import ExactModelDeployment
-    from exp.runtime.gateway.native_accounting import _deployment_priced_for_service_tier
+    from exp.runtime.gateway.native_execution import deployment_priced_for_service_tier
 
     deployment = ExactModelDeployment(
         deployment_id="d1",
@@ -834,7 +863,7 @@ def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() 
         ),
     )
 
-    flex = _deployment_priced_for_service_tier(deployment, "flex", forwards_tier=True)
+    flex = deployment_priced_for_service_tier(deployment, "flex", forwards_tier=True)
     assert flex is not deployment
     assert flex.gateway.prices.input_micro_usd_per_million_tokens == 500_000
     assert flex.gateway.prices.output_micro_usd_per_million_tokens == 2_000_000
@@ -842,13 +871,12 @@ def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() 
     assert flex.deployment_id == "d1" and flex.exact_model_id == "exact-one"
 
     # No tier, default/auto, and a tier the deployment does not carry: unchanged.
-    assert _deployment_priced_for_service_tier(deployment, None, forwards_tier=False) is deployment
+    assert deployment_priced_for_service_tier(deployment, None, forwards_tier=False) is deployment
     assert (
-        _deployment_priced_for_service_tier(deployment, "default", forwards_tier=False)
-        is deployment
+        deployment_priced_for_service_tier(deployment, "default", forwards_tier=False) is deployment
     )
     assert (
-        _deployment_priced_for_service_tier(deployment, "priority", forwards_tier=False)
+        deployment_priced_for_service_tier(deployment, "priority", forwards_tier=False)
         is deployment
     )
 
@@ -856,9 +884,7 @@ def test_deployment_priced_for_service_tier_overrides_only_for_a_carried_tier() 
     # whose wire would strip the tier) bills the BASE schedule, never the card:
     # forwards_tier=False returns the deployment unchanged even though the flex
     # card exists.
-    assert (
-        _deployment_priced_for_service_tier(deployment, "flex", forwards_tier=False) is deployment
-    )
+    assert deployment_priced_for_service_tier(deployment, "flex", forwards_tier=False) is deployment
 
 
 def test_start_attempt_reprices_only_when_the_selected_depth_forwards_the_tier() -> None:
@@ -955,7 +981,7 @@ def test_start_attempt_reprices_only_when_the_selected_depth_forwards_the_tier()
 def test_customer_owned_failures_round_trip_and_file_as_the_callers_invalid_request() -> None:
     """A BYOK credential failure keeps its ladder class, echoes its ownership, and
     is recorded as the caller's invalid request."""
-    parsed = _failure_from_payload(
+    parsed = failure_from_boundary_payload(
         {
             "failure_class": "provider_authentication",
             "safe_message": "your connected openai credential was rejected by the provider",
@@ -969,7 +995,7 @@ def test_customer_owned_failures_round_trip_and_file_as_the_callers_invalid_requ
     assert ledger_failure(parsed).failure_class == GatewayFailureClass.INVALID_REQUEST
     # Only the two customer-configurable provider classes re-file; a
     # house-shaped failure (or one without the flag) is untouched.
-    house = _failure_from_payload(
+    house = failure_from_boundary_payload(
         {
             "failure_class": "provider_authentication",
             "safe_message": "provider authentication failed",
@@ -995,3 +1021,378 @@ def test_customer_owned_failures_round_trip_and_file_as_the_callers_invalid_requ
     assert isinstance(failure_payload, dict)
     assert failure_payload["customer_owned"] is True
     assert failure_payload["failure_class"] == "provider_quota"
+
+
+def _rated_pair(
+    *,
+    requests_per_minute: int | None = None,
+    tokens_per_minute: int | None = None,
+) -> tuple[ExactModelDeployment, ExactModelDeployment]:
+    """Build a rate-capped lead rung with an unlimited spill rung behind it."""
+    return (
+        _deployment(
+            "deployment-a",
+            connection_sha256="b" * 64,
+            dispatch=GatewayRungDispatchPolicy(
+                requests_per_minute=requests_per_minute,
+                tokens_per_minute=tokens_per_minute,
+            ),
+        ),
+        _deployment("deployment-b", connection_sha256="c" * 64),
+    )
+
+
+class TestRateLimitSheds:
+    """Rate windows spill sideways pre-429 and force-admit at exhaustion."""
+
+    def test_request_rate_shed_spills_sideways_with_disclosure(self) -> None:
+        """The over-rate dispatch lands on the next rung, disclosed verbatim."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = _rated_pair(requests_per_minute=1)
+        _admit(registry, deployments, request_id="request-1")
+        _admit(registry, deployments, request_id="request-2")
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        spilled = _start(registry, ordinal=0, request_id="request-2")
+        assert spilled["route_depth"] == 1
+        assert ledger.started[1]["dispatch_reason"] == "rate_limit"
+        assert ledger.started[1]["preferred_deployment_id"] == "deployment-a"
+        assert registry.rung_admission_counters() == (1, 0)
+        assert registry.rung_rate_counters() == (1, 0)
+
+    def test_token_rate_counts_the_worst_case_reservation(self) -> None:
+        """A token cap below one request's worst case spills every dispatch."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = _rated_pair(tokens_per_minute=1)
+        _admit(registry, deployments, request_id="request-1")
+        spilled = _start(registry, ordinal=0, request_id="request-1")
+        assert spilled["route_depth"] == 1
+        assert ledger.started[0]["dispatch_reason"] == "rate_limit"
+
+    def test_whole_ladder_rate_limited_still_force_admits(self) -> None:
+        """A single rate-capped rung never manufactures a failure."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        only = (
+            _deployment(
+                "deployment-a",
+                connection_sha256="b" * 64,
+                dispatch=GatewayRungDispatchPolicy(requests_per_minute=1),
+            ),
+        )
+        _admit(registry, only, request_id="request-1")
+        _admit(registry, only, request_id="request-2")
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        overflow = _start(registry, ordinal=0, request_id="request-2")
+        assert overflow["route_depth"] == 0
+        assert ledger.started[1]["dispatch_reason"] == "saturated_overflow"
+        assert registry.rung_admission_counters() == (1, 1)
+
+    def test_throttled_settle_teaches_the_rungs_learned_ceiling(self) -> None:
+        """A provider 429 clamps the physical lane's learned request ceiling."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = _rated_pair(requests_per_minute=100)
+        _admit(registry, deployments, request_id="request-1")
+        started = _start(registry, ordinal=0, request_id="request-1")
+        _settle(
+            registry,
+            attempt_id=str(started["attempt_id"]),
+            outcome="failed",
+            finalize=True,
+            failure={
+                "failure_class": "throttled",
+                "safe_message": "provider throttled the request",
+                "failover_eligible": True,
+            },
+            request_id="request-1",
+        )
+        # One dispatch observed in the window: learned = max(1, 1 * 0.9) = 1.
+        assert registry.loads.learned_ceilings() == {"deployment-a:bbbbbbbb": 1}
+
+    def test_bound_only_rungs_calibrate_and_unpolicied_rungs_do_not(self) -> None:
+        """A bound-only rung learns from its real window; unpolicied lanes never do."""
+        throttle: JsonObject = {
+            "failure_class": "throttled",
+            "safe_message": "provider throttled the request",
+            "failover_eligible": True,
+        }
+        # Bound-only: the reservation fed the window, so the throttle clamps
+        # to the observed dispatch rate rather than an empty window's floor.
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = _bounded_pair(4)
+        _admit(registry, deployments, request_id="request-1")
+        started = _start(registry, ordinal=0, request_id="request-1")
+        _settle(
+            registry,
+            attempt_id=str(started["attempt_id"]),
+            outcome="failed",
+            finalize=True,
+            failure=throttle,
+            request_id="request-1",
+        )
+        assert registry.loads.learned_ceilings() == {"deployment-a:bbbbbbbb": 1}
+        # Unpolicied: a throttle teaches nothing (nothing would enforce it and
+        # the window never observed the lane's rate).
+        bare_ledger = _RecordingLedger()
+        bare_registry = NativeAttemptAccounting(bare_ledger)
+        bare = (
+            _deployment("deployment-a", connection_sha256="b" * 64),
+            _deployment("deployment-b", connection_sha256="c" * 64),
+        )
+        _admit(bare_registry, bare, request_id="request-1")
+        bare_started = _start(bare_registry, ordinal=0, request_id="request-1")
+        _settle(
+            bare_registry,
+            attempt_id=str(bare_started["attempt_id"]),
+            outcome="failed",
+            finalize=True,
+            failure=throttle,
+            request_id="request-1",
+        )
+        assert bare_registry.loads.learned_ceilings() == {}
+
+
+class TestRateLimitSettlement:
+    """Harvested rate-limit headers reach the ledger and the throttle window."""
+
+    def test_settle_plumbs_harvested_headers_to_the_ledger(self) -> None:
+        """The normalized header integers ride the finish_attempt kwargs."""
+        registry, ledger, _entry = _registry()
+        started = _start(registry, ordinal=0)
+        registry.settle(
+            json.dumps(
+                {
+                    "request_id": "request-one",
+                    "attempt_id": str(started["attempt_id"]),
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "tool_names": [],
+                    "failure": None,
+                    "finalize": True,
+                    "opened": True,
+                    "rate_limit_headers": {
+                        "x-ratelimit-limit-requests": "10000",
+                        "x-ratelimit-remaining-requests": "9999",
+                        "x-ratelimit-limit-tokens": "180000000",
+                        "x-ratelimit-remaining-tokens": "179000000",
+                    },
+                }
+            )
+        )
+        assert ledger.rate_limit_settlements == [
+            {
+                "attempt_id": str(started["attempt_id"]),
+                "retry_after_seconds": None,
+                "ratelimit_limit_requests": 10_000,
+                "ratelimit_remaining_requests": 9_999,
+                "ratelimit_limit_tokens": 180_000_000,
+                "ratelimit_remaining_tokens": 179_000_000,
+            }
+        ]
+
+    def test_settle_without_headers_records_no_rate_limit_values(self) -> None:
+        """An engine that sends no header map keeps every kwarg None."""
+        registry, ledger, _entry = _registry()
+        started = _start(registry, ordinal=0)
+        _settle(
+            registry,
+            attempt_id=str(started["attempt_id"]),
+            outcome="completed",
+            finalize=True,
+        )
+        assert ledger.rate_limit_settlements == []
+
+    def test_settle_feeds_the_cached_fraction_ewma(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Settled cached and input tokens reach the load registry's EWMA."""
+        recorded: list[tuple[tuple[str, str], str, int, int]] = []
+        registry, _ledger, _entry = _registry()
+
+        def _record(
+            key: tuple[str, str],
+            organization_id: str,
+            *,
+            cached_tokens: int,
+            input_tokens: int,
+        ) -> None:
+            """Record one EWMA sample instead of folding it."""
+            recorded.append((key, organization_id, cached_tokens, input_tokens))
+
+        monkeypatch.setattr(registry.loads, "record_settle", _record)
+        started = _start(registry, ordinal=0)
+        registry.settle(
+            json.dumps(
+                {
+                    "request_id": "request-one",
+                    "attempt_id": str(started["attempt_id"]),
+                    "outcome": "completed",
+                    "usage": {
+                        "input_tokens": 200,
+                        "cached_input_tokens": 800,
+                        "output_tokens": 5,
+                    },
+                    "tool_names": [],
+                    "failure": None,
+                    "finalize": True,
+                    "opened": True,
+                }
+            )
+        )
+        assert recorded == [(("deployment-a", "b" * 64), "organization-one", 800, 200)]
+
+
+class TestStickySpillBindings:
+    """Dispatches record conversation bindings; disclosures name sticky leads."""
+
+    def test_affinity_dispatch_binds_the_fingerprint_to_its_rung(self) -> None:
+        """A sticky-enabled rung records where the conversation's cache lives."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = (
+            _deployment(
+                "deployment-a",
+                connection_sha256="b" * 64,
+                dispatch=GatewayRungDispatchPolicy(sticky_spill_seconds=600),
+            ),
+            _deployment(
+                "deployment-b",
+                connection_sha256="c" * 64,
+                dispatch=GatewayRungDispatchPolicy(sticky_spill_seconds=600),
+            ),
+        )
+        _admit(
+            registry,
+            deployments,
+            request_id="request-1",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-1",
+        )
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        assert registry.sticky.bound_deployment(b"conversation-1") == "deployment-a"
+        # A spilled dispatch of another conversation binds to the spill rung.
+        bounded = (
+            deployments[0].model_copy(
+                update={
+                    "gateway": deployments[0].gateway.model_copy(
+                        update={
+                            "dispatch": GatewayRungDispatchPolicy(
+                                concurrency_bound=1, sticky_spill_seconds=600
+                            )
+                        }
+                    )
+                }
+            ),
+            deployments[1],
+        )
+        _admit(
+            registry,
+            bounded,
+            request_id="request-2",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-2",
+        )
+        _admit(
+            registry,
+            bounded,
+            request_id="request-3",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-3",
+        )
+        assert _start(registry, ordinal=0, request_id="request-2")["route_depth"] == 0
+        spilled = _start(registry, ordinal=0, request_id="request-3")
+        assert spilled["route_depth"] == 1
+        assert registry.sticky.bound_deployment(b"conversation-3") == "deployment-b"
+
+    def test_rung_without_sticky_lifetime_records_no_binding(self) -> None:
+        """No authored lifetime means no binding, even on an affinity pool."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = (
+            _deployment("deployment-a", connection_sha256="b" * 64),
+            _deployment("deployment-b", connection_sha256="c" * 64),
+        )
+        _admit(
+            registry,
+            deployments,
+            request_id="request-1",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-1",
+        )
+        _start(registry, ordinal=0, request_id="request-1")
+        assert registry.sticky.size() == 0
+
+    def test_sticky_lead_discloses_affinity_sticky(self) -> None:
+        """A route whose depth 0 was sticky-chosen names the binding, not rendezvous."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = (
+            _deployment("deployment-a", connection_sha256="b" * 64),
+            _deployment("deployment-b", connection_sha256="c" * 64),
+        )
+        _admit(
+            registry,
+            deployments,
+            request_id="request-1",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"conversation-1",
+            sticky_preferred=True,
+        )
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        assert ledger.started[0]["dispatch_reason"] == "affinity_sticky"
+        assert ledger.started[0]["preferred_deployment_id"] is None
+
+
+class TestFreshSessionSpillDispatch:
+    """The early threshold spills fresh sessions and keeps warm ones home."""
+
+    def test_fresh_session_sheds_early_while_a_warm_session_admits(self) -> None:
+        """At the early threshold the fresh session spills, the bound one stays."""
+        ledger = _RecordingLedger()
+        registry = NativeAttemptAccounting(ledger)
+        deployments = (
+            _deployment(
+                "deployment-a",
+                connection_sha256="b" * 64,
+                dispatch=GatewayRungDispatchPolicy(
+                    concurrency_bound=2,
+                    fresh_session_spill_fraction=0.5,
+                    sticky_spill_seconds=600,
+                ),
+            ),
+            _deployment("deployment-b", connection_sha256="c" * 64),
+        )
+        # A first (fresh) conversation occupies the sub-threshold slot and, by
+        # dispatching, becomes warm on the rung.
+        _admit(
+            registry,
+            deployments,
+            request_id="request-1",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"warm-conversation",
+        )
+        assert _start(registry, ordinal=0, request_id="request-1")["route_depth"] == 0
+        # A second fresh conversation hits the early threshold (1 >= 2 * 0.5)
+        # and spills, disclosed as a fresh-session spill...
+        _admit(
+            registry,
+            deployments,
+            request_id="request-2",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"fresh-conversation",
+        )
+        spilled = _start(registry, ordinal=0, request_id="request-2")
+        assert spilled["route_depth"] == 1
+        assert ledger.started[1]["dispatch_reason"] == "fresh_session_spill"
+        assert ledger.started[1]["preferred_deployment_id"] == "deployment-a"
+        assert registry.rung_rate_counters() == (0, 1)
+        # ...while the warm conversation's next turn rides to the hard bound.
+        _admit(
+            registry,
+            deployments,
+            request_id="request-3",
+            failover_mode="maximize_cache_affinity",
+            affinity_fingerprint=b"warm-conversation",
+        )
+        assert _start(registry, ordinal=0, request_id="request-3")["route_depth"] == 0

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -1226,24 +1226,26 @@ class TestRateLimitSettlement:
 
         monkeypatch.setattr(registry.loads, "record_settle", _record)
         started = _start(registry, ordinal=0)
-        registry.settle(
-            json.dumps(
-                {
-                    "request_id": "request-one",
-                    "attempt_id": str(started["attempt_id"]),
-                    "outcome": "completed",
-                    "usage": {
-                        "input_tokens": 1_000,
-                        "cached_input_tokens": 800,
-                        "output_tokens": 5,
-                    },
-                    "tool_names": [],
-                    "failure": None,
-                    "finalize": True,
-                    "opened": True,
-                }
-            )
+        settlement = json.dumps(
+            {
+                "request_id": "request-one",
+                "attempt_id": str(started["attempt_id"]),
+                "outcome": "completed",
+                "usage": {
+                    "input_tokens": 1_000,
+                    "cached_input_tokens": 800,
+                    "output_tokens": 5,
+                },
+                "tool_names": [],
+                "failure": None,
+                "finalize": False,
+                "opened": True,
+            }
         )
+        registry.settle(settlement)
+        # A redelivered settlement (the ledger write is idempotent) must not
+        # fold the same attempt's sample into the EWMA a second time.
+        registry.settle(settlement)
         assert recorded == [(("deployment-a", "b" * 64), "organization-one", 800, 1_000)]
 
     def test_swept_retained_settlement_still_records_the_cache_fraction(

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from exp.common.models.catalog import GatewayDeploymentCapabilities
 from exp.runtime.gateway.affinity import (
@@ -27,6 +28,7 @@ from exp.runtime.gateway.contracts import AuthorizationSnapshot, DirectTarget, G
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_execution import (
+    deployment_health_key,
     reorder_route_deployments,
     request_carries_cache_markers,
     select_route_deployments,
@@ -65,6 +67,22 @@ _logger = logging.getLogger(__name__)
 _ResolvedWires = tuple[tuple[GatewayWireProfile, NativeWireClient], ...]
 
 
+@dataclass(frozen=True)
+class AffinityPlacement:
+    """The affinity facts one admission resolved for dispatch accounting.
+
+    ``fingerprint`` is present only on ``maximize_cache_affinity`` routes (the
+    tenant-isolated conversation identity that keyed placement), so dispatch
+    reservation can read and refresh the worker-local sticky binding and apply
+    the fresh-session spill threshold. ``sticky_preferred`` marks a route
+    whose depth 0 was chosen by a live sticky binding rather than rendezvous
+    order, for the ``affinity_sticky`` disclosure.
+    """
+
+    fingerprint: bytes | None = None
+    sticky_preferred: bool = False
+
+
 def _with_cache_affinity(
     provider_request: GatewayRequest, authorization: AuthorizationSnapshot
 ) -> GatewayRequest:
@@ -96,7 +114,7 @@ def admitted_route_requests(
     accounting: NativeAttemptAccounting,
     authorization: AuthorizationSnapshot,
     continuation: ContinuationContext | None = None,
-) -> tuple[GatewayRoute, _ResolvedWires, GatewayRequest, GatewayRequest]:
+) -> tuple[GatewayRoute, _ResolvedWires, GatewayRequest, GatewayRequest, AffinityPlacement]:
     """Narrow one certified route to rungs that serve the admitted request.
 
     Args:
@@ -110,8 +128,9 @@ def admitted_route_requests(
             conversation's cache-affinity placement.
 
     Returns:
-        The narrowed route and wires plus the public request (carrying any
-        coercion disclosures) and the streaming-forced provider request.
+        The narrowed route and wires, the public request (carrying any
+        coercion disclosures), the streaming-forced provider request, and the
+        resolved affinity placement.
 
     Raises:
         ProviderParameterError: No rung preserves a generation control and no
@@ -274,14 +293,15 @@ def admitted_route_requests(
         )
     provider_request = _with_cache_affinity(provider_request, authorization)
     route, resolved_wires = _prefer_cache_capable_rungs(route, resolved_wires, provider_request)
-    route, resolved_wires = _affinity_ordered_rungs(
+    route, resolved_wires, placement = _affinity_ordered_rungs(
         route,
         resolved_wires,
         provider_request,
+        accounting=accounting,
         authorization=authorization,
         continuation=continuation,
     )
-    return route, resolved_wires, public_request, provider_request
+    return route, resolved_wires, public_request, provider_request, placement
 
 
 def route_rejection(
@@ -357,25 +377,28 @@ def _affinity_ordered_rungs(
     resolved_wires: _ResolvedWires,
     provider_request: GatewayRequest,
     *,
+    accounting: NativeAttemptAccounting,
     authorization: AuthorizationSnapshot,
     continuation: ContinuationContext | None,
-) -> tuple[GatewayRoute, _ResolvedWires]:
-    """Dispatch rungs in weighted rendezvous order on affinity pools.
+) -> tuple[GatewayRoute, _ResolvedWires, AffinityPlacement]:
+    """Dispatch rungs in sticky-then-rendezvous order on affinity pools.
 
     Under ``maximize_cache_affinity`` the certified order is replaced by the
     request fingerprint's rendezvous permutation over the surviving rungs, so
     every worker sends one conversation to the same rung and, when that rung
     sheds or dies, to the same deterministic alternate. Weights come from each
     deployment's authored ``GatewayRungDispatchPolicy.affinity_weight``
-    (default 1.0). The cache-marker guarantee composes: a cache-marked request
-    on a route mixing marker-honoring and marker-dropping wires still
-    dispatches the marker-honoring group first, rendezvous-ordered within each
-    group. The other two failover modes are untouched.
+    (default 1.0). A live worker-local sticky binding is honored AHEAD of
+    rendezvous order (its rung holds the conversation's warm cache after a
+    spill), except when its rung is suppressed (throttled or circuit-open)
+    right now, in which case the binding is cleared so stickiness can never
+    pin a conversation to a dead lane. The cache-marker guarantee composes: a
+    cache-marked request on a route mixing marker-honoring and marker-dropping
+    wires still dispatches the marker-honoring group first, ordered within
+    each group. The other two failover modes are untouched.
     """
     if route.snapshot.failover_mode != "maximize_cache_affinity":
-        return route, resolved_wires
-    if len(resolved_wires) < 2:
-        return route, resolved_wires
+        return route, resolved_wires, AffinityPlacement()
     material = affinity_seed_material(
         provider_request,
         continuation_episode_key=None if continuation is None else continuation.episode_key,
@@ -386,6 +409,8 @@ def _affinity_ordered_rungs(
         identity_id=authorization.identity_id,
         material=material,
     )
+    if len(resolved_wires) < 2:
+        return route, resolved_wires, AffinityPlacement(fingerprint=fingerprint)
     weighted_rungs = tuple(
         (
             deployment.deployment_id,
@@ -399,6 +424,13 @@ def _affinity_ordered_rungs(
         for deployment in route.deployments
     )
     order = rendezvous_order(fingerprint, weighted_rungs)
+    order, sticky_index = _sticky_first_order(
+        order,
+        route,
+        fingerprint=fingerprint,
+        accounting=accounting,
+        authorization=authorization,
+    )
     if request_carries_cache_markers(provider_request):
         marker_capable = frozenset(
             index
@@ -410,10 +442,66 @@ def _affinity_ordered_rungs(
                 *(index for index in order if index in marker_capable),
                 *(index for index in order if index not in marker_capable),
             )
+    placement = AffinityPlacement(
+        fingerprint=fingerprint,
+        sticky_preferred=sticky_index is not None and order[0] == sticky_index,
+    )
     return (
         reorder_route_deployments(route, order),
         tuple(resolved_wires[index] for index in order),
+        placement,
     )
+
+
+def _sticky_first_order(
+    order: tuple[int, ...],
+    route: GatewayRoute,
+    *,
+    fingerprint: bytes,
+    accounting: NativeAttemptAccounting,
+    authorization: AuthorizationSnapshot,
+) -> tuple[tuple[int, ...], int | None]:
+    """Move a live sticky binding's rung to the front of the rendezvous order.
+
+    A binding whose rung left the route is ignored (the binding expires on its
+    own); a binding whose rung is suppressed right now is cleared and ignored,
+    so a throttled or dead spill target releases the conversation back to
+    rendezvous placement. A binding already at the rendezvous front changes
+    nothing and is not reported as sticky.
+
+    Args:
+        order: Rendezvous permutation of the route's deployment indexes.
+        route: Frozen route the permutation indexes into.
+        fingerprint: The request's affinity fingerprint.
+        accounting: Shared accounting owning the sticky and health registries.
+        authorization: Frozen authority, for the health key.
+
+    Returns:
+        The (possibly reordered) permutation and the sticky rung's route
+        index when a live binding moved or confirmed the front (``None``
+        when rendezvous order stands on its own).
+    """
+    bound = accounting.sticky.bound_deployment(fingerprint)
+    if bound is None:
+        return order, None
+    sticky_index = next(
+        (
+            index
+            for index, deployment in enumerate(route.deployments)
+            if deployment.deployment_id == bound
+        ),
+        None,
+    )
+    if sticky_index is None:
+        return order, None
+    if accounting.health.suppressed(
+        deployment_health_key(authorization, route.deployments[sticky_index])
+    ):
+        accounting.sticky.clear(fingerprint)
+        return order, None
+    if order[0] == sticky_index:
+        return order, None
+    return (sticky_index, *(index for index in order if index != sticky_index)), sticky_index
 
 
 def _candidate_serves(

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from dataclasses import dataclass
 
 from exp.common.models.catalog import GatewayDeploymentCapabilities
 from exp.runtime.gateway.affinity import (
@@ -28,7 +27,6 @@ from exp.runtime.gateway.contracts import AuthorizationSnapshot, DirectTarget, G
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_execution import (
-    deployment_health_key,
     reorder_route_deployments,
     request_carries_cache_markers,
     select_route_deployments,
@@ -37,6 +35,7 @@ from exp.runtime.gateway.native_responses import ContinuationContext
 from exp.runtime.gateway.prompt_cache_affinity import provider_prompt_cache_key
 from exp.runtime.gateway.prompt_size import require_prompt_fits_context_window
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
+from exp.runtime.gateway.sticky_affinity import AffinityPlacement, sticky_first_order
 from exp.runtime.models.providers import (
     emulated_gateway_capabilities,
     preflight_gateway_request,
@@ -65,22 +64,6 @@ from exp.runtime.openai_protocol.state import ProtocolNamespace, episode_namespa
 _logger = logging.getLogger(__name__)
 
 _ResolvedWires = tuple[tuple[GatewayWireProfile, NativeWireClient], ...]
-
-
-@dataclass(frozen=True)
-class AffinityPlacement:
-    """The affinity facts one admission resolved for dispatch accounting.
-
-    ``fingerprint`` is present only on ``maximize_cache_affinity`` routes (the
-    tenant-isolated conversation identity that keyed placement), so dispatch
-    reservation can read and refresh the worker-local sticky binding and apply
-    the fresh-session spill threshold. ``sticky_preferred`` marks a route
-    whose depth 0 was chosen by a live sticky binding rather than rendezvous
-    order, for the ``affinity_sticky`` disclosure.
-    """
-
-    fingerprint: bytes | None = None
-    sticky_preferred: bool = False
 
 
 def _with_cache_affinity(
@@ -424,11 +407,12 @@ def _affinity_ordered_rungs(
         for deployment in route.deployments
     )
     order = rendezvous_order(fingerprint, weighted_rungs)
-    order, sticky_index = _sticky_first_order(
+    order, sticky_index = sticky_first_order(
         order,
         route,
         fingerprint=fingerprint,
-        accounting=accounting,
+        sticky=accounting.sticky,
+        health=accounting.health,
         authorization=authorization,
     )
     if request_carries_cache_markers(provider_request):
@@ -451,57 +435,6 @@ def _affinity_ordered_rungs(
         tuple(resolved_wires[index] for index in order),
         placement,
     )
-
-
-def _sticky_first_order(
-    order: tuple[int, ...],
-    route: GatewayRoute,
-    *,
-    fingerprint: bytes,
-    accounting: NativeAttemptAccounting,
-    authorization: AuthorizationSnapshot,
-) -> tuple[tuple[int, ...], int | None]:
-    """Move a live sticky binding's rung to the front of the rendezvous order.
-
-    A binding whose rung left the route is ignored (the binding expires on its
-    own); a binding whose rung is suppressed right now is cleared and ignored,
-    so a throttled or dead spill target releases the conversation back to
-    rendezvous placement. A binding already at the rendezvous front changes
-    nothing and is not reported as sticky.
-
-    Args:
-        order: Rendezvous permutation of the route's deployment indexes.
-        route: Frozen route the permutation indexes into.
-        fingerprint: The request's affinity fingerprint.
-        accounting: Shared accounting owning the sticky and health registries.
-        authorization: Frozen authority, for the health key.
-
-    Returns:
-        The (possibly reordered) permutation and the sticky rung's route
-        index when a live binding moved or confirmed the front (``None``
-        when rendezvous order stands on its own).
-    """
-    bound = accounting.sticky.bound_deployment(fingerprint)
-    if bound is None:
-        return order, None
-    sticky_index = next(
-        (
-            index
-            for index, deployment in enumerate(route.deployments)
-            if deployment.deployment_id == bound
-        ),
-        None,
-    )
-    if sticky_index is None:
-        return order, None
-    if accounting.health.suppressed(
-        deployment_health_key(authorization, route.deployments[sticky_index])
-    ):
-        accounting.sticky.clear(fingerprint)
-        return order, None
-    if order[0] == sticky_index:
-        return order, None
-    return (sticky_index, *(index for index in order if index != sticky_index)), sticky_index
 
 
 def _candidate_serves(

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -27,11 +27,14 @@ from exp.runtime.gateway.contracts import (
     DirectTarget,
     ExecutionSnapshot,
     GatewayApiSurface,
+    GatewayFailure,
+    GatewayFailureClass,
     GatewayMessage,
     GatewayNamedToolChoice,
     GatewayRequest,
     GatewayToolDefinition,
 )
+from exp.runtime.gateway.health import DeploymentHealthRegistry
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_admission import (
     _affinity_ordered_rungs,
@@ -42,8 +45,10 @@ from exp.runtime.gateway.native_admission import (
     shape_parallel_tool_calls,
 )
 from exp.runtime.gateway.native_dispatch import NativeWireClient
+from exp.runtime.gateway.native_execution import deployment_health_key
 from exp.runtime.gateway.prompt_size import MAXIMUM_BYTES_PER_TOKEN
 from exp.runtime.gateway.routing import GatewayRoute
+from exp.runtime.gateway.sticky_affinity import StickySpillRegistry
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderCapabilityError, ProviderParameterError
 
@@ -455,7 +460,7 @@ def test_mixed_waterfall_drops_the_tier_to_serve_the_preserving_rung() -> None:
         ),
         (GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test"), client),
     )
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         wires,
         request,
@@ -516,7 +521,7 @@ def test_admission_attaches_a_tenant_namespaced_cache_affinity_key() -> None:
             stream=True,
             include_usage=True,
         )
-        _narrowed, _wires_out, public, provider = admitted_route_requests(
+        _narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
             route,
             wires,
             request,
@@ -606,7 +611,7 @@ def test_disabled_thinking_on_an_adaptive_only_mixed_route_is_dropped_with_discl
             client,
         ),
     )
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         wires,
         request,
@@ -701,7 +706,7 @@ def test_tool_result_image_passes_through_on_a_vision_anthropic_route(stream: bo
     )
     accounting = _AdmissionCoercionCounter()
 
-    _narrowed, _wires_out, public, provider = admitted_route_requests(
+    _narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         wires,
         _tool_screenshot_route_request(stream=stream),
@@ -746,7 +751,7 @@ def test_tool_result_image_degrades_with_disclosure_on_a_non_vision_route(stream
     )
     accounting = _AdmissionCoercionCounter()
 
-    _narrowed, _wires_out, public, provider = admitted_route_requests(
+    _narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         wires,
         _tool_screenshot_route_request(stream=stream),
@@ -800,7 +805,7 @@ def test_a_thinking_config_translates_through_admission_on_an_openai_route() -> 
             client,
         ),
     )
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         wires,
         request,
@@ -917,7 +922,7 @@ def test_tier_priced_host_lane_admits_the_named_tier() -> None:
         messages=(GatewayMessage(role="user", content="go"),),
         service_tier="flex",
     )
-    _narrowed, _wires_out, _public, provider = admitted_route_requests(
+    _narrowed, _wires_out, _public, provider, _placement = admitted_route_requests(
         route,
         wires,
         request,
@@ -1009,7 +1014,7 @@ def test_tier_without_a_card_rejects_while_byok_forwards_any_tier() -> None:
             client,
         ),
     )
-    _n, _w, _p, provider = admitted_route_requests(
+    _n, _w, _p, provider, _placement = admitted_route_requests(
         byok_route,
         byok_wires,
         priority_request,
@@ -1098,7 +1103,7 @@ def test_a_forced_choice_narrows_to_the_rung_that_can_force_tools(
     )
     route = _mixed_route("maximize_availability", deployments, surface)
     accounting = _CoercionCounter()
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         _fable_and_shim_wires(),
         _forced_choice_request(surface, choice),
@@ -1128,7 +1133,7 @@ def test_a_forced_choice_relaxes_to_auto_with_disclosure_when_no_rung_can_force(
     deployments = (_deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),)
     route = _mixed_route("maximize_availability", deployments, surface)
     accounting = _CoercionCounter()
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         _fable_and_shim_wires()[:1],
         _forced_choice_request(surface, choice),
@@ -1171,7 +1176,7 @@ def test_a_strict_schema_the_anthropic_validator_rejects_prefers_a_strict_capabl
     )
     route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.CHAT_COMPLETIONS)
     accounting = _CoercionCounter()
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         _fable_and_shim_wires(),
         _strict_tool_request(_MAX_ITEMS_SCHEMA),
@@ -1191,7 +1196,7 @@ def test_a_strict_schema_no_rung_can_honor_drops_strict_and_keeps_the_schema() -
     deployments = (_deployment("native", provider="anthropic", gateway=_TOOL_CAPABLE),)
     route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.CHAT_COMPLETIONS)
     accounting = _CoercionCounter()
-    narrowed, _wires_out, public, provider = admitted_route_requests(
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         _fable_and_shim_wires()[:1],
         _strict_tool_request(_MAX_ITEMS_SCHEMA),
@@ -1213,7 +1218,7 @@ def test_an_open_strict_schema_is_closed_for_the_anthropic_rung_with_disclosure(
     route = _mixed_route("maximize_availability", deployments, GatewayApiSurface.CHAT_COMPLETIONS)
     accounting = _CoercionCounter()
     open_schema: JsonObject = {"type": "object", "properties": {"city": {"type": "string"}}}
-    _narrowed, _wires_out, public, provider = admitted_route_requests(
+    _narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
         route,
         _fable_and_shim_wires()[:1],
         _strict_tool_request(open_schema),
@@ -1330,6 +1335,20 @@ def _order(route: GatewayRoute) -> tuple[str, ...]:
     return tuple(item.deployment_id for item in route.deployments)
 
 
+class _AffinityAccounting:
+    """Just the sticky and health registries affinity ordering reads."""
+
+    def __init__(self) -> None:
+        """Compose fresh empty registries."""
+        self.sticky = StickySpillRegistry()
+        self.health = DeploymentHealthRegistry()
+
+
+def _affinity_accounting() -> NativeAttemptAccounting:
+    """Build one registry-only accounting fake for affinity ordering."""
+    return cast(NativeAttemptAccounting, _AffinityAccounting())
+
+
 class TestAffinityOrderedRungs:
     """Rendezvous ordering under the affinity flag, and the flag-off gate."""
 
@@ -1337,25 +1356,28 @@ class TestAffinityOrderedRungs:
         """The two shipped modes return the identical route, byte for byte."""
         for mode in ("maximize_availability", "maximize_cache"):
             route, wires = _affinity_fixture(mode)
-            ordered, ordered_wires = _affinity_ordered_rungs(
+            ordered, ordered_wires, placement = _affinity_ordered_rungs(
                 route,
                 wires,
                 _session_request("session-1"),
+                accounting=_affinity_accounting(),
                 authorization=route.snapshot.authorization,
                 continuation=None,
             )
             assert ordered is route
             assert ordered_wires is wires
+            assert placement.fingerprint is None
 
     def test_simulated_workers_order_one_session_identically(self) -> None:
         """Independent computations of one session agree on the full ladder."""
         orders = set()
         for _worker in range(6):
             route, wires = _affinity_fixture()
-            ordered, _wires_out = _affinity_ordered_rungs(
+            ordered, _wires_out, _placement = _affinity_ordered_rungs(
                 route,
                 wires,
                 _session_request("session-42"),
+                accounting=_affinity_accounting(),
                 authorization=route.snapshot.authorization,
                 continuation=None,
             )
@@ -1367,10 +1389,11 @@ class TestAffinityOrderedRungs:
         first_rungs = set()
         for index in range(64):
             route, wires = _affinity_fixture()
-            ordered, _wires_out = _affinity_ordered_rungs(
+            ordered, _wires_out, _placement = _affinity_ordered_rungs(
                 route,
                 wires,
                 _session_request(f"session-{index}"),
+                accounting=_affinity_accounting(),
                 authorization=route.snapshot.authorization,
                 continuation=None,
             )
@@ -1380,10 +1403,11 @@ class TestAffinityOrderedRungs:
     def test_wires_stay_aligned_with_the_reordered_route(self) -> None:
         """Each reordered rung keeps its own resolved wire."""
         route, wires = _affinity_fixture()
-        ordered, ordered_wires = _affinity_ordered_rungs(
+        ordered, ordered_wires, _placement = _affinity_ordered_rungs(
             route,
             wires,
             _session_request("session-7"),
+            accounting=_affinity_accounting(),
             authorization=route.snapshot.authorization,
             continuation=None,
         )
@@ -1396,10 +1420,11 @@ class TestAffinityOrderedRungs:
         from exp.runtime.openai_protocol.state import ProtocolNamespace
 
         route, wires = _affinity_fixture()
-        original, _wires_out = _affinity_ordered_rungs(
+        original, _wires_out, _placement = _affinity_ordered_rungs(
             route,
             wires,
             _session_request("session-original"),
+            accounting=_affinity_accounting(),
             authorization=route.snapshot.authorization,
             continuation=None,
         )
@@ -1414,10 +1439,11 @@ class TestAffinityOrderedRungs:
             messages=(),
         )
         continued_route, continued_wires = _affinity_fixture()
-        continued, _wires_out = _affinity_ordered_rungs(
+        continued, _wires_out, _placement = _affinity_ordered_rungs(
             continued_route,
             continued_wires,
             _session_request("a-fresh-per-turn-id"),
+            accounting=_affinity_accounting(),
             authorization=continued_route.snapshot.authorization,
             continuation=continuation,
         )
@@ -1438,10 +1464,11 @@ class TestAffinityOrderedRungs:
             (GatewayWireProfile(dialect="anthropic_messages", url="https://b.test"), client),
         )
         marked = _marked_request().model_copy(update={"client_request_id": "session-1"})
-        ordered, _wires_out = _affinity_ordered_rungs(
+        ordered, _wires_out, _placement = _affinity_ordered_rungs(
             route,
             wires,
             marked,
+            accounting=_affinity_accounting(),
             authorization=route.snapshot.authorization,
             continuation=None,
         )
@@ -1453,12 +1480,81 @@ class TestAffinityOrderedRungs:
             _mixed_route("maximize_cache_affinity", deployments, GatewayApiSurface.MESSAGES),
             wires,
         )
-        plain_ordered, _wires_out = _affinity_ordered_rungs(
+        plain_ordered, _wires_out, _placement = _affinity_ordered_rungs(
             plain_route,
             plain_wires,
             _session_request("session-1"),
+            accounting=_affinity_accounting(),
             authorization=plain_route.snapshot.authorization,
             continuation=None,
         )
         plain_native_order = tuple(name for name in _order(plain_ordered) if name != "dep-shim")
         assert _order(ordered)[:2] == plain_native_order
+
+    def test_sticky_binding_is_honored_bypassed_and_expired(self) -> None:
+        """A live binding leads the order; a suppressed or expired one does not.
+
+        The binding is honored ahead of rendezvous, cleared (and rendezvous
+        restored) when its rung is throttled, and ignored once its authored
+        lifetime passes, so stickiness can never pin a conversation to a lane
+        that cannot serve it or outlive the provider cache it protects.
+        """
+        route, wires = _affinity_fixture()
+        accounting = _affinity_accounting()
+        request = _session_request("session-sticky")
+        rendezvous, _wires_out, rendezvous_placement = _affinity_ordered_rungs(
+            route,
+            wires,
+            request,
+            accounting=accounting,
+            authorization=route.snapshot.authorization,
+            continuation=None,
+        )
+        assert rendezvous_placement.fingerprint is not None
+        assert rendezvous_placement.sticky_preferred is False
+        # Bind the conversation to a rung rendezvous did NOT rank first (the
+        # spill target a congested preferred rung shed it onto).
+        spill_target = _order(rendezvous)[1]
+        accounting.sticky.bind(rendezvous_placement.fingerprint, spill_target, ttl_seconds=600.0)
+        sticky, _wires_out, sticky_placement = _affinity_ordered_rungs(
+            route,
+            wires,
+            request,
+            accounting=accounting,
+            authorization=route.snapshot.authorization,
+            continuation=None,
+        )
+        assert _order(sticky)[0] == spill_target
+        assert sticky_placement.sticky_preferred is True
+        assert _order(sticky)[1:] == tuple(
+            name for name in _order(rendezvous) if name != spill_target
+        )
+        # The bound rung throttles: the binding is bypassed AND cleared, so
+        # rendezvous order stands again even after the throttle lifts.
+        bound_deployment = next(
+            item for item in route.deployments if item.deployment_id == spill_target
+        )
+        accounting.health.failed(
+            deployment_health_key(route.snapshot.authorization, bound_deployment),
+            GatewayFailure(
+                failure_class=GatewayFailureClass.THROTTLED,
+                safe_message="provider throttled the request",
+            ),
+        )
+        bypassed, _wires_out, bypassed_placement = _affinity_ordered_rungs(
+            route,
+            wires,
+            request,
+            accounting=accounting,
+            authorization=route.snapshot.authorization,
+            continuation=None,
+        )
+        assert _order(bypassed) == _order(rendezvous)
+        assert bypassed_placement.sticky_preferred is False
+        assert accounting.sticky.bound_deployment(rendezvous_placement.fingerprint) is None
+        # An expired binding is ignored without needing a suppression event.
+        clock = [0.0]
+        expiring = StickySpillRegistry(clock=lambda: clock[0])
+        expiring.bind(b"fingerprint", "dep-house", ttl_seconds=600.0)
+        clock[0] = 601.0
+        assert expiring.bound_deployment(b"fingerprint") is None

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -46,7 +46,6 @@ from exp.runtime.gateway.guardrails.native import enforce_native_input, enforce_
 from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
-    gateway_updating_failure,
     record_dead_admission_rungs,
 )
 from exp.runtime.gateway.native_accounting import (
@@ -110,6 +109,7 @@ from exp.runtime.gateway.native_responses import (
 )
 from exp.runtime.gateway.native_rungs import build_rung_dispatch
 from exp.runtime.gateway.native_settlement import (
+    gateway_updating_failure,
     optional_text,
 )
 from exp.runtime.gateway.reasoning_carrier import (
@@ -513,13 +513,15 @@ class NativeControlPlane(
         try:
             if probe_failure is not None or route is None or resolved_wires is None:
                 raise probe_failure or GatewayRoutingError("authorized route did not resolve")
-            route, resolved_wires, public_request, provider_request = admitted_route_requests(
-                route,
-                resolved_wires,
-                request,
-                accounting=self._accounting,
-                authorization=authorization,
-                continuation=continuation_context,
+            route, resolved_wires, public_request, provider_request, placement = (
+                admitted_route_requests(
+                    route,
+                    resolved_wires,
+                    request,
+                    accounting=self._accounting,
+                    authorization=authorization,
+                    continuation=continuation_context,
+                )
             )
             wire_route: list[JsonObject] = []
             parallel_disclosures: set[str] = set()
@@ -640,6 +642,8 @@ class NativeControlPlane(
                     profile.forwards_tier(provider_request.service_tier)
                     for profile, _client in resolved_wires
                 ),
+                affinity_fingerprint=placement.fingerprint,
+                sticky_preferred=placement.sticky_preferred,
             )
         )
         response: JsonObject = {

--- a/exp/runtime/gateway/native_components.py
+++ b/exp/runtime/gateway/native_components.py
@@ -60,8 +60,19 @@ class SyncWriteLedger(Protocol):
         failure: GatewayFailure | None,
         finalize_request: bool = True,
         first_token_at: datetime | None = None,
+        retry_after_seconds: int | None = None,
+        ratelimit_limit_requests: int | None = None,
+        ratelimit_remaining_requests: int | None = None,
+        ratelimit_limit_tokens: int | None = None,
+        ratelimit_remaining_tokens: int | None = None,
     ) -> None:
-        """Durably settle one attempt exactly once."""
+        """Durably settle one attempt exactly once.
+
+        The ``retry_after_seconds`` and ``ratelimit_*`` values are the
+        provider's own rate-limit response headers, normalized, present on
+        successes and failures alike when the data plane harvested any; a
+        hosted ledger persists them per attempt for calibration analytics.
+        """
         ...
 
     def finish_request(

--- a/exp/runtime/gateway/native_embeddings.py
+++ b/exp/runtime/gateway/native_embeddings.py
@@ -34,7 +34,6 @@ from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
     authority_error,
-    gateway_updating_failure,
     record_dead_admission_rungs,
 )
 from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
@@ -48,6 +47,7 @@ from exp.runtime.gateway.native_execution import (
     dispatchable_route_profiles,
     select_route_deployments,
 )
+from exp.runtime.gateway.native_settlement import gateway_updating_failure
 from exp.runtime.gateway.routing import GatewayRoutingError
 from exp.runtime.models.providers import require_gateway_provider
 from exp.runtime.models.providers.openai_compatible import openai_embedding_request

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -40,6 +40,7 @@ from exp.runtime.gateway.native_responses import ContinuationContext
 from exp.runtime.gateway.native_settlement import deployment_operation_key
 from exp.runtime.gateway.reasoning_carrier import ReasoningCarrierAuthority
 from exp.runtime.gateway.routing import GatewayRoute, GatewayRoutingError
+from exp.runtime.gateway.rung_admission import RungLoadKey
 from exp.runtime.models import ModelConnectionError, RuntimeModelCatalog
 from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.providers.base import GatewayWireProfile
@@ -126,6 +127,14 @@ class InflightRequest:
     # forward and bill stay consistent even if a card sits on a lane that would
     # strip it. Empty on surfaces without a service tier (images, embeddings).
     tier_forwarded_by_depth: tuple[bool, ...] = ()
+    # The request's tenant-isolated affinity fingerprint on a
+    # ``maximize_cache_affinity`` pool (None elsewhere), captured at admission
+    # so dispatch reservation can read and refresh the worker-local sticky
+    # binding and apply the fresh-session spill threshold.
+    affinity_fingerprint: bytes | None = None
+    # Whether the route's depth 0 was chosen by a live sticky binding rather
+    # than rendezvous order, for the ``affinity_sticky`` disclosure.
+    sticky_preferred: bool = False
 
     def __post_init__(self) -> None:
         """Size the per-deployment attempt counters to the frozen route."""
@@ -143,6 +152,96 @@ def deployment_health_key(
         deployment.deployment_id,
         deployment.connection_sha256,
     )
+
+
+def rung_load_key(deployment: ExactModelDeployment) -> RungLoadKey:
+    """Return one deployment's physical-lane load key (never revision-scoped)."""
+    return (deployment.deployment_id, deployment.connection_sha256)
+
+
+def deployment_priced_for_service_tier(
+    deployment: ExactModelDeployment,
+    service_tier: str | None,
+    *,
+    forwards_tier: bool,
+) -> ExactModelDeployment:
+    """Reprice one deployment for a requested flex/priority processing tier.
+
+    v1 bills the REQUESTED tier: when the SELECTED candidate actually FORWARDS
+    the tier to its provider and carries a pass-through card for it, the card's
+    rates replace the base schedule on a copy used only for THIS reservation, so
+    the ceiling, the stored per-token rates, and settlement all bill the tier
+    transparently. ``forwards_tier`` is the admission-time forwarding decision
+    for this exact depth (``GatewayWireProfile.forwards_tier``); gating on it
+    keeps FORWARD and BILL consistent even if a card ever sits on a lane whose
+    wire would strip the tier (non-tier dialect, tier disabled): such a depth
+    runs the provider's base schedule, so it must bill the base schedule too. No
+    tier, no forwarding, or no card returns the deployment unchanged. The copy
+    stays Python-side and never crosses the native boundary.
+    """
+    if not forwards_tier:
+        return deployment
+    effective = deployment.gateway.prices.for_service_tier(service_tier)
+    if effective is deployment.gateway.prices:
+        return deployment
+    return deployment.model_copy(
+        update={"gateway": deployment.gateway.model_copy(update={"prices": effective})}
+    )
+
+
+def dispatch_disclosure(
+    route: GatewayRoute,
+    candidate: int,
+    *,
+    policy_sheds: list[tuple[int, str]],
+    forced_overflow: bool,
+    sticky_preferred: bool = False,
+) -> tuple[str | None, ExactModelDeployment | None]:
+    """Name why the chosen rung serves and the bypassed preferred rung, if any.
+
+    Emission is gated so an alias the platform never opted in keeps byte-null
+    disclosure columns. On a ``maximize_cache_affinity`` pool every attempt
+    discloses against the preferred depth-0 rung: ``affinity`` on the happy
+    path (``affinity_sticky`` when a live sticky binding, not rendezvous,
+    chose depth 0), the shed reason when depth 0 was policy-shed in this
+    reservation, ``rung_dead`` when it was bypassed by health or an earlier
+    failure, ``saturated_overflow`` when the ladder force-admitted past a
+    bound. On any other pool a disclosure appears only when a dispatch policy
+    actually shed a rung in this reservation, and the preferred rung is the
+    shed rung itself (the counterfactual the shed is measured against).
+
+    Args:
+        route: Frozen ordered route for this request.
+        candidate: The route depth about to dispatch.
+        policy_sheds: ``(depth, reason)`` for every policy shed this
+            reservation, in ladder order.
+        forced_overflow: Whether this dispatch was forced past a bound.
+        sticky_preferred: Whether the route's depth 0 was chosen by a sticky
+            spill binding rather than rendezvous order.
+
+    Returns:
+        ``(dispatch_reason, preferred_deployment)``; the deployment is
+        ``None`` whenever the chosen rung IS the disclosure's preferred rung.
+    """
+    if route.snapshot.failover_mode == "maximize_cache_affinity":
+        target_depth = 0
+        if forced_overflow:
+            reason = "saturated_overflow"
+        elif candidate == 0:
+            reason = "affinity_sticky" if sticky_preferred else "affinity"
+        else:
+            lead_shed = next((shed for depth, shed in policy_sheds if depth == 0), None)
+            reason = lead_shed or "rung_dead"
+    elif forced_overflow:
+        target_depth = policy_sheds[0][0]
+        reason = "saturated_overflow"
+    elif policy_sheds:
+        target_depth, reason = policy_sheds[0]
+    else:
+        return None, None
+    if target_depth == candidate:
+        return reason, None
+    return reason, route.deployments[target_depth]
 
 
 def claim_route_from(

--- a/exp/runtime/gateway/native_execution.py
+++ b/exp/runtime/gateway/native_execution.py
@@ -132,6 +132,11 @@ class InflightRequest:
     # so dispatch reservation can read and refresh the worker-local sticky
     # binding and apply the fresh-session spill threshold.
     affinity_fingerprint: bytes | None = None
+    # Attempts whose settled usage already fed the cache-priority EWMA: a
+    # settlement can land through the direct path AND the retained-settlement
+    # sweep (both idempotent at the ledger), so the fold is guarded to exactly
+    # once per attempt.
+    cache_recorded_attempts: set[str] = field(default_factory=set)
     # Whether the route's depth 0 was chosen by a live sticky binding rather
     # than rendezvous order, for the ``affinity_sticky`` disclosure.
     sticky_preferred: bool = False

--- a/exp/runtime/gateway/native_images.py
+++ b/exp/runtime/gateway/native_images.py
@@ -33,7 +33,6 @@ from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
     authority_error,
-    gateway_updating_failure,
     record_dead_admission_rungs,
 )
 from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
@@ -47,6 +46,7 @@ from exp.runtime.gateway.native_execution import (
     dispatchable_route_profiles,
     select_route_deployments,
 )
+from exp.runtime.gateway.native_settlement import gateway_updating_failure
 from exp.runtime.gateway.routing import GatewayRoutingError
 from exp.runtime.models.providers import require_gateway_provider
 from exp.runtime.models.providers.openai_compatible import openai_images_request

--- a/exp/runtime/gateway/native_metrics_text.py
+++ b/exp/runtime/gateway/native_metrics_text.py
@@ -68,6 +68,14 @@ _CONTROL_PLANE_COUNTERS: tuple[tuple[str, str], ...] = (
         "Dispatches forced past a saturated rung bound.",
     ),
     (
+        "rung_rate_limit_sheds",
+        "Dispatches shed by a rung's rate window.",
+    ),
+    (
+        "rung_fresh_session_spills",
+        "Fresh-session dispatches shed early to spill.",
+    ),
+    (
         "reconciled_expired_requests",
         "Crashed requests reconciled at startup.",
     ),
@@ -219,6 +227,12 @@ def render_metrics_text(snapshot: JsonObject) -> str:
         "gauge",
         "In-flight attempt reservations on the control plane.",
         [f"{_PREFIX}inflight_attempts {_value(control_plane['inflight_attempts'])}"],
+    )
+    lines += _family(
+        f"{_PREFIX}sticky_spill_bindings",
+        "gauge",
+        "Worker-local sticky conversation-to-rung bindings retained.",
+        [f"{_PREFIX}sticky_spill_bindings {_value(control_plane['sticky_spill_bindings'])}"],
     )
     lines += _family(
         f"{_PREFIX}accounting_healthy",

--- a/exp/runtime/gateway/native_metrics_text_test.py
+++ b/exp/runtime/gateway/native_metrics_text_test.py
@@ -43,6 +43,12 @@ def _control_plane() -> JsonObject:
         "admission_parameter_coercions": 0,
         "rung_admission_sheds": 0,
         "rung_saturated_overflows": 0,
+        "rung_rate_limit_sheds": 3,
+        "rung_fresh_session_spills": 1,
+        "sticky_spill_bindings": 4,
+        # JSON-snapshot-only: per-rung learned ceilings never render as text,
+        # so the exposition carries no per-rung label cardinality.
+        "rung_learned_ceilings": {"dep-house:abcd1234": 96},
         "inflight_attempts": 2,
         "reconciled_expired_requests": 0,
         "reconciled_unknown_attempts": 0,
@@ -115,6 +121,12 @@ exp_gateway_rung_admission_sheds_total 0
 # HELP exp_gateway_rung_saturated_overflows_total Dispatches forced past a saturated rung bound.
 # TYPE exp_gateway_rung_saturated_overflows_total counter
 exp_gateway_rung_saturated_overflows_total 0
+# HELP exp_gateway_rung_rate_limit_sheds_total Dispatches shed by a rung's rate window.
+# TYPE exp_gateway_rung_rate_limit_sheds_total counter
+exp_gateway_rung_rate_limit_sheds_total 3
+# HELP exp_gateway_rung_fresh_session_spills_total Fresh-session dispatches shed early to spill.
+# TYPE exp_gateway_rung_fresh_session_spills_total counter
+exp_gateway_rung_fresh_session_spills_total 1
 # HELP exp_gateway_reconciled_expired_requests_total Crashed requests reconciled at startup.
 # TYPE exp_gateway_reconciled_expired_requests_total counter
 exp_gateway_reconciled_expired_requests_total 0
@@ -124,6 +136,9 @@ exp_gateway_reconciled_unknown_attempts_total 0
 # HELP exp_gateway_inflight_attempts In-flight attempt reservations on the control plane.
 # TYPE exp_gateway_inflight_attempts gauge
 exp_gateway_inflight_attempts 2
+# HELP exp_gateway_sticky_spill_bindings Worker-local sticky conversation-to-rung bindings retained.
+# TYPE exp_gateway_sticky_spill_bindings gauge
+exp_gateway_sticky_spill_bindings 4
 # HELP exp_gateway_accounting_healthy Control-plane accounting health (1 healthy, 0 failed).
 # TYPE exp_gateway_accounting_healthy gauge
 exp_gateway_accounting_healthy 1

--- a/exp/runtime/gateway/native_observability.py
+++ b/exp/runtime/gateway/native_observability.py
@@ -142,6 +142,7 @@ class NativeObservabilityMixin:
         retained_replayed, abandoned_cancelled, inflight = self._accounting.counters()
         lead_rungs_skipped, dead_rungs_skipped = self._accounting.admission_rung_skips()
         rung_sheds, rung_overflows = self._accounting.rung_admission_counters()
+        rate_limit_sheds, fresh_session_spills = self._accounting.rung_rate_counters()
         control_plane: JsonObject = {
             "sweep_retained_settlements_replayed": retained_replayed,
             "sweep_abandoned_attempts_cancelled": abandoned_cancelled,
@@ -150,6 +151,13 @@ class NativeObservabilityMixin:
             "admission_parameter_coercions": self._accounting.admission_parameter_coercions(),
             "rung_admission_sheds": rung_sheds,
             "rung_saturated_overflows": rung_overflows,
+            "rung_rate_limit_sheds": rate_limit_sheds,
+            "rung_fresh_session_spills": fresh_session_spills,
+            "sticky_spill_bindings": self._accounting.sticky.size(),
+            # Live learned request ceilings keyed by rung (JSON snapshot only;
+            # the Prometheus rendering stays worker-global counters so no
+            # per-rung label cardinality is exported).
+            "rung_learned_ceilings": self._accounting.loads.learned_ceilings(),
             "inflight_attempts": inflight,
             "reconciled_expired_requests": self._components.reconciled_expired_requests,
             "reconciled_unknown_attempts": self._components.reconciled_unknown_attempts,

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -1,8 +1,16 @@
-"""Normalize native data-plane settlement payloads for durable accounting."""
+"""Normalize native data-plane settlement payloads for durable accounting.
+
+Also home to the sanitized failure vocabulary the accounting boundary answers
+with (quota exhaustion, exhausted or throttled pools, transient roll
+conditions) and the parser that turns one boundary failure payload into a
+typed :class:`GatewayFailure`.
+"""
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
+from typing import cast
 
 from exp.common.core.artifacts import JsonObject, stable_id
 from exp.common.models.gateway_catalog import ExactModelDeployment
@@ -14,14 +22,115 @@ from exp.runtime.gateway.contracts import (
     GatewayRefusalReason,
     GatewayUsage,
 )
+from exp.runtime.gateway.rate_limit_headers import (
+    RateLimitObservation,
+    rate_limit_observation_from_payload,
+)
 from exp.runtime.gateway.routing import GatewayRoute
-from exp.runtime.openai_protocol.errors import OpenAIProtocolError, public_failure_error
+from exp.runtime.openai_protocol.errors import (
+    THROTTLED_RETRY_AFTER_SECONDS,
+    OpenAIProtocolError,
+    public_failure_error,
+)
 
 _TERMINAL_KINDS = {
     "completed": GatewayEventKind.COMPLETED,
     "incomplete": GatewayEventKind.INCOMPLETE,
     "failed": GatewayEventKind.FAILED,
 }
+
+
+def budget_quota_failure() -> GatewayFailure:
+    """Return the sanitized quota failure after no route can reserve its cost."""
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.QUOTA_EXCEEDED,
+        safe_message="monthly gateway allocation is exhausted",
+    )
+
+
+def all_routes_unavailable_failure() -> GatewayFailure:
+    """Return the sanitized terminal failure for an exhausted certified pool."""
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.PROVIDER_INTERNAL,
+        safe_message="all exact-model deployments are unavailable",
+    )
+
+
+def all_routes_throttled_failure(remaining_seconds: float) -> GatewayFailure:
+    """Return the throttle-window failure for a route the provider backed off.
+
+    Every deployment sitting inside a provider throttle window is caller-facing
+    rate limiting (the provider answered 429 and asked for backoff), not
+    platform deadness: classing it provider_internal misfiled 429 storms as
+    outages and paged operators for caller-driven load (2026-09-04 ledger,
+    deepseek-v4-flash-vision-exp). One computed wait (the remaining window,
+    floored at the default throttle backoff) rides both the message and
+    ``retry_after_seconds`` so the Retry-After header a client honors never
+    disagrees with the sentence it reads.
+
+    Args:
+        remaining_seconds: Longest remaining throttle window across the route.
+
+    Returns:
+        Sanitized throttled failure naming the retry window.
+    """
+    seconds = max(THROTTLED_RETRY_AFTER_SECONDS, math.ceil(remaining_seconds))
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.THROTTLED,
+        safe_message=(
+            "all exact-model deployments are inside a provider throttle window; "
+            f"retry in {seconds}s"
+        ),
+        retry_after_seconds=seconds,
+    )
+
+
+def gateway_updating_failure() -> GatewayFailure:
+    """Return the sanitized retryable failure for a transient roll condition.
+
+    A pod that cannot build the authorized catalog revision during a rolling
+    deploy (a snapshot authored by another engine version it cannot reconcile)
+    surfaces this instead of a closed INTERNAL: the condition clears on its own
+    once the roll settles, so the honest answer is a retryable 503, never a bug
+    signal that pages or opens a deployment circuit.
+    """
+    return GatewayFailure(
+        failure_class=GatewayFailureClass.UNAVAILABLE,
+        safe_message="the gateway is updating; retry the request",
+    )
+
+
+def failure_from_boundary_payload(payload: object) -> GatewayFailure | None:
+    """Parse one optional classified failure from a boundary payload."""
+    if not isinstance(payload, dict):
+        return None
+    data = cast("JsonObject", payload)
+    rejected_parameter = data.get("rejected_parameter")
+    provider_detail = data.get("provider_detail")
+    retry_after = data.get("retry_after_seconds")
+    return GatewayFailure(
+        failure_class=GatewayFailureClass(str(data["failure_class"])),
+        safe_message=str(data["safe_message"]),
+        retryable_same_deployment=bool(data.get("retryable_same_deployment", False)),
+        failover_eligible=bool(data.get("failover_eligible", False)),
+        rejected_parameter=(
+            rejected_parameter
+            if isinstance(rejected_parameter, str) and rejected_parameter
+            else None
+        ),
+        provider_detail=(
+            provider_detail if isinstance(provider_detail, str) and provider_detail else None
+        ),
+        customer_owned=data.get("customer_owned") is True,
+        retry_after_seconds=(
+            retry_after
+            if isinstance(retry_after, int)
+            and not isinstance(retry_after, bool)
+            and retry_after >= 1
+            else None
+        ),
+        refusal_reason=refusal_reason_from_payload(data.get("refusal_reason")),
+    )
 
 
 def refusal_reason_from_payload(value: object) -> GatewayRefusalReason | None:
@@ -82,10 +191,22 @@ def terminal_from_settlement(
                 provider_detail if isinstance(provider_detail, str) and provider_detail else None
             ),
             customer_owned=failure_payload.get("customer_owned") is True,
+            retry_after_seconds=_optional_wait(failure_payload.get("retry_after_seconds")),
             # The bounded refusal category rides the settlement argument so the
             # control plane counts refusals by reason without parsing detail.
             refusal_reason=refusal_reason_from_payload(failure_payload.get("refusal_reason")),
         )
+        if (
+            failure.failure_class == GatewayFailureClass.THROTTLED
+            and failure.retry_after_seconds is None
+        ):
+            # A throttled settlement whose failure names no wait still carries
+            # the provider's own Retry-After when the data plane harvested the
+            # rate-limit headers; sizing the throttle window from it is what
+            # lets a daily-quota reset actually suppress the rung for hours.
+            observed = settlement_rate_limit(data).retry_after_seconds
+            if observed is not None:
+                failure = failure.model_copy(update={"retry_after_seconds": observed})
         # A rejected credential or exhausted account on the customer's own
         # BYOK rung kept its ladder class in the data plane (so another
         # customer-managed rung could still serve), but the ledger files it
@@ -146,6 +267,30 @@ def _optional_count(value: object) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value
+
+
+def _optional_wait(value: object) -> int | None:
+    """Return one positive integer wait in seconds or ``None``."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return None
+    return value
+
+
+def settlement_rate_limit(data: JsonObject) -> RateLimitObservation:
+    """Parse the settlement's optional harvested rate-limit headers.
+
+    The data plane forwards the allowlisted provider rate-limit response
+    headers (successes and failures alike) as ``rate_limit_headers``; an
+    engine that predates the field, or a response carrying none, yields the
+    empty observation.
+
+    Args:
+        data: Parsed native settlement payload.
+
+    Returns:
+        The typed observation for the ledger and throttle calibration.
+    """
+    return rate_limit_observation_from_payload(data.get("rate_limit_headers"))
 
 
 def deployment_operation_key(route: GatewayRoute, deployment: ExactModelDeployment) -> str:

--- a/exp/runtime/gateway/native_settlement_test.py
+++ b/exp/runtime/gateway/native_settlement_test.py
@@ -12,6 +12,7 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.gateway.native_settlement import (
     _usage_from_payload,  # noqa: PLC2701 - direct unit coverage for normalization.
     first_token_at_from_settlement,
+    settlement_rate_limit,
     terminal_from_settlement,
 )
 
@@ -188,3 +189,83 @@ def test_customer_owned_failures_settle_as_the_callers_invalid_request() -> None
     )
     assert house is not None
     assert house.failure_class == GatewayFailureClass.PROVIDER_AUTHENTICATION
+
+
+def test_throttled_settlement_takes_retry_after_from_harvested_headers() -> None:
+    """A throttled failure without its own wait borrows the header's wait."""
+    _terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "failure": {
+                "failure_class": "throttled",
+                "safe_message": "provider throttled the request",
+            },
+            "rate_limit_headers": {"retry-after": "3600"},
+        }
+    )
+    assert failure is not None
+    assert failure.retry_after_seconds == 3_600
+
+
+def test_failure_payloads_own_retry_after_wins_over_the_headers() -> None:
+    """A wait the failure payload names is kept verbatim."""
+    _terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "failure": {
+                "failure_class": "throttled",
+                "safe_message": "provider throttled the request",
+                "retry_after_seconds": 42,
+            },
+            "rate_limit_headers": {"retry-after": "3600"},
+        }
+    )
+    assert failure is not None
+    assert failure.retry_after_seconds == 42
+
+
+def test_non_throttled_failures_never_borrow_a_retry_after() -> None:
+    """Only the throttled class reads the harvested wait; garbage stays None."""
+    _terminal, failure = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "failure": {
+                "failure_class": "provider_internal",
+                "safe_message": "provider service failed",
+            },
+            "rate_limit_headers": {"retry-after": "3600"},
+        }
+    )
+    assert failure is not None
+    assert failure.retry_after_seconds is None
+    _terminal, garbled = terminal_from_settlement(
+        {
+            "outcome": "failed",
+            "failure": {
+                "failure_class": "throttled",
+                "safe_message": "provider throttled the request",
+                "retry_after_seconds": "soon",
+            },
+            "rate_limit_headers": {"retry-after": "eventually"},
+        }
+    )
+    assert garbled is not None
+    assert garbled.retry_after_seconds is None
+
+
+def test_settlement_rate_limit_reads_the_optional_header_map() -> None:
+    """The typed observation parses when present and stays empty when absent."""
+    observation = settlement_rate_limit(
+        {
+            "outcome": "completed",
+            "rate_limit_headers": {
+                "anthropic-ratelimit-requests-limit": "10000",
+                "anthropic-ratelimit-requests-remaining": "9500",
+                "retry-after": "7",
+            },
+        }
+    )
+    assert observation.limit_requests == 10_000
+    assert observation.remaining_requests == 9_500
+    assert observation.retry_after_seconds == 7
+    assert settlement_rate_limit({"outcome": "completed"}).is_empty

--- a/exp/runtime/gateway/rate_limit_headers.py
+++ b/exp/runtime/gateway/rate_limit_headers.py
@@ -50,6 +50,16 @@ class RateLimitObservation(ContractModel):
 
 _EMPTY_OBSERVATION = RateLimitObservation()
 
+# Bounds on what a provider header may claim. The raw strings cross the
+# boundary unbounded (Python integers are arbitrary precision), and a value
+# past SQLite's signed 64-bit column would fail every settlement write for the
+# attempt — a wedge one hostile BYOK server header must never be able to
+# cause. A wait is clamped to a week (a longer ask is still "come back much
+# later" for the ledger; the health window clamps far tighter anyway); a
+# limit/remaining count past the sanity ceiling is garbage and reads as absent.
+MAXIMUM_RETRY_AFTER_SECONDS = 7 * 24 * 3_600
+_MAXIMUM_OBSERVED_COUNT = 10**15
+
 # The small provider header map: one canonical field per provider spelling.
 # OpenAI-compatible wires send x-ratelimit-*; Anthropic sends
 # anthropic-ratelimit-*. Nothing else is special-cased per provider.
@@ -71,7 +81,9 @@ def parse_retry_after_seconds(value: str, *, now: datetime | None = None) -> int
     Both RFC 9110 forms are accepted: a nonnegative integer second count and
     an HTTP-date, whose wait is measured from ``now``. A parseable wait is
     floored at one second so a zero or already-passed date still expresses
-    "back off briefly" rather than vanishing; anything unparseable yields
+    "back off briefly" rather than vanishing, and capped at
+    ``MAXIMUM_RETRY_AFTER_SECONDS`` so one absurd header can neither distort
+    the ledger nor overflow an integer column; anything unparseable yields
     ``None`` so garbage degrades to the caller's default window.
 
     Args:
@@ -90,7 +102,9 @@ def parse_retry_after_seconds(value: str, *, now: datetime | None = None) -> int
     except ValueError:
         pass
     else:
-        return max(1, seconds) if seconds >= 0 else None
+        if seconds < 0:
+            return None
+        return min(max(1, seconds), MAXIMUM_RETRY_AFTER_SECONDS)
     try:
         when = parsedate_to_datetime(text)
     except (TypeError, ValueError):
@@ -98,7 +112,7 @@ def parse_retry_after_seconds(value: str, *, now: datetime | None = None) -> int
     if when.tzinfo is None:
         when = when.replace(tzinfo=UTC)
     reference = now if now is not None else datetime.now(UTC)
-    return max(1, math.ceil((when - reference).total_seconds()))
+    return min(max(1, math.ceil((when - reference).total_seconds())), MAXIMUM_RETRY_AFTER_SECONDS)
 
 
 def rate_limit_observation(headers: Mapping[str, str]) -> RateLimitObservation:
@@ -152,9 +166,14 @@ def rate_limit_observation_from_payload(payload: object) -> RateLimitObservation
 
 
 def _parse_count(value: str) -> int | None:
-    """Parse one nonnegative integer header value, tolerating garbage."""
+    """Parse one nonnegative integer header value, tolerating garbage.
+
+    A count past the sanity ceiling is treated as garbage rather than clamped:
+    no provider states a real quota there, and an unbounded integer would
+    overflow the ledger's 64-bit columns and fail the settlement write.
+    """
     try:
         count = int(value.strip())
     except ValueError:
         return None
-    return count if count >= 0 else None
+    return count if 0 <= count <= _MAXIMUM_OBSERVED_COUNT else None

--- a/exp/runtime/gateway/rate_limit_headers.py
+++ b/exp/runtime/gateway/rate_limit_headers.py
@@ -1,0 +1,160 @@
+"""Normalize provider rate-limit response headers into one typed observation.
+
+The native data plane forwards the small allowlisted subset of provider
+response headers that describe rate limiting (``retry-after`` plus the OpenAI
+``x-ratelimit-*`` and Anthropic ``anthropic-ratelimit-*`` families) on the
+settlement payload, for successes and failures alike. This module owns the
+one place those raw header strings become typed integers: the observation
+rides the attempt ledger for calibration analytics, and a throttled
+settlement's ``retry-after`` sizes the deployment's throttle window instead
+of the fixed default. Parsing is deliberately tolerant: a missing, garbled,
+or unknown header yields ``None`` for its field, never an error, because a
+provider's header hygiene must not be able to fail a settlement.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+from exp.common.core.artifacts import ContractModel
+
+
+class RateLimitObservation(ContractModel):
+    """Typed rate-limit facts harvested from one provider response's headers."""
+
+    retry_after_seconds: int | None = None
+    """Provider-requested wait before the next attempt, floored at one second."""
+    limit_requests: int | None = None
+    """The account's request-rate ceiling as the provider states it."""
+    remaining_requests: int | None = None
+    """Requests left in the provider's current window."""
+    limit_tokens: int | None = None
+    """The account's token-rate ceiling as the provider states it."""
+    remaining_tokens: int | None = None
+    """Tokens left in the provider's current window."""
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether no header produced a value."""
+        return (
+            self.retry_after_seconds is None
+            and self.limit_requests is None
+            and self.remaining_requests is None
+            and self.limit_tokens is None
+            and self.remaining_tokens is None
+        )
+
+
+_EMPTY_OBSERVATION = RateLimitObservation()
+
+# The small provider header map: one canonical field per provider spelling.
+# OpenAI-compatible wires send x-ratelimit-*; Anthropic sends
+# anthropic-ratelimit-*. Nothing else is special-cased per provider.
+_HEADER_FIELDS: tuple[tuple[str, str], ...] = (
+    ("x-ratelimit-limit-requests", "limit_requests"),
+    ("x-ratelimit-remaining-requests", "remaining_requests"),
+    ("x-ratelimit-limit-tokens", "limit_tokens"),
+    ("x-ratelimit-remaining-tokens", "remaining_tokens"),
+    ("anthropic-ratelimit-requests-limit", "limit_requests"),
+    ("anthropic-ratelimit-requests-remaining", "remaining_requests"),
+    ("anthropic-ratelimit-tokens-limit", "limit_tokens"),
+    ("anthropic-ratelimit-tokens-remaining", "remaining_tokens"),
+)
+
+
+def parse_retry_after_seconds(value: str, *, now: datetime | None = None) -> int | None:
+    """Parse one raw ``Retry-After`` header value into whole seconds.
+
+    Both RFC 9110 forms are accepted: a nonnegative integer second count and
+    an HTTP-date, whose wait is measured from ``now``. A parseable wait is
+    floored at one second so a zero or already-passed date still expresses
+    "back off briefly" rather than vanishing; anything unparseable yields
+    ``None`` so garbage degrades to the caller's default window.
+
+    Args:
+        value: Raw header value.
+        now: Reference wall-clock time for the HTTP-date form; defaults to
+            the current UTC time.
+
+    Returns:
+        Whole seconds to wait, or ``None`` when the value is unparseable.
+    """
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        seconds = int(text)
+    except ValueError:
+        pass
+    else:
+        return max(1, seconds) if seconds >= 0 else None
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    reference = now if now is not None else datetime.now(UTC)
+    return max(1, math.ceil((when - reference).total_seconds()))
+
+
+def rate_limit_observation(headers: Mapping[str, str]) -> RateLimitObservation:
+    """Build one typed observation from raw provider response headers.
+
+    Args:
+        headers: Header names (any case) mapped to raw string values; only
+            the allowlisted rate-limit subset is read.
+
+    Returns:
+        The parsed observation; fields whose headers are absent or garbled
+        stay ``None``.
+    """
+    lowered = {str(name).lower(): str(value) for name, value in headers.items()}
+    values: dict[str, int | None] = {}
+    for header, field_name in _HEADER_FIELDS:
+        if values.get(field_name) is not None:
+            continue
+        raw = lowered.get(header)
+        if raw is not None:
+            values[field_name] = _parse_count(raw)
+    retry_after = lowered.get("retry-after")
+    return RateLimitObservation(
+        retry_after_seconds=(
+            None if retry_after is None else parse_retry_after_seconds(retry_after)
+        ),
+        limit_requests=values.get("limit_requests"),
+        remaining_requests=values.get("remaining_requests"),
+        limit_tokens=values.get("limit_tokens"),
+        remaining_tokens=values.get("remaining_tokens"),
+    )
+
+
+def rate_limit_observation_from_payload(payload: object) -> RateLimitObservation:
+    """Read the optional raw-header map off one boundary settlement payload.
+
+    Args:
+        payload: The settlement's ``rate_limit_headers`` value: a mapping of
+            raw header names to string values when the data plane harvested
+            any, else anything (absent, null, wrong shape).
+
+    Returns:
+        The parsed observation; a missing or malformed payload yields the
+        empty observation rather than an error.
+    """
+    if not isinstance(payload, Mapping):
+        return _EMPTY_OBSERVATION
+    return rate_limit_observation(
+        {str(name): str(value) for name, value in payload.items() if isinstance(value, str)}
+    )
+
+
+def _parse_count(value: str) -> int | None:
+    """Parse one nonnegative integer header value, tolerating garbage."""
+    try:
+        count = int(value.strip())
+    except ValueError:
+        return None
+    return count if count >= 0 else None

--- a/exp/runtime/gateway/rate_limit_headers_test.py
+++ b/exp/runtime/gateway/rate_limit_headers_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from exp.runtime.gateway.rate_limit_headers import (
+    MAXIMUM_RETRY_AFTER_SECONDS,
     RateLimitObservation,
     parse_retry_after_seconds,
     rate_limit_observation,
@@ -33,6 +34,22 @@ class TestParseRetryAfter:
         """Unparseable values never raise and never invent a wait."""
         for value in ("", "soon", "-5", "Mon, 99 Foo 2026", "12.5"):
             assert parse_retry_after_seconds(value, now=_NOW) is None
+
+    def test_absurd_waits_clamp_to_the_ceiling(self) -> None:
+        """A wait past the week ceiling clamps for both RFC forms.
+
+        Python parses arbitrary-precision integers, and an unbounded value
+        would overflow the ledger's signed 64-bit column and wedge the
+        settlement in a retry loop, so one hostile BYOK server header must
+        never cross the boundary unbounded.
+        """
+        assert parse_retry_after_seconds("9" * 40, now=_NOW) == MAXIMUM_RETRY_AFTER_SECONDS
+        assert (
+            parse_retry_after_seconds("Fri, 01 Jan 2100 00:00:00 GMT", now=_NOW)
+            == MAXIMUM_RETRY_AFTER_SECONDS
+        )
+        # A day-scale quota reset stays exact: the ceiling only cuts absurdity.
+        assert parse_retry_after_seconds("86400", now=_NOW) == 86_400
 
 
 class TestHeaderMap:
@@ -85,6 +102,18 @@ class TestHeaderMap:
         assert observation.limit_requests is None
         assert observation.remaining_requests is None
         assert observation.is_empty
+
+    def test_counts_past_the_sanity_ceiling_read_as_absent(self) -> None:
+        """An arbitrary-precision count never reaches the 64-bit ledger columns."""
+        observation = rate_limit_observation(
+            {
+                "x-ratelimit-limit-tokens": "9" * 40,
+                "x-ratelimit-remaining-tokens": "15000000000",
+            }
+        )
+        assert observation.limit_tokens is None
+        # A large-but-real published quota (OpenAI scale-tier TPM) stays exact.
+        assert observation.remaining_tokens == 15_000_000_000
 
 
 class TestPayloadTolerance:

--- a/exp/runtime/gateway/rate_limit_headers_test.py
+++ b/exp/runtime/gateway/rate_limit_headers_test.py
@@ -1,0 +1,103 @@
+"""Retry-After parsing and provider header-map normalization tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from exp.runtime.gateway.rate_limit_headers import (
+    RateLimitObservation,
+    parse_retry_after_seconds,
+    rate_limit_observation,
+    rate_limit_observation_from_payload,
+)
+
+_NOW = datetime(2026, 9, 7, 12, 0, 0, tzinfo=UTC)
+
+
+class TestParseRetryAfter:
+    """Both RFC 9110 forms parse; garbage degrades to None."""
+
+    def test_integer_seconds_floor_at_one(self) -> None:
+        """Plain seconds parse; zero still expresses a minimal backoff."""
+        assert parse_retry_after_seconds("30") == 30
+        assert parse_retry_after_seconds(" 7 ") == 7
+        assert parse_retry_after_seconds("0") == 1
+
+    def test_http_date_measures_from_now(self) -> None:
+        """An HTTP-date wait is the ceiling of the remaining seconds."""
+        assert parse_retry_after_seconds("Mon, 07 Sep 2026 12:02:00 GMT", now=_NOW) == 120
+        # An already-passed date still floors at one second of backoff.
+        assert parse_retry_after_seconds("Mon, 07 Sep 2026 11:00:00 GMT", now=_NOW) == 1
+
+    def test_garbage_and_negatives_yield_none(self) -> None:
+        """Unparseable values never raise and never invent a wait."""
+        for value in ("", "soon", "-5", "Mon, 99 Foo 2026", "12.5"):
+            assert parse_retry_after_seconds(value, now=_NOW) is None
+
+
+class TestHeaderMap:
+    """The small OpenAI and Anthropic header families normalize identically."""
+
+    def test_openai_family(self) -> None:
+        """x-ratelimit-* headers map onto the four count fields."""
+        observation = rate_limit_observation(
+            {
+                "X-RateLimit-Limit-Requests": "10000",
+                "x-ratelimit-remaining-requests": "9998",
+                "x-ratelimit-limit-tokens": "180000000",
+                "x-ratelimit-remaining-tokens": "179000000",
+                "retry-after": "12",
+            }
+        )
+        assert observation == RateLimitObservation(
+            retry_after_seconds=12,
+            limit_requests=10_000,
+            remaining_requests=9_998,
+            limit_tokens=180_000_000,
+            remaining_tokens=179_000_000,
+        )
+
+    def test_anthropic_family(self) -> None:
+        """anthropic-ratelimit-* headers map onto the same fields."""
+        observation = rate_limit_observation(
+            {
+                "anthropic-ratelimit-requests-limit": "10000",
+                "anthropic-ratelimit-requests-remaining": "9500",
+                "anthropic-ratelimit-tokens-limit": "12000000",
+                "anthropic-ratelimit-tokens-remaining": "11000000",
+            }
+        )
+        assert observation.limit_requests == 10_000
+        assert observation.remaining_requests == 9_500
+        assert observation.limit_tokens == 12_000_000
+        assert observation.remaining_tokens == 11_000_000
+        assert observation.retry_after_seconds is None
+
+    def test_garbled_counts_stay_none_and_unknown_headers_are_ignored(self) -> None:
+        """A garbled or negative count yields None; unrelated headers do nothing."""
+        observation = rate_limit_observation(
+            {
+                "x-ratelimit-limit-requests": "many",
+                "x-ratelimit-remaining-requests": "-2",
+                "content-type": "application/json",
+            }
+        )
+        assert observation.limit_requests is None
+        assert observation.remaining_requests is None
+        assert observation.is_empty
+
+
+class TestPayloadTolerance:
+    """The boundary reader degrades to the empty observation, never an error."""
+
+    def test_absent_or_malformed_payload_is_empty(self) -> None:
+        """None, wrong shapes, and non-string values all degrade quietly."""
+        assert rate_limit_observation_from_payload(None).is_empty
+        assert rate_limit_observation_from_payload("headers").is_empty
+        assert rate_limit_observation_from_payload(["retry-after"]).is_empty
+        assert rate_limit_observation_from_payload({"retry-after": 30}).is_empty
+
+    def test_mapping_payload_parses(self) -> None:
+        """A well-shaped payload map parses exactly like raw headers."""
+        observation = rate_limit_observation_from_payload({"retry-after": "45"})
+        assert observation.retry_after_seconds == 45

--- a/exp/runtime/gateway/rung_admission.py
+++ b/exp/runtime/gateway/rung_admission.py
@@ -62,11 +62,16 @@ RATE_WINDOW_SECONDS = 60.0
 # Passive-adaptive calibration constants. A throttle clamps the learned
 # request ceiling to the observed rate times the clamp factor; every recovery
 # interval without a throttle creeps it up by the creep fraction (at least one
-# request); a ceiling unthrottled for the expiry horizon is forgotten.
+# request); a ceiling unthrottled for the expiry horizon is forgotten. The
+# ceiling stays a FLOAT and may sit below one request per minute: per-worker
+# enforcement multiplies across the fleet, so a provider whose account ceiling
+# is below one request per worker per minute (zai's ~6/min against 8 workers)
+# is only expressible sub-1; the floor exists to keep the value positive.
 LEARNED_CLAMP_FACTOR = 0.9
 LEARNED_CREEP_FRACTION = 0.05
 LEARNED_RECOVERY_INTERVAL_SECONDS = 60.0
 LEARNED_EXPIRY_SECONDS = 6.0 * 3_600.0
+LEARNED_MINIMUM_RPM = 0.1
 
 # Cached-fraction EWMA: half-life of roughly ten minutes of activity, with the
 # per-sample decay floored at one second of elapsed time so a burst of settles
@@ -110,11 +115,12 @@ class RungShed:
     """One refused reservation and the disclosure reason for the bypass."""
 
     reason: RungShedReason
-    learned_requests_per_minute: int | None = None
+    learned_requests_per_minute: float | None = None
     """The learned working request ceiling behind a ``rate_limit`` shed.
 
     Carried so the shed can be logged and counted with the ceiling that caused
-    it; the durable disclosure column stays the bare reason code.
+    it; the durable disclosure column stays the bare reason code. A float
+    because the ceiling can sit below one request per minute per worker.
     """
 
 
@@ -311,13 +317,19 @@ class RungLoadRegistry:
                 return RungShed("fresh_session_spill")
         working_rpm = self._working_rpm(rung, requests_per_minute, now)
         if working_rpm is not None and rung.window_requests + 1 > working_rpm:
-            learned = None if rung.learned_rpm is None else int(rung.learned_rpm)
-            return RungShed("rate_limit", learned_requests_per_minute=learned)
-        if tokens_per_minute is not None and rung.window_tokens + reserved_tokens > (
-            tokens_per_minute
+            return RungShed("rate_limit", learned_requests_per_minute=rung.learned_rpm)
+        # Burst allowance: a single request whose worst-case reservation alone
+        # exceeds the token cap must still be admissible into an EMPTY window
+        # (deepseek p99 input is 230k tokens against 125k/worker pilot caps),
+        # or the cap becomes a permanent shed loop for big prompts rather than
+        # rate limiting. It then occupies the window and blocks further
+        # dispatches until it slides out.
+        if (
+            tokens_per_minute is not None
+            and rung.window_tokens > 0
+            and rung.window_tokens + reserved_tokens > tokens_per_minute
         ):
-            learned = None if rung.learned_rpm is None else int(rung.learned_rpm)
-            return RungShed("rate_limit", learned_requests_per_minute=learned)
+            return RungShed("rate_limit", learned_requests_per_minute=rung.learned_rpm)
         if not fair_share or bound is None:
             return None
         congestion = rung.total / bound
@@ -396,10 +408,13 @@ class RungLoadRegistry:
         """Clamp one rung's learned request ceiling after a provider throttle.
 
         The ceiling becomes the dispatch rate actually observed in the sliding
-        window at this moment times the clamp factor (floored at one request
-        per minute): the provider just proved the observed rate is too high,
-        so the worker assumes it throttles there again and lets recovery creep
-        re-discover the real headroom.
+        window at this moment times the clamp factor: the provider just proved
+        the observed rate is too high, so the worker assumes it throttles
+        there again and lets recovery creep re-discover the real headroom. The
+        value is a float and may sit below one request per minute (floored
+        only at a small positive minimum), because per-worker ceilings
+        multiply across the fleet and some provider accounts allow less than
+        one request per worker per minute.
 
         Args:
             key: Physical rung identity.
@@ -408,8 +423,7 @@ class RungLoadRegistry:
         with self._lock:
             rung = self._rungs.setdefault(key, _RungLoad())
             self._prune_window(rung, now)
-            observed = max(1, rung.window_requests)
-            rung.learned_rpm = max(1.0, observed * LEARNED_CLAMP_FACTOR)
+            rung.learned_rpm = max(LEARNED_MINIMUM_RPM, rung.window_requests * LEARNED_CLAMP_FACTOR)
             rung.learned_throttled_at = now
             rung.learned_crept_at = now
 
@@ -452,16 +466,17 @@ class RungLoadRegistry:
                 )
             organization.cached_sampled_at = now
 
-    def learned_ceilings(self) -> dict[str, int]:
+    def learned_ceilings(self) -> dict[str, float]:
         """Return live learned request ceilings keyed by rung, for metrics.
 
         Keys are ``deployment_id:connection-prefix`` (catalog identifiers,
         content-free); only rungs currently holding a learned ceiling appear,
         so the map stays as small as the set of recently throttled rungs.
+        Values are floats because a ceiling can sit below one per minute.
         """
         with self._lock:
             return {
-                f"{deployment_id}:{connection[:8]}": int(rung.learned_rpm)
+                f"{deployment_id}:{connection[:8]}": rung.learned_rpm
                 for (deployment_id, connection), rung in self._rungs.items()
                 if rung.learned_rpm is not None
             }

--- a/exp/runtime/gateway/rung_admission.py
+++ b/exp/runtime/gateway/rung_admission.py
@@ -427,12 +427,14 @@ class RungLoadRegistry:
             key: Physical rung identity.
             organization_id: The settling organization.
             cached_tokens: Provider-reported cached input tokens.
-            input_tokens: Provider-reported (uncached) input tokens.
+            input_tokens: Provider-reported TOTAL input tokens, which already
+                include the cached ones (the same semantics settlement billing
+                subtracts against), so the fraction is cached over total,
+                clamped in case a provider ever reports cached past total.
         """
-        denominator = cached_tokens + input_tokens
-        if denominator <= 0:
+        if input_tokens <= 0:
             return
-        sample = cached_tokens / denominator
+        sample = min(cached_tokens, input_tokens) / input_tokens
         now = self._clock()
         with self._lock:
             # A long stream can settle after its organization's request-recency

--- a/exp/runtime/gateway/rung_admission.py
+++ b/exp/runtime/gateway/rung_admission.py
@@ -77,14 +77,23 @@ LEARNED_MINIMUM_RPM = 0.1
 # per-sample decay floored at one second of elapsed time so a burst of settles
 # still moves the estimate. An organization's estimate is retained for the
 # retention horizon after its last sample so a conversational cadence (minutes
-# between turns) keeps its cache standing.
+# between turns) keeps its cache standing. Estimates live in their own
+# per-rung map, NOT on the fairness recency entries: retention is 360x the
+# activity window, and folding them into ``organizations`` would grow the
+# per-reservation prune and active-share scans from "orgs seen in the last
+# ten seconds" to "orgs settled in the last hour" under the registry lock.
 EWMA_HALF_LIFE_SECONDS = 600.0
 EWMA_MINIMUM_STEP_SECONDS = 1.0
 EWMA_RETENTION_SECONDS = 3_600.0
+# Stale cache estimates are swept at most this often (amortized off both the
+# reserve and settle paths), keeping each sweep O(retained estimates) once a
+# minute per rung instead of per decision.
+EWMA_PRUNE_INTERVAL_SECONDS = 60.0
 
 
 def _effective_weight(
     load: _OrganizationLoad,
+    cached_fraction: float,
     *,
     alpha: float | None,
     congestion: float,
@@ -99,6 +108,7 @@ def _effective_weight(
 
     Args:
         load: The organization's per-rung state, under the registry lock.
+        cached_fraction: The organization's live cache estimate (0 when none).
         alpha: The rung's authored ``cache_priority_alpha``, if any.
         congestion: The rung's in-flight total over its bound.
 
@@ -107,7 +117,13 @@ def _effective_weight(
     """
     if alpha is None or alpha <= 0.0:
         return float(load.weight)
-    return load.weight * (1.0 + alpha * congestion * load.cached_fraction)
+    return load.weight * (1.0 + alpha * congestion * cached_fraction)
+
+
+def _cached_fraction(rung: _RungLoad, organization_id: str) -> float:
+    """Return one organization's live cache estimate on this rung, else zero."""
+    signal = rung.cache_fractions.get(organization_id)
+    return 0.0 if signal is None else signal.fraction
 
 
 @dataclass(frozen=True)
@@ -126,16 +142,19 @@ class RungShed:
 
 @dataclass
 class _OrganizationLoad:
-    """Per-organization in-flight count, recency, and cache EWMA on one rung."""
+    """Per-organization in-flight count and recency on one rung."""
 
     inflight: int = 0
     last_seen: float = 0.0
     weight: int = 1
-    # Time-decayed EWMA of the organization's settled cached-token fraction on
-    # this rung, and the monotonic time of its last sample (None = no signal;
-    # new organizations weigh at their base weight).
-    cached_fraction: float = 0.0
-    cached_sampled_at: float | None = None
+
+
+@dataclass
+class _CacheSignal:
+    """One organization's cache EWMA on one rung and its last sample time."""
+
+    fraction: float
+    sampled_at: float
 
 
 @dataclass
@@ -144,6 +163,12 @@ class _RungLoad:
 
     total: int = 0
     organizations: dict[str, _OrganizationLoad] = field(default_factory=dict)
+    # Time-decayed EWMA of each organization's settled cached-token fraction
+    # on this rung (absent = no signal; such organizations weigh at their base
+    # weight). Kept apart from ``organizations`` so its hour-scale retention
+    # never lengthens the per-reservation prune and share scans.
+    cache_fractions: dict[str, _CacheSignal] = field(default_factory=dict)
+    cache_pruned_at: float = 0.0
     # Sliding 60s dispatch window: (reserved_at, reserved_tokens) per admitted
     # reservation, with running totals so every decision is O(1) amortized.
     window: deque[tuple[float, int]] = field(default_factory=deque)
@@ -334,31 +359,30 @@ class RungLoadRegistry:
             return None
         congestion = rung.total / bound
         recency_floor = organization.last_seen - self._window
-        active = [
-            candidate
-            for candidate in rung.organizations.values()
+        # Each ACTIVE organization's effective weight is resolved once; the
+        # requesting organization is always active (its last_seen was just
+        # stamped), so the ``next`` below cannot exhaust.
+        weighted = [
+            (
+                candidate,
+                _effective_weight(
+                    candidate,
+                    _cached_fraction(rung, candidate_id),
+                    alpha=cache_priority_alpha,
+                    congestion=congestion,
+                ),
+            )
+            for candidate_id, candidate in rung.organizations.items()
             if candidate.inflight > 0 or candidate.last_seen >= recency_floor
         ]
-        total_weight = sum(
-            _effective_weight(candidate, alpha=cache_priority_alpha, congestion=congestion)
-            for candidate in active
-        )
-        share = (
-            bound
-            * _effective_weight(organization, alpha=cache_priority_alpha, congestion=congestion)
-            / total_weight
-        )
+        total_weight = sum(weight for _candidate, weight in weighted)
+        own_weight = next(weight for candidate, weight in weighted if candidate is organization)
+        share = bound * own_weight / total_weight
         if organization.inflight + 1 <= share:
             return None
         reserved_deficit = sum(
-            max(
-                0.0,
-                bound
-                * _effective_weight(candidate, alpha=cache_priority_alpha, congestion=congestion)
-                / total_weight
-                - candidate.inflight,
-            )
-            for candidate in active
+            max(0.0, bound * weight / total_weight - candidate.inflight)
+            for candidate, weight in weighted
             if candidate is not organization
         )
         if rung.total + 1 + int(reserved_deficit) > bound:
@@ -444,27 +468,28 @@ class RungLoadRegistry:
             input_tokens: Provider-reported TOTAL input tokens, which already
                 include the cached ones (the same semantics settlement billing
                 subtracts against), so the fraction is cached over total,
-                clamped in case a provider ever reports cached past total.
+                clamped in case a provider ever reports cached outside
+                [0, total].
         """
         if input_tokens <= 0:
             return
-        sample = min(cached_tokens, input_tokens) / input_tokens
+        sample = min(max(cached_tokens, 0), input_tokens) / input_tokens
         now = self._clock()
         with self._lock:
             # A long stream can settle after its organization's request-recency
-            # entry was pruned; the sample still counts, so the entry is
-            # recreated (inactive for fairness until its next reservation).
+            # entry was pruned; the estimate lives apart from that entry, so
+            # the sample still counts without re-marking the organization
+            # active for fairness.
             rung = self._rungs.setdefault(key, _RungLoad())
-            organization = rung.organizations.setdefault(organization_id, _OrganizationLoad())
-            if organization.cached_sampled_at is None:
-                organization.cached_fraction = sample
-            else:
-                elapsed = max(EWMA_MINIMUM_STEP_SECONDS, now - organization.cached_sampled_at)
-                retained = 0.5 ** (elapsed / EWMA_HALF_LIFE_SECONDS)
-                organization.cached_fraction = organization.cached_fraction * retained + sample * (
-                    1.0 - retained
-                )
-            organization.cached_sampled_at = now
+            self._prune_cache_fractions(rung, now)
+            signal = rung.cache_fractions.get(organization_id)
+            if signal is None:
+                rung.cache_fractions[organization_id] = _CacheSignal(sample, now)
+                return
+            elapsed = max(EWMA_MINIMUM_STEP_SECONDS, now - signal.sampled_at)
+            retained = 0.5 ** (elapsed / EWMA_HALF_LIFE_SECONDS)
+            signal.fraction = signal.fraction * retained + sample * (1.0 - retained)
+            signal.sampled_at = now
 
     def learned_ceilings(self) -> dict[str, float]:
         """Return live learned request ceilings keyed by rung, for metrics.
@@ -546,32 +571,50 @@ class RungLoadRegistry:
     def _prune(self, key: RungLoadKey, rung: _RungLoad, now: float) -> None:
         """Drop idle organizations past the activity window, bounding memory.
 
-        An organization holding a live cached-fraction estimate is retained
-        past the activity window (its cache standing outlives one request's
-        recency), until the EWMA retention horizon passes with no new sample.
-        A rung entry itself survives while it holds any organization, window
-        entry, or learned ceiling, because the learned ceiling must outlive
-        the traffic that taught it.
+        Cache estimates are pruned on their own (longer) horizon and their own
+        amortized cadence, so this per-reservation scan stays bounded by the
+        organizations active within the ten-second window. A rung entry itself
+        survives while it holds any organization, cache estimate, window
+        entry, or learned ceiling, because the learned ceiling and estimates
+        must outlive the traffic that taught them.
         """
         stale = [
             organization_id
             for organization_id, load in rung.organizations.items()
-            if load.inflight == 0
-            and load.last_seen < now - self._window
-            and (
-                load.cached_sampled_at is None
-                or load.cached_sampled_at < now - EWMA_RETENTION_SECONDS
-            )
+            if load.inflight == 0 and load.last_seen < now - self._window
         ]
         for organization_id in stale:
             del rung.organizations[organization_id]
+        self._prune_cache_fractions(rung, now)
         if (
             rung.total == 0
             and not rung.organizations
+            and not rung.cache_fractions
             and not rung.window
             and rung.learned_rpm is None
         ):
             self._rungs.pop(key, None)
+
+    @staticmethod
+    def _prune_cache_fractions(rung: _RungLoad, now: float) -> None:
+        """Sweep expired cache estimates at most once per prune interval.
+
+        Retention is hour-scale while reservations are per-request, so the
+        sweep is amortized: between intervals the map is only read (O(1) per
+        lookup), keeping the hot path independent of how many organizations
+        settled on the rung in the last hour.
+        """
+        if now - rung.cache_pruned_at < EWMA_PRUNE_INTERVAL_SECONDS:
+            return
+        rung.cache_pruned_at = now
+        horizon = now - EWMA_RETENTION_SECONDS
+        stale = [
+            organization_id
+            for organization_id, signal in rung.cache_fractions.items()
+            if signal.sampled_at < horizon
+        ]
+        for organization_id in stale:
+            del rung.cache_fractions[organization_id]
 
     def _prune_window(self, rung: _RungLoad, now: float) -> None:
         """Slide one rung's dispatch window forward, keeping totals exact."""

--- a/exp/runtime/gateway/rung_admission.py
+++ b/exp/runtime/gateway/rung_admission.py
@@ -1,12 +1,22 @@
-"""In-process bounded and weighted fair-share admission per certified rung.
+"""In-process bounded, rate-limited, weighted fair-share admission per rung.
 
 One registry per worker tracks in-flight dispatches on rungs that author a
 ``GatewayRungDispatchPolicy``: a rung at its per-worker ``concurrency_bound``
 sheds new dispatches down the waterfall (spill in seconds, never a queue that
-dies at the request deadline), and a ``fair_share`` rung additionally bounds
-each organization's admissions by its weighted max-min share while the rung is
-contended. Every decision is lock-guarded in-memory arithmetic over counters
-this registry already holds: no database read, no shared state, no waiting.
+dies at the request deadline), a rung past its sliding-window request or
+token rate sheds the same way BEFORE the provider answers 429, and a
+``fair_share`` rung additionally bounds each organization's admissions by its
+weighted max-min share while the rung is contended. Every decision is
+lock-guarded in-memory arithmetic over counters this registry already holds:
+no database read, no shared state, no waiting.
+
+Rate calibration is passive-adaptive: a provider throttle clamps the rung's
+working request rate to ninety percent of the rate actually observed at that
+moment, and the working ceiling then creeps back up by five percent every
+recovery interval without a throttle (each creep step IS the probe: a few
+more requests go through to see whether they make it further this time). A
+learned ceiling that sees no throttle for the expiry horizon is forgotten.
+There are never synthetic probe requests, only real traffic let through.
 
 Fairness is deliberately conservative because there is no queue and no
 preemption. Capacity below the bound is always borrowable (work-conserving: a
@@ -14,14 +24,20 @@ lone organization uses the whole rung), and an organization above its weighted
 share is shed only when admitting it would eat capacity currently reserved for
 another RECENTLY ACTIVE under-share organization. A shed marks its organization
 active, so a flooded-out organization accrues a reservation and converges to
-its share as slots free, without ever pausing a running request.
+its share as slots free, without ever pausing a running request. When a rung
+authors ``cache_priority_alpha``, each organization's effective weight scales
+with the rung's congestion and the worker's EWMA of that organization's
+settled cached-token fraction, so at the contended margin cache-heavy traffic
+is admitted ahead of cold traffic.
 """
 
 from __future__ import annotations
 
+import math
 import threading
 import time
 import uuid
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Literal
@@ -31,7 +47,7 @@ from typing import Literal
 # not change the box's capacity, so counters must survive alias revisions.
 RungLoadKey = tuple[str, str]
 
-RungShedReason = Literal["fair_share_shed", "queue_bound"]
+RungShedReason = Literal["fair_share_shed", "queue_bound", "rate_limit", "fresh_session_spill"]
 
 # How long a request (admitted or shed) keeps its organization "active" for
 # share accounting. Long enough that a flooded-out caller's retry cadence keeps
@@ -39,29 +55,98 @@ RungShedReason = Literal["fair_share_shed", "queue_bound"]
 # borrowable again almost immediately.
 ACTIVITY_WINDOW_SECONDS = 10.0
 
+# The sliding rate window. Both authored rates are per minute, so the window
+# is fixed rather than configurable.
+RATE_WINDOW_SECONDS = 60.0
+
+# Passive-adaptive calibration constants. A throttle clamps the learned
+# request ceiling to the observed rate times the clamp factor; every recovery
+# interval without a throttle creeps it up by the creep fraction (at least one
+# request); a ceiling unthrottled for the expiry horizon is forgotten.
+LEARNED_CLAMP_FACTOR = 0.9
+LEARNED_CREEP_FRACTION = 0.05
+LEARNED_RECOVERY_INTERVAL_SECONDS = 60.0
+LEARNED_EXPIRY_SECONDS = 6.0 * 3_600.0
+
+# Cached-fraction EWMA: half-life of roughly ten minutes of activity, with the
+# per-sample decay floored at one second of elapsed time so a burst of settles
+# still moves the estimate. An organization's estimate is retained for the
+# retention horizon after its last sample so a conversational cadence (minutes
+# between turns) keeps its cache standing.
+EWMA_HALF_LIFE_SECONDS = 600.0
+EWMA_MINIMUM_STEP_SECONDS = 1.0
+EWMA_RETENTION_SECONDS = 3_600.0
+
+
+def _effective_weight(
+    load: _OrganizationLoad,
+    *,
+    alpha: float | None,
+    congestion: float,
+) -> float:
+    """Return one organization's admission weight with the cache-priority term.
+
+    ``weight * (1 + alpha * congestion * cached_fraction)``: the boost is zero
+    for an organization with no cache signal, zero on an idle rung, and grows
+    with both the rung's congestion and how much of the organization's settled
+    input the provider served from cache. ``alpha`` off returns the base weight
+    so authored fairness without the term is byte-identical to before.
+
+    Args:
+        load: The organization's per-rung state, under the registry lock.
+        alpha: The rung's authored ``cache_priority_alpha``, if any.
+        congestion: The rung's in-flight total over its bound.
+
+    Returns:
+        The effective (float) weight used by share arithmetic.
+    """
+    if alpha is None or alpha <= 0.0:
+        return float(load.weight)
+    return load.weight * (1.0 + alpha * congestion * load.cached_fraction)
+
 
 @dataclass(frozen=True)
 class RungShed:
     """One refused reservation and the disclosure reason for the bypass."""
 
     reason: RungShedReason
+    learned_requests_per_minute: int | None = None
+    """The learned working request ceiling behind a ``rate_limit`` shed.
+
+    Carried so the shed can be logged and counted with the ceiling that caused
+    it; the durable disclosure column stays the bare reason code.
+    """
 
 
 @dataclass
 class _OrganizationLoad:
-    """Per-organization in-flight count and recency on one rung."""
+    """Per-organization in-flight count, recency, and cache EWMA on one rung."""
 
     inflight: int = 0
     last_seen: float = 0.0
     weight: int = 1
+    # Time-decayed EWMA of the organization's settled cached-token fraction on
+    # this rung, and the monotonic time of its last sample (None = no signal;
+    # new organizations weigh at their base weight).
+    cached_fraction: float = 0.0
+    cached_sampled_at: float | None = None
 
 
 @dataclass
 class _RungLoad:
-    """Aggregate and per-organization in-flight state for one rung."""
+    """Aggregate, per-organization, and rate-window state for one rung."""
 
     total: int = 0
     organizations: dict[str, _OrganizationLoad] = field(default_factory=dict)
+    # Sliding 60s dispatch window: (reserved_at, reserved_tokens) per admitted
+    # reservation, with running totals so every decision is O(1) amortized.
+    window: deque[tuple[float, int]] = field(default_factory=deque)
+    window_requests: int = 0
+    window_tokens: int = 0
+    # Passive-adaptive learned request ceiling (None = nothing learned).
+    learned_rpm: float | None = None
+    learned_throttled_at: float = 0.0
+    learned_crept_at: float = 0.0
 
 
 class RungLoadRegistry:
@@ -103,20 +188,38 @@ class RungLoadRegistry:
         *,
         organization_id: str,
         weight: int,
-        bound: int,
+        bound: int | None,
         fair_share: bool,
+        requests_per_minute: int | None = None,
+        tokens_per_minute: int | None = None,
+        cache_priority_alpha: float | None = None,
+        reserved_tokens: int = 0,
+        warm_session: bool = True,
+        fresh_spill_fraction: float | None = None,
         force: bool = False,
     ) -> str | RungShed:
-        """Reserve one in-flight slot on a bounded rung, or shed with a reason.
+        """Reserve one slot on a policy-bounded rung, or shed with a reason.
 
         Args:
             key: Physical rung identity.
             organization_id: Authorized organization for share accounting.
             weight: The organization's fair-share weight (>= 1).
-            bound: The rung's authored per-worker in-flight cap.
+            bound: The rung's authored per-worker in-flight cap, or ``None``
+                when only rate windows are authored.
             fair_share: Whether contended admission is weighted max-min fair.
-            force: Admit past the bound (the caller proved no other rung can
-                serve; the bound must never manufacture a failure).
+            requests_per_minute: Authored per-worker dispatch rate cap.
+            tokens_per_minute: Authored per-worker token rate cap.
+            cache_priority_alpha: Congestion multiplier for the cache-priority
+                fairness term; ``None`` leaves base weights.
+            reserved_tokens: Worst-case tokens this dispatch reserves, counted
+                against the token window.
+            warm_session: Whether the request's affinity fingerprint holds a
+                live sticky binding on THIS rung (its provider cache is warm
+                here); fresh sessions shed at the early threshold.
+            fresh_spill_fraction: Fraction of the bound where fresh sessions
+                shed early; ``None`` disables the early threshold.
+            force: Admit past every policy limit (the caller proved no other
+                rung can serve; policy must never manufacture a failure).
 
         Returns:
             An opaque ticket on admission, else the shed disclosure.
@@ -130,12 +233,32 @@ class RungLoadRegistry:
             organization.last_seen = now
             organization.weight = weight
             self._prune(key, rung, now)
+            self._prune_window(rung, now)
             if not force:
-                shed = self._shed_reason(rung, organization, bound=bound, fair_share=fair_share)
+                shed = self._shed_reason(
+                    rung,
+                    organization,
+                    now=now,
+                    bound=bound,
+                    fair_share=fair_share,
+                    requests_per_minute=requests_per_minute,
+                    tokens_per_minute=tokens_per_minute,
+                    cache_priority_alpha=cache_priority_alpha,
+                    reserved_tokens=reserved_tokens,
+                    warm_session=warm_session,
+                    fresh_spill_fraction=fresh_spill_fraction,
+                )
                 if shed is not None:
                     return shed
             organization.inflight += 1
             rung.total += 1
+            # Every policy reservation feeds the dispatch window, not only
+            # rate-authored ones: a bound-only rung that later throttles must
+            # clamp its learned ceiling to a REAL observed rate, never to an
+            # empty window's floor of one.
+            rung.window.append((now, reserved_tokens))
+            rung.window_requests += 1
+            rung.window_tokens += reserved_tokens
             ticket = f"rung-{uuid.uuid4().hex}"
             self._tickets[ticket] = (key, organization_id)
             return ticket
@@ -145,45 +268,201 @@ class RungLoadRegistry:
         rung: _RungLoad,
         organization: _OrganizationLoad,
         *,
-        bound: int,
+        now: float,
+        bound: int | None,
         fair_share: bool,
+        requests_per_minute: int | None,
+        tokens_per_minute: int | None,
+        cache_priority_alpha: float | None,
+        reserved_tokens: int,
+        warm_session: bool,
+        fresh_spill_fraction: float | None,
     ) -> RungShed | None:
         """Decide one reservation under the registry lock; ``None`` admits.
 
         The bound is hard: at or beyond it every arrival spills, which is the
-        queue-death fix. Below it, fairness sheds an over-share organization
-        only when the remaining slots are reserved for other recently active
-        under-share organizations; otherwise unused capacity is borrowable.
-        Shares stay EXACT (a 3:1:1 weighting of a bound of 8 guarantees
-        4.8:1.6:1.6, never a per-share rounding), and only the AGGREGATE
-        reservation is floored to whole slots: slots are indivisible, so the
-        sub-slot remainder of the summed deficits is capacity no organization
-        could occupy right now, and reserving it would strand the bound's last
-        slots against sustained demand (three equal organizations on a bound
-        of 8 would otherwise freeze at 6).
+        queue-death fix. Fresh sessions (no warm sticky standing on this rung)
+        spill earlier, at ``bound * fresh_spill_fraction``, reserving the top
+        slice of the bound for sessions whose provider cache lives here. The
+        rate check sheds a dispatch the sliding window cannot absorb under the
+        working ceiling (the authored rate clamped by the learned one) BEFORE
+        the provider answers 429. Below all of those, fairness sheds an
+        over-share organization only when the remaining slots are reserved for
+        other recently active under-share organizations; otherwise unused
+        capacity is borrowable. Shares stay EXACT (a 3:1:1 weighting of a
+        bound of 8 guarantees 4.8:1.6:1.6, never a per-share rounding), and
+        only the AGGREGATE reservation is floored to whole slots: slots are
+        indivisible, so the sub-slot remainder of the summed deficits is
+        capacity no organization could occupy right now, and reserving it
+        would strand the bound's last slots against sustained demand (three
+        equal organizations on a bound of 8 would otherwise freeze at 6).
+        With ``cache_priority_alpha`` authored, every share reads EFFECTIVE
+        weights ``weight * (1 + alpha * congestion * cached_fraction)``, so the
+        boost is zero on an idle rung and strongest exactly at saturation.
         """
-        if rung.total >= bound:
-            return RungShed("queue_bound")
-        if not fair_share:
+        if bound is not None:
+            if rung.total >= bound:
+                return RungShed("queue_bound")
+            if (
+                fresh_spill_fraction is not None
+                and not warm_session
+                and rung.total >= bound * fresh_spill_fraction
+            ):
+                return RungShed("fresh_session_spill")
+        working_rpm = self._working_rpm(rung, requests_per_minute, now)
+        if working_rpm is not None and rung.window_requests + 1 > working_rpm:
+            learned = None if rung.learned_rpm is None else int(rung.learned_rpm)
+            return RungShed("rate_limit", learned_requests_per_minute=learned)
+        if tokens_per_minute is not None and rung.window_tokens + reserved_tokens > (
+            tokens_per_minute
+        ):
+            learned = None if rung.learned_rpm is None else int(rung.learned_rpm)
+            return RungShed("rate_limit", learned_requests_per_minute=learned)
+        if not fair_share or bound is None:
             return None
+        congestion = rung.total / bound
         recency_floor = organization.last_seen - self._window
         active = [
             candidate
             for candidate in rung.organizations.values()
             if candidate.inflight > 0 or candidate.last_seen >= recency_floor
         ]
-        total_weight = sum(candidate.weight for candidate in active)
-        share = bound * organization.weight / total_weight
+        total_weight = sum(
+            _effective_weight(candidate, alpha=cache_priority_alpha, congestion=congestion)
+            for candidate in active
+        )
+        share = (
+            bound
+            * _effective_weight(organization, alpha=cache_priority_alpha, congestion=congestion)
+            / total_weight
+        )
         if organization.inflight + 1 <= share:
             return None
         reserved_deficit = sum(
-            max(0.0, bound * candidate.weight / total_weight - candidate.inflight)
+            max(
+                0.0,
+                bound
+                * _effective_weight(candidate, alpha=cache_priority_alpha, congestion=congestion)
+                / total_weight
+                - candidate.inflight,
+            )
             for candidate in active
             if candidate is not organization
         )
         if rung.total + 1 + int(reserved_deficit) > bound:
             return RungShed("fair_share_shed")
         return None
+
+    def _working_rpm(self, rung: _RungLoad, authored: int | None, now: float) -> float | None:
+        """Return the rung's working request ceiling, advancing calibration.
+
+        The working ceiling is the authored rate clamped by the learned one.
+        Lazily applied here (no timer thread): an expired learned ceiling (no
+        throttle for the expiry horizon) is forgotten, and every elapsed
+        recovery interval since the last creep raises the learned ceiling by
+        the creep fraction (at least one request), capped at the authored rate
+        when one is authored and unbounded otherwise, because each creep step
+        is exactly "send a few more and see whether they make it further".
+
+        Args:
+            rung: The rung's mutable state, under the registry lock.
+            authored: The authored per-worker requests-per-minute, if any.
+            now: Monotonic decision time.
+
+        Returns:
+            The working ceiling, or ``None`` when nothing limits requests.
+        """
+        learned = rung.learned_rpm
+        if learned is not None:
+            if now - rung.learned_throttled_at >= LEARNED_EXPIRY_SECONDS:
+                learned = None
+            else:
+                steps = int((now - rung.learned_crept_at) // LEARNED_RECOVERY_INTERVAL_SECONDS)
+                for _ in range(steps):
+                    learned += max(1.0, float(math.ceil(LEARNED_CREEP_FRACTION * learned)))
+                    if authored is not None and learned >= authored:
+                        learned = float(authored)
+                        break
+                if steps:
+                    rung.learned_crept_at += steps * LEARNED_RECOVERY_INTERVAL_SECONDS
+            rung.learned_rpm = learned
+        if learned is None:
+            return None if authored is None else float(authored)
+        if authored is None:
+            return learned
+        return min(float(authored), learned)
+
+    def record_throttle(self, key: RungLoadKey) -> None:
+        """Clamp one rung's learned request ceiling after a provider throttle.
+
+        The ceiling becomes the dispatch rate actually observed in the sliding
+        window at this moment times the clamp factor (floored at one request
+        per minute): the provider just proved the observed rate is too high,
+        so the worker assumes it throttles there again and lets recovery creep
+        re-discover the real headroom.
+
+        Args:
+            key: Physical rung identity.
+        """
+        now = self._clock()
+        with self._lock:
+            rung = self._rungs.setdefault(key, _RungLoad())
+            self._prune_window(rung, now)
+            observed = max(1, rung.window_requests)
+            rung.learned_rpm = max(1.0, observed * LEARNED_CLAMP_FACTOR)
+            rung.learned_throttled_at = now
+            rung.learned_crept_at = now
+
+    def record_settle(
+        self,
+        key: RungLoadKey,
+        organization_id: str,
+        *,
+        cached_tokens: int,
+        input_tokens: int,
+    ) -> None:
+        """Fold one settled attempt's cached-token fraction into the org EWMA.
+
+        Args:
+            key: Physical rung identity.
+            organization_id: The settling organization.
+            cached_tokens: Provider-reported cached input tokens.
+            input_tokens: Provider-reported (uncached) input tokens.
+        """
+        denominator = cached_tokens + input_tokens
+        if denominator <= 0:
+            return
+        sample = cached_tokens / denominator
+        now = self._clock()
+        with self._lock:
+            # A long stream can settle after its organization's request-recency
+            # entry was pruned; the sample still counts, so the entry is
+            # recreated (inactive for fairness until its next reservation).
+            rung = self._rungs.setdefault(key, _RungLoad())
+            organization = rung.organizations.setdefault(organization_id, _OrganizationLoad())
+            if organization.cached_sampled_at is None:
+                organization.cached_fraction = sample
+            else:
+                elapsed = max(EWMA_MINIMUM_STEP_SECONDS, now - organization.cached_sampled_at)
+                retained = 0.5 ** (elapsed / EWMA_HALF_LIFE_SECONDS)
+                organization.cached_fraction = organization.cached_fraction * retained + sample * (
+                    1.0 - retained
+                )
+            organization.cached_sampled_at = now
+
+    def learned_ceilings(self) -> dict[str, int]:
+        """Return live learned request ceilings keyed by rung, for metrics.
+
+        Keys are ``deployment_id:connection-prefix`` (catalog identifiers,
+        content-free); only rungs currently holding a learned ceiling appear,
+        so the map stays as small as the set of recently throttled rungs.
+        """
+        with self._lock:
+            return {
+                f"{deployment_id}:{connection[:8]}": int(rung.learned_rpm)
+                for (deployment_id, connection), rung in self._rungs.items()
+                if rung.learned_rpm is not None
+            }
 
     def bind(self, ticket: str, attempt_id: str) -> None:
         """Attach one reservation to its durable attempt for settle release.
@@ -248,13 +527,40 @@ class RungLoadRegistry:
             rung.total -= 1
 
     def _prune(self, key: RungLoadKey, rung: _RungLoad, now: float) -> None:
-        """Drop idle organizations past the activity window, bounding memory."""
+        """Drop idle organizations past the activity window, bounding memory.
+
+        An organization holding a live cached-fraction estimate is retained
+        past the activity window (its cache standing outlives one request's
+        recency), until the EWMA retention horizon passes with no new sample.
+        A rung entry itself survives while it holds any organization, window
+        entry, or learned ceiling, because the learned ceiling must outlive
+        the traffic that taught it.
+        """
         stale = [
             organization_id
             for organization_id, load in rung.organizations.items()
-            if load.inflight == 0 and load.last_seen < now - self._window
+            if load.inflight == 0
+            and load.last_seen < now - self._window
+            and (
+                load.cached_sampled_at is None
+                or load.cached_sampled_at < now - EWMA_RETENTION_SECONDS
+            )
         ]
         for organization_id in stale:
             del rung.organizations[organization_id]
-        if rung.total == 0 and not rung.organizations:
+        if (
+            rung.total == 0
+            and not rung.organizations
+            and not rung.window
+            and rung.learned_rpm is None
+        ):
             self._rungs.pop(key, None)
+
+    def _prune_window(self, rung: _RungLoad, now: float) -> None:
+        """Slide one rung's dispatch window forward, keeping totals exact."""
+        horizon = now - RATE_WINDOW_SECONDS
+        window = rung.window
+        while window and window[0][0] <= horizon:
+            _reserved_at, tokens = window.popleft()
+            rung.window_requests -= 1
+            rung.window_tokens -= tokens

--- a/exp/runtime/gateway/rung_admission_test.py
+++ b/exp/runtime/gateway/rung_admission_test.py
@@ -1,4 +1,4 @@
-"""Fairness, bound, work-conservation, and release tests for rung admission."""
+"""Fairness, bound, rate-window, calibration, and release tests for rung admission."""
 
 from __future__ import annotations
 
@@ -19,8 +19,14 @@ def _reserve(
     organization_id: str,
     *,
     weight: int = 1,
-    bound: int = 4,
+    bound: int | None = 4,
     fair_share: bool = False,
+    requests_per_minute: int | None = None,
+    tokens_per_minute: int | None = None,
+    cache_priority_alpha: float | None = None,
+    reserved_tokens: int = 0,
+    warm_session: bool = True,
+    fresh_spill_fraction: float | None = None,
     force: bool = False,
 ) -> str | RungShed:
     """Reserve one slot on the shared test rung."""
@@ -30,6 +36,12 @@ def _reserve(
         weight=weight,
         bound=bound,
         fair_share=fair_share,
+        requests_per_minute=requests_per_minute,
+        tokens_per_minute=tokens_per_minute,
+        cache_priority_alpha=cache_priority_alpha,
+        reserved_tokens=reserved_tokens,
+        warm_session=warm_session,
+        fresh_spill_fraction=fresh_spill_fraction,
         force=force,
     )
 
@@ -219,6 +231,250 @@ class TestFairShare:
         )
         assert registry.inflight(_KEY, "org-a") == 8
         assert all(isinstance(ticket, str) for ticket in tickets)
+
+
+class TestRateWindows:
+    """Sliding-window request and token caps shed sideways before the 429."""
+
+    def test_request_rate_sheds_at_the_cap_and_slides_forward(self) -> None:
+        """The 61st-second slot frees exactly the requests that left the window."""
+        now = [0.0]
+        registry = _registry(now)
+        for index in range(3):
+            now[0] = float(index)
+            assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=3), str)
+        now[0] = 3.0
+        shed = _reserve(registry, "org-a", bound=None, requests_per_minute=3)
+        assert shed == RungShed("rate_limit")
+        # At t=60.5 the t=0 dispatch has left the 60s window; one slot frees.
+        now[0] = 60.5
+        assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=3), str)
+        assert _reserve(registry, "org-a", bound=None, requests_per_minute=3) == RungShed(
+            "rate_limit"
+        )
+
+    def test_token_rate_counts_worst_case_reservations(self) -> None:
+        """The token window sheds the reservation that would overflow the cap."""
+        now = [0.0]
+        registry = _registry(now)
+        assert isinstance(
+            _reserve(registry, "org-a", bound=None, tokens_per_minute=1_000, reserved_tokens=600),
+            str,
+        )
+        shed = _reserve(registry, "org-a", bound=None, tokens_per_minute=1_000, reserved_tokens=600)
+        assert shed == RungShed("rate_limit")
+        # A smaller reservation still fits under the cap.
+        assert isinstance(
+            _reserve(registry, "org-a", bound=None, tokens_per_minute=1_000, reserved_tokens=400),
+            str,
+        )
+
+    def test_force_admits_past_the_rate_window(self) -> None:
+        """A ladder exhausted only by rate sheds still dispatches somewhere."""
+        now = [0.0]
+        registry = _registry(now)
+        assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=1), str)
+        assert _reserve(registry, "org-a", bound=None, requests_per_minute=1) == RungShed(
+            "rate_limit"
+        )
+        assert isinstance(
+            _reserve(registry, "org-a", bound=None, requests_per_minute=1, force=True), str
+        )
+
+
+class TestPassiveAdaptiveCalibration:
+    """AIMD: throttles clamp the working ceiling, recovery creeps it back."""
+
+    def test_throttle_clamps_to_ninety_percent_of_the_observed_rate(self) -> None:
+        """A 429 with 20 dispatches in the window learns a ceiling of 18."""
+        now = [0.0]
+        registry = _registry(now)
+        for index in range(20):
+            now[0] = index * 0.1
+            assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=100), str)
+        registry.record_throttle(_KEY)
+        assert registry.learned_ceilings() == {"dep-house:connecti": 18}
+        # The working ceiling is now the learned 18, not the authored 100:
+        # window holds 20 >= 18, so the next reservation sheds.
+        now[0] = 2.1
+        shed = _reserve(registry, "org-a", bound=None, requests_per_minute=100)
+        assert shed == RungShed("rate_limit", learned_requests_per_minute=18)
+
+    def test_recovery_creep_raises_the_ceiling_and_caps_at_authored(self) -> None:
+        """Each unthrottled minute adds max(1, ceil(5%)), never past authored."""
+        now = [0.0]
+        registry = _registry(now)
+        for index in range(20):
+            now[0] = index * 0.1
+            assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=20), str)
+        registry.record_throttle(_KEY)  # learned 18.0 at t=1.9
+        # Two full recovery intervals later: 18 -> 19 -> 20, capped at the
+        # authored 20 (ceil(0.05*18)=1, then ceil(0.05*19)=1).
+        now[0] = 1.9 + 120.0
+        assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=20), str)
+        assert registry.learned_ceilings() == {"dep-house:connecti": 20}
+
+    def test_learned_ceiling_creeps_unbounded_without_an_authored_rate(self) -> None:
+        """With no authored rpm each creep step keeps probing for headroom."""
+        now = [0.0]
+        registry = _registry(now)
+        for index in range(20):
+            now[0] = index * 0.1
+            assert isinstance(_reserve(registry, "org-a", bound=None, tokens_per_minute=10**9), str)
+        registry.record_throttle(_KEY)  # learned 18.0
+        now[0] = 1.9 + 180.0
+        # Three creep steps: 18 -> 19 -> 20 -> 21; window is empty by now so
+        # the reservation admits under the learned-only working ceiling.
+        assert isinstance(_reserve(registry, "org-a", bound=None, tokens_per_minute=10**9), str)
+        assert registry.learned_ceilings() == {"dep-house:connecti": 21}
+
+    def test_fresh_throttle_reclamps_and_quiet_expiry_forgets(self) -> None:
+        """A new 429 re-clamps mid-recovery; six quiet hours forget the lesson."""
+        now = [0.0]
+        registry = _registry(now)
+        for index in range(10):
+            now[0] = index * 0.1
+            assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=50), str)
+        registry.record_throttle(_KEY)  # learned 9.0 from 10 observed
+        assert registry.learned_ceilings() == {"dep-house:connecti": 9}
+        now[0] = 61.0
+        registry.record_throttle(_KEY)  # window empty: observed floors at 1
+        assert registry.learned_ceilings() == {"dep-house:connecti": 1}
+        # Six hours without a throttle expire the learned ceiling entirely.
+        now[0] = 61.0 + 6 * 3_600.0
+        assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=50), str)
+        assert registry.learned_ceilings() == {}
+
+
+class TestCachePriority:
+    """The congestion-scaled EWMA term admits warm-cache traffic at the margin."""
+
+    def test_settled_cache_fractions_fold_into_a_time_decayed_ewma(self) -> None:
+        """The first sample seeds the estimate; later samples decay toward it."""
+        now = [0.0]
+        registry = _registry(now)
+        assert isinstance(_reserve(registry, "org-a", bound=8, fair_share=True), str)
+        registry.record_settle(_KEY, "org-a", cached_tokens=800, input_tokens=200)
+        # Zero-token settles record nothing; the seeded estimate stands.
+        registry.record_settle(_KEY, "org-a", cached_tokens=0, input_tokens=0)
+        now[0] = 600.0
+        # One half-life later a fully-cold sample halves the estimate:
+        # 0.8 * 0.5 + 0.0 * 0.5 = 0.4.
+        registry.record_settle(_KEY, "org-a", cached_tokens=0, input_tokens=1_000)
+        now[0] = 600.5
+        # Pin the folded value through the share arithmetic below rather than
+        # reading private state: with alpha=0 the estimate is inert.
+        assert isinstance(_reserve(registry, "org-a", bound=8, fair_share=True), str)
+
+    def test_congestion_boost_flips_a_freed_slot_to_the_cached_org(self) -> None:
+        """Exact margin arithmetic for alpha=2 on a contended bound of 8.
+
+        Both organizations weigh 1 and hold 4 slots each; org-cache's EWMA is
+        1.0 (fully cached), org-cold has no signal (fraction 0). org-cold then
+        frees one slot (total 7, congestion 7/8). Effective weights:
+        org-cache 1 * (1 + 2 * 7/8 * 1.0) = 2.75, org-cold 1, total 3.75.
+          - org-cold reclaiming its own slot: share 8 * 1/3.75 ~= 2.133,
+            held+1 = 4 > share, and org-cache's deficit
+            (8 * 2.75/3.75 - 4 ~= 1.867, aggregate floor 1) reserves the free
+            slot, so the COLD organization is SHED.
+          - org-cache: share ~= 5.867 >= held+1 = 5, so the CACHED
+            organization ADMITS into the slot the cold one freed.
+        The alpha-off twin below proves base fairness decides the SAME release
+        the opposite way, so this pins the term itself, not the scenario.
+        """
+        now = [0.0]
+        registry = _registry(now)
+        cold_tickets: list[str] = []
+        for organization in ("org-cache", "org-cold"):
+            for _ in range(4):
+                ticket = _reserve(
+                    registry,
+                    organization,
+                    bound=8,
+                    fair_share=True,
+                    cache_priority_alpha=2.0,
+                )
+                assert isinstance(ticket, str)
+                if organization == "org-cold":
+                    cold_tickets.append(ticket)
+        registry.record_settle(_KEY, "org-cache", cached_tokens=1_000, input_tokens=0)
+        now[0] = 1.0
+        registry.release_ticket(cold_tickets[0])
+        # The cold organization cannot reclaim its own freed slot...
+        assert _reserve(
+            registry, "org-cold", bound=8, fair_share=True, cache_priority_alpha=2.0
+        ) == RungShed("fair_share_shed")
+        # ...because the boosted cache-heavy organization is owed it.
+        assert isinstance(
+            _reserve(registry, "org-cache", bound=8, fair_share=True, cache_priority_alpha=2.0),
+            str,
+        )
+
+    def test_alpha_off_decides_the_same_release_the_opposite_way(self) -> None:
+        """Without alpha the cold org reclaims its slot and the cache org is shed."""
+        now = [0.0]
+        registry = _registry(now)
+        cold_tickets: list[str] = []
+        for organization in ("org-cache", "org-cold"):
+            for _ in range(4):
+                ticket = _reserve(registry, organization, bound=8, fair_share=True)
+                assert isinstance(ticket, str)
+                if organization == "org-cold":
+                    cold_tickets.append(ticket)
+        registry.record_settle(_KEY, "org-cache", cached_tokens=1_000, input_tokens=0)
+        now[0] = 1.0
+        registry.release_ticket(cold_tickets[0])
+        # Base weights: org-cache is above its 4-slot share and the freed slot
+        # is reserved for org-cold's deficit, cache history notwithstanding.
+        assert _reserve(registry, "org-cache", bound=8, fair_share=True) == RungShed(
+            "fair_share_shed"
+        )
+        assert isinstance(_reserve(registry, "org-cold", bound=8, fair_share=True), str)
+
+
+class TestFreshSessionSpill:
+    """Fresh sessions shed at the early threshold; warm sessions ride to the bound."""
+
+    def test_fresh_sheds_early_and_warm_sheds_only_at_the_bound(self) -> None:
+        """With bound 8 and fraction 0.75, fresh sheds at 6 while warm fills 8."""
+        now = [0.0]
+        registry = _registry(now)
+        for _ in range(6):
+            assert isinstance(
+                _reserve(
+                    registry,
+                    "org-a",
+                    bound=8,
+                    warm_session=False,
+                    fresh_spill_fraction=0.75,
+                ),
+                str,
+            )
+        assert _reserve(
+            registry, "org-a", bound=8, warm_session=False, fresh_spill_fraction=0.75
+        ) == RungShed("fresh_session_spill")
+        # Warm sessions keep the reserved top slice up to the hard bound.
+        for _ in range(2):
+            assert isinstance(
+                _reserve(
+                    registry,
+                    "org-a",
+                    bound=8,
+                    warm_session=True,
+                    fresh_spill_fraction=0.75,
+                ),
+                str,
+            )
+        assert _reserve(
+            registry, "org-a", bound=8, warm_session=True, fresh_spill_fraction=0.75
+        ) == RungShed("queue_bound")
+
+    def test_no_fraction_means_no_early_threshold(self) -> None:
+        """Fresh sessions behave exactly like warm ones when nothing is authored."""
+        registry = _registry([0.0])
+        for _ in range(4):
+            assert isinstance(_reserve(registry, "org-a", warm_session=False), str)
+        assert _reserve(registry, "org-a", warm_session=False) == RungShed("queue_bound")
 
 
 class TestRegistryContracts:

--- a/exp/runtime/gateway/rung_admission_test.py
+++ b/exp/runtime/gateway/rung_admission_test.py
@@ -435,6 +435,43 @@ class TestCachePriority:
             str,
         )
 
+    def test_settle_only_organizations_never_join_the_fairness_scans(self) -> None:
+        """Hour-scale cache retention must not lengthen the reservation path.
+
+        The prune and active-share scans run per reservation under the
+        registry lock and are bounded by the ten-second activity window; the
+        cache estimates are retained for an hour. Folding the estimates into
+        the fairness entries would grow those scans 360-fold on a rung many
+        organizations settle on (the house fair-share lanes), so a settle-only
+        organization must hold a cache estimate WITHOUT a fairness entry.
+        """
+        now = [0.0]
+        registry = _registry(now)
+        for index in range(50):
+            registry.record_settle(_KEY, f"org-{index}", cached_tokens=1_000, input_tokens=1_000)
+        rung = registry._rungs[_KEY]  # Private read: pins the structural bound itself.
+        assert rung.organizations == {}
+        assert len(rung.cache_fractions) == 50
+        # The estimate still boosts the organization once it does reserve, and
+        # a settle-only organization contributes no weight to anyone's share.
+        assert isinstance(
+            _reserve(registry, "org-0", bound=8, fair_share=True, cache_priority_alpha=2.0),
+            str,
+        )
+        # Past the retention horizon the estimates sweep out and the rung
+        # entry (nothing else held) is dropped.
+        now[0] = 3_601.0
+        registry.record_settle(_KEY, "org-fresh", cached_tokens=0, input_tokens=10)
+        assert set(registry._rungs[_KEY].cache_fractions) == {"org-fresh"}
+
+    def test_negative_cached_tokens_clamp_to_a_cold_sample(self) -> None:
+        """A provider reporting cached below zero folds as zero, never negative."""
+        now = [0.0]
+        registry = _registry(now)
+        registry.record_settle(_KEY, "org-a", cached_tokens=-500, input_tokens=1_000)
+        rung = registry._rungs[_KEY]  # Private read: the clamp is otherwise unobservable.
+        assert rung.cache_fractions["org-a"].fraction == 0.0
+
     def test_alpha_off_decides_the_same_release_the_opposite_way(self) -> None:
         """Without alpha the cold org reclaims its slot and the cache org is shed."""
         now = [0.0]

--- a/exp/runtime/gateway/rung_admission_test.py
+++ b/exp/runtime/gateway/rung_admission_test.py
@@ -269,6 +269,31 @@ class TestRateWindows:
             str,
         )
 
+    def test_single_over_cap_reservation_bursts_into_an_empty_window(self) -> None:
+        """A request bigger than the whole token cap is not permanently shed.
+
+        Worst-case reservations can exceed a per-worker cap outright (230k-token
+        prompts against a 125k cap); the burst allowance admits exactly one
+        into an EMPTY window, which then blocks further dispatches until the
+        window slides past it.
+        """
+        now = [0.0]
+        registry = _registry(now)
+        assert isinstance(
+            _reserve(registry, "org-a", bound=None, tokens_per_minute=1_000, reserved_tokens=2_000),
+            str,
+        )
+        # Even a tiny follow-up is shed while the burst occupies the window.
+        assert _reserve(
+            registry, "org-a", bound=None, tokens_per_minute=1_000, reserved_tokens=10
+        ) == RungShed("rate_limit")
+        # Once the window slides past the burst, admission resumes.
+        now[0] = 61.0
+        assert isinstance(
+            _reserve(registry, "org-a", bound=None, tokens_per_minute=1_000, reserved_tokens=10),
+            str,
+        )
+
     def test_force_admits_past_the_rate_window(self) -> None:
         """A ladder exhausted only by rate sheds still dispatches somewhere."""
         now = [0.0]
@@ -338,8 +363,8 @@ class TestPassiveAdaptiveCalibration:
         registry.record_throttle(_KEY)  # learned 9.0 from 10 observed
         assert registry.learned_ceilings() == {"dep-house:connecti": 9}
         now[0] = 61.0
-        registry.record_throttle(_KEY)  # window empty: observed floors at 1
-        assert registry.learned_ceilings() == {"dep-house:connecti": 1}
+        registry.record_throttle(_KEY)  # window empty: floors at the positive minimum
+        assert registry.learned_ceilings() == {"dep-house:connecti": 0.1}
         # Six hours without a throttle expire the learned ceiling entirely.
         now[0] = 61.0 + 6 * 3_600.0
         assert isinstance(_reserve(registry, "org-a", bound=None, requests_per_minute=50), str)

--- a/exp/runtime/gateway/rung_admission_test.py
+++ b/exp/runtime/gateway/rung_admission_test.py
@@ -354,7 +354,7 @@ class TestCachePriority:
         now = [0.0]
         registry = _registry(now)
         assert isinstance(_reserve(registry, "org-a", bound=8, fair_share=True), str)
-        registry.record_settle(_KEY, "org-a", cached_tokens=800, input_tokens=200)
+        registry.record_settle(_KEY, "org-a", cached_tokens=800, input_tokens=1_000)
         # Zero-token settles record nothing; the seeded estimate stands.
         registry.record_settle(_KEY, "org-a", cached_tokens=0, input_tokens=0)
         now[0] = 600.0
@@ -397,7 +397,7 @@ class TestCachePriority:
                 assert isinstance(ticket, str)
                 if organization == "org-cold":
                     cold_tickets.append(ticket)
-        registry.record_settle(_KEY, "org-cache", cached_tokens=1_000, input_tokens=0)
+        registry.record_settle(_KEY, "org-cache", cached_tokens=1_000, input_tokens=1_000)
         now[0] = 1.0
         registry.release_ticket(cold_tickets[0])
         # The cold organization cannot reclaim its own freed slot...
@@ -421,7 +421,7 @@ class TestCachePriority:
                 assert isinstance(ticket, str)
                 if organization == "org-cold":
                     cold_tickets.append(ticket)
-        registry.record_settle(_KEY, "org-cache", cached_tokens=1_000, input_tokens=0)
+        registry.record_settle(_KEY, "org-cache", cached_tokens=1_000, input_tokens=1_000)
         now[0] = 1.0
         registry.release_ticket(cold_tickets[0])
         # Base weights: org-cache is above its 4-slot share and the freed slot

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 18
+SCHEMA_VERSION = 19
 
 
 class GatewaySchemaError(RuntimeError):
@@ -697,6 +697,20 @@ _MIGRATION_18 = (
     """,
 )
 
+# v19: per-attempt provider rate-limit observability. The data plane harvests
+# the allowlisted rate-limit response headers (retry-after, x-ratelimit-*,
+# anthropic-ratelimit-*) on successes and failures alike; these columns
+# persist the normalized integers so throttle calibration can be audited
+# against what the provider actually said, per attempt. Header names and
+# numbers only: no content, no credentials.
+_MIGRATION_19 = (
+    "ALTER TABLE gateway_attempts ADD COLUMN retry_after_seconds INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN ratelimit_limit_requests INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN ratelimit_remaining_requests INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN ratelimit_limit_tokens INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN ratelimit_remaining_tokens INTEGER",
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -716,6 +730,7 @@ _MIGRATIONS = {
     16: _MIGRATION_16,
     17: _MIGRATION_17,
     18: _MIGRATION_18,
+    19: _MIGRATION_19,
 }
 
 

--- a/exp/runtime/gateway/sticky_affinity.py
+++ b/exp/runtime/gateway/sticky_affinity.py
@@ -1,0 +1,105 @@
+"""Worker-local sticky binding of affinity fingerprints to serving rungs.
+
+Under a pool's ``maximize_cache_affinity`` policy, rendezvous hashing gives a
+conversation a stable preferred rung, but a conversation that SPILLS (bound,
+rate window, fairness, deadness) builds its warm prompt cache on the spill
+target. Bouncing it back to the higher-ranked rung the moment that rung stops
+shedding would abandon that cache, so each dispatch records a worker-local
+``fingerprint -> deployment`` binding with an authored time-to-live
+(``GatewayRungDispatchPolicy.sticky_spill_seconds``), refreshed on every hit
+and honored ahead of rendezvous order on subsequent requests. The binding is
+deliberately worker-local: the serving edge's pooled keep-alives pin one
+client to one worker, so per-worker memory covers the common case, and the
+cross-worker imprecision costs at most one cold dispatch on the rendezvous
+rung. A binding to a dead or throttled rung is cleared by admission so
+stickiness can never pin a conversation to a lane that cannot serve it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+
+# Bound on remembered conversations per worker. At two cache lines of payload
+# per entry this is a few megabytes; the least recently used binding is
+# evicted first, which is also the coldest provider cache.
+_MAXIMUM_BINDINGS = 65_536
+
+
+class StickySpillRegistry:
+    """Bounded, lock-guarded LRU of affinity fingerprints to serving rungs."""
+
+    def __init__(
+        self,
+        *,
+        maximum_bindings: int = _MAXIMUM_BINDINGS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Initialize an empty registry with an injectable clock for tests.
+
+        Args:
+            maximum_bindings: LRU capacity; the oldest binding evicts first.
+            clock: Monotonic clock.
+
+        Raises:
+            ValueError: The capacity is not positive.
+        """
+        if maximum_bindings < 1:
+            raise ValueError("sticky binding capacity must be positive")
+        self._maximum = maximum_bindings
+        self._clock = clock
+        self._bindings: OrderedDict[bytes, tuple[str, float]] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def bind(self, fingerprint: bytes, deployment_id: str, *, ttl_seconds: float) -> None:
+        """Record or refresh one fingerprint's serving rung.
+
+        Args:
+            fingerprint: Tenant-isolated affinity fingerprint.
+            deployment_id: The rung that served (or is about to serve) it.
+            ttl_seconds: Authored binding lifetime; not positive records nothing.
+        """
+        if ttl_seconds <= 0:
+            return
+        expires_at = self._clock() + ttl_seconds
+        with self._lock:
+            self._bindings[fingerprint] = (deployment_id, expires_at)
+            self._bindings.move_to_end(fingerprint)
+            while len(self._bindings) > self._maximum:
+                self._bindings.popitem(last=False)
+
+    def bound_deployment(self, fingerprint: bytes) -> str | None:
+        """Return the fingerprint's live binding, dropping an expired one.
+
+        Args:
+            fingerprint: Tenant-isolated affinity fingerprint.
+
+        Returns:
+            The bound deployment id, or ``None`` when no live binding exists.
+        """
+        now = self._clock()
+        with self._lock:
+            entry = self._bindings.get(fingerprint)
+            if entry is None:
+                return None
+            deployment_id, expires_at = entry
+            if expires_at <= now:
+                del self._bindings[fingerprint]
+                return None
+            return deployment_id
+
+    def clear(self, fingerprint: bytes) -> None:
+        """Drop one fingerprint's binding (its rung died or throttled); idempotent.
+
+        Args:
+            fingerprint: Tenant-isolated affinity fingerprint.
+        """
+        with self._lock:
+            self._bindings.pop(fingerprint, None)
+
+    def size(self) -> int:
+        """Return the number of retained bindings, for metrics."""
+        with self._lock:
+            return len(self._bindings)

--- a/exp/runtime/gateway/sticky_affinity.py
+++ b/exp/runtime/gateway/sticky_affinity.py
@@ -21,11 +21,92 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Callable
+from dataclasses import dataclass
+
+from exp.runtime.gateway.contracts import AuthorizationSnapshot
+from exp.runtime.gateway.health import DeploymentHealthRegistry
+from exp.runtime.gateway.native_execution import deployment_health_key
+from exp.runtime.gateway.routing import GatewayRoute
 
 # Bound on remembered conversations per worker. At two cache lines of payload
 # per entry this is a few megabytes; the least recently used binding is
 # evicted first, which is also the coldest provider cache.
 _MAXIMUM_BINDINGS = 65_536
+
+# Hard cap on one binding's total age, as a multiple of its authored lifetime.
+# Refresh-on-hit alone would let one transient congestion pin a long-running
+# agent session to its (possibly pricier) spill rung forever; past the cap the
+# binding lapses even under continuous hits, the conversation returns to its
+# rendezvous rung once, and a still-congested rung simply re-spills and
+# re-binds it.
+STICKY_MAXIMUM_AGE_LIFETIMES = 4.0
+
+
+@dataclass(frozen=True)
+class AffinityPlacement:
+    """The affinity facts one admission resolved for dispatch accounting.
+
+    ``fingerprint`` is present only on ``maximize_cache_affinity`` routes (the
+    tenant-isolated conversation identity that keyed placement), so dispatch
+    reservation can read and refresh the worker-local sticky binding and apply
+    the fresh-session spill threshold. ``sticky_preferred`` marks a route
+    whose depth 0 was chosen by a live sticky binding rather than rendezvous
+    order, for the ``affinity_sticky`` disclosure.
+    """
+
+    fingerprint: bytes | None = None
+    sticky_preferred: bool = False
+
+
+def sticky_first_order(
+    order: tuple[int, ...],
+    route: GatewayRoute,
+    *,
+    fingerprint: bytes,
+    sticky: StickySpillRegistry,
+    health: DeploymentHealthRegistry,
+    authorization: AuthorizationSnapshot,
+) -> tuple[tuple[int, ...], int | None]:
+    """Move a live sticky binding's rung to the front of the rendezvous order.
+
+    A binding whose rung left the route is ignored (the binding expires on its
+    own); a binding whose rung is suppressed right now is cleared and ignored,
+    so a throttled or dead spill target releases the conversation back to
+    rendezvous placement. A binding already at the rendezvous front changes
+    nothing and is not reported as sticky.
+
+    Args:
+        order: Rendezvous permutation of the route's deployment indexes.
+        route: Frozen route the permutation indexes into.
+        fingerprint: The request's affinity fingerprint.
+        sticky: Worker-local conversation-to-rung bindings.
+        health: Deployment circuit and throttle registry.
+        authorization: Frozen authority, for the health key.
+
+    Returns:
+        The (possibly reordered) permutation and the sticky rung's route
+        index when a live binding moved or confirmed the front (``None``
+        when rendezvous order stands on its own).
+    """
+    bound = sticky.bound_deployment(fingerprint)
+    if bound is None:
+        return order, None
+    sticky_index = next(
+        (
+            index
+            for index, deployment in enumerate(route.deployments)
+            if deployment.deployment_id == bound
+        ),
+        None,
+    )
+    if sticky_index is None:
+        return order, None
+    if health.suppressed(deployment_health_key(authorization, route.deployments[sticky_index])):
+        sticky.clear(fingerprint)
+        return order, None
+    if order[0] == sticky_index:
+        return order, None
+    return (sticky_index, *(index for index in order if index != sticky_index)), sticky_index
 
 
 class StickySpillRegistry:
@@ -50,11 +131,18 @@ class StickySpillRegistry:
             raise ValueError("sticky binding capacity must be positive")
         self._maximum = maximum_bindings
         self._clock = clock
-        self._bindings: OrderedDict[bytes, tuple[str, float]] = OrderedDict()
+        # fingerprint -> (deployment_id, expires_at, age_deadline). The age
+        # deadline is fixed when the binding is (re)created for a deployment
+        # and survives refreshes, so continuous hits cannot extend one binding
+        # forever.
+        self._bindings: OrderedDict[bytes, tuple[str, float, float]] = OrderedDict()
         self._lock = threading.Lock()
 
     def bind(self, fingerprint: bytes, deployment_id: str, *, ttl_seconds: float) -> None:
         """Record or refresh one fingerprint's serving rung.
+
+        A refresh extends the idle lifetime but never the age deadline; a
+        binding to a DIFFERENT rung starts a fresh age (a new cache home).
 
         Args:
             fingerprint: Tenant-isolated affinity fingerprint.
@@ -63,9 +151,18 @@ class StickySpillRegistry:
         """
         if ttl_seconds <= 0:
             return
-        expires_at = self._clock() + ttl_seconds
+        now = self._clock()
+        expires_at = now + ttl_seconds
+        age_deadline = now + STICKY_MAXIMUM_AGE_LIFETIMES * ttl_seconds
         with self._lock:
-            self._bindings[fingerprint] = (deployment_id, expires_at)
+            entry = self._bindings.get(fingerprint)
+            if entry is not None and entry[0] == deployment_id:
+                age_deadline = entry[2]
+            self._bindings[fingerprint] = (
+                deployment_id,
+                min(expires_at, age_deadline),
+                age_deadline,
+            )
             self._bindings.move_to_end(fingerprint)
             while len(self._bindings) > self._maximum:
                 self._bindings.popitem(last=False)
@@ -84,7 +181,7 @@ class StickySpillRegistry:
             entry = self._bindings.get(fingerprint)
             if entry is None:
                 return None
-            deployment_id, expires_at = entry
+            deployment_id, expires_at, _age_deadline = entry
             if expires_at <= now:
                 del self._bindings[fingerprint]
                 return None

--- a/exp/runtime/gateway/sticky_affinity_test.py
+++ b/exp/runtime/gateway/sticky_affinity_test.py
@@ -1,0 +1,69 @@
+"""Lifetime, refresh, eviction, and clearing tests for sticky spill bindings."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.runtime.gateway.sticky_affinity import StickySpillRegistry
+
+
+def _registry(now: list[float], *, maximum_bindings: int = 8) -> StickySpillRegistry:
+    """Build a registry on a mutable fake clock."""
+    return StickySpillRegistry(maximum_bindings=maximum_bindings, clock=lambda: now[0])
+
+
+def test_binding_is_returned_until_its_lifetime_passes() -> None:
+    """A live binding answers; an expired one is dropped and answers None."""
+    now = [0.0]
+    registry = _registry(now)
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    assert registry.bound_deployment(b"conversation") == "dep-spill"
+    now[0] = 599.9
+    assert registry.bound_deployment(b"conversation") == "dep-spill"
+    now[0] = 600.0
+    assert registry.bound_deployment(b"conversation") is None
+    assert registry.size() == 0
+
+
+def test_rebinding_refreshes_the_lifetime_and_can_move_the_rung() -> None:
+    """Each hit extends the binding; a new rung replaces the old one."""
+    now = [0.0]
+    registry = _registry(now)
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    now[0] = 500.0
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    now[0] = 1_050.0
+    assert registry.bound_deployment(b"conversation") == "dep-spill"
+    registry.bind(b"conversation", "dep-house", ttl_seconds=600.0)
+    assert registry.bound_deployment(b"conversation") == "dep-house"
+
+
+def test_capacity_evicts_the_least_recently_bound_conversation() -> None:
+    """The LRU cap drops the coldest binding first and never grows past it."""
+    now = [0.0]
+    registry = _registry(now, maximum_bindings=2)
+    registry.bind(b"one", "dep-a", ttl_seconds=600.0)
+    registry.bind(b"two", "dep-b", ttl_seconds=600.0)
+    registry.bind(b"one", "dep-a", ttl_seconds=600.0)
+    registry.bind(b"three", "dep-c", ttl_seconds=600.0)
+    assert registry.size() == 2
+    assert registry.bound_deployment(b"two") is None
+    assert registry.bound_deployment(b"one") == "dep-a"
+    assert registry.bound_deployment(b"three") == "dep-c"
+
+
+def test_clear_is_idempotent_and_nonpositive_lifetimes_record_nothing() -> None:
+    """Clearing a dead rung's binding is safe to repeat; TTL 0 is a no-op."""
+    registry = _registry([0.0])
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=0.0)
+    assert registry.bound_deployment(b"conversation") is None
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    registry.clear(b"conversation")
+    registry.clear(b"conversation")
+    assert registry.bound_deployment(b"conversation") is None
+
+
+def test_rejects_a_nonpositive_capacity() -> None:
+    """The LRU capacity must be positive."""
+    with pytest.raises(ValueError, match="capacity"):
+        StickySpillRegistry(maximum_bindings=0)

--- a/exp/runtime/gateway/sticky_affinity_test.py
+++ b/exp/runtime/gateway/sticky_affinity_test.py
@@ -38,6 +38,31 @@ def test_rebinding_refreshes_the_lifetime_and_can_move_the_rung() -> None:
     assert registry.bound_deployment(b"conversation") == "dep-house"
 
 
+def test_continuous_hits_cannot_extend_a_binding_past_the_age_cap() -> None:
+    """A binding lapses at four lifetimes from creation despite steady refreshes.
+
+    Refresh-on-hit alone would let one transient congestion pin a long agent
+    session to its spill rung forever; the age cap releases it back to
+    rendezvous, and a still-congested rung simply re-spills and re-binds.
+    """
+    now = [0.0]
+    registry = _registry(now)
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    # Refresh every 500s, well inside the idle lifetime, past the 2400s cap.
+    for tick in range(1, 6):
+        now[0] = tick * 500.0
+        if registry.bound_deployment(b"conversation") is not None:
+            registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    now[0] = 2_400.0
+    assert registry.bound_deployment(b"conversation") is None
+    # Rebinding to a DIFFERENT rung starts a fresh age (a new cache home).
+    registry.bind(b"conversation", "dep-spill", ttl_seconds=600.0)
+    now[0] = 2_500.0
+    registry.bind(b"conversation", "dep-house", ttl_seconds=600.0)
+    now[0] = 3_000.0
+    assert registry.bound_deployment(b"conversation") == "dep-house"
+
+
 def test_capacity_evicts_the_least_recently_bound_conversation() -> None:
     """The LRU cap drops the coldest binding first and never grows past it."""
     now = [0.0]

--- a/exp/runtime/gateway/tests/native_spill_soak_test.py
+++ b/exp/runtime/gateway/tests/native_spill_soak_test.py
@@ -106,12 +106,19 @@ class _FastHouseTarget(BaseHTTPRequestHandler):
     """A fast house rung for the rate-window scenario: sheds are never queueing."""
 
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract.
-        """Stream one instant success identifying the house rung."""
+        """Stream one instant success identifying the house rung.
+
+        The response carries provider rate-limit headers so the scenario also
+        proves the data plane harvests the allowlisted set into settlement and
+        the ledger persists the normalized integers per attempt.
+        """
         length = int(self.headers.get("content-length", "0"))
         self.rfile.read(length)
         try:
             self.send_response(200)
             self.send_header("content-type", "text/event-stream")
+            self.send_header("x-ratelimit-limit-requests", "60")
+            self.send_header("x-ratelimit-remaining-requests", "41")
             self.end_headers()
             self.wfile.write(_content_chunk("from-house"))
             self.wfile.write(_terminal_frames())
@@ -376,10 +383,18 @@ def test_rate_limited_rung_spills_the_burst_before_any_provider_429(
         (failures,) = connection.execute(
             "SELECT count(*) FROM gateway_attempts WHERE failure_class IS NOT NULL"
         ).fetchone()
+        harvested = connection.execute(
+            "SELECT deployment_id, ratelimit_limit_requests, ratelimit_remaining_requests"
+            " FROM gateway_attempts WHERE ratelimit_remaining_requests IS NOT NULL"
+        ).fetchall()
     assert failures == 0
     assert len(sheds) == _BURST_REQUESTS - 1
     assert {reason for reason, _preferred in sheds} == {"rate_limit"}
     assert {preferred for _reason, preferred in sheds} == {"alpha"}
+    # The one dispatch that reached the house rung settled the provider's own
+    # rate-limit headers end to end: harvested by the data plane, normalized
+    # by accounting, persisted as integer columns on exactly that attempt.
+    assert harvested == [("alpha", 60, 41)]
 
 
 def test_unbounded_rung_queues_the_burst_into_deadline_deaths(

--- a/exp/runtime/gateway/tests/native_spill_soak_test.py
+++ b/exp/runtime/gateway/tests/native_spill_soak_test.py
@@ -102,6 +102,27 @@ class _FastSpillTarget(BaseHTTPRequestHandler):
         del format, args
 
 
+class _FastHouseTarget(BaseHTTPRequestHandler):
+    """A fast house rung for the rate-window scenario: sheds are never queueing."""
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract.
+        """Stream one instant success identifying the house rung."""
+        length = int(self.headers.get("content-length", "0"))
+        self.rfile.read(length)
+        try:
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(_content_chunk("from-house"))
+            self.wfile.write(_terminal_frames())
+        except OSError:
+            return
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress request logs so test output cannot retain payload context."""
+        del format, args
+
+
 class _DetachedServer(ThreadingHTTPServer):
     """Loopback provider whose stuck handlers never block test teardown."""
 
@@ -122,8 +143,8 @@ class _SoakEngine:
         return f"http://{_HOST}:{self.port}"
 
 
-def _author_lead_rung_bound(root: Path) -> tuple[Path, str]:
-    """Author ``concurrency_bound=1`` on the pool's lead rung and re-snapshot.
+def _author_lead_rung_policy(root: Path, policy: GatewayRungDispatchPolicy) -> tuple[Path, str]:
+    """Author one dispatch policy on the pool's lead rung and re-snapshot.
 
     Mirrors the hosted platform's authoring path: the dispatch policy is
     catalog data on the deployment's gateway metadata, so opting in is a
@@ -139,11 +160,7 @@ def _author_lead_rung_bound(root: Path) -> tuple[Path, str]:
     lead = catalog.models["alpha"]
     assert lead.gateway is not None
     bounded = lead.model_copy(
-        update={
-            "gateway": lead.gateway.model_copy(
-                update={"dispatch": GatewayRungDispatchPolicy(concurrency_bound=1)}
-            )
-        }
+        update={"gateway": lead.gateway.model_copy(update={"dispatch": policy})}
     )
     write_model_catalog(
         catalog_path,
@@ -156,10 +173,11 @@ def _author_lead_rung_bound(root: Path) -> tuple[Path, str]:
 def _serve_engine(
     root: Path,
     *,
-    bounded: bool,
+    policy: GatewayRungDispatchPolicy | None,
+    house_handler: type[BaseHTTPRequestHandler] = _CapacityOneBox,
 ) -> Iterator[tuple[_SoakEngine, subprocess.Popen[str], list[_DetachedServer]]]:
-    """Seed one pool root, optionally author the bound, and boot the engine."""
-    house = _DetachedServer((_HOST, 0), _CapacityOneBox)
+    """Seed one pool root, optionally author a lead policy, and boot the engine."""
+    house = _DetachedServer((_HOST, 0), house_handler)
     spill = _DetachedServer((_HOST, 0), _FastSpillTarget)
     for server in (house, spill):
         threading.Thread(target=server.serve_forever, daemon=True).start()
@@ -170,8 +188,8 @@ def _serve_engine(
             f"http://{_HOST}:{spill.server_address[1]}/v1",
         ),
     )
-    if bounded:
-        snapshot, digest = _author_lead_rung_bound(root)
+    if policy is not None:
+        snapshot, digest = _author_lead_rung_policy(root, policy)
         manager.activate_direct_alias(
             alias_id="coding",
             alias_name="coding",
@@ -250,7 +268,9 @@ def _serve_engine(
 @pytest.fixture(name="spill_engine")
 def _spill_engine(tmp_path: Path) -> Iterator[_SoakEngine]:
     """Serve the pool with ``concurrency_bound=1`` authored on the lead rung."""
-    generator = _serve_engine(tmp_path / "bounded-root", bounded=True)
+    generator = _serve_engine(
+        tmp_path / "bounded-root", policy=GatewayRungDispatchPolicy(concurrency_bound=1)
+    )
     engine, _process, _servers = next(generator)
     yield engine
     for _tail in generator:
@@ -260,7 +280,25 @@ def _spill_engine(tmp_path: Path) -> Iterator[_SoakEngine]:
 @pytest.fixture(name="baseline_engine")
 def _baseline_engine(tmp_path: Path) -> Iterator[_SoakEngine]:
     """Serve the identical pool with no dispatch policy authored (today)."""
-    generator = _serve_engine(tmp_path / "baseline-root", bounded=False)
+    generator = _serve_engine(tmp_path / "baseline-root", policy=None)
+    engine, _process, _servers = next(generator)
+    yield engine
+    for _tail in generator:
+        pass
+
+
+@pytest.fixture(name="rate_limited_engine")
+def _rate_limited_engine(tmp_path: Path) -> Iterator[_SoakEngine]:
+    """Serve the pool with ``requests_per_minute=1`` on a FAST lead rung.
+
+    The house rung answers instantly here: every shed in this scenario is
+    purely the sliding rate window firing pre-emptively, never queueing.
+    """
+    generator = _serve_engine(
+        tmp_path / "rated-root",
+        policy=GatewayRungDispatchPolicy(requests_per_minute=1),
+        house_handler=_FastHouseTarget,
+    )
     engine, _process, _servers = next(generator)
     yield engine
     for _tail in generator:
@@ -311,6 +349,36 @@ def test_bounded_rung_spills_the_burst_with_zero_deadline_deaths(
     assert timeouts == 0
     assert len(sheds) >= _BURST_REQUESTS - 2
     assert {reason for reason, _preferred in sheds} == {"queue_bound"}
+    assert {preferred for _reason, preferred in sheds} == {"alpha"}
+
+
+def test_rate_limited_rung_spills_the_burst_before_any_provider_429(
+    rate_limited_engine: _SoakEngine,
+) -> None:
+    """The rate window sheds pre-emptively: one dispatch stays home, the rest spill.
+
+    The lead rung authors ``requests_per_minute=1`` and answers instantly, so
+    a shed here can only be the sliding window firing before the provider
+    would have 429'd. Every burst request completes, exactly one serves off
+    the house rung inside the window, and every spilled attempt disclosed
+    ``rate_limit`` against the bypassed preferred rung.
+    """
+    responses = _burst(rate_limited_engine)
+    assert [response.status_code for response in responses] == [200] * _BURST_REQUESTS
+    contents = [response.json()["choices"][0]["message"]["content"] for response in responses]
+    assert contents.count("from-house") == 1
+    assert contents.count("from-spill") == _BURST_REQUESTS - 1
+    with sqlite3.connect(rate_limited_engine.database_path) as connection:
+        sheds = connection.execute(
+            "SELECT dispatch_reason, preferred_deployment_id FROM gateway_attempts"
+            " WHERE dispatch_reason IS NOT NULL"
+        ).fetchall()
+        (failures,) = connection.execute(
+            "SELECT count(*) FROM gateway_attempts WHERE failure_class IS NOT NULL"
+        ).fetchone()
+    assert failures == 0
+    assert len(sheds) == _BURST_REQUESTS - 1
+    assert {reason for reason, _preferred in sheds} == {"rate_limit"}
     assert {preferred for _reason, preferred in sheds} == {"alpha"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.45,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.46,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.52"
+version = "0.7.53"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.52"
+version = "0.7.53"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.45"
+version = "0.3.46"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Adaptive rate limits, passive calibration, cache-priority fair share, and sticky spill affinity

One engine PR of a two-PR program (platform PR follows and authors nothing until this releases). It extends the #785 rung dispatch policy with pre-emptive rate limiting, passive-adaptive throttle calibration, a congestion-scaled cache-priority term for weighted fair share, cache-aware fresh-session spill, and worker-local sticky spill bindings, plus per-attempt rate-limit observability through the ledger protocol.

### What is in here

**New authored dispatch-policy fields** (`exp/common/models/dispatch_policy.py`, all Optional and inert by default):
- `requests_per_minute`, `tokens_per_minute`: per-worker sliding 60s window caps. An over-window reservation sheds sideways as `rate_limit` BEFORE the provider 429s, riding the existing spill / force-admit / disclosure machinery unchanged (prod data: only 1.5% of throttled requests ever got a second attempt, and 99% of those succeeded; this makes the second attempt the first). Usable without a `concurrency_bound`. The token cap carries a burst allowance: a single reservation whose worst case exceeds the whole cap admits into an EMPTY window (deepseek's p99 input is 230k tokens against 125k/worker pilot caps; without the allowance such prompts would be permanently inadmissible), then occupies the window until it slides out.
- `cache_priority_alpha`: on a `fair_share` rung, effective weight = `weight * (1 + alpha * congestion * cached_fraction)`, where congestion is in-flight total over the bound and the cached fraction is a per-(org, rung) time-decayed EWMA (half-life ~10min) of settled cached tokens over settled TOTAL input. Zero effect on an idle rung, strongest exactly at saturation, no effect on an org with no cache signal. Requires `fair_share` (validator). A hosted composition can veto individual samples through the new `NativeAttemptAccounting(cache_sample_gate=...)` injection (same pattern as `budget_error_factory`): the host knows which attempts are promo-funded, and admitting those samples would let free-tier replay traffic buy fair-share weight with the very prefixes the promotion already made costless. A raising gate skips the sample (fails closed). The platform PR wires this to its promo-funded attempt state.
- `fresh_session_spill_fraction`: under `maximize_cache_affinity`, a request whose affinity fingerprint holds no live sticky binding on the rung sheds early at `bound * fraction` (`fresh_session_spill`), reserving the top slice for warm sessions, which shed only at the hard bound. Requires `concurrency_bound` AND `sticky_spill_seconds` (warm standing IS a live binding; without a binding lifetime every session would stay fresh forever and the reserved slice would only be reachable through force admission).
- `sticky_spill_seconds`: worker-local LRU binding `fingerprint -> deployment` recorded on each affinity-pool dispatch to a rung authoring it, refreshed per hit, honored AHEAD of rendezvous order, cleared when the bound rung is throttled or circuit-open, and hard-capped at FOUR lifetimes of total age from creation (refreshes extend the idle lifetime, never the age deadline), so one transient congestion cannot pin a long-running agent session to a pricier spill rung forever. A spilled conversation therefore keeps serving off the rung holding its warm cache instead of bouncing back the moment the preferred rung stops shedding. Disclosed as `affinity_sticky` when the binding (not rendezvous) chose depth 0.

  The binding keys on the #785 affinity fingerprint (the session identity rendezvous already uses, seed precedence untouched), deliberately NOT on a derived provider `prompt_cache_key` stem: OpenAI-compatible shim lanes, including the Experiential Cloud vLLM boxes, never get `prompt_cache_key` forwarded, and vLLM's automatic prefix cache is content-addressed, so gateway-side session-to-rung consistency is the entire cache-preservation mechanism on those lanes.

All the sticky-spill and fresh-session logic lives in one self-contained module (`exp/runtime/gateway/sticky_affinity.py`: registry, `AffinityPlacement`, `sticky_first_order`), with single-line hooks at the admission and accounting call sites, so the open admission/execution PRs (#769/#770) rebase over this mechanically.

**Passive-adaptive calibration (AIMD)** in `RungLoadRegistry`, per worker, keyed on the physical lane `(deployment_id, connection_sha256)` (deliberately not revision-scoped; BYOK per-connection variant deployments carry distinct ids, so one org's provider quota never clamps another's): a provider THROTTLED settlement on a policy-authored rung clamps a learned ceiling to `observed_window_rate * 0.9`; every unthrottled recovery minute creeps it up by `max(1, ceil(0.05 * learned))` (capped at the authored rpm when one exists, unbounded otherwise - each creep step IS the probe: a few more real requests go through to see whether they make it further); a ceiling unthrottled for 6h is forgotten. NEVER a synthetic probe request. Working ceiling = min(authored, learned). The ceiling is a FLOAT and may sit below one request per minute per worker (floored at 0.1): per-worker ceilings multiply across the fleet, and some provider accounts (zai ~6/min against 8 workers) allow less than one per worker per minute. Timeouts deliberately do NOT feed calibration: EC boxes never 429, their congestion is timeout-shaped, and client deadlines would pollute the signal - authored bounds govern those lanes.

**Retry-After-aware throttle windows** (`health.py`): a throttled settlement carrying a parseable `Retry-After` (integer seconds or HTTP-date; garbage degrades to the default) sizes `throttle_until` from it, clamped to [5s, 6h]; absent keeps the existing 30s. A long Retry-After (an openrouter daily-quota reset) thereby marks the rung dead-for-hours and the waterfall skips it: quota-state handling with no new subsystem.

**Per-attempt rate-limit observability, end to end (native 0.3.46 + control plane)**: the Rust data plane now harvests a CLOSED allowlist of provider response headers (`retry-after`, OpenAI `x-ratelimit-limit/remaining-requests/tokens`, Anthropic `anthropic-ratelimit-requests/tokens-limit/remaining`; arbitrary provider headers are never forwarded - exotic providers put account identifiers in theirs) on successes and failures alike: an opened attempt records them on its settlement guard, a failed OPEN carries them on its `Failure` with the integer `Retry-After` filled on throttles, and `settle_argument` emits them as the optional `rate_limit_headers` map. Python-side, `rate_limit_headers.py` normalizes the raw strings (integer seconds AND HTTP-date `Retry-After`; garbled values degrade to None), `SyncWriteLedger.finish_attempt` gains OPTIONAL kwargs (`retry_after_seconds`, `ratelimit_limit_requests`, `ratelimit_remaining_requests`, `ratelimit_limit_tokens`, `ratelimit_remaining_tokens` - the platform side already accepts exactly these names), and engine SQLite migration 18 adds the five nullable integer columns. A throttled settlement's harvested wait sizes the deployment's throttle window (E5). Note: open PR #814 also adds a SQLite migration and, once rebased onto main (already at 17), will want slot 18 too - whichever lands second renumbers (migrations must stay contiguous, so neither can pre-skip).

**Telemetry**: worker-global counters `rung_rate_limit_sheds`, `rung_fresh_session_spills` (Prometheus text + JSON), `sticky_spill_bindings` gauge, and a JSON-only `rung_learned_ceilings` map (deployment-keyed; deliberately not exported as Prometheus labels to avoid cardinality).

### Owner decisions implemented
1. Weighted max-min fair share stays (no strict tiers); the cache/congestion term makes it dynamic. No reserved capacity beyond the existing work-conserving reservation arithmetic.
2. Cache priority = engine-side EWMA of settled cached fraction.
3. Calibration is passive-adaptive: learn the ceiling from real throttles, creep to re-discover headroom, never synthetic ramp probes (free-lane quotas are never probed).
4. No committed simulation harness; scenario tests are committed instead (see below).

### Digest and schema stability (why no SNAPSHOT_SCHEMA_VERSION bump)
All five new fields default to inert and the catalog digest is computed exclude-defaults, so an unauthored rung contributes zero identity bytes: no snapshot digest moves, no schema bump (`dispatch_policy_test.py::test_default_policy_contributes_zero_identity_bytes` plus the existing catalog-level proof). Authoring a value is a real catalog change and produces a new content address. `ContractModel` is `extra="forbid"`, so a worker that predates these fields fails a newly-authored alias closed through the existing per-alias fail-safe: exactly the documented deployment-ordered vocabulary contract.

### Rollout contract
Engine release first, then the platform pins it fleet-wide, then the catalog authors values (drafts lane). Nothing changes behavior before authoring: every new field ships defaulted, the rate windows and thresholds only engage on rungs that author them, and the ledger kwargs are optional (the platform's `apply_*` no-op pattern accepts them before the pin lands, in the platform PR).

Note on activation: everything in this PR is live once the release ships and values are authored. The sliding windows, AIMD calibration, cache-priority term, fresh-session spill, and sticky bindings key off state the control plane already owns; the Retry-After window sizing and header persistence are fed by the native 0.3.45 harvest in this same PR, so an engine release from this branch publishes matching `experiential` and `exp-gateway-native` wheels (the dependency floor moves to `exp-gateway-native>=0.3.46`).

### Composition with #769 / #770 (mvanhorn)
- Affinity seed precedence in `affinity.py` is untouched (`prompt_cache_key > continuation episode > X-Client-Request-Id > Idempotency-Key > request_id`).
- #769 derives a `prompt_cache_key` at admission (cache-KEY derivation); this PR's sticky binding acts at RUNG selection, keyed on the same fingerprint the rendezvous already uses, downstream of whatever key #769 derives. A #769-derived key feeds `affinity_seed_material` exactly like a caller-supplied one, so the two compose: the derived key stabilizes the fingerprint, the binding stabilizes the rung.
- #770 is router-policy-side (`KnnGuard.cache_switch`); no shared surfaces beyond `contracts.py`, where this PR adds no fields.
- The overlap in `native_admission.py` is confined to `admitted_route_requests`'s return arity (a new `AffinityPlacement` element) and `_affinity_ordered_rungs`; #769's edits are in `resolve_admission_route` and new functions, so a rebase on either side is mechanical.

### Structural moves (line-limit gate)
`native_accounting.py` crossed the repo's 999-line limit, so two cohesive groups moved to their natural homes with no behavior change: the sanitized boundary failure vocabulary and payload parser to `native_settlement.py` (`budget_quota_failure`, `all_routes_unavailable_failure`, `all_routes_throttled_failure`, `gateway_updating_failure`, `failure_from_boundary_payload`), and the dispatch-policy helpers to `native_execution.py` (`rung_load_key`, `deployment_priced_for_service_tier`, `dispatch_disclosure`). Import sites updated; nothing re-exported.

### Tests
Every new behavior has a regression test:
- rpm/tpm window sheds and 60s slide; force-admit past the window; whole-ladder rate-limited still serves (`rung_admission_test.py`, `native_accounting_test.py`, and a live-engine soak scenario in `tests/native_spill_soak_test.py` where a fast rung authored `requests_per_minute=1` spills the burst with `rate_limit` disclosures and zero failures).
- AIMD arithmetic pinned exactly: clamp 20 observed -> 18; creep 18 -> 19 -> 20 capped at authored; unbounded creep 18 -> 21 with no authored rate; re-clamp on a fresh throttle; 6h expiry. Bound-only rungs calibrate from a REAL window; unpolicied rungs never learn (regression for the empty-window clamp bug found during the build).
- Retry-After parsing (seconds, HTTP-date, garbage) and the [5s, 6h] clamp on the throttle window; default window preserved when absent.
- EWMA cache-priority margin arithmetic pinned in a differential pair: with alpha=2 at congestion 7/8 the cached org takes the slot the cold org freed (effective weights 2.75 vs 1, shares 5.867 vs 2.133); with alpha off the SAME release admits the cold org and sheds the cached one, so the tests pin the term itself, not the scenario.
- Fresh-session early shed (bound 8, fraction 0.75: fresh sheds at 6, warm rides to 8) at both the registry and the dispatch level.
- Sticky binding honored ahead of rendezvous, refreshed per hit, bypassed AND cleared on a throttled rung, expired by TTL, LRU-capped; `affinity_sticky` disclosure; no binding without an authored lifetime.
- Header kwargs flow through the settle path to the ledger protocol and persist as SQLite columns (migration 18); retained-settlement sweep replays them; throttled failures borrow the harvested wait (failure payload's own value wins). Rust-side: crate unit tests pin the allowlist (unknown headers never forwarded), the integer-only Retry-After parse, throttled-only fill that never overwrites, and the settle payload shape; the rate-limited soak scenario proves the WHOLE pipeline live (the house response's `x-ratelimit-*` headers land as integer columns on exactly the attempt that reached it). `cargo fmt --check`, `cargo clippy --no-default-features -- -D warnings`, and `cargo test` (263 tests) are green.
- Validation-memo red-team regressions: over-cap reservation bursts into an empty token window then blocks the next dispatch until the window drains; continuous hits cannot extend a sticky binding past four lifetimes; the cache_sample_gate excludes vetoed (promo-funded) samples and fails closed when raising; `fresh_session_spill` sheds force-admit like `rate_limit` on a narrow ladder (never a minted 429); sub-1 learned ceilings (a throttle on a 1-dispatch window learns 0.9, an empty window floors at 0.1).

`uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, and `uv run pytest -q` are green.

### Version
pyproject and uv.lock bump `experiential` to **0.7.53** and the native crate to **exp-gateway-native 0.3.46**, with the root dependency floor moved to match, so the release publishes fresh wheels. (0.7.49/#845, 0.7.50/#848, 0.7.51/#852, and 0.7.52/#853 all shipped while this PR was in review; native 0.3.43/#843, 0.3.44/#847, 0.3.45/#851 are taken. The branch is rebased onto main past all of them; #851's dangling-reference 400 in the same `open_stream` branch also carries the harvested rate-limit facts.)
