### PR TITLE
release: bump experiential to 0.7.54 (native 0.3.47)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.53"
+version = "0.7.54"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.53"
+version = "0.7.54"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the v0.7.54 release, shipping #856: forced `tool_choice` and mid-conversation system turns keyed on the Claude model on every wire, and OpenAI-compatible relay streams whose tool arguments end mid-token settle incomplete instead of malformed. Publishing: merge, then `gh release create v0.7.54 --target <merge sha>`, then the platform repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)