### PR TITLE
release: 0.7.56

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.55"
+version = "0.7.56"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.55"
+version = "0.7.56"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only (pyproject + uv.lock). Ships #859: an `additional_tools` input item with `tools: []` (Codex Apps with no connected tools) is accepted and forwarded instead of answered with `400 Invalid value for 'input.0.tools'`. Native crate unchanged (0.3.47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)