### PR TITLE
Allow a trusted custom origin for native provider dialects (0.7.52)

### DIFF
--- a/exp/cli/providers/setup.py
+++ b/exp/cli/providers/setup.py
@@ -637,6 +637,7 @@ def existing_setup_connections(existing: ModelCatalog | None) -> tuple[ProviderC
             region=connection.region,
             aws_access_key_id_env=connection.aws_access_key_id_env,
             bedrock_auth_mode=connection.bedrock_auth_mode,
+            trusted_custom_origin=connection.trusted_custom_origin,
         )
         for name, connection in sorted(existing.connections.items())
         if connection.provider in SETUP_PROVIDERS

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -149,12 +149,8 @@ class ConnectionConfig(ContractModel):
     region: str | None = Field(default=None, max_length=64)
     aws_access_key_id_env: str | None = Field(default=None, max_length=256)
     bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
-    # A native provider (anthropic/openai/gemini/openrouter) uses its built-in
-    # official endpoint by default. Set this to route it through a customer-run
-    # trusted endpoint via ``base_url`` in the SAME wire dialect (e.g. a reseller
-    # that speaks the Anthropic Messages API), preserving the native auth and
-    # response shape. Opt-in and default-off: the caller asserts the origin is
-    # trusted; the fixed-origin guard below stays in force for every other case.
+    # Opt-in: route a native provider (anthropic/openai/gemini/openrouter) through a
+    # customer-run trusted endpoint via ``base_url`` in its own dialect. Default-off.
     trusted_custom_origin: bool = False
 
     @field_validator("api_key_env", "aws_access_key_id_env")
@@ -192,18 +188,13 @@ class ConnectionConfig(ContractModel):
             )
         if self.trusted_custom_origin:
             if self.provider not in _FIXED_ORIGIN_PROVIDERS:
-                raise ValueError(
-                    "trusted_custom_origin applies only to a native provider "
-                    f"({', '.join(sorted(_FIXED_ORIGIN_PROVIDERS))}); "
-                    f"{self.provider!r} already accepts a base_url"
-                )
+                raise ValueError("trusted_custom_origin applies only to a native provider")
             if self.base_url is None:
                 raise ValueError("trusted_custom_origin requires an explicit base_url")
         elif self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
             raise ValueError(
                 f"native provider {self.provider!r} uses its built-in official endpoint; "
-                "set trusted_custom_origin=True to route it through a trusted custom base_url, "
-                "or use provider='openai-compatible' for an OpenAI-wire custom endpoint"
+                "set trusted_custom_origin=True or use provider='openai-compatible'"
             )
         if self.provider == "azure":
             if self.base_url is None:
@@ -319,10 +310,7 @@ class ConnectionConfig(ContractModel):
             identity["azure_api_surface"] = "model_inference"
         if self.region is not None:
             identity["region"] = self.region
-        if self.trusted_custom_origin:
-            # A trusted custom origin routes a native dialect to a customer host;
-            # it is part of the endpoint identity (only added when set, so an
-            # official-origin connection keeps its pre-existing digest).
+        if self.trusted_custom_origin:  # endpoint identity; added only when set
             identity["trusted_custom_origin"] = True
         effective_bedrock_auth_mode = self.bedrock_auth_mode
         if (

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -319,6 +319,11 @@ class ConnectionConfig(ContractModel):
             identity["azure_api_surface"] = "model_inference"
         if self.region is not None:
             identity["region"] = self.region
+        if self.trusted_custom_origin:
+            # A trusted custom origin routes a native dialect to a customer host;
+            # it is part of the endpoint identity (only added when set, so an
+            # official-origin connection keeps its pre-existing digest).
+            identity["trusted_custom_origin"] = True
         effective_bedrock_auth_mode = self.bedrock_auth_mode
         if (
             self.provider == "bedrock"
@@ -353,6 +358,8 @@ class ConnectionConfig(ContractModel):
             serialized.pop("aws_access_key_id_env", None)
         if self.bedrock_auth_mode is None:
             serialized.pop("bedrock_auth_mode", None)
+        if not self.trusted_custom_origin:
+            serialized.pop("trusted_custom_origin", None)
         return serialized
 
 

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -149,6 +149,13 @@ class ConnectionConfig(ContractModel):
     region: str | None = Field(default=None, max_length=64)
     aws_access_key_id_env: str | None = Field(default=None, max_length=256)
     bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    # A native provider (anthropic/openai/gemini/openrouter) uses its built-in
+    # official endpoint by default. Set this to route it through a customer-run
+    # trusted endpoint via ``base_url`` in the SAME wire dialect (e.g. a reseller
+    # that speaks the Anthropic Messages API), preserving the native auth and
+    # response shape. Opt-in and default-off: the caller asserts the origin is
+    # trusted; the fixed-origin guard below stays in force for every other case.
+    trusted_custom_origin: bool = False
 
     @field_validator("api_key_env", "aws_access_key_id_env")
     @classmethod
@@ -183,10 +190,20 @@ class ConnectionConfig(ContractModel):
                 "aws_access_key_id_env and bedrock_auth_mode are only accepted for "
                 "provider='bedrock'"
             )
-        if self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
+        if self.trusted_custom_origin:
+            if self.provider not in _FIXED_ORIGIN_PROVIDERS:
+                raise ValueError(
+                    "trusted_custom_origin applies only to a native provider "
+                    f"({', '.join(sorted(_FIXED_ORIGIN_PROVIDERS))}); "
+                    f"{self.provider!r} already accepts a base_url"
+                )
+            if self.base_url is None:
+                raise ValueError("trusted_custom_origin requires an explicit base_url")
+        elif self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
             raise ValueError(
                 f"native provider {self.provider!r} uses its built-in official endpoint; "
-                "use provider='openai-compatible' for a trusted custom endpoint"
+                "set trusted_custom_origin=True to route it through a trusted custom base_url, "
+                "or use provider='openai-compatible' for an OpenAI-wire custom endpoint"
             )
         if self.provider == "azure":
             if self.base_url is None:

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -149,8 +149,7 @@ class ConnectionConfig(ContractModel):
     region: str | None = Field(default=None, max_length=64)
     aws_access_key_id_env: str | None = Field(default=None, max_length=256)
     bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
-    # Opt-in: route a native provider (anthropic/openai/gemini/openrouter) through a
-    # customer-run trusted endpoint via ``base_url`` in its own dialect. Default-off.
+    # Opt-in: native provider via a trusted https base_url in its own dialect (default-off).
     trusted_custom_origin: bool = False
 
     @field_validator("api_key_env", "aws_access_key_id_env")
@@ -191,6 +190,8 @@ class ConnectionConfig(ContractModel):
                 raise ValueError("trusted_custom_origin applies only to a native provider")
             if self.base_url is None:
                 raise ValueError("trusted_custom_origin requires an explicit base_url")
+            if urlsplit(self.base_url).scheme != "https":
+                raise ValueError("trusted_custom_origin requires an https base_url")
         elif self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
             raise ValueError(
                 f"native provider {self.provider!r} uses its built-in official endpoint; "

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -539,6 +539,13 @@ def test_trusted_custom_origin_requires_a_base_url_and_a_native_provider() -> No
             api_key_env="FIXTURE_API_KEY",
             trusted_custom_origin=True,
         )
+    with pytest.raises(ValueError, match="requires an https base_url"):
+        ConnectionConfig(
+            provider="anthropic",
+            base_url="http://reseller.example.test/v1",
+            api_key_env="FIXTURE_API_KEY",
+            trusted_custom_origin=True,
+        )
 
 
 def test_azure_surface_inference_follows_the_resource_host() -> None:

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -511,6 +511,36 @@ def test_native_provider_rejects_a_custom_endpoint_that_could_receive_its_key(
         )
 
 
+def test_trusted_custom_origin_allows_a_native_dialect_custom_endpoint() -> None:
+    """An explicit trusted origin routes a native provider through a custom base_url.
+
+    A reseller that speaks the Anthropic Messages API serves claude-* in the
+    native dialect when the caller opts in; the fixed-origin guard stays on for
+    every case that does not set the flag.
+    """
+    connection = ConnectionConfig(
+        provider="anthropic",
+        base_url="https://reseller.example.test/v1",
+        api_key_env="FIXTURE_API_KEY",
+        trusted_custom_origin=True,
+    )
+    assert connection.base_url == "https://reseller.example.test/v1"
+    assert connection.trusted_custom_origin is True
+
+
+def test_trusted_custom_origin_requires_a_base_url_and_a_native_provider() -> None:
+    """The opt-in is meaningless without a custom origin, and only for native providers."""
+    with pytest.raises(ValueError, match="requires an explicit base_url"):
+        ConnectionConfig(provider="anthropic", trusted_custom_origin=True)
+    with pytest.raises(ValueError, match="only to a native provider"):
+        ConnectionConfig(
+            provider="openai-compatible",
+            base_url="https://reseller.example.test/v1",
+            api_key_env="FIXTURE_API_KEY",
+            trusted_custom_origin=True,
+        )
+
+
 def test_azure_surface_inference_follows_the_resource_host() -> None:
     """Foundry hosts serve model inference, Azure OpenAI hosts serve deployments."""
     assert infer_azure_api_surface("https://resource.openai.azure.com") == "openai_deployments"

--- a/exp/common/models/setup.py
+++ b/exp/common/models/setup.py
@@ -50,6 +50,9 @@ class ProviderConnection(ContractModel):
     region: str | None = Field(default=None, max_length=64)
     aws_access_key_id_env: str | None = Field(default=None, max_length=256)
     bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    # Opt-in: route a native provider through a trusted custom base_url in its
+    # own dialect (mirrors ConnectionConfig.trusted_custom_origin).
+    trusted_custom_origin: bool = False
 
     @model_validator(mode="after")
     def _require_supported_connection_shape(self) -> ProviderConnection:
@@ -107,10 +110,15 @@ class ProviderConnection(ContractModel):
         else:
             if self.api_key_env is None:
                 raise ValueError(f"{self.provider} requires api_key_env")
-            if self.base_url is not None and self.provider != "openai-compatible":
+            if (
+                self.base_url is not None
+                and self.provider != "openai-compatible"
+                and not self.trusted_custom_origin
+            ):
                 raise ValueError(
                     "base_url is only accepted for provider='openai-compatible' or "
-                    "provider='azure'; other native providers use their official endpoint"
+                    "provider='azure'; set trusted_custom_origin to route a native provider "
+                    "through a trusted custom endpoint"
                 )
             if self.api_version is not None:
                 raise ValueError("api_version is only accepted for provider='azure'")
@@ -125,6 +133,7 @@ class ProviderConnection(ContractModel):
             region=self.region,
             aws_access_key_id_env=self.aws_access_key_id_env,
             bedrock_auth_mode=self.bedrock_auth_mode,
+            trusted_custom_origin=self.trusted_custom_origin,
         )
         return self
 
@@ -139,6 +148,7 @@ class ProviderConnection(ContractModel):
             region=self.region,
             aws_access_key_id_env=self.aws_access_key_id_env,
             bedrock_auth_mode=self.bedrock_auth_mode,
+            trusted_custom_origin=self.trusted_custom_origin,
         )
 
     @model_serializer(mode="wrap")
@@ -152,6 +162,8 @@ class ProviderConnection(ContractModel):
             serialized.pop("aws_access_key_id_env", None)
         if self.bedrock_auth_mode is None:
             serialized.pop("bedrock_auth_mode", None)
+        if not self.trusted_custom_origin:
+            serialized.pop("trusted_custom_origin", None)
         return serialized
 
 

--- a/exp/runtime/gateway/platform.py
+++ b/exp/runtime/gateway/platform.py
@@ -148,6 +148,7 @@ class ProviderConnectionRevision(ContractModel):
     secret_reference: OpaqueSecretReference | None = None
     access_key_id_reference: OpaqueSecretReference | None = None
     bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    trusted_custom_origin: bool = False
     connection_sha256: Sha256
     active: bool = True
     created_at: AwareDatetime
@@ -576,6 +577,7 @@ class UpsertProviderConnectionCommand(ContractModel):
     secret_reference: OpaqueSecretReference | None = None
     access_key_id_reference: OpaqueSecretReference | None = None
     bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    trusted_custom_origin: bool = False
     replace: bool = False
 
 

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 17
+SCHEMA_VERSION = 18
 
 
 class GatewaySchemaError(RuntimeError):
@@ -685,6 +685,18 @@ _MIGRATION_17 = (
     "ALTER TABLE gateway_attempts ADD COLUMN counterfactual_cost_micro_usd INTEGER",
 )
 
+# v18: a native provider (anthropic/openai/gemini/openrouter) may carry a
+# custom base_url when trusted_custom_origin is set, so the flag rides the
+# revision alongside base_url or a reconstructed connection defaults it to 0
+# and the fixed-origin validator rejects the reload.
+_MIGRATION_18 = (
+    """
+    ALTER TABLE provider_connection_revisions
+    ADD COLUMN trusted_custom_origin INTEGER NOT NULL DEFAULT 0
+    CHECK (trusted_custom_origin IN (0, 1))
+    """,
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -703,6 +715,7 @@ _MIGRATIONS = {
     15: _MIGRATION_15,
     16: _MIGRATION_16,
     17: _MIGRATION_17,
+    18: _MIGRATION_18,
 }
 
 

--- a/exp/runtime/gateway/sqlite/platform.py
+++ b/exp/runtime/gateway/sqlite/platform.py
@@ -437,6 +437,7 @@ class SQLiteGatewayPlatform:
                         'Literal["access_key_pair", "api_key"]', str(row["bedrock_auth_mode"])
                     )
                 ),
+                trusted_custom_origin=bool(row["trusted_custom_origin"]),
                 connection_sha256=str(row["connection_sha256"]),
                 active=bool(row["active"]) and row["active_revision_id"] == row["revision_id"],
                 created_at=_datetime(row["created_at"]),

--- a/exp/runtime/gateway/sqlite/provider_authority.py
+++ b/exp/runtime/gateway/sqlite/provider_authority.py
@@ -128,8 +128,9 @@ def upsert_provider_connection(
         INSERT INTO provider_connection_revisions (
             revision_id, organization_id, connection_id, revision_number,
             provider, base_url, api_key_env, api_version, azure_api_surface, region,
-            aws_access_key_id_env, bedrock_auth_mode, connection_sha256, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            aws_access_key_id_env, bedrock_auth_mode, trusted_custom_origin,
+            connection_sha256, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             revision_id,
@@ -144,6 +145,7 @@ def upsert_provider_connection(
             config.region,
             config.aws_access_key_id_env,
             config.bedrock_auth_mode,
+            1 if config.trusted_custom_origin else 0,
             digest,
             now,
         ),
@@ -198,7 +200,7 @@ def bound_provider_connections(
         SELECT c.connection_id, r.revision_id, r.revision_number,
                r.provider, r.base_url, r.api_key_env, r.api_version,
                r.azure_api_surface, r.region,
-               r.aws_access_key_id_env, r.bedrock_auth_mode,
+               r.aws_access_key_id_env, r.bedrock_auth_mode, r.trusted_custom_origin,
                r.connection_sha256, c.active
         FROM alias_revision_provider_connections AS b
         JOIN provider_connections AS c
@@ -340,6 +342,7 @@ def _authority(row: sqlite3.Row) -> ProviderConnectionAuthority:
             if row["bedrock_auth_mode"] is None
             else cast('Literal["access_key_pair", "api_key"]', str(row["bedrock_auth_mode"]))
         ),
+        trusted_custom_origin=bool(row["trusted_custom_origin"]),
     )
     digest = str(row["connection_sha256"])
     if config.identity_sha256() != digest:
@@ -358,7 +361,7 @@ _SELECT_AUTHORITY = """
 SELECT c.connection_id, r.revision_id, r.revision_number,
        r.provider, r.base_url, r.api_key_env, r.api_version,
        r.azure_api_surface, r.region,
-       r.aws_access_key_id_env, r.bedrock_auth_mode,
+       r.aws_access_key_id_env, r.bedrock_auth_mode, r.trusted_custom_origin,
        r.connection_sha256, c.active
 FROM provider_connections AS c
 JOIN provider_connection_revisions AS r

--- a/exp/runtime/gateway/sqlite/provider_commands.py
+++ b/exp/runtime/gateway/sqlite/provider_commands.py
@@ -29,6 +29,7 @@ def sqlite_connection_config(command: UpsertProviderConnectionCommand) -> Connec
         region=command.region,
         aws_access_key_id_env=_environment_name(command.access_key_id_reference),
         bedrock_auth_mode=command.bedrock_auth_mode,
+        trusted_custom_origin=command.trusted_custom_origin,
     )
 
 

--- a/exp/runtime/gateway/sqlite/store_test.py
+++ b/exp/runtime/gateway/sqlite/store_test.py
@@ -1112,6 +1112,47 @@ def test_cross_tenant_grant_is_rejected_by_composite_foreign_keys(tmp_path: Path
         )
 
 
+def test_trusted_custom_origin_survives_sqlite_persistence(tmp_path: Path) -> None:
+    """A native custom-origin connection reloads with the flag and base_url intact.
+
+    Without persisting ``trusted_custom_origin`` the reconstruction would default
+    it to False and the fixed-origin validator would reject the reload (the
+    Greptile P1 on #853).
+    """
+    db = tmp_path / "gateway.db"
+    store = SQLiteGatewayStore(db)
+    store.create_organization(organization_id="org-one", slug="one", display_name="One")
+    store.upsert_provider_connection(
+        organization_id="org-one",
+        connection_id="reseller",
+        revision_id="provider-revision-one",
+        config=ConnectionConfig(
+            provider="anthropic",
+            base_url="https://reseller.example.test/v1",
+            api_key_env="RESELLER_API_KEY",
+            trusted_custom_origin=True,
+        ),
+    )
+    store.upsert_provider_connection(
+        organization_id="org-one",
+        connection_id="official",
+        revision_id="provider-revision-two",
+        config=ConnectionConfig(provider="anthropic", api_key_env="ANTHROPIC_API_KEY"),
+    )
+
+    # A FRESH store reads the persisted rows and reconstructs each ConnectionConfig
+    # back through the fixed-origin validator.
+    reopened = SQLiteGatewayStore(db)
+    by_id = {
+        authority.connection_id: authority.config
+        for authority in reopened.provider_connections(organization_id="org-one")
+    }
+    assert by_id["reseller"].trusted_custom_origin is True
+    assert by_id["reseller"].base_url == "https://reseller.example.test/v1"
+    assert by_id["official"].trusted_custom_origin is False
+    assert by_id["official"].base_url is None
+
+
 def test_provider_revisions_are_sqlite_authority_and_alias_bindings_remain_frozen(
     tmp_path: Path,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.51"
+version = "0.7.52"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.51"
+version = "0.7.52"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why
The platform's new "Serve it yourself" feature lets a Pro org route an existing model (e.g. `claude-sonnet-5`) through **their own** endpoint — a reseller/proxy — while preserving the model's native wire dialect (Anthropic Messages response type). Today `ConnectionConfig` rejects a `base_url` for the native providers (`_FIXED_ORIGIN_PROVIDERS`), forcing custom origins onto `openai-compatible` (OpenAI-chat wire), which loses the Anthropic response type.

## What
Add an opt-in `ConnectionConfig.trusted_custom_origin: bool = False`. When set, a native provider (anthropic/openai/gemini/openrouter) may carry a custom `base_url` and is dispatched in its native dialect to that origin. Default-off — the fixed-origin guard is unchanged for every case that doesn't set the flag — and the flag requires a native provider **and** an explicit `base_url`. No registry/client change: the registry already builds native HTTP clients with `connection.base_url or default_base_url`, and `AnthropicClient` already accepts `base_url`.

The caller (the platform) asserts the origin is trusted and performs SSRF validation + a live dialect probe before ever constructing such a connection; this flag is the engine's explicit, auditable opt-in seam.

Pure-Python change; native crate unchanged. Bumps `experiential` to 0.7.52.

## Tests
`exp/common/models/catalog_test.py`: the flag admits a native custom origin; it requires a base_url; it's rejected on a non-native provider; the flagless native+base_url case still raises (existing guard preserved). Adjacent suites green: `exp/common/models/` (251), connection-authoring (3), registry (20).