### PR TITLE
gateway: forward cache_sample_gate through the native control plane (0.7.55)

### DIFF
--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -187,6 +187,7 @@ class NativeControlPlane(
         readiness_probe: Callable[[], bool] | None = None,
         usage_reporter: Callable[[], JsonObject] | None = None,
         budget_error_factory: Callable[[str], NativeBridgeError] | None = None,
+        cache_sample_gate: Callable[[str], bool] | None = None,
         native_route_eligible: Callable[[GatewayRoute, GatewayRequest], bool] | None = None,
         guardrails: GuardrailEngine | None = None,
     ) -> None:
@@ -205,6 +206,11 @@ class NativeControlPlane(
             readiness_probe: Optional hosted lifecycle readiness callback.
             usage_reporter: Optional hosted usage report callback.
             budget_error_factory: Optional hosted mapping for a rejected reservation.
+            cache_sample_gate: Optional hosted predicate deciding whether one
+                settled attempt (by its ledger attempt id) may feed the
+                cache-priority EWMA; the host excludes promo-funded attempts
+                so subsidized replay cannot buy fair-share weight. ``None``
+                admits every sample; a raising gate skips the sample.
             native_route_eligible: Optional hosted policy for complete native semantics.
             guardrails: Optional identity-scoped engine. ``None`` leaves traffic unguarded.
         """
@@ -235,6 +241,7 @@ class NativeControlPlane(
         self._accounting = NativeAttemptAccounting(
             self._write_ledger,
             budget_error_factory=budget_error_factory,
+            cache_sample_gate=cache_sample_gate,
         )
 
     @property

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -2963,6 +2963,44 @@ def _settle_one_completed_chat(control: NativeControlPlane, raw_key: str) -> Non
     assert settled == "{}"
 
 
+def test_cache_sample_gate_reaches_accounting_through_the_control_plane(tmp_path: Path) -> None:
+    """A hosted gate forwarded at construction vets settled cache samples.
+
+    The hosted composition builds only ``NativeControlPlane``, never the
+    accounting registry directly, so the gate must ride the control plane's
+    constructor; a dropped kwarg would silently let promo-funded replay feed
+    the cache-priority EWMA.
+    """
+    gated: list[str] = []
+
+    def _gate(attempt_id: str) -> bool:
+        """Record the consulted attempt and veto its sample."""
+        gated.append(attempt_id)
+        return False
+
+    _manager, raw_key = _configured_gateway(tmp_path)
+    components = load_gateway_components(
+        tmp_path,
+        environment={"TEST_PROVIDER_KEY": "provider-secret-canary"},
+    )
+    control = NativeControlPlane(components, cache_sample_gate=_gate)
+    admission = _admit_started(control, raw_key, _chat_body())
+    settled = control.settle(
+        json.dumps(
+            {
+                "request_id": admission["request_id"],
+                "attempt_id": admission["attempt_id"],
+                "outcome": "completed",
+                "usage": {"input_tokens": 10, "cached_input_tokens": 4, "output_tokens": 2},
+                "tool_names": [],
+                "failure": None,
+            }
+        )
+    )
+    assert settled == "{}"
+    assert gated == [admission["attempt_id"]]
+
+
 def test_usage_callbacks_scope_reports_to_the_presented_key(tmp_path: Path) -> None:
     """A key sees only its own identity; anonymous callers see the whole organization."""
     control, raw_key = _control_plane(tmp_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.54"
+version = "0.7.55"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.54"
+version = "0.7.55"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## The promo-EWMA exclusion gate was unreachable from hosted compositions

0.7.53 (#849) declared `cache_sample_gate` on `NativeAttemptAccounting.__init__` with the agreed fail-closed semantics, but `NativeControlPlane.__init__` neither declared nor forwarded it - and the hosted composition builds only the control plane, never the accounting registry directly. So the anti-gaming exclusion (a hosted predicate vetoing promo-funded attempts from the cache-priority EWMA, validation-memo red-team #3) could not be wired: once `cache_priority_alpha` is authored anywhere, promo-funded settles would feed the EWMA and subsidized replay could buy fair-share weight. Reported by the platform integration, whose feature detection (`"cache_sample_gate" in signature(NativeControlPlane.__init__).parameters`) correctly read absent on 0.7.53.

Fix: the control plane takes the kwarg (documented like its `budget_error_factory` sibling) and forwards it to accounting. The regression test builds a real control plane with a recording gate and proves it is consulted exactly once with the settled attempt's LEDGER id through the full admit/start/settle path - the exact seam the platform keys its promo map on.

Not urgent in production terms (nothing authors `cache_priority_alpha` yet, and the EC activation gate additionally blocks it until cached>0 is observed), but it must ship before any alpha authoring.

Version: experiential 0.7.55 (0.7.54 is claimed by open release PR #857). Pure Python: no native change, the crate stays as main carries it (0.3.47, unreleased). No migration, no digest movement.

Gates: ruff check, ruff format --check, ty check, full pytest (3988 passed / 6 skipped), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)