### PR TITLE
gateway: dangling-reference 404s become the caller's 400, provider handles are masked not dropped, foreign item ids repaired on replay (native 0.3.45)

### DIFF
--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.44"
+version = "0.3.45"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.44"
+version = "0.3.45"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.44"
+version = "0.3.45"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -160,11 +160,9 @@ fn provider_error_detail(
             .take_while(|character| !character.is_control())
             .collect();
         let collapsed = cut.split_whitespace().collect::<Vec<_>>().join(" ");
-        (!collapsed.is_empty()
-            && !collapsed.split(' ').any(|word| {
-                crate::param_attribution::carries_provider_identifier(word, request_words)
-            }))
-        .then_some(collapsed)
+        // Provider-side handles are masked, never dropped with the sentence.
+        (!collapsed.is_empty())
+            .then(|| crate::param_attribution::bounded_masked_line(&collapsed, request_words))
     });
     let detail = match (code, line) {
         (None, None) => return None,
@@ -823,25 +821,34 @@ mod stream_error_detail_tests {
     }
 
     #[test]
-    fn secret_shaped_words_drop_the_whole_detail_line() {
+    fn secret_shaped_words_are_masked_out_of_the_detail_line() {
         // The identifier screen treats any letter+digit label as a handle,
-        // which covers key and token shapes: a sentence carrying one drops
-        // entirely (never partially redacted), for every dialect that feeds
-        // the shared detail path, Bedrock exception messages included.
-        for message in [
-            "Invalid key sk-abc123def provided.",
-            "The access key AKIA9X7EXAMPLE is not authorized for this model.",
-            "Bearer eyJhbGciOi9 was rejected.",
+        // which covers key and token shapes: the word is masked and the
+        // sentence around it survives, for every dialect that feeds the
+        // shared detail path, Bedrock exception messages included.
+        for (message, masked) in [
+            (
+                "Invalid key sk-abc123def provided.",
+                "Invalid key [redacted] provided.",
+            ),
+            (
+                "The access key AKIA9X7EXAMPLE is not authorized for this model.",
+                "The access key [redacted] is not authorized for this model.",
+            ),
+            (
+                "Bearer eyJhbGciOi9 was rejected.",
+                "Bearer [redacted] was rejected.",
+            ),
         ] {
             assert_eq!(
-                provider_error_detail(None, Some(message), &[]),
-                None,
-                "a credential-shaped word must drop the sentence: {message}"
+                provider_error_detail(None, Some(message), &[]).as_deref(),
+                Some(masked),
+                "a credential-shaped word must be masked: {message}"
             );
             assert_eq!(
                 provider_error_detail(Some("validation_error"), Some(message), &[]).as_deref(),
-                Some("validation_error"),
-                "the safe code token alone survives: {message}"
+                Some(format!("validation_error: {masked}").as_str()),
+                "the code rides with the masked sentence: {message}"
             );
         }
     }
@@ -915,11 +922,11 @@ mod stream_error_detail_tests {
             })))
             .expect("error frame normalizes");
         // The model id trips the identifier screen (letters+digits label), so
-        // the sentence drops while the code token survives: the mechanism
-        // stays named without relaying a label-shaped word to the ledger.
+        // it is masked while the code and the sentence around it survive: the
+        // mechanism stays named without relaying a label-shaped word.
         assert_eq!(
             failed_detail(&events).as_deref(),
-            Some("rate_limit_exceeded")
+            Some("rate_limit_exceeded: Rate limit reached for [redacted].")
         );
     }
 

--- a/exp/runtime/gateway/native/src/lib.rs
+++ b/exp/runtime/gateway/native/src/lib.rs
@@ -18,6 +18,7 @@ mod guardrails;
 mod memory;
 mod metrics;
 mod param_attribution;
+mod rejection_shapes;
 mod relay;
 mod replay;
 mod respond;

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -25,6 +25,10 @@
 use serde_json::Value;
 
 use crate::dialects::Dialect;
+pub use crate::rejection_shapes::{
+    rejected_by_lane_limitation, rejected_by_routing_gate, rejected_caller_reference_not_found,
+    upstream_relayed_message,
+};
 
 /// Longest parameter path relayed; anything longer is treated as prose.
 const MAXIMUM_PATH_LENGTH: usize = 128;
@@ -70,21 +74,10 @@ pub fn rejected_parameter(dialect: Dialect, body: &str) -> Option<String> {
 /// OpenAI-family `error.code` naming a deployment model the provider cannot serve.
 const MODEL_NOT_FOUND_CODE: &str = "model_not_found";
 
-/// Sentences a provider answers with a 400 for a request shape the OpenAI
-/// contract allows but THIS lane's serving stack cannot carry (a chat
-/// template that only accepts a leading system turn). They are lane
-/// limitations, not caller errors: the request fails over to the next rung and
-/// only a route with no other rung surfaces the sentence.
-const LANE_LIMITATION_PHRASES: &[&str] = &[
-    "system message must be at the beginning",
-    "system message should be at the beginning",
-    "only the first message can be a system message",
-];
-
 /// The provider's own error sentence from one client-error body, read only
 /// from the dialect's documented message field (never from echoed request
 /// data or unrelated metadata).
-fn error_message_field(dialect: Dialect, value: &Value) -> Option<&str> {
+pub(crate) fn error_message_field(dialect: Dialect, value: &Value) -> Option<&str> {
     match dialect {
         Dialect::OpenAiResponses
         | Dialect::OpenAiCompatible
@@ -93,54 +86,6 @@ fn error_message_field(dialect: Dialect, value: &Value) -> Option<&str> {
         // Bedrock reports a modeling error as a bare top-level `message`.
         Dialect::BedrockConverseStream => value.get("message")?.as_str(),
     }
-}
-
-/// Whether a 4xx body's error SENTENCE describes a limitation of the lane
-/// rather than of the caller's request (see [`LANE_LIMITATION_PHRASES`]). Only
-/// the dialect's message field is read, so request text echoed elsewhere in
-/// the body cannot change routing.
-pub fn rejected_by_lane_limitation(dialect: Dialect, body: &str) -> bool {
-    let value: Value = match serde_json::from_str(body) {
-        Ok(value) => value,
-        Err(_) => return false,
-    };
-    error_message_field(dialect, &value).is_some_and(|message| {
-        let lowered = message.to_ascii_lowercase();
-        LANE_LIMITATION_PHRASES
-            .iter()
-            .any(|phrase| lowered.contains(phrase))
-    })
-}
-
-/// Whether a 403 body is an aggregator ROUTING verdict rather than a
-/// credential one. OpenRouter runs its routing funnel only AFTER the key has
-/// authenticated, and reports the funnel it walked (`metadata.routing_funnel`)
-/// plus the step that refused (`metadata.failed_routing_step`; "Gate Free
-/// Endpoints by Agentic Harness" on its app-allow-listed free endpoints,
-/// 2026-09-06). Both fields together mean the key is fine and this lane will
-/// not serve this model for the gateway's account, so it takes the not-found
-/// policy and the ladder advances. Only the OpenAI-compatible wire OpenRouter
-/// speaks is read; other dialects keep the credential verdict.
-pub fn rejected_by_routing_gate(dialect: Dialect, body: &str) -> bool {
-    if dialect != Dialect::OpenAiCompatible {
-        return false;
-    }
-    let value: Value = match serde_json::from_str(body) {
-        Ok(value) => value,
-        Err(_) => return false,
-    };
-    let Some(metadata) = value.get("error").and_then(|error| error.get("metadata")) else {
-        return false;
-    };
-    let walked_funnel = metadata
-        .get("routing_funnel")
-        .and_then(Value::as_array)
-        .is_some_and(|steps| !steps.is_empty());
-    let failed_step = metadata
-        .get("failed_routing_step")
-        .and_then(Value::as_str)
-        .is_some_and(|step| !step.trim().is_empty());
-    walked_funnel && failed_step
 }
 
 /// Whether one client-error body reports that the dispatched model does not exist.
@@ -205,73 +150,6 @@ pub fn rejected_detail(dialect: Dialect, body: &str, request_words: &[&str]) -> 
         }
     }
     sanitized_detail(message, request_words)
-}
-
-/// Aggregator sentences that say nothing about what was refused.
-const GENERIC_AGGREGATOR_MESSAGES: &[&str] = &["provider returned error", "provider error"];
-
-/// The upstream provider's own sentence behind an aggregator's generic one.
-///
-/// OpenRouter answers a rejected relay with "Provider returned error" and
-/// puts the upstream body in `error.metadata.raw` (a JSON document or plain
-/// text) plus the upstream's name in `error.metadata.provider_name`. The
-/// generic sentence leaves the caller nothing to act on (673 such 400s across
-/// 137 orgs in the 24h to 2026-09-07 00:20 UTC), so when the aggregator's
-/// message is generic the upstream sentence is read instead, prefixed with
-/// the provider's name. Only the message field of a JSON `raw` is used; a
-/// plain-text `raw` is taken whole. The result still passes the same
-/// identifier screen and length bound as any relayed sentence.
-pub fn upstream_relayed_message(error: &Value, message: &str) -> Option<String> {
-    let lowered = message.trim().trim_end_matches('.').to_ascii_lowercase();
-    if !GENERIC_AGGREGATOR_MESSAGES.contains(&lowered.as_str()) {
-        return None;
-    }
-    let metadata = error.get("metadata")?;
-    let raw = metadata.get("raw")?;
-    let upstream = match raw {
-        Value::String(text) => match serde_json::from_str::<Value>(text) {
-            Ok(document) => json_error_sentence(&document)?,
-            Err(_) => text.trim().to_string(),
-        },
-        Value::Object(_) => json_error_sentence(raw)?,
-        _ => return None,
-    };
-    if upstream.is_empty() {
-        return None;
-    }
-    let provider = metadata
-        .get("provider_name")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|name| {
-            !name.is_empty()
-                && name.chars().all(|c| {
-                    c.is_ascii_alphanumeric() || c == ' ' || c == '-' || c == '_' || c == '.'
-                })
-        });
-    Some(match provider {
-        Some(name) => format!("{name}: {upstream}"),
-        None => upstream,
-    })
-}
-
-/// The human sentence of one upstream error document, whichever documented
-/// spelling it uses (`error.message`, `message`, `detail`, or a bare string
-/// `error`).
-fn json_error_sentence(document: &Value) -> Option<String> {
-    let error = document.get("error");
-    let candidates = [
-        error.and_then(|error| error.get("message")),
-        document.get("message"),
-        document.get("detail"),
-        error.filter(|value| value.is_string()),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .find_map(|value| value.as_str())
-        .map(|text| text.trim().to_string())
-        .filter(|text| !text.is_empty())
 }
 
 /// The provider's own error code or type from one client-error body, as a
@@ -382,34 +260,6 @@ pub(crate) fn bounded_masked_line(collapsed: &str, request_words: &[&str]) -> St
     let mut cut: String = masked.chars().take(MAXIMUM_DETAIL_LENGTH - 1).collect();
     cut.push('\u{2026}');
     cut
-}
-
-/// Whether a 404 body is the provider refusing a CALLER reference (an
-/// `item_reference`, `conversation`, or similar handle the provider does not
-/// hold) rather than a missing model. OpenAI answers those as HTTP 404 with
-/// `type: invalid_request_error` and no `model_not_found` code (live
-/// 2026-09-07: "Item with id 'rs_...' not found. Items are not persisted when
-/// `store` is set to false." and "Conversation with id 'conv_...' not
-/// found."). The catalog is fine and every other rung would answer the same,
-/// so the request is the caller's 400, never a lane 404 that fails over: one
-/// client replaying foreign item ids drove 361 attempts across the astra
-/// ladder in three and a half hours.
-pub fn rejected_caller_reference_not_found(dialect: Dialect, body: &str) -> bool {
-    if !matches!(
-        dialect,
-        Dialect::OpenAiResponses | Dialect::OpenAiCompatible
-    ) {
-        return false;
-    }
-    let value: Value = match serde_json::from_str(body) {
-        Ok(value) => value,
-        Err(_) => return false,
-    };
-    let Some(error) = value.get("error") else {
-        return false;
-    };
-    error.get("type").and_then(Value::as_str) == Some("invalid_request_error")
-        && !rejected_model_not_found(dialect, body)
 }
 
 /// Whether one word of a provider sentence names provider-side infrastructure.
@@ -639,36 +489,6 @@ mod tests {
         // Any other message keeps the content-free failure.
         let other = r#"{"error": {"message": "This model is not available to your account."}}"#;
         assert_eq!(rejected_parameter(Dialect::OpenAiCompatible, other), None);
-    }
-
-    #[test]
-    fn an_aggregators_generic_sentence_yields_to_the_upstream_message() {
-        let body = r#"{"error":{"message":"Provider returned error","code":400,
-            "metadata":{"raw":"{\"error\":{\"message\":\"Input exceeds the maximum context window.\",\"type\":\"invalid_request_error\"}}",
-            "provider_name":"Relace"}}}"#;
-        assert_eq!(
-            rejected_detail(Dialect::OpenAiCompatible, body, &[]).as_deref(),
-            Some("Relace: Input exceeds the maximum context window.")
-        );
-        // A plain-text raw is relayed whole; a specific aggregator sentence is kept.
-        let plain = r#"{"error":{"message":"Provider returned error","code":400,
-            "metadata":{"raw":"model is overloaded, try again","provider_name":"Fugu"}}}"#;
-        assert_eq!(
-            rejected_detail(Dialect::OpenAiCompatible, plain, &[]).as_deref(),
-            Some("Fugu: model is overloaded, try again")
-        );
-        let specific = r#"{"error":{"message":"temperature must be <= 1","code":400,
-            "metadata":{"raw":"{\"error\":{\"message\":\"ignored\"}}"}}}"#;
-        assert_eq!(
-            rejected_detail(Dialect::OpenAiCompatible, specific, &[]).as_deref(),
-            Some("temperature must be <= 1")
-        );
-        // Without metadata the generic sentence stays what it was.
-        let bare = r#"{"error":{"message":"Provider returned error","code":400}}"#;
-        assert_eq!(
-            rejected_detail(Dialect::OpenAiCompatible, bare, &[]).as_deref(),
-            Some("Provider returned error")
-        );
     }
 
     #[test]
@@ -1050,38 +870,5 @@ mod request_word_tests {
             .as_deref(),
             Some("Model [redacted] is unavailable.")
         );
-    }
-
-    #[test]
-    fn a_404_refusing_a_caller_reference_is_the_callers_error_not_a_missing_model() {
-        let item = r#"{"error":{"message":"Item with id 'rs_0' not found. Items are not persisted when `store` is set to false.","type":"invalid_request_error","param":"input","code":null}}"#;
-        assert!(rejected_caller_reference_not_found(
-            Dialect::OpenAiResponses,
-            item
-        ));
-        assert!(rejected_caller_reference_not_found(
-            Dialect::OpenAiCompatible,
-            item
-        ));
-        let conversation = r#"{"error":{"message":"Conversation with id 'conv_0' not found.","type":"invalid_request_error","param":null,"code":null}}"#;
-        assert!(rejected_caller_reference_not_found(
-            Dialect::OpenAiResponses,
-            conversation
-        ));
-        let model = r#"{"error":{"message":"The model `x` does not exist.","type":"invalid_request_error","param":"model","code":"model_not_found"}}"#;
-        assert!(!rejected_caller_reference_not_found(
-            Dialect::OpenAiResponses,
-            model
-        ));
-        let anthropic =
-            r#"{"type":"error","error":{"type":"not_found_error","message":"model: x"}}"#;
-        assert!(!rejected_caller_reference_not_found(
-            Dialect::AnthropicMessages,
-            anthropic
-        ));
-        assert!(!rejected_caller_reference_not_found(
-            Dialect::OpenAiResponses,
-            "<html>"
-        ));
     }
 }

--- a/exp/runtime/gateway/native/src/param_attribution.rs
+++ b/exp/runtime/gateway/native/src/param_attribution.rs
@@ -325,14 +325,19 @@ pub fn generic_error_code(token: &str) -> bool {
 
 /// One provider sentence reduced to bounded, single-line, printable text.
 ///
-/// Control characters end the candidate rather than being escaped: their
-/// presence means the field carries a payload, not a sentence. Interior runs
-/// of spaces and tabs collapse so the relayed text stays one readable line,
-/// and [`carries_provider_identifier`] then rejects any sentence naming
-/// provider-side infrastructure, except words the request itself carried.
+/// Control characters mean the field carries a payload, not a sentence, and
+/// the candidate drops. Interior runs of spaces and tabs collapse so the
+/// relayed text stays one readable line. Every word
+/// [`carries_provider_identifier`] flags (an account, deployment, key, or
+/// network handle the provider echoed) is MASKED as `[redacted]`, keeping
+/// the sentence around it: dropping the whole line left 459 callers a day
+/// (2026-09-07) with "verify the request fields" and nothing to act on,
+/// while the handle itself is the only part that must not cross. Words the
+/// request itself carried stay. An over-long sentence is cut to the bound
+/// with an ellipsis rather than dropped.
 fn sanitized_detail(message: &str, request_words: &[&str]) -> Option<String> {
     let trimmed = message.trim();
-    if trimmed.is_empty() || trimmed.chars().count() > MAXIMUM_DETAIL_LENGTH {
+    if trimmed.is_empty() {
         return None;
     }
     if trimmed
@@ -342,14 +347,69 @@ fn sanitized_detail(message: &str, request_words: &[&str]) -> Option<String> {
         return None;
     }
     let collapsed = trimmed.split_whitespace().collect::<Vec<_>>().join(" ");
-    if collapsed.is_empty()
-        || collapsed
-            .split(' ')
-            .any(|word| carries_provider_identifier(word, request_words))
-    {
+    if collapsed.is_empty() {
         return None;
     }
-    Some(collapsed)
+    Some(bounded_masked_line(&collapsed, request_words))
+}
+
+/// The placeholder a provider-side handle becomes in a relayed sentence.
+pub(crate) const REDACTED: &str = "[redacted]";
+
+/// Mask every identifier-bearing word of one collapsed line and bound its
+/// length. Trailing punctuation on a masked word survives so the sentence
+/// still reads (`org_a1b2c3:` -> `[redacted]:`).
+pub(crate) fn bounded_masked_line(collapsed: &str, request_words: &[&str]) -> String {
+    let masked = collapsed
+        .split(' ')
+        .map(|word| {
+            if carries_provider_identifier(word, request_words) {
+                let tail_start = word
+                    .char_indices()
+                    .rev()
+                    .find(|(_, c)| c.is_alphanumeric())
+                    .map_or(word.len(), |(index, c)| index + c.len_utf8());
+                format!("{REDACTED}{}", &word[tail_start..])
+            } else {
+                word.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if masked.chars().count() <= MAXIMUM_DETAIL_LENGTH {
+        return masked;
+    }
+    let mut cut: String = masked.chars().take(MAXIMUM_DETAIL_LENGTH - 1).collect();
+    cut.push('\u{2026}');
+    cut
+}
+
+/// Whether a 404 body is the provider refusing a CALLER reference (an
+/// `item_reference`, `conversation`, or similar handle the provider does not
+/// hold) rather than a missing model. OpenAI answers those as HTTP 404 with
+/// `type: invalid_request_error` and no `model_not_found` code (live
+/// 2026-09-07: "Item with id 'rs_...' not found. Items are not persisted when
+/// `store` is set to false." and "Conversation with id 'conv_...' not
+/// found."). The catalog is fine and every other rung would answer the same,
+/// so the request is the caller's 400, never a lane 404 that fails over: one
+/// client replaying foreign item ids drove 361 attempts across the astra
+/// ladder in three and a half hours.
+pub fn rejected_caller_reference_not_found(dialect: Dialect, body: &str) -> bool {
+    if !matches!(
+        dialect,
+        Dialect::OpenAiResponses | Dialect::OpenAiCompatible
+    ) {
+        return false;
+    }
+    let value: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let Some(error) = value.get("error") else {
+        return false;
+    };
+    error.get("type").and_then(Value::as_str) == Some("invalid_request_error")
+        && !rejected_model_not_found(dialect, body)
 }
 
 /// Whether one word of a provider sentence names provider-side infrastructure.
@@ -791,14 +851,14 @@ mod tests {
             rejected_detail(Dialect::OpenAiCompatible, multiline, &[]),
             None
         );
+        // An over-long sentence is bounded with an ellipsis, not dropped.
         let oversized = format!(
             r#"{{"error": {{"message": "{}"}}}}"#,
             "x".repeat(MAXIMUM_DETAIL_LENGTH + 1)
         );
-        assert_eq!(
-            rejected_detail(Dialect::OpenAiCompatible, &oversized, &[]),
-            None
-        );
+        let bounded = rejected_detail(Dialect::OpenAiCompatible, &oversized, &[]).expect("bounded");
+        assert_eq!(bounded.chars().count(), MAXIMUM_DETAIL_LENGTH);
+        assert!(bounded.ends_with('\u{2026}'));
         assert_eq!(rejected_detail(Dialect::OpenAiCompatible, "{}", &[]), None);
         assert_eq!(
             rejected_detail(Dialect::OpenAiCompatible, "<html>", &[]),
@@ -809,26 +869,57 @@ mod tests {
     }
 
     #[test]
-    fn provider_explanation_is_dropped_when_it_names_provider_infrastructure() {
+    fn provider_infrastructure_is_masked_and_the_sentence_relayed() {
         // One readable sentence each, differing only in the operator-facing
-        // value the provider chose to echo back.
-        for message in [
-            "The deployment gpt4o-prod-7f2a91be44 is not configured for this account.",
-            "Model access denied for account 5f4dcc3b5aa765d61d8327deb882cf99.",
-            "Request 3f8a1c2e-9b44-4d17-9a1e-77c0d2b8e451 failed validation.",
-            "Route your request to https://eastus2.api.internal.example.com instead.",
-            "Contact platform-oncall@example.com about this quota.",
-            "The endpoint 10.42.117.8 rejected the model.",
-            "Deployment prod-7 is retired.",
-            "Quota exhausted for acct-123.",
-            "Use region eastus2 instead.",
-            "Model arn:aws:bedrock:us-east-1:481516234299:model/private is unavailable.",
+        // value the provider chose to echo back: the value is masked, the
+        // sentence around it (what the caller can act on) survives.
+        for (message, masked) in [
+            (
+                "The deployment gpt4o-prod-7f2a91be44 is not configured for this account.",
+                "The deployment [redacted] is not configured for this account.",
+            ),
+            (
+                "Model access denied for account 5f4dcc3b5aa765d61d8327deb882cf99.",
+                "Model access denied for account [redacted].",
+            ),
+            (
+                "Request 3f8a1c2e-9b44-4d17-9a1e-77c0d2b8e451 failed validation.",
+                "Request [redacted] failed validation.",
+            ),
+            (
+                "Route your request to https://eastus2.api.internal.example.com instead.",
+                "Route your request to [redacted] instead.",
+            ),
+            (
+                "Contact platform-oncall@example.com about this quota.",
+                "Contact [redacted] about this quota.",
+            ),
+            (
+                "The endpoint 10.42.117.8 rejected the model.",
+                "The endpoint [redacted] rejected the model.",
+            ),
+            (
+                "Deployment prod-7 is retired.",
+                "Deployment [redacted] is retired.",
+            ),
+            (
+                "Quota exhausted for acct-123.",
+                "Quota exhausted for [redacted].",
+            ),
+            (
+                "Use region eastus2 instead.",
+                "Use region [redacted] instead.",
+            ),
+            (
+                "Model arn:aws:bedrock:us-east-1:481516234299:model/private is unavailable.",
+                "Model [redacted] is unavailable.",
+            ),
         ] {
             let body = format!(r#"{{"error": {{"message": "{message}"}}}}"#);
             assert_eq!(
-                rejected_detail(Dialect::OpenAiCompatible, &body, &[]),
-                None,
-                "relayed an identifier-bearing sentence: {message}"
+                rejected_detail(Dialect::OpenAiCompatible, &body, &[]).as_deref(),
+                Some(masked),
+                "identifier not masked: {message}"
             );
         }
         // Ordinary caller-actionable prose stays relayable, including the
@@ -917,9 +1008,12 @@ mod request_word_tests {
         let body = r#"{"type": "error", "error": {"type": "invalid_request_error",
             "message": "claude-fable-5-1 requires Claude Code version 2.1.251 or later. Please upgrade Claude Code to continue."}}"#;
         assert_eq!(
-            rejected_detail(Dialect::AnthropicMessages, body, &[]),
-            None,
-            "without the request's own words the label-shaped model id still redacts"
+            rejected_detail(Dialect::AnthropicMessages, body, &[]).as_deref(),
+            Some(
+                "[redacted] requires Claude Code version 2.1.251 or later. \
+                 Please upgrade Claude Code to continue."
+            ),
+            "without the request's own words the label-shaped model id is masked"
         );
         assert_eq!(
             rejected_detail(Dialect::AnthropicMessages, body, &["claude-fable-5-1"]).as_deref(),
@@ -935,9 +1029,9 @@ mod request_word_tests {
         let body = r#"{"type": "error", "error": {"type": "invalid_request_error",
             "message": "claude-fable-5-1 is retired on deployment prod-7f2a; contact your operator."}}"#;
         assert_eq!(
-            rejected_detail(Dialect::AnthropicMessages, body, &["claude-fable-5-1"]),
-            None,
-            "an infrastructure label beside the known word still redacts the sentence"
+            rejected_detail(Dialect::AnthropicMessages, body, &["claude-fable-5-1"]).as_deref(),
+            Some("claude-fable-5-1 is retired on deployment [redacted]; contact your operator."),
+            "an infrastructure label beside the known word is masked, the known word kept"
         );
     }
 
@@ -952,8 +1046,42 @@ mod request_word_tests {
                 Dialect::AnthropicMessages,
                 body,
                 &["arn:aws:bedrock:us-east-1:123:model/x"],
-            ),
-            None
+            )
+            .as_deref(),
+            Some("Model [redacted] is unavailable.")
         );
+    }
+
+    #[test]
+    fn a_404_refusing_a_caller_reference_is_the_callers_error_not_a_missing_model() {
+        let item = r#"{"error":{"message":"Item with id 'rs_0' not found. Items are not persisted when `store` is set to false.","type":"invalid_request_error","param":"input","code":null}}"#;
+        assert!(rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            item
+        ));
+        assert!(rejected_caller_reference_not_found(
+            Dialect::OpenAiCompatible,
+            item
+        ));
+        let conversation = r#"{"error":{"message":"Conversation with id 'conv_0' not found.","type":"invalid_request_error","param":null,"code":null}}"#;
+        assert!(rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            conversation
+        ));
+        let model = r#"{"error":{"message":"The model `x` does not exist.","type":"invalid_request_error","param":"model","code":"model_not_found"}}"#;
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            model
+        ));
+        let anthropic =
+            r#"{"type":"error","error":{"type":"not_found_error","message":"model: x"}}"#;
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::AnthropicMessages,
+            anthropic
+        ));
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            "<html>"
+        ));
     }
 }

--- a/exp/runtime/gateway/native/src/rejection_shapes.rs
+++ b/exp/runtime/gateway/native/src/rejection_shapes.rs
@@ -1,0 +1,262 @@
+//! Provider rejection SHAPES the pre-stream and in-stream failure paths read
+//! off a client-error body: an aggregator's generic sentence hiding the
+//! upstream's own, a lane limitation a caller cannot fix, an aggregator
+//! routing gate that is not a credential verdict, and a 404 that refuses a
+//! handle the caller sent rather than naming a missing model. Each reads only
+//! the dialect's documented fields and never logs body text.
+
+use serde_json::Value;
+
+use crate::dialects::Dialect;
+use crate::param_attribution::{error_message_field, rejected_model_not_found};
+
+/// Sentences a provider answers with a 400 for a request shape the OpenAI
+/// contract allows but THIS lane's serving stack cannot carry (a chat
+/// template that only accepts a leading system turn). They are lane
+/// limitations, not caller errors: the request fails over to the next rung and
+/// only a route with no other rung surfaces the sentence.
+const LANE_LIMITATION_PHRASES: &[&str] = &[
+    "system message must be at the beginning",
+    "system message should be at the beginning",
+    "only the first message can be a system message",
+];
+
+/// Whether a 4xx body's error SENTENCE describes a limitation of the lane
+/// rather than of the caller's request (see [`LANE_LIMITATION_PHRASES`]). Only
+/// the dialect's message field is read, so request text echoed elsewhere in
+/// the body cannot change routing.
+pub fn rejected_by_lane_limitation(dialect: Dialect, body: &str) -> bool {
+    let value: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    error_message_field(dialect, &value).is_some_and(|message| {
+        let lowered = message.to_ascii_lowercase();
+        LANE_LIMITATION_PHRASES
+            .iter()
+            .any(|phrase| lowered.contains(phrase))
+    })
+}
+
+/// Whether a 403 body is an aggregator ROUTING verdict rather than a
+/// credential one. OpenRouter runs its routing funnel only AFTER the key has
+/// authenticated, and reports the funnel it walked (`metadata.routing_funnel`)
+/// plus the step that refused (`metadata.failed_routing_step`; "Gate Free
+/// Endpoints by Agentic Harness" on its app-allow-listed free endpoints,
+/// 2026-09-06). Both fields together mean the key is fine and this lane will
+/// not serve this model for the gateway's account, so it takes the not-found
+/// policy and the ladder advances. Only the OpenAI-compatible wire OpenRouter
+/// speaks is read; other dialects keep the credential verdict.
+pub fn rejected_by_routing_gate(dialect: Dialect, body: &str) -> bool {
+    if dialect != Dialect::OpenAiCompatible {
+        return false;
+    }
+    let value: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let Some(metadata) = value.get("error").and_then(|error| error.get("metadata")) else {
+        return false;
+    };
+    let walked_funnel = metadata
+        .get("routing_funnel")
+        .and_then(Value::as_array)
+        .is_some_and(|steps| !steps.is_empty());
+    let failed_step = metadata
+        .get("failed_routing_step")
+        .and_then(Value::as_str)
+        .is_some_and(|step| !step.trim().is_empty());
+    walked_funnel && failed_step
+}
+
+/// Aggregator sentences that say nothing about what was refused.
+const GENERIC_AGGREGATOR_MESSAGES: &[&str] = &["provider returned error", "provider error"];
+
+/// The upstream provider's own sentence behind an aggregator's generic one.
+///
+/// OpenRouter answers a rejected relay with "Provider returned error" and
+/// puts the upstream body in `error.metadata.raw` (a JSON document or plain
+/// text) plus the upstream's name in `error.metadata.provider_name`. The
+/// generic sentence leaves the caller nothing to act on (673 such 400s across
+/// 137 orgs in the 24h to 2026-09-07 00:20 UTC), so when the aggregator's
+/// message is generic the upstream sentence is read instead, prefixed with
+/// the provider's name. Only the message field of a JSON `raw` is used; a
+/// plain-text `raw` is taken whole. The result still passes the same
+/// identifier screen and length bound as any relayed sentence.
+pub fn upstream_relayed_message(error: &Value, message: &str) -> Option<String> {
+    let lowered = message.trim().trim_end_matches('.').to_ascii_lowercase();
+    if !GENERIC_AGGREGATOR_MESSAGES.contains(&lowered.as_str()) {
+        return None;
+    }
+    let metadata = error.get("metadata")?;
+    let raw = metadata.get("raw")?;
+    let upstream = match raw {
+        Value::String(text) => match serde_json::from_str::<Value>(text) {
+            Ok(document) => json_error_sentence(&document)?,
+            Err(_) => text.trim().to_string(),
+        },
+        Value::Object(_) => json_error_sentence(raw)?,
+        _ => return None,
+    };
+    if upstream.is_empty() {
+        return None;
+    }
+    let provider = metadata
+        .get("provider_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| {
+            !name.is_empty()
+                && name.chars().all(|c| {
+                    c.is_ascii_alphanumeric() || c == ' ' || c == '-' || c == '_' || c == '.'
+                })
+        });
+    Some(match provider {
+        Some(name) => format!("{name}: {upstream}"),
+        None => upstream,
+    })
+}
+
+/// The human sentence of one upstream error document, whichever documented
+/// spelling it uses (`error.message`, `message`, `detail`, or a bare string
+/// `error`).
+fn json_error_sentence(document: &Value) -> Option<String> {
+    let error = document.get("error");
+    let candidates = [
+        error.and_then(|error| error.get("message")),
+        document.get("message"),
+        document.get("detail"),
+        error.filter(|value| value.is_string()),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find_map(|value| value.as_str())
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+/// Whether a 404 body is the provider refusing a CALLER reference (an
+/// `item_reference`, `conversation`, or similar handle the provider does not
+/// hold) rather than a missing model. OpenAI answers those as HTTP 404 with
+/// `type: invalid_request_error` and no `model_not_found` code (live
+/// 2026-09-07: "Item with id 'rs_...' not found. Items are not persisted when
+/// `store` is set to false." and "Conversation with id 'conv_...' not
+/// found."). The catalog is fine and every other rung would answer the same,
+/// so the request is the caller's 400, never a lane 404 that fails over: one
+/// client replaying foreign item ids drove 361 attempts across the astra
+/// ladder in three and a half hours.
+pub fn rejected_caller_reference_not_found(dialect: Dialect, body: &str) -> bool {
+    if !matches!(
+        dialect,
+        Dialect::OpenAiResponses | Dialect::OpenAiCompatible
+    ) {
+        return false;
+    }
+    let value: Value = match serde_json::from_str(body) {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let Some(error) = value.get("error") else {
+        return false;
+    };
+    if error.get("type").and_then(Value::as_str) != Some("invalid_request_error")
+        || rejected_model_not_found(dialect, body)
+    {
+        return false;
+    }
+    // Positive evidence only: the provider names the `input` field, or the
+    // sentence opens with one of its reference-not-found shapes. A 404 that
+    // names neither (a model or deployment reported without the documented
+    // code) keeps the lane policy so another rung can still serve.
+    let names_input = error.get("param").and_then(Value::as_str) == Some("input");
+    let sentence = error.get("message").and_then(Value::as_str).unwrap_or("");
+    names_input
+        || CALLER_REFERENCE_SENTENCES
+            .iter()
+            .any(|prefix| sentence.starts_with(prefix))
+}
+
+/// How OpenAI opens a 404 about a handle the caller sent (live 2026-09-07).
+const CALLER_REFERENCE_SENTENCES: &[&str] = &[
+    "Item with id ",
+    "Conversation with id ",
+    "Previous response with id ",
+    "Response with id ",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::param_attribution::rejected_detail;
+
+    #[test]
+    fn an_aggregators_generic_sentence_yields_to_the_upstream_message() {
+        let body = r#"{"error":{"message":"Provider returned error","code":400,
+            "metadata":{"raw":"{\"error\":{\"message\":\"Input exceeds the maximum context window.\",\"type\":\"invalid_request_error\"}}",
+            "provider_name":"Relace"}}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, body, &[]).as_deref(),
+            Some("Relace: Input exceeds the maximum context window.")
+        );
+        // A plain-text raw is relayed whole; a specific aggregator sentence is kept.
+        let plain = r#"{"error":{"message":"Provider returned error","code":400,
+            "metadata":{"raw":"model is overloaded, try again","provider_name":"Fugu"}}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, plain, &[]).as_deref(),
+            Some("Fugu: model is overloaded, try again")
+        );
+        let specific = r#"{"error":{"message":"temperature must be <= 1","code":400,
+            "metadata":{"raw":"{\"error\":{\"message\":\"ignored\"}}"}}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, specific, &[]).as_deref(),
+            Some("temperature must be <= 1")
+        );
+        // Without metadata the generic sentence stays what it was.
+        let bare = r#"{"error":{"message":"Provider returned error","code":400}}"#;
+        assert_eq!(
+            rejected_detail(Dialect::OpenAiCompatible, bare, &[]).as_deref(),
+            Some("Provider returned error")
+        );
+    }
+
+    #[test]
+    fn a_404_refusing_a_caller_reference_is_the_callers_error_not_a_missing_model() {
+        let item = r#"{"error":{"message":"Item with id 'rs_0' not found. Items are not persisted when `store` is set to false.","type":"invalid_request_error","param":"input","code":null}}"#;
+        assert!(rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            item
+        ));
+        assert!(rejected_caller_reference_not_found(
+            Dialect::OpenAiCompatible,
+            item
+        ));
+        let conversation = r#"{"error":{"message":"Conversation with id 'conv_0' not found.","type":"invalid_request_error","param":null,"code":null}}"#;
+        assert!(rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            conversation
+        ));
+        let model = r#"{"error":{"message":"The model `x` does not exist.","type":"invalid_request_error","param":"model","code":"model_not_found"}}"#;
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            model
+        ));
+        // A model reported as a 404 WITHOUT the documented code, naming neither
+        // `input` nor a reference shape, keeps the lane policy.
+        let uncoded_model = r#"{"error":{"message":"The model `x` was not found.","type":"invalid_request_error","param":"model","code":null}}"#;
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            uncoded_model
+        ));
+        let anthropic =
+            r#"{"type":"error","error":{"type":"not_found_error","message":"model: x"}}"#;
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::AnthropicMessages,
+            anthropic
+        ));
+        assert!(!rejected_caller_reference_not_found(
+            Dialect::OpenAiResponses,
+            "<html>"
+        ));
+    }
+}

--- a/exp/runtime/gateway/native/src/upstream.rs
+++ b/exp/runtime/gateway/native/src/upstream.rs
@@ -8,8 +8,9 @@ use serde_json::Value;
 use crate::dialects::Dialect;
 use crate::errors::{Failure, FailureClass};
 use crate::param_attribution::{
-    generic_error_code, rejected_by_lane_limitation, rejected_by_routing_gate, rejected_code,
-    rejected_detail, rejected_model_not_found, rejected_parameter,
+    generic_error_code, rejected_by_lane_limitation, rejected_by_routing_gate,
+    rejected_caller_reference_not_found, rejected_code, rejected_detail, rejected_model_not_found,
+    rejected_parameter,
 };
 
 /// Build the shared pooled upstream client, mirroring the pooling constants in
@@ -174,8 +175,9 @@ pub async fn open_stream(
         // is read bounded, and the relayable facts are a validated parameter
         // path plus the provider's own bounded explanation of what the caller
         // got wrong; every other class stays content-free. A 403 is read too,
-        // only to tell an aggregator routing gate from a credential verdict.
-        if failure.failure_class != FailureClass::InvalidRequest && status != 403 {
+        // only to tell an aggregator routing gate from a credential verdict,
+        // and a 404 to tell a caller's dangling reference from a missing model.
+        if failure.failure_class != FailureClass::InvalidRequest && status != 403 && status != 404 {
             return Err(failure);
         }
         // The attribution read never outlives the rung's own header-phase
@@ -188,6 +190,38 @@ pub async fn open_stream(
             Ok(Some(body)) => Some(body),
             _ => None,
         };
+        if status == 404 {
+            // OpenAI answers 404 for an `item_reference`, `conversation`, or
+            // similar handle the caller sent but the provider does not hold
+            // (store=false items are never persisted). The catalog is fine and
+            // every rung would answer the same, so it is the caller's 400 with
+            // the provider's sentence, never a lane 404 that walks the ladder.
+            if body
+                .as_deref()
+                .is_some_and(|body| rejected_caller_reference_not_found(dialect, body))
+            {
+                let request_words: Vec<&str> = payload
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .into_iter()
+                    .collect();
+                let detail = body
+                    .as_deref()
+                    .and_then(|body| rejected_detail(dialect, body, &request_words));
+                let parameter = body
+                    .as_deref()
+                    .and_then(|body| rejected_parameter(dialect, body));
+                return Err(Failure::new(
+                    FailureClass::InvalidRequest,
+                    "the request references a provider-side item, response, or conversation \
+                     the provider does not hold; resend that content inline",
+                )
+                .with_retry(false, false)
+                .with_rejected_parameter(parameter)
+                .with_provider_detail(detail));
+            }
+            return Err(failure);
+        }
         if status == 403 {
             if body
                 .as_deref()
@@ -403,8 +437,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_dropped_provider_sentence_still_relays_the_provider_code() {
-        // The sentence names an account handle, so the identifier screen drops
-        // it; the caller still learns WHICH rejection it was.
+        // The sentence names an account handle: the handle is masked and the
+        // sentence around it still reaches the caller.
         let failure = open_against_body(
             "400 Bad Request",
             "{\"error\":{\"code\":\"invalid_value\",\"type\":\"invalid_request_error\",\
@@ -413,11 +447,57 @@ mod tests {
         )
         .await;
         assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
-        assert_eq!(failure.provider_detail.as_deref(), Some("invalid_value"));
+        assert_eq!(
+            failure.provider_detail.as_deref(),
+            Some("Invalid value for organization [redacted]: not allowed")
+        );
         assert_eq!(
             failure.public_error().message,
-            "provider rejected the request: invalid_value"
+            "provider rejected the request: Invalid value for organization [redacted]: not allowed"
         );
+    }
+
+    #[tokio::test]
+    async fn a_404_for_a_callers_dangling_item_reference_is_the_callers_400() {
+        let failure = open_against_body(
+            "404 Not Found",
+            "{\"error\":{\"message\":\"Item with id 'rs_0000' not found. Items are not \
+             persisted when `store` is set to false.\",\"type\":\"invalid_request_error\",\
+             \"param\":\"input\",\"code\":null}}",
+            "gpt-6-astra",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::InvalidRequest);
+        assert!(
+            !failure.failover_eligible,
+            "every rung would answer the same"
+        );
+        assert_eq!(failure.public_error().status_code, 400);
+        assert!(failure
+            .provider_detail
+            .as_deref()
+            .is_some_and(|detail| detail.starts_with("Item with id 'rs_0000' not found")));
+    }
+
+    #[tokio::test]
+    async fn a_404_naming_a_missing_model_keeps_the_lane_policy() {
+        let failure = open_against_body(
+            "404 Not Found",
+            "{\"error\":{\"message\":\"The model `x` does not exist or you do not have \
+             access to it.\",\"type\":\"invalid_request_error\",\"param\":\"model\",\
+             \"code\":\"model_not_found\"}}",
+            "x",
+        )
+        .await;
+        assert_eq!(failure.failure_class, FailureClass::ProviderNotFound);
+        assert!(failure.failover_eligible);
+    }
+
+    #[tokio::test]
+    async fn a_bodiless_404_keeps_the_lane_policy() {
+        let failure = open_against_body("404 Not Found", "", "m").await;
+        assert_eq!(failure.failure_class, FailureClass::ProviderNotFound);
+        assert!(failure.failover_eligible);
     }
 
     #[tokio::test]

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -26,17 +26,35 @@ from exp.runtime.models.providers.wire_messages import (
 )
 
 _INPUT_MESSAGE_ROLES = frozenset({"user", "system", "developer"})
+# Item ids another gateway's Responses emulation mints; no OpenAI wire issues
+# them, and OpenAI refuses a replayed item carrying one ("Expected an ID that
+# begins with 'rs'" / 'msg'; 164 requests across six orgs in the 48h to
+# 2026-09-07). Only this observed shape is treated as foreign.
+_FOREIGN_ITEM_ID_PREFIX = "item_"
 
 
-def _without_input_message_status(item: JsonObject) -> JsonObject:
-    """Drop ``status`` from a replayed input message; every other item is verbatim."""
+def _replayable_native_item(item: JsonObject) -> JsonObject | None:
+    """Shape one replayed Responses item for the OpenAI wire; ``None`` drops it.
+
+    Two client habits are repaired, everything else re-emits verbatim: an
+    input MESSAGE loses the output-only ``status`` OpenAI rejects on it, and
+    an item carrying a foreign ``id`` loses the id (a reasoning item with a
+    foreign id is dropped whole: without its encrypted content the provider
+    has nothing to resume from, and the id alone is refused).
+    """
+    shaped = item
+    item_id = shaped.get("id")
+    if isinstance(item_id, str) and item_id.startswith(_FOREIGN_ITEM_ID_PREFIX):
+        if shaped.get("type") == "reasoning" and "encrypted_content" not in shaped:
+            return None
+        shaped = {key: value for key, value in shaped.items() if key != "id"}
     if (
-        "status" in item
-        and item.get("type") in (None, "message")
-        and item.get("role") in _INPUT_MESSAGE_ROLES
+        "status" in shaped
+        and shaped.get("type") in (None, "message")
+        and shaped.get("role") in _INPUT_MESSAGE_ROLES
     ):
-        return {key: value for key, value in item.items() if key != "status"}
-    return item
+        shaped = {key: value for key, value in shaped.items() if key != "status"}
+    return shaped
 
 
 def openai_responses_stream_payload(
@@ -84,7 +102,9 @@ def openai_responses_stream_payload(
             # the input-message schema has no such field and OpenAI answers
             # 400 "Unknown parameter: 'input[N].status'". Hosted tool items
             # keep theirs (their schema defines it).
-            items.append(_without_input_message_status(message.provider_native_item))
+            replayable = _replayable_native_item(message.provider_native_item)
+            if replayable is not None:
+                items.append(replayable)
         elif message.role in {"system", "developer"}:
             if message.content is None:
                 raise ProviderResponseError("instruction messages require text")

--- a/exp/runtime/models/providers/openai_payloads_test.py
+++ b/exp/runtime/models/providers/openai_payloads_test.py
@@ -97,3 +97,45 @@ def test_replayed_responses_items_drop_the_output_only_status_field() -> None:
     assert hosted in items
     # The caller's own item object is left untouched.
     assert replayed["status"] == "completed"
+
+
+def test_replayed_items_with_foreign_ids_are_repaired_for_the_openai_wire() -> None:
+    """An ``item_``-prefixed id (another gateway's emulation) is dropped from a
+    replayed message and function call, a reasoning item carrying one is dropped
+    whole, and OpenAI's own ids pass untouched."""
+    foreign_message: JsonObject = {
+        "type": "message",
+        "role": "assistant",
+        "id": "item_4762e0563d44cba8b5696951",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "hello", "annotations": []}],
+    }
+    foreign_call: JsonObject = {
+        "type": "function_call",
+        "id": "item_9f1c",
+        "call_id": "call_1",
+        "name": "read",
+        "arguments": "{}",
+    }
+    foreign_reasoning: JsonObject = {"type": "reasoning", "id": "item_ab12", "summary": []}
+    own_reasoning: JsonObject = {"type": "reasoning", "id": "rs_1", "summary": []}
+    request = GatewayRequest(
+        surface=GatewayApiSurface.RESPONSES,
+        messages=(
+            GatewayMessage(role="user", content="go"),
+            GatewayMessage(role="assistant", provider_native_item=foreign_reasoning),
+            GatewayMessage(role="assistant", provider_native_item=foreign_message),
+            GatewayMessage(role="assistant", provider_native_item=foreign_call),
+            GatewayMessage(role="assistant", provider_native_item=own_reasoning),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = openai_responses_stream_payload("gpt-5.6-sol", request, supports_temperature=False)
+    items = payload["input"]
+    assert isinstance(items, list)
+    assert foreign_reasoning not in items
+    assert {key: value for key, value in foreign_message.items() if key != "id"} in items
+    assert {key: value for key, value in foreign_call.items() if key != "id"} in items
+    assert own_reasoning in items
+    assert all("item_" not in str(item.get("id", "")) for item in items if isinstance(item, dict))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.44,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.45,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.44"
+version = "0.3.45"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

Three findings from the 2026-09-07 alerts triage.

- **A 404 storm misreported as "deployment not found".** 361 attempts on gpt-6-astra from one org (and 8 from another) were filed `provider_not_found` with "ask the gateway operator to verify the deployment model ID", and failed over across the whole ladder for three and a half hours. Live probe: OpenAI answers HTTP 404 `invalid_request_error` (code null) for an `item_reference` or `conversation` the caller sent but OpenAI does not hold ("Item with id 'rs_…' not found. Items are not persisted when `store` is set to false."). The engine read no body on a 404.
- **Opaque "verify the request fields" 400s.** 459 in 24h across OpenAI, OpenRouter, Tencent, Experiential Cloud and Cerebras lanes: the provider sentence was dropped whenever one word looked like an identifier, so the caller learned nothing.
- **Foreign item ids on Responses replays.** 164 requests across six orgs replay items whose ids start with `item_`, a shape no OpenAI wire issues; OpenAI rejects them with "Expected an ID that begins with 'rs'/'msg'".

## What

- `upstream.rs`: a 404 body is read (same bounded, deadline-capped read as 400/403). `rejected_caller_reference_not_found` (OpenAI dialects, `type: invalid_request_error`, not `model_not_found`) turns it into `InvalidRequest`, no failover, with the provider sentence relayed and a static fallback naming the remedy (resend the referenced content inline). `model_not_found` and bodiless 404s keep the lane policy.
- `param_attribution.rs` / `dialects.rs`: identifier-bearing words are masked as `[redacted]` (trailing punctuation kept) instead of dropping the sentence, on both the pre-stream and in-stream detail paths; over-long sentences are cut to the 240-char bound with an ellipsis. Multi-line payloads still drop entirely, so the existing e2e guarantee that a payload dump never reaches the caller holds. Credential-shaped words (`sk-…`, `AKIA…`, `eyJ…`) are masked like any other handle.
- `openai_payloads.py`: a replayed Responses item with an `item_`-prefixed id loses the id; a reasoning item carrying one without `encrypted_content` is dropped whole; everything else, hosted echoes included, re-emits verbatim.
- native 0.3.45.

## Verification

`cargo fmt --check`, `clippy -D warnings`, `cargo test --no-default-features` (262; new tests: the caller-reference 404 → 400 with detail, a `model_not_found` 404 and a bodiless 404 keep the lane policy, masking across ten infrastructure shapes, bounded truncation, masked credential shapes on the stream path). `ruff`, `ty`, payload/admission suites green with a new foreign-id test. Full pytest running.

Also done outside this PR: the `arcee-ai/virtuoso-large` and `ibm-granite/granite-4.1-8b` OpenRouter lanes (both ids gone upstream) are disabled via catalog drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)