### PR TITLE
docs: index portable project bundle reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ results, and plans do not live here.
 | `reference/openai-compatible-recipes.md` | Verified Fireworks, Modal, and Experiential Cloud connection recipes through the openai-compatible provider family. |
 | `reference/ingest.md` | Current declared local trace source contract for every supported source. |
 | `reference/immutable-real-trace-rag.md` | Immutable real-trace retrieval provenance, leakage, persistence, and historical restoration contract. |
+| `reference/project-bundles.md` | Portable Project bundle export, integrity, restore, and runtime-state exclusion contract. |
 | `reference/router_optimization_config.md` | Exact completed-evidence configuration recipe for router optimization. |
 | `release-scope.md` | Supported and explicitly excluded release claims. |
 | `research/w16-router-sandbox-evidence.md` | Deterministic W16 router and local sandbox evidence, limits, and replay commands. |

--- a/exp/tests/release_test.py
+++ b/exp/tests/release_test.py
@@ -3176,13 +3176,20 @@ def test_w16_public_evidence_apis_resolve_from_release_owners() -> None:
 
 
 def test_documentation_index_commands_and_release_scope_are_current() -> None:
-    """Every indexed doc exists and release docs name current commands and explicit exclusions."""
+    """Every public doc is indexed and release docs name current commands and exclusions."""
     repository = Path(__file__).resolve().parent.parent.parent
     docs = repository / "docs"
     index = (docs / "README.md").read_text(encoding="utf-8")
     indexed_paths = re.findall(r"\| `([^`]+\.md)` \|", index)
     assert indexed_paths
+    assert len(indexed_paths) == len(set(indexed_paths))
     assert not [path for path in indexed_paths if not (docs / path).is_file()]
+    public_paths = {
+        path.relative_to(docs).as_posix()
+        for path in docs.rglob("*.md")
+        if path != docs / "README.md"
+    }
+    assert set(indexed_paths) == public_paths
 
     usage = (docs / "usage.md").read_text(encoding="utf-8")
     assert "exp optimize router" in usage


### PR DESCRIPTION
## Why

The public `docs/reference/project-bundles.md` page is missing from `docs/README.md`, even though the
repository requires the index to cover every public document. The release test checks that indexed
paths exist but does not detect existing pages that were never indexed.

## What

- Add `reference/project-bundles.md` to the documentation index.
- Extend the release test to compare indexed Markdown paths with all public Markdown files under
  `docs/`, excluding the index itself.
- Reject duplicate index rows as part of the same completeness contract.

## Validation

- Before the documentation change, the focused regression failed and reported
  `reference/project-bundles.md` as the extra unindexed path.
- `pytest -q exp/tests/release_test.py::test_documentation_index_commands_and_release_scope_are_current`: 1 passed.
- `pytest -q exp/tests/release_test.py`: 5 passed, 1 skipped; the installed-wheel evidence test was
  blocked because its isolated build could not reach PyPI from the sandbox.
- `ruff check .`: passed.
- `ruff format --check .`: 821 files already formatted.
- `ty check`: passed.

Closes #863
