### PR TITLE
providers: assistant-prefill pre-check keys on the Claude release, not the wire

### DIFF
--- a/exp/runtime/models/providers/generation_parameter_validation.py
+++ b/exp/runtime/models/providers/generation_parameter_validation.py
@@ -118,7 +118,12 @@ def require_assistant_prefill_supported(
     Anthropic's 4.6+ and 5-generation releases answer assistant prefill with a
     400 after the request was dispatched and billed for admission. The rungs
     that carry such a model narrow out here with the same fact stated for the
-    caller; a route with no other rung surfaces it as the request's 400.
+    caller; a route with no other rung surfaces it as the request's 400. The
+    check keys on the MODEL, not the wire: relays (OpenRouter's
+    ``anthropic/claude-opus-5``, Azure Foundry's Claude deployments) forward
+    the same rejection (live 2026-09-07: "Azure: This model does not support
+    assistant message prefill" through OpenRouter), and the release matcher
+    only ever matches a Claude release id.
 
     Raises:
         ProviderParameterError: The final message is an assistant turn and a
@@ -129,10 +134,7 @@ def require_assistant_prefill_supported(
     if request.messages[-1].provider_native_item is not None:
         return
     for profile in profiles:
-        if profile.dialect not in {
-            "anthropic_messages",
-            "bedrock_converse_stream",
-        } or not anthropic_rejects_assistant_prefill(profile.model_id):
+        if not anthropic_rejects_assistant_prefill(profile.model_id):
             continue
         raise ProviderParameterError(
             message=(

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2662,7 +2662,9 @@ def test_assistant_prefill_narrows_out_rungs_whose_model_rejects_it() -> None:
         model_id="anthropic.claude-fable-5-1-20260901-v1:0",
     )
     relayed = GatewayWireProfile(
-        dialect="openrouter", url="https://openrouter.test", model_id="anthropic/claude-opus-5"
+        dialect="openai_compatible",
+        url="https://openrouter.test",
+        model_id="anthropic/claude-opus-5",
     )
     accepting = GatewayWireProfile(
         dialect="anthropic_messages", url="https://anthropic.test", model_id="claude-sonnet-4-5"

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2661,10 +2661,13 @@ def test_assistant_prefill_narrows_out_rungs_whose_model_rejects_it() -> None:
         url="https://bedrock.test",
         model_id="anthropic.claude-fable-5-1-20260901-v1:0",
     )
+    relayed = GatewayWireProfile(
+        dialect="openrouter", url="https://openrouter.test", model_id="anthropic/claude-opus-5"
+    )
     accepting = GatewayWireProfile(
         dialect="anthropic_messages", url="https://anthropic.test", model_id="claude-sonnet-4-5"
     )
-    for profile in (rejecting, bedrock):
+    for profile in (rejecting, bedrock, relayed):
         with pytest.raises(ProviderParameterError) as prefill:
             route_generation_parameter_requests((profile,), request)
         assert prefill.value.param == "messages"


### PR DESCRIPTION
Follow-up to #839, from the first 20 minutes of prod on 0.7.46: `require_assistant_prefill_supported` only narrowed `anthropic_messages` / `bedrock_converse_stream` rungs, so a relayed Claude rung (OpenRouter `anthropic/claude-opus-5`, upstream Azure) still dispatched and came back with "Azure: This model does not support assistant message prefill" (2 in 20 min).

The release matcher only ever matches a Claude release id, so the dialect restriction bought nothing; it is removed and the test gains an OpenRouter-relayed profile. Python only, no native change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)