### PR TITLE
openai_protocol: accept an empty additional_tools item (Codex Apps)

### DIFF
--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -1694,6 +1694,38 @@ def test_empty_tool_call_arguments_decode_as_the_canonical_empty_object() -> Non
     assert responses.request.messages[0].tool_calls[0].raw_arguments == "{}"
 
 
+def test_an_empty_additional_tools_item_forwards_natively() -> None:
+    """Codex's Apps integration ships ``additional_tools`` with ``tools: []``
+    when the connected app exposes no tools (live capture 2026-09-07, after
+    an app reconnect); the provider accepts it, so the gateway must forward
+    the item byte-for-byte instead of refusing the turn with a 400."""
+    additional_tools = {
+        "type": "additional_tools",
+        "id": "at_empty",
+        "role": "developer",
+        "tools": [],
+    }
+    decoded = decode_responses(
+        {
+            "model": "gpt-5.6",
+            "input": [
+                additional_tools,
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Run ls."}],
+                },
+            ],
+        }
+    )
+    natives = [
+        message.provider_native_item
+        for message in decoded.request.messages
+        if message.provider_native_item is not None
+    ]
+    assert natives == [additional_tools]
+
+
 def test_the_captured_codex_request_shape_decodes_losslessly() -> None:
     """Regression fixture: the field shapes real Codex (0.151.0) sends by
     default, trimmed from a live capture (2026-08-29). Native items carry

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -788,13 +788,17 @@ class _AdditionalToolsItem(_WireModel):
     has no cross-wire representation, so validation is deliberately shallow
     and the raw item forwards byte-for-byte on native Responses rungs only
     (captured live from Codex 0.151.0 and accepted by the provider with a
-    plain API key, 2026-08-29).
+    plain API key, 2026-08-29). ``tools`` may be EMPTY: Codex's Apps
+    integration ships the item with ``tools: []`` when the connected app
+    exposes no tools (observed 2026-09-07 after an app reconnect), and the
+    provider accepts that shape; requiring one entry turned every such turn
+    into a 400 that no other wire produces.
     """
 
     type: Literal["additional_tools"]
     id: str | None = Field(default=None, min_length=1, max_length=256)
     role: str | None = Field(default=None, max_length=64)
-    tools: tuple[JsonValue, ...] = Field(min_length=1)
+    tools: tuple[JsonValue, ...]
 
 
 class _CustomToolCall(_WireModel):


### PR DESCRIPTION
## Why

Codex's **Apps** integration puts an `additional_tools` item first in `input`; when the connected app exposes no tools (observed live 2026-09-07 right after an app "Reconnecting"), that item carries `tools: []`. OpenAI accepts it. Our wire model `_AdditionalToolsItem.tools` had `Field(min_length=1)`, so the gateway answered every such turn with:

```
{"error":{"message":"Invalid value for 'input.0.tools'.","type":"invalid_request_error","param":"input.0.tools","code":"invalid_parameter"}}
```

Reproduced against production with curl (`{"type":"additional_tools","tools":[]}` as `input[0]`), and seen twice in a real Codex session log (18:17Z after a 312 s turn, 19:32Z).

## What

`exp/runtime/openai_protocol/wire_models.py`: the `tools` tuple may be empty; docstring records why. Validation stays shallow and the item still forwards byte-for-byte on native Responses rungs (no Rust change: the hosted pass-through union already carries `additional_tools` opaquely). New regression test `test_an_empty_additional_tools_item_forwards_natively`.

## Validation

`pytest exp/runtime/openai_protocol/requests_test.py wire_models_test.py`: 146 passed. `ruff format/check` and `ty check` clean on the touched files.

Platform follow-up: pin bump once this is released; separately the platform gains a ledger for these pre-admission 400s (they currently leave no row anywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
