### PR TITLE
release: bump experiential to 0.7.51 (native 0.3.45)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.50"
+version = "0.7.51"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.50"
+version = "0.7.51"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the v0.7.51 release. Ships the two merged, unreleased changes:

- #850: the assistant-prefill pre-check keys on the Claude release, not the wire, so relayed Claude rungs (OpenRouter/Azure) are covered.
- #851 (native 0.3.45): a 404 for a caller's dangling `item_reference` / `conversation` is the caller's 400 with the provider sentence, not a lane 404 that walks the ladder; provider handles in error sentences are masked as `[redacted]` instead of dropping the sentence; replayed Responses items with foreign `item_` ids are repaired.

Publishing: merge, then `gh release create v0.7.51 --target <merge sha>`, then the platform repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)