### PR TITLE
gateway: ChatGPT plan connections (subscription = chatgpt) with per-dispatch bearers and usage-window rotation

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -257,8 +257,15 @@ rate-limit response headers per attempt when the data plane harvests them (`retr
 OpenAI `x-ratelimit-*` and Anthropic `anthropic-ratelimit-*` families, normalized to integers),
 and a throttled settlement carrying a parseable `Retry-After` (seconds or HTTP-date) sizes that
 deployment's throttle window from it, clamped to [5s, 6h], instead of the fixed default, so a
-daily-quota reset actually suppresses the rung for the wait the provider asked for. Pools and
-rungs that author none of this keep byte-identical behavior and null disclosure columns.
+daily-quota reset actually suppresses the rung for the wait the provider asked for. A ChatGPT
+plan rung (`subscription = "chatgpt"`) adds its rolling usage windows: the `x-codex-primary-*`
+and `x-codex-secondary-*` percent-used and reset headers land in the attempt's `plan_*` columns,
+and a window at 100 percent throttles that rung until the stated reset, success or not, so a
+certified pool of several plans rotates before the first 429 while sticky affinity keeps each
+conversation on one plan while it has room. A plan rung's bearer is minted per physical dispatch
+through the body-signing seam (`sign_dispatch`), the same hook Bedrock uses for SigV4, so queue
+time never ages a token and every redial signs afresh. Pools and rungs that author none of this
+keep byte-identical behavior and null disclosure columns.
 
 Under `maximize_cache_affinity`, two further per-rung fields keep provider prompt caches warm
 across spills. `sticky_spill_seconds` gives each dispatch a worker-local

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -54,6 +54,7 @@ unchanged: it uses the AWS credential chain and has no stored API key.
 | Provider | Catalog `provider` | Credential | Endpoint identity |
 |---|---|---|---|
 | OpenAI | `openai` | `api_key_env` (suggested `OPENAI_API_KEY`) | Official OpenAI origin |
+| ChatGPT plan (Codex) | `openai` with `subscription = "chatgpt"` | Browser sign-in stored under the connection ID; no `api_key_env` | `https://chatgpt.com/backend-api/codex` |
 | OpenRouter | `openrouter` | `api_key_env` (suggested `OPENROUTER_API_KEY`) | Official OpenRouter origin |
 | Anthropic | `anthropic` | `api_key_env` (suggested `ANTHROPIC_API_KEY`) | Official Anthropic origin |
 | Gemini | `gemini` | `api_key_env` (suggested `GEMINI_API_KEY`) | Official Gemini origin |
@@ -66,6 +67,45 @@ unchanged: it uses the AWS credential chain and has no stored API key.
 
 Native fixed-origin providers reject a custom `base_url`. Use `openai-compatible` for a trusted
 third-party OpenAI-compatible host.
+
+## ChatGPT plan connections
+
+A `subscription = "chatgpt"` connection dispatches on a ChatGPT plan (Plus, Pro, Team, or
+Enterprise seat) instead of an OpenAI API key. It is the sign-in Codex itself uses: the same
+public OAuth client, the same loopback callback (`http://localhost:1455/auth/callback`), and the
+same Codex Responses backend. The connection carries no credential name and accepts no endpoint
+override; the tokens live in the user-only credential file as a `type = "oauth"` record under the
+connection ID, beside API-key records.
+
+```console
+exp config gateway provider add plan-a --provider openai --subscription chatgpt --root ROOT
+exp config gateway provider add plan-b --provider openai --subscription chatgpt \
+  --codex-auth-file ~/.codex/auth.json --non-interactive --root ROOT
+```
+
+The first form opens the browser and waits for the callback (the port must be free: a running
+`codex login` holds it). The second imports an existing Codex sign-in without touching Codex's
+file; from then on the two refresh independently. Re-running `add` with `--replace` signs in
+again; `update` never re-authenticates. `provider list` shows `subscription = "chatgpt"` for the
+connection. The gateway mints a fresh bearer for every physical dispatch from the stored tokens,
+refreshing five minutes ahead of expiry and persisting the rotated refresh token, so a
+long-running worker never dispatches on a stale token. Every other CLI path, including
+`exp config providers`, build, and optimize, is API-key only: the plan backend serves streaming
+requests only, so a plan connection is gateway-only and its non-streaming completion path fails
+closed.
+
+The backend is stricter than the public Responses API and the connection's wire profile encodes
+that: requests always stream with provider storage disabled, and the caller's
+`max_output_tokens` is dropped structurally because the backend rejects the field. Every response
+carries the plan's rolling usage windows as `x-codex-primary-*` (the short window) and
+`x-codex-secondary-*` (the weekly window) headers; the gateway records them per attempt and, when
+a window reaches 100 percent, throttles that connection until the stated reset so a certified
+pool of several plans rotates to the next one before the first 429.
+
+Using a consumer plan through a gateway is subject to OpenAI's terms for that plan. The engine
+sends the client's own identity (`originator: experiential`) and never impersonates another
+client. Anthropic restricts Claude plan tokens to Claude Code, so no `subscription` kind exists
+for it.
 
 ## OpenAI-compatible listing metadata
 

--- a/docs/release-scope.md
+++ b/docs/release-scope.md
@@ -59,6 +59,7 @@ credentials. `Not run` means exactly that; it is not inferred from fixture cover
 | Provider surface | Deterministic evidence in this release | Credential-gated live evidence |
 |---|---|---|
 | OpenAI | Native Responses fixtures for text, tool arguments, usage, cancellation, and refusal; all eight official SDK quadrants run against the installed local gateway | Not run; requires an OpenAI credential |
+| ChatGPT plan (Codex backend) | Shares the native Responses fixtures; deterministic coverage of the sign-in store, code exchange and refresh grants, per-dispatch bearer minting, and usage-window throttling | Not run in CI; requires a signed-in ChatGPT plan |
 | Anthropic | Native Messages fixtures for text, tool arguments, usage, cancellation, and refusal through both public gateway surfaces | Not run; requires an Anthropic credential |
 | Generic OpenAI-compatible | Real loopback upstream through the installed gateway; text, tool arguments, usage, cancellation, and refusal contracts | Not run; requires a compatible hosted endpoint and credential |
 | Azure OpenAI | Compatible-adapter fixtures for text, tool arguments, usage, cancellation, and refusal | Not run; requires Azure endpoint and credential |

--- a/exp/cli/gateway/provider.py
+++ b/exp/cli/gateway/provider.py
@@ -6,13 +6,23 @@ from pathlib import Path
 from typing import Literal
 
 import typer
+from rich.console import Console
 
 from exp.cli.gateway.receipts import GatewayReceipt, emit_items, emit_receipt
+from exp.cli.providers.chatgpt_sign_in import chatgpt_browser_sign_in
 from exp.cli.shared.options import ROOT_OPTION, usage_error
-from exp.common.core.artifacts import ContractModel
+from exp.common.auth import ProviderAuthStore, StoredOAuthTokens
+from exp.common.core.artifacts import ContractModel, JsonObject
 from exp.common.core.locks import FileLockTimeout
 from exp.common.models import ConnectionConfig
+from exp.common.models.connection import SubscriptionKind
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.models.credentials import connection_credential_binding
+from exp.runtime.models.providers.chatgpt_subscription import (
+    ChatGptSignInError,
+    chatgpt_account_claims,
+    tokens_from_codex_auth_file,
+)
 
 provider_app = typer.Typer(
     help="Manage role-free gateway provider connections.", no_args_is_help=True
@@ -28,6 +38,16 @@ _AZURE_API_SURFACE_OPTION = typer.Option(None, "--azure-api-surface")
 _REGION_OPTION = typer.Option(None, "--region")
 _CLEAR_CREDENTIALS_OPTION = typer.Option(False, "--clear-credentials")
 _CLEAR_REGION_OPTION = typer.Option(False, "--clear-region")
+_SUBSCRIPTION_OPTION = typer.Option(
+    None,
+    "--subscription",
+    help="Sign in with a consumer plan instead of an API key (chatgpt).",
+)
+_CODEX_AUTH_FILE_OPTION = typer.Option(
+    None,
+    "--codex-auth-file",
+    help="Import an existing Codex auth.json sign-in instead of opening the browser.",
+)
 
 
 class GatewayProviderView(ContractModel):
@@ -35,6 +55,7 @@ class GatewayProviderView(ContractModel):
 
     name: str
     provider: str
+    subscription: SubscriptionKind | None = None
     credential_env: str | None = None
     access_key_id_env: str | None = None
     bedrock_auth_mode: str | None = None
@@ -95,6 +116,7 @@ def provider_list(root: Path = ROOT_OPTION, json_output: bool = _JSON_OPTION) ->
         GatewayProviderView(
             name=name,
             provider=connection.provider,
+            subscription=connection.subscription,
             credential_env=connection.api_key_env,
             access_key_id_env=connection.aws_access_key_id_env,
             bedrock_auth_mode=connection.bedrock_auth_mode,
@@ -107,6 +129,56 @@ def provider_list(root: Path = ROOT_OPTION, json_output: bool = _JSON_OPTION) ->
         for name, connection in ((authority.connection_id, authority.config),)
     )
     emit_items("providers", items, json_output=json_output)
+
+
+def _acquire_plan_sign_in(
+    *,
+    subscription: SubscriptionKind,
+    codex_auth_file: Path | None,
+    non_interactive: bool,
+) -> StoredOAuthTokens:
+    """Obtain the plan sign-in for a subscription connection.
+
+    Args:
+        subscription: The plan kind being connected.
+        codex_auth_file: Optional Codex ``auth.json`` to import instead of the browser.
+        non_interactive: Whether a browser sign-in may be opened.
+
+    Returns:
+        The tokens to store under the connection.
+
+    Raises:
+        ValueError: No sign-in source is usable without a browser, or the source failed.
+    """
+    del subscription  # exactly one kind exists; the parameter keeps the call site honest.
+    try:
+        if codex_auth_file is not None:
+            return tokens_from_codex_auth_file(codex_auth_file)
+        if non_interactive:
+            raise ValueError(
+                "a plan sign-in needs a browser; pass --codex-auth-file ~/.codex/auth.json to "
+                "import an existing Codex sign-in instead"
+            )
+        return chatgpt_browser_sign_in(console=Console())
+    except ChatGptSignInError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def _upsert_connection(
+    *,
+    name: str,
+    config: ConnectionConfig,
+    root: Path,
+    replace: bool,
+) -> bool:
+    """Create or revise one connection, translating store failures to usage errors."""
+    with usage_error(ValueError, FileLockTimeout):
+        changed, _authority = GatewayManagement(root).upsert_provider_connection(
+            connection_id=name,
+            config=config,
+            replace=replace,
+        )
+    return changed
 
 
 @provider_app.command("add")
@@ -123,34 +195,62 @@ def provider_add(
         _AZURE_API_SURFACE_OPTION
     ),
     region: str | None = _REGION_OPTION,
+    subscription: SubscriptionKind | None = _SUBSCRIPTION_OPTION,
+    codex_auth_file: Path | None = _CODEX_AUTH_FILE_OPTION,
     replace: bool = typer.Option(False, "--replace"),
     non_interactive: bool = _NON_INTERACTIVE_OPTION,
     json_output: bool = _JSON_OPTION,
 ) -> None:
-    """Add one environment-reference-only provider connection."""
-    del non_interactive
-    with usage_error(ValueError, FileLockTimeout):
-        changed, _authority = GatewayManagement(root).upsert_provider_connection(
-            connection_id=name,
-            config=ConnectionConfig(
-                provider=provider,
-                base_url=base_url,
-                api_key_env=credential_env,
-                aws_access_key_id_env=access_key_id_env,
-                bedrock_auth_mode=bedrock_auth_mode,
-                api_version=api_version,
-                azure_api_surface=azure_api_surface,
-                region=region,
-            ),
-            replace=replace,
+    """Add one provider connection: an environment-reference-only key, or a plan sign-in.
+
+    A ``--subscription`` connection signs in through the browser (or imports a Codex
+    ``auth.json``) and stores the tokens in the user-only credential file under the
+    connection name; re-running with ``--replace`` signs in again.
+    """
+    with usage_error(ValueError):
+        if codex_auth_file is not None and subscription is None:
+            raise ValueError("--codex-auth-file requires --subscription chatgpt")
+        config = ConnectionConfig(
+            provider=provider,
+            base_url=base_url,
+            api_key_env=credential_env,
+            subscription=subscription,
+            aws_access_key_id_env=access_key_id_env,
+            bedrock_auth_mode=bedrock_auth_mode,
+            api_version=api_version,
+            azure_api_surface=azure_api_surface,
+            region=region,
         )
+        tokens = (
+            None
+            if subscription is None
+            else _acquire_plan_sign_in(
+                subscription=subscription,
+                codex_auth_file=codex_auth_file,
+                non_interactive=non_interactive,
+            )
+        )
+    changed = _upsert_connection(name=name, config=config, root=root, replace=replace)
+    data: JsonObject = {}
+    if credential_env is not None:
+        data["credential_env"] = credential_env
+    if tokens is not None and subscription is not None:
+        with usage_error(ValueError, FileLockTimeout):
+            ProviderAuthStore().put_oauth(
+                name, tokens, binding=connection_credential_binding(config)
+            )
+            claims = chatgpt_account_claims(tokens.access_token)
+        data["subscription"] = subscription
+        data["sign_in"] = "codex-auth-file" if codex_auth_file is not None else "browser"
+        if claims.plan_type is not None:
+            data["plan_type"] = claims.plan_type
     emit_receipt(
         GatewayReceipt(
             operation="provider.add",
             resource_kind="provider",
             resource_id=name,
             changed=changed,
-            data={"credential_env": credential_env} if credential_env is not None else {},
+            data=data,
         ),
         json_output=json_output,
         human=f"provider {name} configured={changed}",
@@ -199,26 +299,48 @@ def provider_update(
                 clear_credentials=clear_credentials,
             )
         )
-    provider_add(
-        name=name,
-        provider=provider,
-        root=root,
-        credential_env=updated_credential_env,
-        access_key_id_env=updated_access_key_id_env,
-        bedrock_auth_mode=updated_bedrock_auth_mode,
-        base_url=current.base_url if base_url is None and same_provider else base_url,
-        api_version=current.api_version if api_version is None and same_provider else api_version,
-        azure_api_surface=(
-            current.azure_api_surface
-            if azure_api_surface is None and same_provider and provider == "azure"
-            else azure_api_surface
+    del non_interactive
+    with usage_error(ValueError):
+        config = ConnectionConfig(
+            provider=provider,
+            base_url=current.base_url if base_url is None and same_provider else base_url,
+            api_key_env=updated_credential_env,
+            # A plan sign-in survives an update untouched; re-authenticating is
+            # 'provider add NAME --subscription chatgpt --replace'.
+            subscription=current.subscription if same_provider else None,
+            aws_access_key_id_env=updated_access_key_id_env,
+            bedrock_auth_mode=updated_bedrock_auth_mode,
+            api_version=(
+                current.api_version if api_version is None and same_provider else api_version
+            ),
+            azure_api_surface=(
+                current.azure_api_surface
+                if azure_api_surface is None and same_provider and provider == "azure"
+                else azure_api_surface
+            ),
+            region=(
+                None
+                if clear_region
+                else current.region
+                if region is None and same_provider
+                else region
+            ),
+        )
+    changed = _upsert_connection(name=name, config=config, root=root, replace=True)
+    emit_receipt(
+        GatewayReceipt(
+            operation="provider.add",
+            resource_kind="provider",
+            resource_id=name,
+            changed=changed,
+            data=(
+                {"credential_env": updated_credential_env}
+                if updated_credential_env is not None
+                else {}
+            ),
         ),
-        region=(
-            None if clear_region else current.region if region is None and same_provider else region
-        ),
-        replace=True,
-        non_interactive=non_interactive,
         json_output=json_output,
+        human=f"provider {name} configured={changed}",
     )
 
 

--- a/exp/cli/gateway/provider_test.py
+++ b/exp/cli/gateway/provider_test.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 
+import pytest
 from click import unstyle
 from typer.testing import CliRunner
 
 from exp.cli.app import app
+from exp.common.auth import ProviderAuthStore
+from exp.common.models import ConnectionConfig
 from exp.runtime.gateway.management import GatewayManagement
+from exp.runtime.models.credentials import connection_credential_binding
 
 _runner = CliRunner()
 
@@ -476,3 +481,212 @@ def test_provider_update_can_clear_bedrock_auth_and_region_to_ambient(tmp_path: 
     assert authority.config.aws_access_key_id_env is None
     assert authority.config.bedrock_auth_mode is None
     assert authority.config.region is None
+
+
+def _codex_auth_file(tmp_path: Path) -> Path:
+    """Write a Codex-shaped ``auth.json`` carrying unsigned fixture tokens.
+
+    Args:
+        tmp_path: Test directory.
+
+    Returns:
+        Path of the fixture file.
+    """
+    claims = {
+        "exp": 4_000_000_000,
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": "acct-fixture",
+            "chatgpt_plan_type": "team",
+        },
+    }
+    segment = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    token = f"header.{segment}.signature"
+    path = tmp_path / "codex-auth.json"
+    path.write_text(
+        json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": token,
+                    "refresh_token": "refresh-fixture",
+                    "id_token": token,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_provider_add_imports_a_codex_sign_in_for_a_chatgpt_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plan connection stores the imported sign-in under the connection and lists its kind."""
+    root = _initialized_root(tmp_path / "root")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    auth_file = _codex_auth_file(tmp_path)
+
+    result = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "plan-a",
+            "--provider",
+            "openai",
+            "--subscription",
+            "chatgpt",
+            "--codex-auth-file",
+            str(auth_file),
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    receipt = json.loads(result.output)
+    assert receipt["data"] == {
+        "subscription": "chatgpt",
+        "sign_in": "codex-auth-file",
+        "plan_type": "team",
+    }
+    connection = GatewayManagement(root).provider_connections()[0]
+    assert connection.config == ConnectionConfig(provider="openai", subscription="chatgpt")
+    stored = ProviderAuthStore().get_oauth(
+        "plan-a", binding=connection_credential_binding(connection.config)
+    )
+    assert stored is not None
+    assert stored.account_id == "acct-fixture"
+    assert "refresh-fixture" not in result.output
+
+    listed = _runner.invoke(
+        app, ["config", "gateway", "provider", "list", "--json", "--root", str(root)]
+    )
+    assert json.loads(listed.output)["items"][0]["subscription"] == "chatgpt"
+
+
+def test_provider_add_for_a_plan_needs_a_browser_or_an_import_file(tmp_path: Path) -> None:
+    """Without a browser, the command names the import alternative instead of hanging."""
+    root = _initialized_root(tmp_path)
+
+    result = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "plan-a",
+            "--provider",
+            "openai",
+            "--subscription",
+            "chatgpt",
+            "--non-interactive",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--codex-auth-file" in _plain_output(result.output)
+    assert GatewayManagement(root).provider_connections() == ()
+
+
+def test_provider_add_rejects_a_plan_with_a_credential_env(tmp_path: Path) -> None:
+    """A plan connection and an API-key locator cannot be combined."""
+    root = _initialized_root(tmp_path)
+
+    result = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "plan-a",
+            "--provider",
+            "openai",
+            "--subscription",
+            "chatgpt",
+            "--credential-env",
+            "OPENAI_API_KEY",
+            "--codex-auth-file",
+            str(tmp_path / "missing.json"),
+            "--non-interactive",
+            "--root",
+            str(root),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "omit api_key_env" in _plain_output(result.output)
+
+
+def test_provider_update_keeps_the_plan_sign_in_and_refuses_a_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Updating a plan connection never re-signs in; adding a key to it is refused."""
+    root = _initialized_root(tmp_path / "root")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    added = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "add",
+            "plan-a",
+            "--provider",
+            "openai",
+            "--subscription",
+            "chatgpt",
+            "--codex-auth-file",
+            str(_codex_auth_file(tmp_path)),
+            "--non-interactive",
+            "--root",
+            str(root),
+        ],
+    )
+    assert added.exit_code == 0, added.output
+
+    unchanged = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "plan-a",
+            "--provider",
+            "openai",
+            "--json",
+            "--root",
+            str(root),
+        ],
+    )
+    assert unchanged.exit_code == 0, unchanged.output
+    assert GatewayManagement(root).provider_connections()[0].config.subscription == "chatgpt"
+
+    keyed = _runner.invoke(
+        app,
+        [
+            "config",
+            "gateway",
+            "provider",
+            "update",
+            "plan-a",
+            "--provider",
+            "openai",
+            "--credential-env",
+            "OPENAI_API_KEY",
+            "--root",
+            str(root),
+        ],
+    )
+    assert keyed.exit_code != 0
+    assert "omit api_key_env" in _plain_output(keyed.output)

--- a/exp/cli/providers/chatgpt_sign_in.py
+++ b/exp/cli/providers/chatgpt_sign_in.py
@@ -1,0 +1,247 @@
+"""Browser sign-in for a ChatGPT plan connection over the loopback callback Codex registered.
+
+The sign-in is the standard authorization-code flow with PKCE against OpenAI's OAuth
+server, using the public Codex client. That client's only registered redirect is
+``http://localhost:1455/auth/callback``, so the listener binds that exact port: a second
+sign-in (this command or Codex's own) already holding it is a clear, recoverable error
+rather than a silently different callback the server would refuse.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import secrets
+import threading
+import webbrowser
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from rich.console import Console
+
+from exp.common.auth import StoredOAuthTokens
+from exp.runtime.models.providers.chatgpt_subscription import (
+    CHATGPT_OAUTH_AUTHORIZE_URL,
+    CHATGPT_OAUTH_CLIENT_ID,
+    CHATGPT_OAUTH_REDIRECT_URI,
+    CHATGPT_OAUTH_SCOPE,
+    ChatGptSignInError,
+    TokenEndpoint,
+    exchange_authorization_code,
+    post_token_request,
+)
+
+SIGN_IN_TIMEOUT_SECONDS = 300.0
+"""How long the command waits for the browser before giving up."""
+_CALLBACK = urlparse(CHATGPT_OAUTH_REDIRECT_URI)
+_CALLBACK_HOST = "127.0.0.1"
+_CALLBACK_PORT = _CALLBACK.port if _CALLBACK.port is not None else 80
+_CALLBACK_PATH = _CALLBACK.path
+
+_SUCCESS_PAGE = b"""<!doctype html>
+<html><body style="font-family: system-ui; padding: 48px; color: #0a0a0a;">
+<h1 style="font-size: 18px;">ChatGPT plan connected</h1>
+<p>The sign-in was handed to your terminal. You can close this tab.</p>
+</body></html>"""
+_FAILURE_PAGE = b"""<!doctype html>
+<html><body style="font-family: system-ui; padding: 48px; color: #0a0a0a;">
+<h1 style="font-size: 18px;">Sign-in not accepted</h1>
+<p>This callback did not match the sign-in your terminal started. Run the command again.</p>
+</body></html>"""
+
+
+class ChatGptSignIn:
+    """One PKCE authorization attempt backed by the fixed loopback callback."""
+
+    def __init__(self, *, callback_port: int = _CALLBACK_PORT) -> None:
+        """Prepare fresh PKCE material and state for one attempt.
+
+        Args:
+            callback_port: Loopback port to bind. The registered callback port is the only
+                one the authorization server redirects to; tests bind an ephemeral port to
+                exercise the handler without holding the real one.
+        """
+        self._callback_port = callback_port
+        self.state = secrets.token_urlsafe(24)
+        self.code_verifier = secrets.token_urlsafe(64)
+        digest = hashlib.sha256(self.code_verifier.encode("ascii")).digest()
+        self.code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        self._code: str | None = None
+        self._code_event = threading.Event()
+        self._code_lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Bind the registered loopback callback and serve one-time codes in a daemon thread.
+
+        Raises:
+            ChatGptSignInError: The callback port is already held (another sign-in, or a
+                Codex login, is in progress).
+        """
+        if self._server is not None:
+            raise ChatGptSignInError("this ChatGPT sign-in has already started")
+        sign_in = self
+        expected_state = self.state
+        code_event = self._code_event
+        code_lock = self._code_lock
+
+        class _CallbackHandler(BaseHTTPRequestHandler):
+            """Accept the authorization code only on the matching loopback callback."""
+
+            def do_GET(self) -> None:  # noqa: N802 - http.server contract
+                """Validate one callback and publish its code to the sign-in waiter."""
+                parsed = urlparse(self.path)
+                if parsed.path != _CALLBACK_PATH:
+                    self.send_error(404)
+                    return
+                params = parse_qs(parsed.query)
+                code = (params.get("code") or [""])[0]
+                state = (params.get("state") or [""])[0]
+                if not code or not secrets.compare_digest(state, expected_state):
+                    self._respond(400, _FAILURE_PAGE)
+                    return
+                with code_lock:
+                    if sign_in._code is not None:
+                        self._respond(400, _FAILURE_PAGE)
+                        return
+                    sign_in._code = code
+                    code_event.set()
+                self._respond(200, _SUCCESS_PAGE)
+
+            def _respond(self, status: int, body: bytes) -> None:
+                """Write one bounded HTML response to the browser."""
+                self.send_response(status)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:
+                """Suppress callback request logs so codes never reach stderr."""
+                del format, args
+
+        try:
+            self._server = ThreadingHTTPServer(
+                (_CALLBACK_HOST, self._callback_port), _CallbackHandler
+            )
+        except OSError as exc:
+            raise ChatGptSignInError(
+                f"the ChatGPT sign-in callback port {_CALLBACK_PORT} is in use; finish or stop "
+                "the other sign-in (this command or 'codex login') and run the command again"
+            ) from exc
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def authorize_url(self) -> str:
+        """Return the OpenAI authorization URL for this attempt.
+
+        Returns:
+            URL carrying the public client, the registered callback, the PKCE challenge, and
+            the one-time state; the organization claim is requested so the id token names the
+            ChatGPT account.
+        """
+        query = urlencode(
+            {
+                "response_type": "code",
+                "client_id": CHATGPT_OAUTH_CLIENT_ID,
+                "redirect_uri": CHATGPT_OAUTH_REDIRECT_URI,
+                "scope": CHATGPT_OAUTH_SCOPE,
+                "code_challenge": self.code_challenge,
+                "code_challenge_method": "S256",
+                "id_token_add_organizations": "true",
+                "state": self.state,
+            }
+        )
+        return f"{CHATGPT_OAUTH_AUTHORIZE_URL}?{query}"
+
+    @property
+    def port(self) -> int:
+        """Return the bound loopback port.
+
+        Raises:
+            ChatGptSignInError: The listener has not started.
+        """
+        if self._server is None:
+            raise ChatGptSignInError("the ChatGPT sign-in listener is not running")
+        return self._server.server_address[1]
+
+    def wait(self, timeout: float = SIGN_IN_TIMEOUT_SECONDS) -> str | None:
+        """Wait for the authorization code or return ``None`` after the bounded timeout.
+
+        Args:
+            timeout: Maximum wait in seconds.
+
+        Returns:
+            The one-time authorization code, or ``None`` when no callback arrived.
+
+        Raises:
+            ValueError: The timeout is not positive.
+        """
+        if timeout <= 0:
+            raise ValueError("sign-in timeout must be positive")
+        if not self._code_event.wait(timeout=timeout):
+            return None
+        with self._code_lock:
+            return self._code
+
+    def close(self) -> None:
+        """Stop the callback listener; repeated cleanup is safe."""
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server.server_close()
+        self._server = None
+        self._thread = None
+
+
+def chatgpt_browser_sign_in(
+    *,
+    console: Console,
+    open_browser: Callable[[str], bool] = webbrowser.open,
+    timeout: float = SIGN_IN_TIMEOUT_SECONDS,
+    token_endpoint: TokenEndpoint = post_token_request,
+    callback_port: int = _CALLBACK_PORT,
+) -> StoredOAuthTokens:
+    """Sign a ChatGPT plan in through the browser and return its tokens.
+
+    Args:
+        console: Terminal receiving progress and the fallback URL.
+        open_browser: Browser opener, injectable for deterministic tests.
+        timeout: Maximum time to wait for the browser callback.
+        token_endpoint: Token endpoint POST, injectable for deterministic tests.
+        callback_port: Loopback port to bind; tests use an ephemeral one.
+
+    Returns:
+        The signed-in tokens, ready to store.
+
+    Raises:
+        ChatGptSignInError: The callback port is busy, the browser never returned, or the
+            code exchange was refused.
+    """
+    attempt = ChatGptSignIn(callback_port=callback_port)
+    attempt.start()
+    try:
+        url = attempt.authorize_url()
+        console.print("[dim]Opening the ChatGPT sign-in in your browser...[/dim]")
+        try:
+            opened = open_browser(url)
+        except (OSError, webbrowser.Error):
+            opened = False
+        if not opened:
+            console.print(f"[yellow]Open this URL to sign in:[/yellow] {html.escape(url)}")
+        console.print("[dim]Approve the sign-in in your browser to continue.[/dim]")
+        code = attempt.wait(timeout)
+    finally:
+        attempt.close()
+    if code is None:
+        raise ChatGptSignInError("the ChatGPT sign-in timed out; run the command again")
+    tokens = exchange_authorization_code(
+        code=code,
+        code_verifier=attempt.code_verifier,
+        token_endpoint=token_endpoint,
+    )
+    console.print("[green]ChatGPT sign-in received.[/green]")
+    return tokens

--- a/exp/cli/providers/chatgpt_sign_in_test.py
+++ b/exp/cli/providers/chatgpt_sign_in_test.py
@@ -1,0 +1,90 @@
+"""Tests for the ChatGPT plan browser sign-in listener and orchestration."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from rich.console import Console
+
+from exp.cli.providers.chatgpt_sign_in import ChatGptSignIn, chatgpt_browser_sign_in
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.models.providers.chatgpt_subscription import (
+    CHATGPT_OAUTH_CLIENT_ID,
+    CHATGPT_OAUTH_REDIRECT_URI,
+    ChatGptSignInError,
+)
+
+
+def _get(url: str) -> int:
+    """Return the HTTP status of one loopback GET without raising on 4xx."""
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return int(response.status)
+    except urllib.error.HTTPError as error:
+        return error.code
+
+
+def test_authorize_url_carries_the_public_client_pkce_and_registered_callback() -> None:
+    """The authorization request names the Codex client, S256 challenge, and one-time state."""
+    attempt = ChatGptSignIn(callback_port=0)
+
+    query = parse_qs(urlparse(attempt.authorize_url()).query)
+
+    assert query["client_id"] == [CHATGPT_OAUTH_CLIENT_ID]
+    assert query["redirect_uri"] == [CHATGPT_OAUTH_REDIRECT_URI]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["code_challenge"] == [attempt.code_challenge]
+    assert query["state"] == [attempt.state]
+    assert query["id_token_add_organizations"] == ["true"]
+    assert attempt.code_verifier not in attempt.authorize_url()
+
+
+def test_callback_accepts_exactly_one_matching_code() -> None:
+    """A wrong state or path is refused; the first matching code wins and later ones are refused."""
+    attempt = ChatGptSignIn(callback_port=0)
+    attempt.start()
+    try:
+        base = f"http://127.0.0.1:{attempt.port}"
+        assert _get(f"{base}/elsewhere?code=x&state={attempt.state}") == 404
+        assert _get(f"{base}/auth/callback?code=x&state=wrong") == 400
+        assert attempt.wait(timeout=0.05) is None
+        assert _get(f"{base}/auth/callback?code=code-1&state={attempt.state}") == 200
+        assert _get(f"{base}/auth/callback?code=code-2&state={attempt.state}") == 400
+        assert attempt.wait(timeout=1) == "code-1"
+    finally:
+        attempt.close()
+
+
+def test_a_busy_callback_port_is_a_recoverable_error() -> None:
+    """Two listeners on one port name the conflict instead of binding elsewhere."""
+    first = ChatGptSignIn(callback_port=0)
+    first.start()
+    try:
+        second = ChatGptSignIn(callback_port=first.port)
+        with pytest.raises(ChatGptSignInError, match="callback port"):
+            second.start()
+    finally:
+        first.close()
+
+
+def test_browser_sign_in_times_out_without_a_callback() -> None:
+    """A browser that never returns ends in a sign-in error, never a hang."""
+    console = Console(record=True, width=120)
+
+    with pytest.raises(ChatGptSignInError, match="timed out"):
+        chatgpt_browser_sign_in(
+            console=console,
+            open_browser=lambda url: False,
+            timeout=0.05,
+            token_endpoint=_never,
+            callback_port=0,
+        )
+    assert "Open this URL to sign in" in console.export_text()
+
+
+def _never(payload: JsonObject) -> JsonObject:
+    """Fail if the token endpoint is reached without a code."""
+    raise AssertionError(f"token endpoint must not be called: {sorted(payload)}")

--- a/exp/common/auth/__init__.py
+++ b/exp/common/auth/__init__.py
@@ -7,7 +7,9 @@ from exp.common.auth.store import (
     ProviderAuthStoreError,
     StoredCredentialBinding,
     StoredCredentialEndpointMismatch,
+    StoredCredentialKindMismatch,
     StoredCredentialStatus,
+    StoredOAuthTokens,
 )
 
 __all__ = [
@@ -17,7 +19,9 @@ __all__ = [
     "ProviderAuthStoreError",
     "StoredCredentialBinding",
     "StoredCredentialEndpointMismatch",
+    "StoredCredentialKindMismatch",
     "StoredCredentialStatus",
+    "StoredOAuthTokens",
     "default_auth_path",
     "derived_api_key_env",
     "provider_data_dir",

--- a/exp/common/auth/store.py
+++ b/exp/common/auth/store.py
@@ -1,9 +1,11 @@
 """Atomic, user-only ``auth.json`` store keyed by provider connection ID.
 
 The document follows the OpenCode ``auth.json`` shape: one object whose keys are connection
-IDs and whose values are ``{"type": "api", "key": "..."}`` records. Optional provider,
-endpoint, and credential-locator fields bind a key to one secret-free connection identity.
-Secret values never appear in ``repr``, ``str``, or raised messages.
+IDs and whose values are either ``{"type": "api", "key": "..."}`` API-key records or
+``{"type": "oauth", "access": "...", "refresh": "...", "expires": <unix ms>}`` sign-in
+records for subscription connections. Optional provider, endpoint, and credential-locator
+fields bind a record to one secret-free connection identity. Secret values never appear in
+``repr``, ``str``, or raised messages.
 """
 
 from __future__ import annotations
@@ -53,13 +55,56 @@ class StoredCredentialEndpointMismatch(ProviderAuthStoreError):
     """A stored key exists but was saved for a different provider endpoint."""
 
 
+class StoredCredentialKindMismatch(ProviderAuthStoreError):
+    """A stored record exists but is an API key where a sign-in was expected, or vice versa."""
+
+
 class StoredCredentialStatus(ContractModel):
     """Public metadata for one stored or configured provider connection."""
 
     connection_id: str
     provider: str
-    source: Literal["environment", "stored", "missing", "aws_chain", "mismatch"]
+    source: Literal["environment", "stored", "signed_in", "missing", "aws_chain", "mismatch"]
     environment_variable: str | None = None
+
+
+@dataclass(frozen=True)
+class StoredOAuthTokens:
+    """One connection's subscription sign-in: bearer tokens plus the access-token expiry.
+
+    Secret values are omitted from ``repr`` and ``str``.
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at_ms: int
+    """Unix time in milliseconds at which ``access_token`` stops being accepted."""
+    account_id: str | None = None
+    """Provider account identifier the tokens belong to, when the provider issues one."""
+
+    def __repr__(self) -> str:
+        """Describe the record without token values."""
+        return (
+            f"StoredOAuthTokens(expires_at_ms={self.expires_at_ms!r}, "
+            f"account_id={self.account_id!r}, access_token='[REDACTED]', "
+            "refresh_token='[REDACTED]')"
+        )
+
+    def __str__(self) -> str:
+        """Describe the record without token values."""
+        return self.__repr__()
+
+    def expires_within(self, seconds: float, *, now_ms: int) -> bool:
+        """Whether the access token expires within ``seconds`` of ``now_ms``.
+
+        Args:
+            seconds: Look-ahead window.
+            now_ms: Current unix time in milliseconds.
+
+        Returns:
+            ``True`` when the token is already expired or expires inside the window.
+        """
+        return self.expires_at_ms - now_ms <= seconds * 1_000
 
 
 @dataclass(frozen=True)
@@ -68,6 +113,17 @@ class _StoredApiRecord:
 
     key: str
     binding: StoredCredentialBinding | None = None
+
+
+@dataclass(frozen=True)
+class _StoredOAuthRecord:
+    """One connection's subscription sign-in plus optional endpoint binding."""
+
+    tokens: StoredOAuthTokens
+    binding: StoredCredentialBinding | None = None
+
+
+_StoredRecord = _StoredApiRecord | _StoredOAuthRecord
 
 
 class ProviderAuthStore:
@@ -114,6 +170,66 @@ class ProviderAuthStore:
             StoredCredentialEndpointMismatch: The stored key belongs to another endpoint.
             ProviderAuthStoreError: The file exists but cannot be used.
         """
+        record = self._record(connection_id, binding=binding)
+        if record is None:
+            return None
+        if isinstance(record, _StoredOAuthRecord):
+            raise StoredCredentialKindMismatch(
+                f"stored credential for connection {connection_id!r} is a subscription sign-in, "
+                "not an API key; remove the connection and add it again"
+            )
+        return record.key
+
+    def get_oauth(
+        self,
+        connection_id: str,
+        *,
+        binding: StoredCredentialBinding | None = None,
+    ) -> StoredOAuthTokens | None:
+        """Return the stored subscription sign-in for one connection, or ``None`` when absent.
+
+        Args:
+            connection_id: Exact catalog or gateway connection name.
+            binding: Optional current endpoint identity. When supplied, an unbound
+                record or a record bound to a different endpoint is refused.
+
+        Returns:
+            The stored tokens, or ``None`` when that connection has no record.
+
+        Raises:
+            StoredCredentialKindMismatch: The stored record is an API key.
+            StoredCredentialEndpointMismatch: The stored sign-in belongs to another endpoint.
+            ProviderAuthStoreError: The file exists but cannot be used.
+        """
+        record = self._record(connection_id, binding=binding)
+        if record is None:
+            return None
+        if isinstance(record, _StoredApiRecord):
+            raise StoredCredentialKindMismatch(
+                f"stored credential for connection {connection_id!r} is an API key, not a "
+                "subscription sign-in; remove the connection and add it again"
+            )
+        return record.tokens
+
+    def _record(
+        self,
+        connection_id: str,
+        *,
+        binding: StoredCredentialBinding | None,
+    ) -> _StoredRecord | None:
+        """Load one record and enforce its endpoint binding.
+
+        Args:
+            connection_id: Exact catalog or gateway connection name.
+            binding: Optional current endpoint identity to enforce.
+
+        Returns:
+            The stored record of either kind, or ``None`` when absent.
+
+        Raises:
+            StoredCredentialEndpointMismatch: The record belongs to another endpoint.
+            ProviderAuthStoreError: The file exists but cannot be used.
+        """
         records = self._load()
         record = records.get(connection_id)
         if record is None:
@@ -123,7 +239,7 @@ class ProviderAuthStore:
                 f"stored credential for connection {connection_id!r} does not match the "
                 f"configured {binding.provider} endpoint; run 'exp config providers'"
             )
-        return record.key
+        return record
 
     def put(
         self,
@@ -153,6 +269,42 @@ class ProviderAuthStore:
             preserved = existing.binding if existing is not None else None
             records[connection_id] = _StoredApiRecord(
                 key=key,
+                binding=binding if binding is not None else preserved,
+            )
+            self._replace(records)
+
+    def put_oauth(
+        self,
+        connection_id: str,
+        tokens: StoredOAuthTokens,
+        *,
+        binding: StoredCredentialBinding | None = None,
+    ) -> None:
+        """Create or replace the stored subscription sign-in for one connection.
+
+        A refreshed token pair replaces the previous one in place, so the record always
+        holds the newest refresh token the provider issued.
+
+        Args:
+            connection_id: Exact catalog or gateway connection name.
+            tokens: Non-empty access and refresh tokens plus the access expiry.
+            binding: Optional endpoint identity to store with the sign-in. When omitted, an
+                existing binding on this connection is preserved.
+
+        Raises:
+            ProviderAuthStoreError: The identity or tokens are invalid, or the write failed.
+        """
+        _validate_connection_id(connection_id)
+        if not tokens.access_token.strip() or not tokens.refresh_token.strip():
+            raise ProviderAuthStoreError("stored sign-in tokens must be non-empty")
+        if tokens.expires_at_ms < 0:
+            raise ProviderAuthStoreError("stored sign-in expiry must be a unix millisecond time")
+        with file_write_lock(self._path, what="provider credential file"):
+            records = self._load()
+            existing = records.get(connection_id)
+            preserved = existing.binding if existing is not None else None
+            records[connection_id] = _StoredOAuthRecord(
+                tokens=tokens,
                 binding=binding if binding is not None else preserved,
             )
             self._replace(records)
@@ -189,11 +341,11 @@ class ProviderAuthStore:
         """
         return tuple(sorted(self._load()))
 
-    def _load(self) -> dict[str, _StoredApiRecord]:
+    def _load(self) -> dict[str, _StoredRecord]:
         """Read and validate the credential document.
 
         Returns:
-            Connection ID to stored API record mapping.
+            Connection ID to stored record mapping.
 
         Raises:
             ProviderAuthStoreError: The path is unsafe or the document is malformed.
@@ -212,7 +364,7 @@ class ProviderAuthStore:
             raise ProviderAuthStoreError(_malformed_message(self._path)) from exc
         return _parse_document(payload, path=self._path)
 
-    def _replace(self, records: Mapping[str, _StoredApiRecord]) -> None:
+    def _replace(self, records: Mapping[str, _StoredRecord]) -> None:
         """Atomically replace the credential file with user-only permissions.
 
         The staging file is restricted before the rename. After ``os.replace`` succeeds the
@@ -220,7 +372,7 @@ class ProviderAuthStore:
         failure cannot report the write as lost.
 
         Args:
-            records: Complete connection ID to stored API record mapping to persist.
+            records: Complete connection ID to stored record mapping to persist.
 
         Raises:
             ProviderAuthStoreError: The destination is unsafe or the write failed before replace.
@@ -292,16 +444,27 @@ def _validate_connection_id(connection_id: str) -> None:
         raise ProviderAuthStoreError("connection IDs must not contain path separators")
 
 
-def _record_payload(record: _StoredApiRecord) -> dict[str, str]:
-    """Serialize one stored API record without extra identity when unbound.
+def _record_payload(record: _StoredRecord) -> dict[str, str | int]:
+    """Serialize one stored record without extra identity when unbound.
 
     Args:
-        record: Key and optional endpoint binding.
+        record: API key or sign-in tokens plus optional endpoint binding.
 
     Returns:
         OpenCode-shaped object, plus binding fields when present.
     """
-    payload = {"type": "api", "key": record.key}
+    payload: dict[str, str | int]
+    if isinstance(record, _StoredApiRecord):
+        payload = {"type": "api", "key": record.key}
+    else:
+        payload = {
+            "type": "oauth",
+            "access": record.tokens.access_token,
+            "refresh": record.tokens.refresh_token,
+            "expires": record.tokens.expires_at_ms,
+        }
+        if record.tokens.account_id is not None:
+            payload["account_id"] = record.tokens.account_id
     if record.binding is not None:
         payload["provider"] = record.binding.provider
         payload["endpoint_sha256"] = record.binding.endpoint_sha256
@@ -310,7 +473,7 @@ def _record_payload(record: _StoredApiRecord) -> dict[str, str]:
     return payload
 
 
-def _parse_document(payload: object, *, path: Path) -> dict[str, _StoredApiRecord]:
+def _parse_document(payload: object, *, path: Path) -> dict[str, _StoredRecord]:
     """Validate one OpenCode-shaped credential document.
 
     Args:
@@ -318,14 +481,14 @@ def _parse_document(payload: object, *, path: Path) -> dict[str, _StoredApiRecor
         path: File path used in recovery messages.
 
     Returns:
-        Connection ID to stored API record mapping.
+        Connection ID to stored record mapping.
 
     Raises:
         ProviderAuthStoreError: The document is not a usable credential object.
     """
     if not isinstance(payload, dict):
         raise ProviderAuthStoreError(_malformed_message(path))
-    records: dict[str, _StoredApiRecord] = {}
+    records: dict[str, _StoredRecord] = {}
     for raw_name, raw_record in payload.items():
         if not isinstance(raw_name, str) or not raw_name:
             raise ProviderAuthStoreError(_malformed_message(path))
@@ -336,22 +499,64 @@ def _parse_document(payload: object, *, path: Path) -> dict[str, _StoredApiRecor
             if not isinstance(field, str):
                 raise ProviderAuthStoreError(_malformed_message(path))
             fields[field] = value
-        record_type = fields.get("type")
-        key = fields.get("key")
-        extra = set(fields) - {
-            "type",
-            "key",
-            "provider",
-            "endpoint_sha256",
-            "credential_locator_sha256",
-        }
-        if extra or record_type != "api" or not isinstance(key, str) or not key.strip():
-            raise ProviderAuthStoreError(_malformed_message(path))
-        records[raw_name] = _StoredApiRecord(
-            key=key,
-            binding=_parse_binding(fields, path=path),
-        )
+        records[raw_name] = _parse_record(fields, path=path)
     return records
+
+
+_BINDING_FIELDS = frozenset({"provider", "endpoint_sha256", "credential_locator_sha256"})
+
+
+def _parse_record(fields: Mapping[str, object], *, path: Path) -> _StoredRecord:
+    """Validate one stored record of either kind.
+
+    Args:
+        fields: Decoded record object with string keys.
+        path: File path used in recovery messages.
+
+    Returns:
+        The typed API-key or sign-in record.
+
+    Raises:
+        ProviderAuthStoreError: The record has an unknown type, unknown fields, or a
+            missing or empty required value.
+    """
+    record_type = fields.get("type")
+    binding = _parse_binding(fields, path=path)
+    if record_type == "api":
+        key = fields.get("key")
+        extra = set(fields) - {"type", "key"} - _BINDING_FIELDS
+        if extra or not isinstance(key, str) or not key.strip():
+            raise ProviderAuthStoreError(_malformed_message(path))
+        return _StoredApiRecord(key=key, binding=binding)
+    if record_type == "oauth":
+        access = fields.get("access")
+        refresh = fields.get("refresh")
+        expires = fields.get("expires")
+        account_id = fields.get("account_id")
+        extra = set(fields) - {"type", "access", "refresh", "expires", "account_id"}
+        extra -= _BINDING_FIELDS
+        if (
+            extra
+            or not isinstance(access, str)
+            or not access.strip()
+            or not isinstance(refresh, str)
+            or not refresh.strip()
+            or isinstance(expires, bool)
+            or not isinstance(expires, int)
+            or expires < 0
+            or (account_id is not None and (not isinstance(account_id, str) or not account_id))
+        ):
+            raise ProviderAuthStoreError(_malformed_message(path))
+        return _StoredOAuthRecord(
+            tokens=StoredOAuthTokens(
+                access_token=access,
+                refresh_token=refresh,
+                expires_at_ms=expires,
+                account_id=account_id,
+            ),
+            binding=binding,
+        )
+    raise ProviderAuthStoreError(_malformed_message(path))
 
 
 def _parse_binding(

--- a/exp/common/auth/store_test.py
+++ b/exp/common/auth/store_test.py
@@ -16,6 +16,8 @@ from exp.common.auth.store import (
     ProviderAuthStoreError,
     StoredCredentialBinding,
     StoredCredentialEndpointMismatch,
+    StoredCredentialKindMismatch,
+    StoredOAuthTokens,
 )
 
 _BINDING = StoredCredentialBinding(provider="openai-compatible", endpoint_sha256="a" * 64)
@@ -267,3 +269,100 @@ def test_symlink_destination_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(ProviderAuthStoreError, match="malformed"):
         _store(path).get("openai")
+
+
+_TOKENS = StoredOAuthTokens(
+    access_token="access-token-value",
+    refresh_token="refresh-token-value",
+    expires_at_ms=1_700_000_000_000,
+    account_id="acct-123",
+)
+
+
+def test_oauth_records_round_trip_in_the_opencode_shape(tmp_path: Path) -> None:
+    """A plan sign-in persists as a type=oauth record with access, refresh, and expiry."""
+    path = tmp_path / "auth.json"
+    _store(path).put_oauth("chatgpt-a", _TOKENS, binding=_BINDING)
+
+    document = json.loads(path.read_text(encoding="utf-8"))
+    assert document["chatgpt-a"] == {
+        "type": "oauth",
+        "access": "access-token-value",
+        "refresh": "refresh-token-value",
+        "expires": 1_700_000_000_000,
+        "account_id": "acct-123",
+        "provider": "openai-compatible",
+        "endpoint_sha256": "a" * 64,
+    }
+    assert _store(path).get_oauth("chatgpt-a", binding=_BINDING) == _TOKENS
+    assert _store(path).get_oauth("missing") is None
+    assert _store(path).connection_ids() == ("chatgpt-a",)
+
+
+def test_oauth_and_api_records_refuse_to_be_read_as_each_other(tmp_path: Path) -> None:
+    """A sign-in is never handed out as an API key, and a key never as a sign-in."""
+    path = tmp_path / "auth.json"
+    store = _store(path)
+    store.put_oauth("plan", _TOKENS)
+    store.put("key", _SECRET)
+
+    with pytest.raises(StoredCredentialKindMismatch, match="subscription sign-in, not an API key"):
+        store.get("plan")
+    with pytest.raises(StoredCredentialKindMismatch, match="API key, not a subscription sign-in"):
+        store.get_oauth("key")
+
+
+def test_oauth_records_enforce_the_endpoint_binding(tmp_path: Path) -> None:
+    """A sign-in saved for one endpoint identity is refused for another."""
+    path = tmp_path / "auth.json"
+    _store(path).put_oauth("plan", _TOKENS, binding=_BINDING)
+
+    with pytest.raises(StoredCredentialEndpointMismatch):
+        _store(path).get_oauth("plan", binding=_OTHER_BINDING)
+
+
+def test_put_oauth_replaces_the_pair_in_place_and_preserves_the_binding(tmp_path: Path) -> None:
+    """A refreshed pair overwrites the old one so the newest refresh token is the stored one."""
+    path = tmp_path / "auth.json"
+    store = _store(path)
+    store.put_oauth("plan", _TOKENS, binding=_BINDING)
+    rotated = StoredOAuthTokens(
+        access_token="access-2", refresh_token="refresh-2", expires_at_ms=1_800_000_000_000
+    )
+    store.put_oauth("plan", rotated)
+
+    assert store.get_oauth("plan", binding=_BINDING) == rotated
+    assert store.remove("plan") is True
+    assert store.get_oauth("plan") is None
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {"type": "oauth", "access": "a", "expires": 1},
+        {"type": "oauth", "access": "a", "refresh": "", "expires": 1},
+        {"type": "oauth", "access": "a", "refresh": "r", "expires": -1},
+        {"type": "oauth", "access": "a", "refresh": "r", "expires": True},
+        {"type": "oauth", "access": "a", "refresh": "r", "expires": 1, "extra": "x"},
+        {"type": "session", "access": "a", "refresh": "r", "expires": 1},
+    ],
+)
+def test_malformed_oauth_records_fail_closed(tmp_path: Path, record: dict[str, object]) -> None:
+    """An incomplete or unknown record shape is a malformed file, never a partial sign-in."""
+    path = tmp_path / "auth.json"
+    path.write_text(json.dumps({"plan": record}), encoding="utf-8")
+
+    with pytest.raises(ProviderAuthStoreError, match="malformed"):
+        _store(path).get_oauth("plan")
+
+
+def test_oauth_tokens_redact_their_values_and_know_their_expiry_window() -> None:
+    """Token text never appears in repr or str, and the look-ahead compares in milliseconds."""
+    text = f"{_TOKENS!r} {_TOKENS!s}"
+
+    assert "access-token-value" not in text
+    assert "refresh-token-value" not in text
+    assert "[REDACTED]" in text
+    assert _TOKENS.expires_within(300, now_ms=1_700_000_000_000 - 200_000)
+    assert not _TOKENS.expires_within(300, now_ms=1_700_000_000_000 - 400_000)
+    assert _TOKENS.expires_within(0, now_ms=1_700_000_000_000)

--- a/exp/common/models/__init__.py
+++ b/exp/common/models/__init__.py
@@ -1,7 +1,6 @@
 """Canonical model identities and data contracts."""
 
 from exp.common.models.catalog import (
-    ConnectionConfig,
     GatewayDeploymentCapabilities,
     GatewayDeploymentMetadata,
     GatewayEquivalenceCertification,
@@ -17,6 +16,7 @@ from exp.common.models.catalog import (
     write_model_catalog,
 )
 from exp.common.models.client import EmbeddingClient, IdempotentModelClient, ModelClient
+from exp.common.models.connection import ConnectionConfig
 from exp.common.models.connection_authoring import (
     ProviderConnectionAuthoringError,
     configure_provider_connections,

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -2,19 +2,15 @@
 
 from __future__ import annotations
 
-import re
 import tomllib
 from pathlib import Path
 from typing import Literal, cast
-from urllib.parse import urlsplit, urlunsplit
 
 import tomli_w
 from pydantic import (
     AwareDatetime,
     Field,
-    SerializerFunctionWrapHandler,
     field_validator,
-    model_serializer,
     model_validator,
 )
 
@@ -30,6 +26,7 @@ from exp.common.core.artifacts import (
     validate_artifact_id,
 )
 from exp.common.core.files import write_text_atomic
+from exp.common.models.connection import EXPLICIT_CAPABILITY_PROVIDERS, ConnectionConfig
 from exp.common.models.dispatch_policy import FailoverMode, GatewayRungDispatchPolicy
 from exp.common.models.model import (
     BillingSource,
@@ -38,318 +35,9 @@ from exp.common.models.model import (
     ReasoningEffort,
 )
 
-_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_AZURE_API_VERSION = re.compile(r"^(?:v1|\d{4}-\d{2}-\d{2}(?:-preview)?)$")
-_AWS_REGION_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
-_VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
-_FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openrouter", "tinker"})
-_EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
-
-AzureApiSurface = Literal["openai_deployments", "model_inference"]
-"""Azure wire surface a connection speaks: classic deployments or Foundry model inference."""
-
-_FOUNDRY_HOST_SUFFIXES = (".services.ai.azure.com", ".inference.ai.azure.com")
-_AZURE_OPENAI_HOST_SUFFIX = ".openai.azure.com"
-_MODEL_INFERENCE_ROOT_SUFFIXES = ("/models", "/openai/v1")
-_MODEL_INFERENCE_IDENTITY_SUFFIX = "/models"
-
-
-def _normalize_base_url(value: str) -> str:
-    """Return the stable endpoint spelling used for connection identity."""
-    parsed = urlsplit(value)
-    hostname = parsed.hostname
-    if hostname is None:
-        raise ValueError("base_url must include a hostname")
-    try:
-        port = parsed.port
-    except ValueError as exc:
-        raise ValueError("base_url must use a valid port") from exc
-    scheme = parsed.scheme.lower()
-    host = hostname.lower()
-    if ":" in host:
-        host = f"[{host}]"
-    default_port = 443 if scheme == "https" else 80
-    netloc = host if port in {None, default_port} else f"{host}:{port}"
-    return urlunsplit((scheme, netloc, parsed.path.rstrip("/"), "", ""))
-
-
-def infer_azure_api_surface(endpoint: str) -> AzureApiSurface | None:
-    """Infer the Azure wire surface one resource endpoint serves.
-
-    Azure AI Foundry resources (``*.services.ai.azure.com``) serve the model-inference surface,
-    which carries provider-specific sampling fields such as ``top_k``. Azure OpenAI resources
-    (``*.openai.azure.com``) serve only the deployment surface.
-
-    Args:
-        endpoint: Azure resource endpoint from a connection.
-
-    Returns:
-        The surface the host is known to serve, or ``None`` for an unrecognized host such as a
-        private endpoint or a local recording proxy.
-    """
-    host = urlsplit(endpoint).hostname
-    if host is None:
-        return None
-    host = host.lower()
-    if host.endswith(_AZURE_OPENAI_HOST_SUFFIX):
-        return "openai_deployments"
-    if any(host.endswith(suffix) for suffix in _FOUNDRY_HOST_SUFFIXES):
-        return "model_inference"
-    return None
-
-
-def strip_model_inference_root(value: str) -> str:
-    """Remove the route suffix one Azure model-inference endpoint spelling carries.
-
-    The model-inference surface serves ``/models`` directly off the resource, so the bare resource,
-    its terminal ``/models`` form, and the Azure OpenAI ``/openai/v1`` root all name one resource.
-
-    Args:
-        value: Endpoint or endpoint path, with or without a trailing slash.
-
-    Returns:
-        The value reduced to the resource itself.
-    """
-    trimmed = value.rstrip("/")
-    for suffix in _MODEL_INFERENCE_ROOT_SUFFIXES:
-        if trimmed.lower().endswith(suffix):
-            return trimmed[: -len(suffix)].rstrip("/")
-    return trimmed
-
-
-def _normalize_connection_base_url(connection: ConnectionConfig) -> str | None:
-    """Normalize one endpoint while preserving provider-surface equivalence."""
-    if connection.base_url is None:
-        return None
-    normalized = _normalize_base_url(connection.base_url)
-    # Endpoint identity is deliberately narrower than request routing: it folds only the terminal
-    # ``/models`` segment, and only for a declared surface, so no stored credential digest moves
-    # for a connection the operator never edited.
-    if (
-        connection.provider == "azure"
-        and connection.azure_api_surface == "model_inference"
-        and normalized.lower().endswith(_MODEL_INFERENCE_IDENTITY_SUFFIX)
-    ):
-        return normalized[: -len(_MODEL_INFERENCE_IDENTITY_SUFFIX)].rstrip("/")
-    return normalized
-
 
 class ModelCatalogError(ValueError):
     """A local model catalog was malformed or named a credential value."""
-
-
-class ConnectionConfig(ContractModel):
-    """Local provider connection metadata, with an optional credential environment name only."""
-
-    provider: str = Field(min_length=1, max_length=128)
-    base_url: str | None = Field(default=None, max_length=2_048)
-    api_key_env: str | None = Field(default=None, max_length=256)
-    api_version: str | None = Field(default=None, max_length=64)
-    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
-    region: str | None = Field(default=None, max_length=64)
-    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
-    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
-    # Opt-in: native provider via a trusted https base_url in its own dialect (default-off).
-    trusted_custom_origin: bool = False
-
-    @field_validator("api_key_env", "aws_access_key_id_env")
-    @classmethod
-    def _require_environment_variable_name(cls, value: str | None) -> str | None:
-        if value is not None and not _ENVIRONMENT_NAME.fullmatch(value):
-            raise ValueError("credential environment fields must name environment variables")
-        return value
-
-    @field_validator("base_url")
-    @classmethod
-    def _reject_embedded_credentials(cls, value: str | None) -> str | None:
-        if value is None:
-            return value
-        parsed = urlsplit(value)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise ValueError("base_url must be an absolute HTTP(S) URL")
-        if parsed.username is not None or parsed.password is not None:
-            raise ValueError("base_url must not embed credentials")
-        if parsed.query or parsed.fragment:
-            raise ValueError("base_url must not include query parameters or fragments")
-        _normalize_base_url(value)
-        return value
-
-    @model_validator(mode="after")
-    def _require_secret_free_connection_metadata(self) -> ConnectionConfig:
-        if self.provider != "azure" and self.azure_api_surface is not None:
-            raise ValueError("azure_api_surface is only accepted for provider='azure'")
-        if self.provider != "bedrock" and (
-            self.aws_access_key_id_env is not None or self.bedrock_auth_mode is not None
-        ):
-            raise ValueError(
-                "aws_access_key_id_env and bedrock_auth_mode are only accepted for "
-                "provider='bedrock'"
-            )
-        if self.trusted_custom_origin:
-            if self.provider not in _FIXED_ORIGIN_PROVIDERS:
-                raise ValueError("trusted_custom_origin applies only to a native provider")
-            if self.base_url is None:
-                raise ValueError("trusted_custom_origin requires an explicit base_url")
-            if urlsplit(self.base_url).scheme != "https":
-                raise ValueError("trusted_custom_origin requires an https base_url")
-        elif self.provider in _FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
-            raise ValueError(
-                f"native provider {self.provider!r} uses its built-in official endpoint; "
-                "set trusted_custom_origin=True or use provider='openai-compatible'"
-            )
-        if self.provider == "azure":
-            if self.base_url is None:
-                raise ValueError("azure requires an explicit resource endpoint in base_url")
-            if self.api_key_env is None:
-                raise ValueError("azure requires api_key_env")
-            if self.api_version is None:
-                raise ValueError(
-                    "azure requires an explicit api_version such as 'v1' or a dated Azure "
-                    "OpenAI version"
-                )
-            if not _AZURE_API_VERSION.fullmatch(self.api_version):
-                raise ValueError(
-                    "azure api_version must be 'v1' or a dated Azure OpenAI version such as "
-                    "2024-10-21"
-                )
-            if self.azure_api_surface == "model_inference" and self.api_version == "v1":
-                raise ValueError(
-                    "azure model_inference requires a dated api_version for the mandatory "
-                    "api-version query parameter"
-                )
-            if self.region is not None:
-                raise ValueError("region is only accepted for provider='bedrock'")
-        elif self.provider == "bedrock":
-            if self.bedrock_auth_mode == "api_key":
-                if self.api_key_env is None or self.aws_access_key_id_env is not None:
-                    raise ValueError(
-                        "bedrock api_key auth requires api_key_env and forbids "
-                        "aws_access_key_id_env"
-                    )
-            elif self.bedrock_auth_mode == "access_key_pair":
-                if self.api_key_env is None or self.aws_access_key_id_env is None:
-                    raise ValueError(
-                        "bedrock access_key_pair auth requires both credential environment names"
-                    )
-            elif (self.api_key_env is None) != (self.aws_access_key_id_env is None):
-                raise ValueError(
-                    "bedrock explicit access-key auth requires both api_key_env naming the "
-                    "secret access key and aws_access_key_id_env naming the access key id"
-                )
-            if self.base_url is not None:
-                raise ValueError("bedrock does not accept base_url")
-            if self.api_version is not None:
-                raise ValueError("api_version is only accepted for provider='azure'")
-            if self.region is not None and not _AWS_REGION_NAME.fullmatch(self.region):
-                raise ValueError("bedrock region must be an AWS region name")
-        elif self.provider == "vertex":
-            if self.base_url is None:
-                raise ValueError(
-                    "vertex requires base_url naming the project-and-location root, such as "
-                    "https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/"
-                    "locations/us-central1"
-                )
-            # The runtime attaches a cloud-platform OAuth token to every request, so the
-            # endpoint host is pinned to Vertex AI service hosts and never operator-chosen.
-            vertex_parts = urlsplit(self.base_url)
-            vertex_host = (vertex_parts.hostname or "").lower()
-            if vertex_parts.scheme != "https" or not _VERTEX_HOST.fullmatch(vertex_host):
-                raise ValueError(
-                    "vertex base_url must use an HTTPS Vertex AI host such as "
-                    "https://us-central1-aiplatform.googleapis.com; OAuth tokens are never "
-                    "sent to other hosts"
-                )
-            if self.api_key_env is None:
-                raise ValueError(
-                    "vertex requires api_key_env naming the environment variable that holds "
-                    "the service-account JSON credential"
-                )
-            if self.api_version is not None:
-                raise ValueError("api_version is only accepted for provider='azure'")
-            if self.region is not None:
-                raise ValueError(
-                    "region is only accepted for provider='bedrock'; the Vertex location "
-                    "lives inside base_url"
-                )
-        else:
-            if self.api_version is not None:
-                raise ValueError("api_version is only accepted for provider='azure'")
-            if self.region is not None:
-                raise ValueError("region is only accepted for provider='bedrock'")
-        try:
-            assert_secret_free(
-                {
-                    "provider": self.provider,
-                    "base_url": self.base_url,
-                    "api_version": self.api_version,
-                    "azure_api_surface": self.azure_api_surface,
-                    "region": self.region,
-                    "bedrock_auth_mode": self.bedrock_auth_mode,
-                }
-            )
-        except SecretBoundaryError as exc:
-            raise ValueError("connection metadata must not contain credential values") from exc
-        return self
-
-    def identity_sha256(self) -> Sha256:
-        """Return a deterministic digest of the secret-free provider endpoint identity.
-
-        Returns:
-            A SHA-256 digest over the provider, normalized endpoint, and any Azure API version or
-            Bedrock region. Credential values and credential-environment metadata are excluded.
-        """
-        identity: JsonObject = {
-            "provider": self.provider,
-            "base_url": _normalize_connection_base_url(self),
-        }
-        if self.api_version is not None:
-            identity["api_version"] = self.api_version
-        if self.provider == "azure" and self.azure_api_surface == "model_inference":
-            # Keep classic Azure revisions byte-compatible with the identity
-            # contract that predates this discriminator. Only the genuinely
-            # different Foundry surface needs a new credential binding.
-            identity["azure_api_surface"] = "model_inference"
-        if self.region is not None:
-            identity["region"] = self.region
-        if self.trusted_custom_origin:  # endpoint identity; added only when set
-            identity["trusted_custom_origin"] = True
-        effective_bedrock_auth_mode = self.bedrock_auth_mode
-        if (
-            self.provider == "bedrock"
-            and effective_bedrock_auth_mode is None
-            and self.api_key_env is not None
-            and self.aws_access_key_id_env is not None
-        ):
-            effective_bedrock_auth_mode = "access_key_pair"
-        if effective_bedrock_auth_mode is not None:
-            identity["bedrock_auth_mode"] = effective_bedrock_auth_mode
-        return sha256_json(identity)
-
-    def canonicalized(self) -> ConnectionConfig:
-        """Return the canonical persisted shape for Bedrock access-key pairs."""
-        if (
-            self.provider == "bedrock"
-            and self.bedrock_auth_mode is None
-            and self.api_key_env is not None
-            and self.aws_access_key_id_env is not None
-        ):
-            return self.model_copy(update={"bedrock_auth_mode": "access_key_pair"})
-        return self
-
-    @model_serializer(mode="wrap")
-    def _serialize_without_absent_bedrock_metadata(
-        self,
-        handler: SerializerFunctionWrapHandler,
-    ) -> dict[str, object]:
-        """Preserve pre-Bedrock canonical bytes on every supported Pydantic version."""
-        serialized: dict[str, object] = handler(self)
-        if self.aws_access_key_id_env is None:
-            serialized.pop("aws_access_key_id_env", None)
-        if self.bedrock_auth_mode is None:
-            serialized.pop("bedrock_auth_mode", None)
-        if not self.trusted_custom_origin:
-            serialized.pop("trusted_custom_origin", None)
-        return serialized
 
 
 class SFTModelProvenance(ContractModel):
@@ -866,10 +554,7 @@ class ModelCatalog(ContractModel):
                     f"model alias {alias!r} names unknown connection {record.connection!r}"
                 )
             connection = self.connections[record.connection]
-            if (
-                connection.provider in _EXPLICIT_CAPABILITY_PROVIDERS
-                and record.capabilities is None
-            ):
+            if connection.provider in EXPLICIT_CAPABILITY_PROVIDERS and record.capabilities is None:
                 raise ValueError(
                     f"{connection.provider} model alias {alias!r} needs an explicit capabilities "
                     "declaration because provider names do not imply protocol support or prices"

--- a/exp/common/models/catalog_test.py
+++ b/exp/common/models/catalog_test.py
@@ -25,10 +25,8 @@ from exp.common.models import (
     load_model_catalog,
     write_model_catalog,
 )
-from exp.common.models.catalog import (
-    SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION,
-    infer_azure_api_surface,
-)
+from exp.common.models.catalog import SANE_MAX_MODEL_CATALOG_SCHEMA_VERSION
+from exp.common.models.connection import infer_azure_api_surface
 
 
 def _catalog() -> ModelCatalog:

--- a/exp/common/models/connection.py
+++ b/exp/common/models/connection.py
@@ -1,0 +1,392 @@
+"""Secret-free provider connection metadata shared by the catalog and the gateway.
+
+A connection names one provider endpoint identity plus, at most, the NAME of the
+environment variable or the stored sign-in that supplies its credential. Credential
+values never appear here. ``identity_sha256`` is the stable digest every stored
+credential binds to, so a connection edited to point at a different endpoint can
+never silently reuse a key saved for the old one.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+from urllib.parse import urlsplit, urlunsplit
+
+from pydantic import (
+    Field,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+
+from exp.common.core.artifacts import (
+    ContractModel,
+    JsonObject,
+    SecretBoundaryError,
+    Sha256,
+    assert_secret_free,
+    sha256_json,
+)
+
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_AZURE_API_VERSION = re.compile(r"^(?:v1|\d{4}-\d{2}-\d{2}(?:-preview)?)$")
+_AWS_REGION_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+_VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
+FIXED_ORIGIN_PROVIDERS = frozenset({"anthropic", "gemini", "openai", "openrouter", "tinker"})
+EXPLICIT_CAPABILITY_PROVIDERS = frozenset({"azure", "bedrock", "openai-compatible", "vertex"})
+
+AzureApiSurface = Literal["openai_deployments", "model_inference"]
+"""Azure wire surface a connection speaks: classic deployments or Foundry model inference."""
+
+_FOUNDRY_HOST_SUFFIXES = (".services.ai.azure.com", ".inference.ai.azure.com")
+_AZURE_OPENAI_HOST_SUFFIX = ".openai.azure.com"
+_MODEL_INFERENCE_ROOT_SUFFIXES = ("/models", "/openai/v1")
+_MODEL_INFERENCE_IDENTITY_SUFFIX = "/models"
+
+
+def _normalize_base_url(value: str) -> str:
+    """Return the stable endpoint spelling used for connection identity."""
+    parsed = urlsplit(value)
+    hostname = parsed.hostname
+    if hostname is None:
+        raise ValueError("base_url must include a hostname")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("base_url must use a valid port") from exc
+    scheme = parsed.scheme.lower()
+    host = hostname.lower()
+    if ":" in host:
+        host = f"[{host}]"
+    default_port = 443 if scheme == "https" else 80
+    netloc = host if port in {None, default_port} else f"{host}:{port}"
+    return urlunsplit((scheme, netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def infer_azure_api_surface(endpoint: str) -> AzureApiSurface | None:
+    """Infer the Azure wire surface one resource endpoint serves.
+
+    Azure AI Foundry resources (``*.services.ai.azure.com``) serve the model-inference surface,
+    which carries provider-specific sampling fields such as ``top_k``. Azure OpenAI resources
+    (``*.openai.azure.com``) serve only the deployment surface.
+
+    Args:
+        endpoint: Azure resource endpoint from a connection.
+
+    Returns:
+        The surface the host is known to serve, or ``None`` for an unrecognized host such as a
+        private endpoint or a local recording proxy.
+    """
+    host = urlsplit(endpoint).hostname
+    if host is None:
+        return None
+    host = host.lower()
+    if host.endswith(_AZURE_OPENAI_HOST_SUFFIX):
+        return "openai_deployments"
+    if any(host.endswith(suffix) for suffix in _FOUNDRY_HOST_SUFFIXES):
+        return "model_inference"
+    return None
+
+
+def strip_model_inference_root(value: str) -> str:
+    """Remove the route suffix one Azure model-inference endpoint spelling carries.
+
+    The model-inference surface serves ``/models`` directly off the resource, so the bare resource,
+    its terminal ``/models`` form, and the Azure OpenAI ``/openai/v1`` root all name one resource.
+
+    Args:
+        value: Endpoint or endpoint path, with or without a trailing slash.
+
+    Returns:
+        The value reduced to the resource itself.
+    """
+    trimmed = value.rstrip("/")
+    for suffix in _MODEL_INFERENCE_ROOT_SUFFIXES:
+        if trimmed.lower().endswith(suffix):
+            return trimmed[: -len(suffix)].rstrip("/")
+    return trimmed
+
+
+def _normalize_connection_base_url(connection: ConnectionConfig) -> str | None:
+    """Normalize one endpoint while preserving provider-surface equivalence."""
+    if connection.base_url is None:
+        return None
+    normalized = _normalize_base_url(connection.base_url)
+    # Endpoint identity is deliberately narrower than request routing: it folds only the terminal
+    # ``/models`` segment, and only for a declared surface, so no stored credential digest moves
+    # for a connection the operator never edited.
+    if (
+        connection.provider == "azure"
+        and connection.azure_api_surface == "model_inference"
+        and normalized.lower().endswith(_MODEL_INFERENCE_IDENTITY_SUFFIX)
+    ):
+        return normalized[: -len(_MODEL_INFERENCE_IDENTITY_SUFFIX)].rstrip("/")
+    return normalized
+
+
+SubscriptionKind = Literal["chatgpt"]
+"""Consumer subscription a connection signs in with instead of an API key.
+
+``chatgpt`` is a ChatGPT plan (the sign-in Codex uses) reaching the Codex Responses
+backend at ``https://chatgpt.com/backend-api/codex``. The connection stores no credential
+NAME at all: the operator's browser sign-in lives in the user-only credential file under the
+connection ID, and the gateway mints a fresh bearer per dispatch from it.
+"""
+
+SUBSCRIPTION_PROVIDERS: dict[SubscriptionKind, str] = {"chatgpt": "openai"}
+"""The one catalog provider each subscription kind is a sign-in for."""
+
+
+class ConnectionConfig(ContractModel):
+    """Local provider connection metadata, with an optional credential environment name only."""
+
+    provider: str = Field(min_length=1, max_length=128)
+    base_url: str | None = Field(default=None, max_length=2_048)
+    api_key_env: str | None = Field(default=None, max_length=256)
+    subscription: SubscriptionKind | None = None
+    """Consumer subscription sign-in this connection dispatches on, instead of an API key."""
+    api_version: str | None = Field(default=None, max_length=64)
+    azure_api_surface: Literal["openai_deployments", "model_inference"] | None = None
+    region: str | None = Field(default=None, max_length=64)
+    aws_access_key_id_env: str | None = Field(default=None, max_length=256)
+    bedrock_auth_mode: Literal["access_key_pair", "api_key"] | None = None
+    # Opt-in: native provider via a trusted https base_url in its own dialect (default-off).
+    trusted_custom_origin: bool = False
+
+    @field_validator("api_key_env", "aws_access_key_id_env")
+    @classmethod
+    def _require_environment_variable_name(cls, value: str | None) -> str | None:
+        if value is not None and not _ENVIRONMENT_NAME.fullmatch(value):
+            raise ValueError("credential environment fields must name environment variables")
+        return value
+
+    @field_validator("base_url")
+    @classmethod
+    def _reject_embedded_credentials(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        parsed = urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("base_url must be an absolute HTTP(S) URL")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("base_url must not embed credentials")
+        if parsed.query or parsed.fragment:
+            raise ValueError("base_url must not include query parameters or fragments")
+        _normalize_base_url(value)
+        return value
+
+    @model_validator(mode="after")
+    def _require_secret_free_connection_metadata(self) -> ConnectionConfig:
+        if self.subscription is not None:
+            self._require_bare_subscription_connection()
+        if self.provider != "azure" and self.azure_api_surface is not None:
+            raise ValueError("azure_api_surface is only accepted for provider='azure'")
+        if self.provider != "bedrock" and (
+            self.aws_access_key_id_env is not None or self.bedrock_auth_mode is not None
+        ):
+            raise ValueError(
+                "aws_access_key_id_env and bedrock_auth_mode are only accepted for "
+                "provider='bedrock'"
+            )
+        if self.trusted_custom_origin:
+            if self.provider not in FIXED_ORIGIN_PROVIDERS:
+                raise ValueError("trusted_custom_origin applies only to a native provider")
+            if self.base_url is None:
+                raise ValueError("trusted_custom_origin requires an explicit base_url")
+            if urlsplit(self.base_url).scheme != "https":
+                raise ValueError("trusted_custom_origin requires an https base_url")
+        elif self.provider in FIXED_ORIGIN_PROVIDERS and self.base_url is not None:
+            raise ValueError(
+                f"native provider {self.provider!r} uses its built-in official endpoint; "
+                "set trusted_custom_origin=True or use provider='openai-compatible'"
+            )
+        if self.provider == "azure":
+            if self.base_url is None:
+                raise ValueError("azure requires an explicit resource endpoint in base_url")
+            if self.api_key_env is None:
+                raise ValueError("azure requires api_key_env")
+            if self.api_version is None:
+                raise ValueError(
+                    "azure requires an explicit api_version such as 'v1' or a dated Azure "
+                    "OpenAI version"
+                )
+            if not _AZURE_API_VERSION.fullmatch(self.api_version):
+                raise ValueError(
+                    "azure api_version must be 'v1' or a dated Azure OpenAI version such as "
+                    "2024-10-21"
+                )
+            if self.azure_api_surface == "model_inference" and self.api_version == "v1":
+                raise ValueError(
+                    "azure model_inference requires a dated api_version for the mandatory "
+                    "api-version query parameter"
+                )
+            if self.region is not None:
+                raise ValueError("region is only accepted for provider='bedrock'")
+        elif self.provider == "bedrock":
+            if self.bedrock_auth_mode == "api_key":
+                if self.api_key_env is None or self.aws_access_key_id_env is not None:
+                    raise ValueError(
+                        "bedrock api_key auth requires api_key_env and forbids "
+                        "aws_access_key_id_env"
+                    )
+            elif self.bedrock_auth_mode == "access_key_pair":
+                if self.api_key_env is None or self.aws_access_key_id_env is None:
+                    raise ValueError(
+                        "bedrock access_key_pair auth requires both credential environment names"
+                    )
+            elif (self.api_key_env is None) != (self.aws_access_key_id_env is None):
+                raise ValueError(
+                    "bedrock explicit access-key auth requires both api_key_env naming the "
+                    "secret access key and aws_access_key_id_env naming the access key id"
+                )
+            if self.base_url is not None:
+                raise ValueError("bedrock does not accept base_url")
+            if self.api_version is not None:
+                raise ValueError("api_version is only accepted for provider='azure'")
+            if self.region is not None and not _AWS_REGION_NAME.fullmatch(self.region):
+                raise ValueError("bedrock region must be an AWS region name")
+        elif self.provider == "vertex":
+            if self.base_url is None:
+                raise ValueError(
+                    "vertex requires base_url naming the project-and-location root, such as "
+                    "https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/"
+                    "locations/us-central1"
+                )
+            # The runtime attaches a cloud-platform OAuth token to every request, so the
+            # endpoint host is pinned to Vertex AI service hosts and never operator-chosen.
+            vertex_parts = urlsplit(self.base_url)
+            vertex_host = (vertex_parts.hostname or "").lower()
+            if vertex_parts.scheme != "https" or not _VERTEX_HOST.fullmatch(vertex_host):
+                raise ValueError(
+                    "vertex base_url must use an HTTPS Vertex AI host such as "
+                    "https://us-central1-aiplatform.googleapis.com; OAuth tokens are never "
+                    "sent to other hosts"
+                )
+            if self.api_key_env is None:
+                raise ValueError(
+                    "vertex requires api_key_env naming the environment variable that holds "
+                    "the service-account JSON credential"
+                )
+            if self.api_version is not None:
+                raise ValueError("api_version is only accepted for provider='azure'")
+            if self.region is not None:
+                raise ValueError(
+                    "region is only accepted for provider='bedrock'; the Vertex location "
+                    "lives inside base_url"
+                )
+        else:
+            if self.api_version is not None:
+                raise ValueError("api_version is only accepted for provider='azure'")
+            if self.region is not None:
+                raise ValueError("region is only accepted for provider='bedrock'")
+        try:
+            assert_secret_free(
+                {
+                    "provider": self.provider,
+                    "base_url": self.base_url,
+                    "api_version": self.api_version,
+                    "azure_api_surface": self.azure_api_surface,
+                    "region": self.region,
+                    "bedrock_auth_mode": self.bedrock_auth_mode,
+                }
+            )
+        except SecretBoundaryError as exc:
+            raise ValueError("connection metadata must not contain credential values") from exc
+        return self
+
+    def _require_bare_subscription_connection(self) -> None:
+        """Reject credential names or endpoint overrides on a subscription sign-in.
+
+        Raises:
+            ValueError: The subscription names a different provider, or the connection also
+                carries an API-key locator or any endpoint override.
+        """
+        if self.subscription is None:
+            return
+        expected_provider = SUBSCRIPTION_PROVIDERS[self.subscription]
+        if self.provider != expected_provider:
+            raise ValueError(
+                f"subscription {self.subscription!r} is a sign-in for provider "
+                f"{expected_provider!r}, not {self.provider!r}"
+            )
+        if self.api_key_env is not None or self.aws_access_key_id_env is not None:
+            raise ValueError(
+                "a subscription connection signs in through the browser and stores no "
+                "credential environment name; omit api_key_env"
+            )
+        if (
+            self.base_url is not None
+            or self.api_version is not None
+            or self.region is not None
+            or self.trusted_custom_origin
+        ):
+            raise ValueError(
+                "a subscription connection reaches its plan's fixed backend; omit base_url "
+                "and every endpoint override"
+            )
+
+    def identity_sha256(self) -> Sha256:
+        """Return a deterministic digest of the secret-free provider endpoint identity.
+
+        Returns:
+            A SHA-256 digest over the provider, normalized endpoint, and any Azure API version or
+            Bedrock region. Credential values and credential-environment metadata are excluded.
+        """
+        identity: JsonObject = {
+            "provider": self.provider,
+            "base_url": _normalize_connection_base_url(self),
+        }
+        if self.api_version is not None:
+            identity["api_version"] = self.api_version
+        if self.provider == "azure" and self.azure_api_surface == "model_inference":
+            # Keep classic Azure revisions byte-compatible with the identity
+            # contract that predates this discriminator. Only the genuinely
+            # different Foundry surface needs a new credential binding.
+            identity["azure_api_surface"] = "model_inference"
+        if self.region is not None:
+            identity["region"] = self.region
+        if self.trusted_custom_origin:  # endpoint identity; added only when set
+            identity["trusted_custom_origin"] = True
+        if self.subscription is not None:  # a different backend than the API-key origin
+            identity["subscription"] = self.subscription
+        effective_bedrock_auth_mode = self.bedrock_auth_mode
+        if (
+            self.provider == "bedrock"
+            and effective_bedrock_auth_mode is None
+            and self.api_key_env is not None
+            and self.aws_access_key_id_env is not None
+        ):
+            effective_bedrock_auth_mode = "access_key_pair"
+        if effective_bedrock_auth_mode is not None:
+            identity["bedrock_auth_mode"] = effective_bedrock_auth_mode
+        return sha256_json(identity)
+
+    def canonicalized(self) -> ConnectionConfig:
+        """Return the canonical persisted shape for Bedrock access-key pairs."""
+        if (
+            self.provider == "bedrock"
+            and self.bedrock_auth_mode is None
+            and self.api_key_env is not None
+            and self.aws_access_key_id_env is not None
+        ):
+            return self.model_copy(update={"bedrock_auth_mode": "access_key_pair"})
+        return self
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_absent_bedrock_metadata(
+        self,
+        handler: SerializerFunctionWrapHandler,
+    ) -> dict[str, object]:
+        """Preserve pre-Bedrock canonical bytes on every supported Pydantic version."""
+        serialized: dict[str, object] = handler(self)
+        if self.aws_access_key_id_env is None:
+            serialized.pop("aws_access_key_id_env", None)
+        if self.bedrock_auth_mode is None:
+            serialized.pop("bedrock_auth_mode", None)
+        if not self.trusted_custom_origin:
+            serialized.pop("trusted_custom_origin", None)
+        if self.subscription is None:
+            serialized.pop("subscription", None)
+        return serialized

--- a/exp/common/models/connection_test.py
+++ b/exp/common/models/connection_test.py
@@ -1,0 +1,63 @@
+"""Tests for secret-free provider connection metadata, including plan sign-in connections."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.common.models.connection import SUBSCRIPTION_PROVIDERS, ConnectionConfig
+
+
+def test_chatgpt_subscription_is_a_bare_openai_connection() -> None:
+    """A plan connection names its provider and kind and nothing else."""
+    connection = ConnectionConfig(provider="openai", subscription="chatgpt")
+
+    assert connection.api_key_env is None
+    assert connection.base_url is None
+    assert SUBSCRIPTION_PROVIDERS[connection.subscription or "chatgpt"] == "openai"
+
+
+def test_subscription_rejects_another_provider() -> None:
+    """A chatgpt plan is a sign-in for openai only."""
+    with pytest.raises(ValueError, match="sign-in for provider 'openai'"):
+        ConnectionConfig(provider="anthropic", subscription="chatgpt")
+
+
+def test_subscription_rejects_a_credential_name() -> None:
+    """A plan sign-in cannot double as an API-key connection."""
+    with pytest.raises(ValueError, match="omit api_key_env"):
+        ConnectionConfig(provider="openai", subscription="chatgpt", api_key_env="OPENAI_API_KEY")
+
+
+def test_subscription_rejects_endpoint_overrides() -> None:
+    """A plan sign-in reaches its fixed backend and cannot point elsewhere."""
+    with pytest.raises(ValueError, match="omit base_url"):
+        ConnectionConfig(
+            provider="openai",
+            subscription="chatgpt",
+            base_url="https://example.com/v1",
+            trusted_custom_origin=True,
+        )
+
+
+def test_subscription_identity_differs_from_the_api_key_origin() -> None:
+    """The plan backend is a different endpoint, so stored sign-ins never bind to API-key rows."""
+    plan = ConnectionConfig(provider="openai", subscription="chatgpt")
+    key = ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY")
+
+    assert plan.identity_sha256() != key.identity_sha256()
+    assert (
+        plan.identity_sha256()
+        == ConnectionConfig(provider="openai", subscription="chatgpt").identity_sha256()
+    )
+
+
+def test_serialization_omits_an_absent_subscription_and_keeps_a_present_one() -> None:
+    """API-key connections keep their exact persisted bytes; plan connections carry the kind."""
+    key = ConnectionConfig(provider="openai", api_key_env="OPENAI_API_KEY").model_dump(mode="json")
+    plan = ConnectionConfig(provider="openai", subscription="chatgpt").model_dump(mode="json")
+
+    assert "subscription" not in key
+    assert plan["subscription"] == "chatgpt"
+    assert ConnectionConfig.model_validate(plan) == ConnectionConfig(
+        provider="openai", subscription="chatgpt"
+    )

--- a/exp/runtime/gateway/group_commit.py
+++ b/exp/runtime/gateway/group_commit.py
@@ -225,6 +225,10 @@ class GroupCommitAttemptLedger:
         ratelimit_remaining_requests: int | None = None,
         ratelimit_limit_tokens: int | None = None,
         ratelimit_remaining_tokens: int | None = None,
+        plan_primary_used_percent: int | None = None,
+        plan_primary_reset_after_seconds: int | None = None,
+        plan_secondary_used_percent: int | None = None,
+        plan_secondary_reset_after_seconds: int | None = None,
     ) -> None:
         """Durably settle one attempt with normalized content-free fields.
 
@@ -239,6 +243,10 @@ class GroupCommitAttemptLedger:
             ratelimit_remaining_requests: Provider-stated requests remaining.
             ratelimit_limit_tokens: Provider-stated token-rate ceiling.
             ratelimit_remaining_tokens: Provider-stated tokens remaining.
+            plan_primary_used_percent: Plan short-window usage, when the rung is a plan.
+            plan_primary_reset_after_seconds: Seconds until the short window resets.
+            plan_secondary_used_percent: Plan long-window usage, when the rung is a plan.
+            plan_secondary_reset_after_seconds: Seconds until the long window resets.
         """
         await self._submit(
             lambda connection: self.core.apply_finish_attempt(
@@ -253,6 +261,10 @@ class GroupCommitAttemptLedger:
                 ratelimit_remaining_requests=ratelimit_remaining_requests,
                 ratelimit_limit_tokens=ratelimit_limit_tokens,
                 ratelimit_remaining_tokens=ratelimit_remaining_tokens,
+                plan_primary_used_percent=plan_primary_used_percent,
+                plan_primary_reset_after_seconds=plan_primary_reset_after_seconds,
+                plan_secondary_used_percent=plan_secondary_used_percent,
+                plan_secondary_reset_after_seconds=plan_secondary_reset_after_seconds,
             )
         )
 
@@ -568,6 +580,10 @@ class SyncGroupCommitLedger:
         ratelimit_remaining_requests: int | None = None,
         ratelimit_limit_tokens: int | None = None,
         ratelimit_remaining_tokens: int | None = None,
+        plan_primary_used_percent: int | None = None,
+        plan_primary_reset_after_seconds: int | None = None,
+        plan_secondary_used_percent: int | None = None,
+        plan_secondary_reset_after_seconds: int | None = None,
     ) -> None:
         """Durably settle one attempt with normalized content-free fields.
 
@@ -582,6 +598,10 @@ class SyncGroupCommitLedger:
             ratelimit_remaining_requests: Provider-stated requests remaining.
             ratelimit_limit_tokens: Provider-stated token-rate ceiling.
             ratelimit_remaining_tokens: Provider-stated tokens remaining.
+            plan_primary_used_percent: Plan short-window usage, when the rung is a plan.
+            plan_primary_reset_after_seconds: Seconds until the short window resets.
+            plan_secondary_used_percent: Plan long-window usage, when the rung is a plan.
+            plan_secondary_reset_after_seconds: Seconds until the long window resets.
         """
         self._writer.submit_blocking(
             lambda connection: self._writer.core.apply_finish_attempt(
@@ -596,6 +616,10 @@ class SyncGroupCommitLedger:
                 ratelimit_remaining_requests=ratelimit_remaining_requests,
                 ratelimit_limit_tokens=ratelimit_limit_tokens,
                 ratelimit_remaining_tokens=ratelimit_remaining_tokens,
+                plan_primary_used_percent=plan_primary_used_percent,
+                plan_primary_reset_after_seconds=plan_primary_reset_after_seconds,
+                plan_secondary_used_percent=plan_secondary_used_percent,
+                plan_secondary_reset_after_seconds=plan_secondary_reset_after_seconds,
             )
         )
 

--- a/exp/runtime/gateway/health.py
+++ b/exp/runtime/gateway/health.py
@@ -211,6 +211,28 @@ class DeploymentHealthRegistry:
                 if state.consecutive_failures >= self._failure_threshold:
                     state.open_until = now + self._open_seconds
 
+    def exhausted(self, key: DeploymentHealthKey, reset_after_seconds: float) -> None:
+        """Suppress one deployment until its provider-stated usage window resets.
+
+        A plan rung reports its rolling usage windows on every response, so a
+        window that reaches 100 percent is known BEFORE the next request would
+        429: the rung is throttled for the reset the provider stated (clamped like
+        a ``Retry-After`` window), and the waterfall moves on to the next plan in
+        the pool. A success on the same response leaves the circuit closed.
+
+        Args:
+            key: Catalog, deployment, and connection identity tuple.
+            reset_after_seconds: Provider-stated seconds until the window reopens.
+        """
+        now = self._clock()
+        window = min(
+            max(float(reset_after_seconds), RETRY_AFTER_WINDOW_MINIMUM_SECONDS),
+            RETRY_AFTER_WINDOW_MAXIMUM_SECONDS,
+        )
+        with self._lock:
+            state = self._states.setdefault(key, _DeploymentHealth())
+            state.throttle_until = max(state.throttle_until, now + window)
+
     def _throttle_window_seconds(self, failure: GatewayFailure) -> float:
         """Size one throttle window from the provider's own stated wait.
 

--- a/exp/runtime/gateway/health_test.py
+++ b/exp/runtime/gateway/health_test.py
@@ -206,3 +206,37 @@ def test_throttled_remaining_seconds_names_a_fully_throttled_route() -> None:
     # One key outside its window makes the route dispatchable again.
     now[0] += 21.0
     assert registry.throttled_remaining_seconds((first, second)) is None
+
+
+def test_exhausted_plan_window_suppresses_the_rung_for_the_stated_reset() -> None:
+    """A reported 100 percent window throttles the deployment until the provider's reset."""
+    now = [1_000.0]
+    registry = DeploymentHealthRegistry(clock=lambda: now[0])
+    key = ("catalog", "plan-a", "connection")
+
+    registry.exhausted(key, 3_600)
+
+    assert registry.suppressed(key)
+    assert not registry.claim(key)
+    assert not registry.claim_forced(key)
+    now[0] += 3_601
+    assert not registry.suppressed(key)
+    assert registry.claim(key)
+
+
+def test_exhaustion_windows_are_clamped_and_never_shortened() -> None:
+    """A week-long reset is clamped to the ceiling; a shorter later report keeps the longer wait."""
+    now = [0.0]
+    registry = DeploymentHealthRegistry(clock=lambda: now[0])
+    key = ("catalog", "plan-a", "connection")
+
+    registry.exhausted(key, 7 * 24 * 3_600)
+    now[0] = 6 * 3_600 - 1
+    assert registry.suppressed(key)
+    now[0] = 6 * 3_600 + 1
+    assert not registry.suppressed(key)
+
+    registry.exhausted(key, 1_000)
+    registry.exhausted(key, 1)
+    now[0] += 900
+    assert registry.suppressed(key)

--- a/exp/runtime/gateway/ledger.py
+++ b/exp/runtime/gateway/ledger.py
@@ -464,6 +464,10 @@ class SQLiteAttemptLedger:
         ratelimit_remaining_requests: int | None = None,
         ratelimit_limit_tokens: int | None = None,
         ratelimit_remaining_tokens: int | None = None,
+        plan_primary_used_percent: int | None = None,
+        plan_primary_reset_after_seconds: int | None = None,
+        plan_secondary_used_percent: int | None = None,
+        plan_secondary_reset_after_seconds: int | None = None,
     ) -> None:
         """Idempotently settle one attempt with normalized content-free fields.
 
@@ -479,6 +483,10 @@ class SQLiteAttemptLedger:
             ratelimit_remaining_requests: Provider-stated requests remaining.
             ratelimit_limit_tokens: Provider-stated token-rate ceiling.
             ratelimit_remaining_tokens: Provider-stated tokens remaining.
+            plan_primary_used_percent: Plan short-window usage, when the rung is a plan.
+            plan_primary_reset_after_seconds: Seconds until the short window resets.
+            plan_secondary_used_percent: Plan long-window usage, when the rung is a plan.
+            plan_secondary_reset_after_seconds: Seconds until the long window resets.
         """
         with self._transaction() as connection:
             self.apply_finish_attempt(
@@ -493,6 +501,10 @@ class SQLiteAttemptLedger:
                 ratelimit_remaining_requests=ratelimit_remaining_requests,
                 ratelimit_limit_tokens=ratelimit_limit_tokens,
                 ratelimit_remaining_tokens=ratelimit_remaining_tokens,
+                plan_primary_used_percent=plan_primary_used_percent,
+                plan_primary_reset_after_seconds=plan_primary_reset_after_seconds,
+                plan_secondary_used_percent=plan_secondary_used_percent,
+                plan_secondary_reset_after_seconds=plan_secondary_reset_after_seconds,
             )
 
     def apply_finish_attempt(
@@ -509,6 +521,10 @@ class SQLiteAttemptLedger:
         ratelimit_remaining_requests: int | None = None,
         ratelimit_limit_tokens: int | None = None,
         ratelimit_remaining_tokens: int | None = None,
+        plan_primary_used_percent: int | None = None,
+        plan_primary_reset_after_seconds: int | None = None,
+        plan_secondary_used_percent: int | None = None,
+        plan_secondary_reset_after_seconds: int | None = None,
     ) -> None:
         """Run the attempt settlement inside the caller's open write transaction.
 
@@ -525,6 +541,10 @@ class SQLiteAttemptLedger:
             ratelimit_remaining_requests: Provider-stated requests remaining.
             ratelimit_limit_tokens: Provider-stated token-rate ceiling.
             ratelimit_remaining_tokens: Provider-stated tokens remaining.
+            plan_primary_used_percent: Plan short-window usage, when the rung is a plan.
+            plan_primary_reset_after_seconds: Seconds until the short window resets.
+            plan_secondary_used_percent: Plan long-window usage, when the rung is a plan.
+            plan_secondary_reset_after_seconds: Seconds until the long window resets.
         """
         state, normalized_failure, failure_message, usage = _terminal_values(
             terminal_event, failure
@@ -600,7 +620,9 @@ class SQLiteAttemptLedger:
                 budget_settled_micro_usd = ?,
                 retry_after_seconds = ?, ratelimit_limit_requests = ?,
                 ratelimit_remaining_requests = ?, ratelimit_limit_tokens = ?,
-                ratelimit_remaining_tokens = ?
+                ratelimit_remaining_tokens = ?,
+                plan_primary_used_percent = ?, plan_primary_reset_after_seconds = ?,
+                plan_secondary_used_percent = ?, plan_secondary_reset_after_seconds = ?
             WHERE attempt_id = ? AND state = 'dispatched'
             """,
             (
@@ -622,6 +644,10 @@ class SQLiteAttemptLedger:
                 ratelimit_remaining_requests,
                 ratelimit_limit_tokens,
                 ratelimit_remaining_tokens,
+                plan_primary_used_percent,
+                plan_primary_reset_after_seconds,
+                plan_secondary_used_percent,
+                plan_secondary_reset_after_seconds,
                 attempt_id,
             ),
         )

--- a/exp/runtime/gateway/native/src/rate_limit_headers.rs
+++ b/exp/runtime/gateway/native/src/rate_limit_headers.rs
@@ -13,8 +13,11 @@
 use reqwest::header::HeaderMap;
 use serde_json::{Map, Value};
 
-/// The closed set of forwarded rate-limit headers, lowercased.
-const ALLOWLISTED_HEADERS: [&str; 9] = [
+/// The closed set of forwarded rate-limit headers, lowercased. The `x-codex-*`
+/// entries are the ChatGPT plan backend's rolling usage windows (percent used,
+/// seconds to reset, window length); numbers only, never the opaque
+/// `x-codex-turn-state` or any account label.
+const ALLOWLISTED_HEADERS: [&str; 15] = [
     "retry-after",
     "x-ratelimit-limit-requests",
     "x-ratelimit-remaining-requests",
@@ -24,6 +27,12 @@ const ALLOWLISTED_HEADERS: [&str; 9] = [
     "anthropic-ratelimit-requests-remaining",
     "anthropic-ratelimit-tokens-limit",
     "anthropic-ratelimit-tokens-remaining",
+    "x-codex-primary-used-percent",
+    "x-codex-primary-reset-after-seconds",
+    "x-codex-primary-window-minutes",
+    "x-codex-secondary-used-percent",
+    "x-codex-secondary-reset-after-seconds",
+    "x-codex-secondary-window-minutes",
 ];
 
 /// Collect the allowlisted rate-limit headers from one provider response.
@@ -88,6 +97,22 @@ mod tests {
         assert_eq!(harvested["retry-after"], "30");
         assert_eq!(harvested["x-ratelimit-remaining-requests"], "9999");
         assert_eq!(harvested["anthropic-ratelimit-tokens-limit"], "12000000");
+    }
+
+    #[test]
+    fn harvest_keeps_plan_window_numbers_but_never_the_turn_state() {
+        let harvested = harvest_rate_limit_headers(&headers(&[
+            ("x-codex-primary-used-percent", "22"),
+            ("x-codex-primary-reset-after-seconds", "11511"),
+            ("x-codex-secondary-window-minutes", "10080"),
+            ("x-codex-turn-state", "gAAAAABqn4w3"),
+            ("x-codex-plan-type", "team"),
+        ]))
+        .unwrap();
+        assert_eq!(harvested.len(), 3);
+        assert_eq!(harvested["x-codex-primary-used-percent"], "22");
+        assert!(!harvested.contains_key("x-codex-turn-state"));
+        assert!(!harvested.contains_key("x-codex-plan-type"));
     }
 
     #[test]

--- a/exp/runtime/gateway/native_accounting.py
+++ b/exp/runtime/gateway/native_accounting.py
@@ -38,7 +38,6 @@ from exp.runtime.gateway.contracts import (
 from exp.runtime.gateway.health import DeploymentHealthRegistry
 from exp.runtime.gateway.native_components import SyncWriteLedger
 from exp.runtime.gateway.native_execution import (
-    DeadRung,
     InflightRequest,
     claim_route_from,
     deployment_health_key,
@@ -55,6 +54,7 @@ from exp.runtime.gateway.native_settlement import (
     failure_from_boundary_payload,
     first_token_at_from_settlement,
     ledger_failure,
+    plan_window_columns,
     settlement_rate_limit,
     terminal_from_settlement,
 )
@@ -647,6 +647,7 @@ class NativeAttemptAccounting:
         terminal, failure = terminal_from_settlement(data)
         first_token_at = first_token_at_from_settlement(data)
         rate_limit = settlement_rate_limit(data)
+        plan = plan_window_columns(rate_limit)
         try:
             self._write_ledger.finish_attempt(
                 attempt_id=attempt_id,
@@ -659,6 +660,10 @@ class NativeAttemptAccounting:
                 ratelimit_remaining_requests=rate_limit.remaining_requests,
                 ratelimit_limit_tokens=rate_limit.limit_tokens,
                 ratelimit_remaining_tokens=rate_limit.remaining_tokens,
+                plan_primary_used_percent=plan.primary_used_percent,
+                plan_primary_reset_after_seconds=plan.primary_reset_after_seconds,
+                plan_secondary_used_percent=plan.secondary_used_percent,
+                plan_secondary_reset_after_seconds=plan.secondary_reset_after_seconds,
             )
         except Exception as exc:  # noqa: BLE001 - the data plane retries.
             # The exact settlement is retained so a retry (from the data
@@ -667,7 +672,9 @@ class NativeAttemptAccounting:
             with self._lock:
                 entry.pending_settlement = data
             raise authority_error(exc) from exc
-        self._record_health(entry, attempt_id, opened=opened, failure=failure)
+        self._record_health(
+            entry, attempt_id, opened=opened, failure=failure, rate_limit=rate_limit
+        )
         self._record_cache_fraction(entry, attempt_id, terminal.usage)
         with self._lock:
             if finalize:
@@ -751,18 +758,22 @@ class NativeAttemptAccounting:
         *,
         opened: bool,
         failure: GatewayFailure | None,
+        rate_limit: RateLimitObservation | None = None,
     ) -> None:
         """Apply one settled attempt's outcome to the deployment circuits.
 
         Mirrors the executor's recording order: a successful dispatch opening
         restores admission first, then the terminal outcome either closes the
-        circuit or counts against it.
+        circuit or counts against it. A plan rung whose response reports an
+        exhausted usage window is throttled until that window resets, success
+        or not, so the pool rotates to the next plan before the first 429.
 
         Args:
             entry: The owning in-flight request.
             attempt_id: The settled attempt.
             opened: Whether the provider dispatch opened successfully.
             failure: The terminal failure, or ``None`` for a success.
+            rate_limit: The response's harvested rate-limit observation.
         """
         # The rung's bounded-admission slot frees with the health recording:
         # both releases are idempotent, so settle, abandon, and the sweep can
@@ -796,6 +807,9 @@ class NativeAttemptAccounting:
             self._health.failed(key, failure)
         else:
             self._health.succeeded(key)
+        exhausted_reset = None if rate_limit is None else rate_limit.exhausted_reset_after_seconds
+        if exhausted_reset is not None:
+            self._health.exhausted(key, exhausted_reset)
 
     def _record_cache_fraction(
         self,
@@ -943,6 +957,7 @@ class NativeAttemptAccounting:
             Whether the swept terminal write reached the ledger.
         """
         observation = RateLimitObservation() if rate_limit is None else rate_limit
+        plan = plan_window_columns(observation)
         try:
             self._write_ledger.finish_attempt(
                 attempt_id=attempt_id,
@@ -954,11 +969,17 @@ class NativeAttemptAccounting:
                 ratelimit_remaining_requests=observation.remaining_requests,
                 ratelimit_limit_tokens=observation.limit_tokens,
                 ratelimit_remaining_tokens=observation.remaining_tokens,
+                plan_primary_used_percent=plan.primary_used_percent,
+                plan_primary_reset_after_seconds=plan.primary_reset_after_seconds,
+                plan_secondary_used_percent=plan.secondary_used_percent,
+                plan_secondary_reset_after_seconds=plan.secondary_reset_after_seconds,
             )
         except Exception:  # noqa: BLE001 - keep the entry; the sweep retries.
             self._accounting_healthy = False
             return False
-        self._record_health(entry, attempt_id, opened=False, failure=failure)
+        self._record_health(
+            entry, attempt_id, opened=False, failure=failure, rate_limit=observation
+        )
         # A retained settlement that finally lands through the sweep carries
         # the same observed usage as the direct path, so the cache-priority
         # EWMA must not depend on WHICH recovery path succeeded.
@@ -969,31 +990,3 @@ class NativeAttemptAccounting:
             elif entry.active_attempt_id == attempt_id:
                 entry.active_attempt_id = None
         return True
-
-
-def record_dead_admission_rungs(
-    accounting: NativeAttemptAccounting,
-    authorization: AuthorizationSnapshot,
-    dead: tuple[DeadRung, ...],
-    *,
-    fallback_available: bool,
-) -> None:
-    """Record admission-dead rungs and surface a lead masked by fallback."""
-    if not dead:
-        return
-    for rung in dead:
-        accounting.health.failed(
-            deployment_health_key(authorization, rung.deployment),
-            rung.failure,
-        )
-    lead = next((rung for rung in dead if rung.index == 0), None)
-    lead_masked = lead is not None and fallback_available
-    accounting.record_admission_rung_skips(len(dead), lead_skipped=lead_masked)
-    if lead is not None and fallback_available:
-        _logger.warning(
-            "gateway admission skipped the lead rung for alias %r: served off a "
-            "fallback because deployment %r (provider %r) was dead at admission",
-            authorization.alias,
-            lead.deployment.deployment_id,
-            lead.deployment.provider,
-        )

--- a/exp/runtime/gateway/native_accounting_test.py
+++ b/exp/runtime/gateway/native_accounting_test.py
@@ -183,6 +183,10 @@ class _RecordingLedger:
         ratelimit_remaining_requests: int | None = None,
         ratelimit_limit_tokens: int | None = None,
         ratelimit_remaining_tokens: int | None = None,
+        plan_primary_used_percent: int | None = None,
+        plan_primary_reset_after_seconds: int | None = None,
+        plan_secondary_used_percent: int | None = None,
+        plan_secondary_reset_after_seconds: int | None = None,
     ) -> None:
         """Record one settled attempt, tracking harvested rate-limit values apart."""
         del terminal_event, first_token_at
@@ -204,6 +208,10 @@ class _RecordingLedger:
                 ratelimit_remaining_requests,
                 ratelimit_limit_tokens,
                 ratelimit_remaining_tokens,
+                plan_primary_used_percent,
+                plan_primary_reset_after_seconds,
+                plan_secondary_used_percent,
+                plan_secondary_reset_after_seconds,
             )
         ):
             self.rate_limit_settlements.append(
@@ -214,6 +222,10 @@ class _RecordingLedger:
                     "ratelimit_remaining_requests": ratelimit_remaining_requests,
                     "ratelimit_limit_tokens": ratelimit_limit_tokens,
                     "ratelimit_remaining_tokens": ratelimit_remaining_tokens,
+                    "plan_primary_used_percent": plan_primary_used_percent,
+                    "plan_primary_reset_after_seconds": plan_primary_reset_after_seconds,
+                    "plan_secondary_used_percent": plan_secondary_used_percent,
+                    "plan_secondary_reset_after_seconds": plan_secondary_reset_after_seconds,
                 }
             )
 
@@ -1245,8 +1257,82 @@ class TestRateLimitSettlement:
                 "ratelimit_remaining_requests": 9_999,
                 "ratelimit_limit_tokens": 180_000_000,
                 "ratelimit_remaining_tokens": 179_000_000,
+                "plan_primary_used_percent": None,
+                "plan_primary_reset_after_seconds": None,
+                "plan_secondary_used_percent": None,
+                "plan_secondary_reset_after_seconds": None,
             }
         ]
+
+    def test_exhausted_plan_window_throttles_the_rung_until_its_reset(self) -> None:
+        """A plan whose short window hit 100 percent is suppressed for the stated reset, even
+        on a success, and its window numbers land in the plan ledger columns."""
+        registry, ledger, entry = _registry()
+        started = _start(registry, ordinal=0)
+        key = deployment_health_key(entry.authorization, entry.route.deployments[0])
+        assert not registry.health.suppressed(key)
+        registry.settle(
+            json.dumps(
+                {
+                    "request_id": "request-one",
+                    "attempt_id": str(started["attempt_id"]),
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "tool_names": [],
+                    "failure": None,
+                    "finalize": True,
+                    "opened": True,
+                    "rate_limit_headers": {
+                        "x-codex-primary-used-percent": "100",
+                        "x-codex-primary-reset-after-seconds": "11511",
+                        "x-codex-primary-window-minutes": "300",
+                        "x-codex-secondary-used-percent": "4",
+                        "x-codex-secondary-reset-after-seconds": "598311",
+                        "x-codex-secondary-window-minutes": "10080",
+                    },
+                }
+            )
+        )
+        assert registry.health.suppressed(key)
+        assert ledger.rate_limit_settlements == [
+            {
+                "attempt_id": str(started["attempt_id"]),
+                "retry_after_seconds": None,
+                "ratelimit_limit_requests": None,
+                "ratelimit_remaining_requests": None,
+                "ratelimit_limit_tokens": None,
+                "ratelimit_remaining_tokens": None,
+                "plan_primary_used_percent": 100,
+                "plan_primary_reset_after_seconds": 11_511,
+                "plan_secondary_used_percent": 4,
+                "plan_secondary_reset_after_seconds": 598_311,
+            }
+        ]
+
+    def test_a_plan_window_below_its_ceiling_leaves_the_rung_admitted(self) -> None:
+        """Window numbers are recorded without suppressing a plan that still has room."""
+        registry, _ledger, entry = _registry()
+        started = _start(registry, ordinal=0)
+        key = deployment_health_key(entry.authorization, entry.route.deployments[0])
+        registry.settle(
+            json.dumps(
+                {
+                    "request_id": "request-one",
+                    "attempt_id": str(started["attempt_id"]),
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "tool_names": [],
+                    "failure": None,
+                    "finalize": True,
+                    "opened": True,
+                    "rate_limit_headers": {
+                        "x-codex-primary-used-percent": "22",
+                        "x-codex-primary-reset-after-seconds": "11511",
+                    },
+                }
+            )
+        )
+        assert not registry.health.suppressed(key)
 
     def test_settle_without_headers_records_no_rate_limit_values(self) -> None:
         """An engine that sends no header map keeps every kwarg None."""
@@ -1411,6 +1497,10 @@ class TestRateLimitSettlement:
                 "ratelimit_remaining_requests": 9_999,
                 "ratelimit_limit_tokens": None,
                 "ratelimit_remaining_tokens": None,
+                "plan_primary_used_percent": None,
+                "plan_primary_reset_after_seconds": None,
+                "plan_secondary_used_percent": None,
+                "plan_secondary_reset_after_seconds": None,
             }
         ]
 

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -27,6 +27,8 @@ from exp.runtime.gateway.contracts import AuthorizationSnapshot, DirectTarget, G
 from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
 from exp.runtime.gateway.native_components import NativeGatewayComponents
 from exp.runtime.gateway.native_execution import (
+    DeadRung,
+    deployment_health_key,
     reorder_route_deployments,
     request_carries_cache_markers,
     select_route_deployments,
@@ -687,3 +689,31 @@ def resolve_admission_route(
         request=request,
         episode_namespace=episode,
     )
+
+
+def record_dead_admission_rungs(
+    accounting: NativeAttemptAccounting,
+    authorization: AuthorizationSnapshot,
+    dead: tuple[DeadRung, ...],
+    *,
+    fallback_available: bool,
+) -> None:
+    """Record admission-dead rungs and surface a lead masked by fallback."""
+    if not dead:
+        return
+    for rung in dead:
+        accounting.health.failed(
+            deployment_health_key(authorization, rung.deployment),
+            rung.failure,
+        )
+    lead = next((rung for rung in dead if rung.index == 0), None)
+    lead_masked = lead is not None and fallback_available
+    accounting.record_admission_rung_skips(len(dead), lead_skipped=lead_masked)
+    if lead is not None and fallback_available:
+        _logger.warning(
+            "gateway admission skipped the lead rung for alias %r: served off a "
+            "fallback because deployment %r (provider %r) was dead at admission",
+            authorization.alias,
+            lead.deployment.deployment_id,
+            lead.deployment.provider,
+        )

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -46,7 +46,6 @@ from exp.runtime.gateway.guardrails.native import enforce_native_input, enforce_
 from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
-    record_dead_admission_rungs,
 )
 from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
@@ -54,6 +53,7 @@ from exp.runtime.gateway.native_accounting import (
 from exp.runtime.gateway.native_admission import (
     admitted_route_requests,
     fold_parallel_tool_call_disclosures,
+    record_dead_admission_rungs,
     resolve_admission_route,
 )
 from exp.runtime.gateway.native_batches import NativeBatchRelayMixin

--- a/exp/runtime/gateway/native_components.py
+++ b/exp/runtime/gateway/native_components.py
@@ -65,6 +65,10 @@ class SyncWriteLedger(Protocol):
         ratelimit_remaining_requests: int | None = None,
         ratelimit_limit_tokens: int | None = None,
         ratelimit_remaining_tokens: int | None = None,
+        plan_primary_used_percent: int | None = None,
+        plan_primary_reset_after_seconds: int | None = None,
+        plan_secondary_used_percent: int | None = None,
+        plan_secondary_reset_after_seconds: int | None = None,
     ) -> None:
         """Durably settle one attempt exactly once.
 

--- a/exp/runtime/gateway/native_embeddings.py
+++ b/exp/runtime/gateway/native_embeddings.py
@@ -34,8 +34,8 @@ from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
     authority_error,
-    record_dead_admission_rungs,
 )
+from exp.runtime.gateway.native_admission import record_dead_admission_rungs
 from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
 from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_embeddings_body
 from exp.runtime.gateway.native_execution import (

--- a/exp/runtime/gateway/native_images.py
+++ b/exp/runtime/gateway/native_images.py
@@ -33,8 +33,8 @@ from exp.runtime.gateway.native_accounting import (
     NativeAttemptAccounting,
     NativeBridgeError,
     authority_error,
-    record_dead_admission_rungs,
 )
+from exp.runtime.gateway.native_admission import record_dead_admission_rungs
 from exp.runtime.gateway.native_components import NativeGatewayComponents, SyncWriteLedger
 from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_images_body
 from exp.runtime.gateway.native_execution import (

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -9,6 +9,7 @@ typed :class:`GatewayFailure`.
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
 
@@ -204,7 +205,12 @@ def terminal_from_settlement(
             # the provider's own Retry-After when the data plane harvested the
             # rate-limit headers; sizing the throttle window from it is what
             # lets a daily-quota reset actually suppress the rung for hours.
-            observed = settlement_rate_limit(data).retry_after_seconds
+            observation = settlement_rate_limit(data)
+            observed = observation.retry_after_seconds
+            if observed is None:
+                # A plan backend's 429 states the wait as its exhausted usage
+                # window's reset rather than a Retry-After.
+                observed = observation.exhausted_reset_after_seconds
             if observed is not None:
                 failure = failure.model_copy(update={"retry_after_seconds": observed})
         # A rejected credential or exhausted account on the customer's own
@@ -291,6 +297,35 @@ def settlement_rate_limit(data: JsonObject) -> RateLimitObservation:
         The typed observation for the ledger and throttle calibration.
     """
     return rate_limit_observation_from_payload(data.get("rate_limit_headers"))
+
+
+@dataclass(frozen=True)
+class PlanWindowColumns:
+    """One observation's plan usage windows flattened to the attempt ledger's columns."""
+
+    primary_used_percent: int | None = None
+    primary_reset_after_seconds: int | None = None
+    secondary_used_percent: int | None = None
+    secondary_reset_after_seconds: int | None = None
+
+
+def plan_window_columns(observation: RateLimitObservation) -> PlanWindowColumns:
+    """Flatten one observation's plan usage windows into the attempt ledger's columns.
+
+    Args:
+        observation: The settlement's harvested rate-limit observation.
+
+    Returns:
+        The four ``plan_*`` column values, ``None`` where the response carried no window.
+    """
+    primary = observation.subscription_window("primary")
+    secondary = observation.subscription_window("secondary")
+    return PlanWindowColumns(
+        primary_used_percent=None if primary is None else primary.used_percent,
+        primary_reset_after_seconds=None if primary is None else primary.reset_after_seconds,
+        secondary_used_percent=None if secondary is None else secondary.used_percent,
+        secondary_reset_after_seconds=None if secondary is None else secondary.reset_after_seconds,
+    )
 
 
 def deployment_operation_key(route: GatewayRoute, deployment: ExactModelDeployment) -> str:

--- a/exp/runtime/gateway/rate_limit_headers.py
+++ b/exp/runtime/gateway/rate_limit_headers.py
@@ -2,7 +2,8 @@
 
 The native data plane forwards the small allowlisted subset of provider
 response headers that describe rate limiting (``retry-after`` plus the OpenAI
-``x-ratelimit-*`` and Anthropic ``anthropic-ratelimit-*`` families) on the
+``x-ratelimit-*`` and Anthropic ``anthropic-ratelimit-*`` families, and the
+ChatGPT plan backend's ``x-codex-*`` usage windows) on the
 settlement payload, for successes and failures alike. This module owns the
 one place those raw header strings become typed integers: the observation
 rides the attempt ledger for calibration analytics, and a throttled
@@ -18,8 +19,32 @@ import math
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
+from typing import Literal
 
 from exp.common.core.artifacts import ContractModel
+
+SubscriptionWindowName = Literal["primary", "secondary"]
+"""A plan's rolling usage windows: the short one (hours) and the long one (a week)."""
+
+EXHAUSTED_USED_PERCENT = 100
+"""The used-percent reading at which a plan window admits no more requests."""
+
+
+class SubscriptionWindowObservation(ContractModel):
+    """One plan usage window as the ChatGPT backend reports it on every response."""
+
+    window: SubscriptionWindowName
+    used_percent: int
+    """Share of the window's allowance already spent, 0 to 100."""
+    reset_after_seconds: int | None = None
+    """Seconds until the window rolls over, when the provider states it."""
+    window_minutes: int | None = None
+    """The window's length, when the provider states it."""
+
+    @property
+    def exhausted(self) -> bool:
+        """Whether the window admits no more requests until it resets."""
+        return self.used_percent >= EXHAUSTED_USED_PERCENT
 
 
 class RateLimitObservation(ContractModel):
@@ -35,6 +60,8 @@ class RateLimitObservation(ContractModel):
     """The account's token-rate ceiling as the provider states it."""
     remaining_tokens: int | None = None
     """Tokens left in the provider's current window."""
+    subscription_windows: tuple[SubscriptionWindowObservation, ...] = ()
+    """Plan usage windows, in primary-then-secondary order, when the rung is a plan."""
 
     @property
     def is_empty(self) -> bool:
@@ -45,7 +72,29 @@ class RateLimitObservation(ContractModel):
             and self.remaining_requests is None
             and self.limit_tokens is None
             and self.remaining_tokens is None
+            and not self.subscription_windows
         )
+
+    def subscription_window(
+        self, window: SubscriptionWindowName
+    ) -> SubscriptionWindowObservation | None:
+        """Return one named plan window, or ``None`` when the response carried none."""
+        return next((item for item in self.subscription_windows if item.window == window), None)
+
+    @property
+    def exhausted_reset_after_seconds(self) -> int | None:
+        """The longest stated reset among exhausted plan windows, or ``None`` when none is.
+
+        A plan whose short window is spent stays unusable until that window rolls over,
+        and a spent long window outlasts a spent short one, so the longest reset is the
+        wait that actually reopens the rung.
+        """
+        waits = [
+            item.reset_after_seconds
+            for item in self.subscription_windows
+            if item.exhausted and item.reset_after_seconds is not None
+        ]
+        return max(waits) if waits else None
 
 
 _EMPTY_OBSERVATION = RateLimitObservation()
@@ -143,7 +192,40 @@ def rate_limit_observation(headers: Mapping[str, str]) -> RateLimitObservation:
         remaining_requests=values.get("remaining_requests"),
         limit_tokens=values.get("limit_tokens"),
         remaining_tokens=values.get("remaining_tokens"),
+        subscription_windows=_subscription_windows(lowered),
     )
+
+
+def _subscription_windows(lowered: Mapping[str, str]) -> tuple[SubscriptionWindowObservation, ...]:
+    """Read the ChatGPT plan backend's ``x-codex-*`` usage windows.
+
+    A window is reported only when its used-percent header parses; the reset and
+    length stay ``None`` when theirs do not, so one garbled header never hides the
+    window's exhaustion.
+
+    Args:
+        lowered: Lowercased header names mapped to raw values.
+
+    Returns:
+        The windows present, primary first.
+    """
+    windows: list[SubscriptionWindowObservation] = []
+    for name in ("primary", "secondary"):
+        used_raw = lowered.get(f"x-codex-{name}-used-percent")
+        used = None if used_raw is None else _parse_count(used_raw)
+        if used is None:
+            continue
+        reset_raw = lowered.get(f"x-codex-{name}-reset-after-seconds")
+        length_raw = lowered.get(f"x-codex-{name}-window-minutes")
+        windows.append(
+            SubscriptionWindowObservation(
+                window=name,
+                used_percent=min(used, EXHAUSTED_USED_PERCENT),
+                reset_after_seconds=None if reset_raw is None else _parse_count(reset_raw),
+                window_minutes=None if length_raw is None else _parse_count(length_raw),
+            )
+        )
+    return tuple(windows)
 
 
 def rate_limit_observation_from_payload(payload: object) -> RateLimitObservation:

--- a/exp/runtime/gateway/rate_limit_headers_test.py
+++ b/exp/runtime/gateway/rate_limit_headers_test.py
@@ -130,3 +130,69 @@ class TestPayloadTolerance:
         """A well-shaped payload map parses exactly like raw headers."""
         observation = rate_limit_observation_from_payload({"retry-after": "45"})
         assert observation.retry_after_seconds == 45
+
+
+class TestPlanWindows:
+    """The ChatGPT plan backend's ``x-codex-*`` usage windows become typed observations."""
+
+    def test_both_windows_parse_primary_first(self) -> None:
+        """Percent, reset, and length ride each window; the observation is not empty."""
+        observation = rate_limit_observation(
+            {
+                "X-Codex-Primary-Used-Percent": "22",
+                "x-codex-primary-reset-after-seconds": "11511",
+                "x-codex-primary-window-minutes": "300",
+                "x-codex-secondary-used-percent": "4",
+                "x-codex-secondary-reset-after-seconds": "598311",
+                "x-codex-secondary-window-minutes": "10080",
+            }
+        )
+
+        assert [window.window for window in observation.subscription_windows] == [
+            "primary",
+            "secondary",
+        ]
+        primary = observation.subscription_window("primary")
+        assert primary is not None
+        assert (primary.used_percent, primary.reset_after_seconds, primary.window_minutes) == (
+            22,
+            11_511,
+            300,
+        )
+        assert not observation.is_empty
+        assert observation.exhausted_reset_after_seconds is None
+
+    def test_exhaustion_takes_the_longest_reset_among_spent_windows(self) -> None:
+        """A spent long window outlasts a spent short one, so its reset is the wait."""
+        observation = rate_limit_observation(
+            {
+                "x-codex-primary-used-percent": "100",
+                "x-codex-primary-reset-after-seconds": "600",
+                "x-codex-secondary-used-percent": "100",
+                "x-codex-secondary-reset-after-seconds": "80000",
+            }
+        )
+
+        assert observation.exhausted_reset_after_seconds == 80_000
+
+    def test_a_window_without_a_percent_is_absent_and_garbage_fields_stay_none(self) -> None:
+        """Only a parseable used-percent reports a window; other garbled fields degrade."""
+        observation = rate_limit_observation(
+            {
+                "x-codex-primary-used-percent": "137",
+                "x-codex-primary-reset-after-seconds": "soon",
+                "x-codex-secondary-reset-after-seconds": "600",
+            }
+        )
+
+        primary = observation.subscription_window("primary")
+        assert primary is not None
+        assert primary.used_percent == 100
+        assert primary.exhausted
+        assert primary.reset_after_seconds is None
+        assert observation.subscription_window("secondary") is None
+        assert observation.exhausted_reset_after_seconds is None
+
+    def test_payload_without_plan_headers_has_no_windows(self) -> None:
+        """API-key rungs keep an empty window tuple."""
+        assert rate_limit_observation_from_payload({"retry-after": "5"}).subscription_windows == ()

--- a/exp/runtime/gateway/sqlite/migrations.py
+++ b/exp/runtime/gateway/sqlite/migrations.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
-SCHEMA_VERSION = 19
+SCHEMA_VERSION = 21
 
 
 class GatewaySchemaError(RuntimeError):
@@ -711,6 +711,28 @@ _MIGRATION_19 = (
     "ALTER TABLE gateway_attempts ADD COLUMN ratelimit_remaining_tokens INTEGER",
 )
 
+# v20: per-attempt plan usage windows. A ChatGPT plan rung answers every request
+# with its rolling windows (percent used and seconds to reset for the short and
+# the long window); persisting them per attempt is what lets the pool view show
+# how full each plan is and audit why the waterfall moved past it. Numbers only.
+_MIGRATION_20 = (
+    "ALTER TABLE gateway_attempts ADD COLUMN plan_primary_used_percent INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN plan_primary_reset_after_seconds INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN plan_secondary_used_percent INTEGER",
+    "ALTER TABLE gateway_attempts ADD COLUMN plan_secondary_reset_after_seconds INTEGER",
+)
+
+# v21: plan sign-in connections. A connection revision may dispatch on a consumer
+# subscription instead of an API key; the kind is part of the connection's
+# identity digest, so it must round-trip through the authority table or every
+# plan revision would fail the digest check on reload.
+_MIGRATION_21 = (
+    """
+    ALTER TABLE provider_connection_revisions
+    ADD COLUMN subscription TEXT CHECK (subscription IN ('chatgpt'))
+    """,
+)
+
 _MIGRATIONS = {
     1: _MIGRATION_1,
     2: _MIGRATION_2,
@@ -731,6 +753,8 @@ _MIGRATIONS = {
     17: _MIGRATION_17,
     18: _MIGRATION_18,
     19: _MIGRATION_19,
+    20: _MIGRATION_20,
+    21: _MIGRATION_21,
 }
 
 

--- a/exp/runtime/gateway/sqlite/provider_authority.py
+++ b/exp/runtime/gateway/sqlite/provider_authority.py
@@ -7,6 +7,7 @@ from typing import Literal, cast
 
 from exp.common.core.artifacts import ContractModel, Sha256, stable_id
 from exp.common.models import ConnectionConfig
+from exp.common.models.connection import SubscriptionKind
 
 
 class ProviderAuthorityError(ValueError):
@@ -129,8 +130,8 @@ def upsert_provider_connection(
             revision_id, organization_id, connection_id, revision_number,
             provider, base_url, api_key_env, api_version, azure_api_surface, region,
             aws_access_key_id_env, bedrock_auth_mode, trusted_custom_origin,
-            connection_sha256, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            subscription, connection_sha256, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             revision_id,
@@ -146,6 +147,7 @@ def upsert_provider_connection(
             config.aws_access_key_id_env,
             config.bedrock_auth_mode,
             1 if config.trusted_custom_origin else 0,
+            config.subscription,
             digest,
             now,
         ),
@@ -201,7 +203,7 @@ def bound_provider_connections(
                r.provider, r.base_url, r.api_key_env, r.api_version,
                r.azure_api_surface, r.region,
                r.aws_access_key_id_env, r.bedrock_auth_mode, r.trusted_custom_origin,
-               r.connection_sha256, c.active
+               r.subscription, r.connection_sha256, c.active
         FROM alias_revision_provider_connections AS b
         JOIN provider_connections AS c
           ON c.organization_id = b.organization_id
@@ -343,6 +345,10 @@ def _authority(row: sqlite3.Row) -> ProviderConnectionAuthority:
             else cast('Literal["access_key_pair", "api_key"]', str(row["bedrock_auth_mode"]))
         ),
         trusted_custom_origin=bool(row["trusted_custom_origin"]),
+        subscription=cast(
+            "SubscriptionKind | None",
+            None if row["subscription"] is None else str(row["subscription"]),
+        ),
     )
     digest = str(row["connection_sha256"])
     if config.identity_sha256() != digest:
@@ -362,7 +368,7 @@ SELECT c.connection_id, r.revision_id, r.revision_number,
        r.provider, r.base_url, r.api_key_env, r.api_version,
        r.azure_api_surface, r.region,
        r.aws_access_key_id_env, r.bedrock_auth_mode, r.trusted_custom_origin,
-       r.connection_sha256, c.active
+       r.subscription, r.connection_sha256, c.active
 FROM provider_connections AS c
 JOIN provider_connection_revisions AS r
   ON r.organization_id = c.organization_id

--- a/exp/runtime/models/credentials.py
+++ b/exp/runtime/models/credentials.py
@@ -15,6 +15,7 @@ from exp.common.auth import (
     ProviderAuthStoreError,
     StoredCredentialBinding,
     StoredCredentialEndpointMismatch,
+    StoredCredentialKindMismatch,
     StoredCredentialStatus,
 )
 from exp.common.core.artifacts import sha256_json
@@ -84,13 +85,17 @@ def lookup_connection_credential(
     """
     if connection.provider == "bedrock" and connection.api_key_env is None:
         return None
+    if connection.subscription is not None:
+        # A plan sign-in is not an API key; its bearer is minted per dispatch from the
+        # stored tokens (see ``describe_connection_credential`` for its status).
+        return None
     values = os.environ if environment is None else environment
     if connection.api_key_env is not None:
         env_value = (values.get(connection.api_key_env) or "").strip()
         if env_value:
             return CredentialResolution(env_value, "environment")
     auth_store = store if store is not None else ProviderAuthStore()
-    stored = auth_store.get(connection_id, binding=_credential_binding(connection))
+    stored = auth_store.get(connection_id, binding=connection_credential_binding(connection))
     if stored:
         return CredentialResolution(stored, "stored")
     return None
@@ -120,6 +125,8 @@ def describe_connection_credential(
             provider=connection.provider,
             source="aws_chain",
         )
+    if connection.subscription is not None:
+        return _describe_subscription_sign_in(connection, connection_id=connection_id, store=store)
     try:
         resolved = lookup_connection_credential(
             connection,
@@ -146,6 +153,41 @@ def describe_connection_credential(
         provider=connection.provider,
         source=source,
         environment_variable=connection.api_key_env,
+    )
+
+
+def _describe_subscription_sign_in(
+    connection: ConnectionConfig,
+    *,
+    connection_id: str,
+    store: ProviderAuthStore | None,
+) -> StoredCredentialStatus:
+    """Report whether one subscription connection has a stored browser sign-in.
+
+    Args:
+        connection: Subscription connection metadata.
+        connection_id: Exact catalog or gateway connection name.
+        store: Optional credential store. When omitted, the platform user-data file is used.
+
+    Returns:
+        ``signed_in`` when the store holds a sign-in bound to this connection's identity,
+        ``mismatch`` when it holds a record for another identity or an API key, else
+        ``missing``.
+    """
+    auth_store = store if store is not None else ProviderAuthStore()
+    source: Literal["signed_in", "missing", "mismatch"]
+    try:
+        tokens = auth_store.get_oauth(
+            connection_id, binding=connection_credential_binding(connection)
+        )
+    except (StoredCredentialEndpointMismatch, StoredCredentialKindMismatch):
+        source = "mismatch"
+    else:
+        source = "missing" if tokens is None else "signed_in"
+    return StoredCredentialStatus(
+        connection_id=connection_id,
+        provider=connection.provider,
+        source=source,
     )
 
 
@@ -193,6 +235,11 @@ def read_connection_api_key(
     """
     if connection.provider == "bedrock" and connection.api_key_env is None:
         raise ModelCredentialError("bedrock ambient authentication has no stored secret access key")
+    if connection.subscription is not None:
+        raise ModelCredentialError(
+            f"connection {connection_id!r} is a {connection.subscription} plan sign-in and has "
+            "no API key"
+        )
     try:
         resolved = lookup_connection_credential(
             connection,
@@ -259,11 +306,11 @@ def resolve_or_prompt_connection_api_key(
     if not key:
         return None
     if persist:
-        auth_store.put(connection_id, key, binding=_credential_binding(connection))
+        auth_store.put(connection_id, key, binding=connection_credential_binding(connection))
     return key
 
 
-def _credential_binding(connection: ConnectionConfig) -> StoredCredentialBinding:
+def connection_credential_binding(connection: ConnectionConfig) -> StoredCredentialBinding:
     """Return the secret-free endpoint and credential-locator identity for one key.
 
     Args:

--- a/exp/runtime/models/credentials_test.py
+++ b/exp/runtime/models/credentials_test.py
@@ -10,12 +10,14 @@ from exp.common.auth import (
     ProviderAuthStore,
     StoredCredentialBinding,
     StoredCredentialEndpointMismatch,
+    StoredOAuthTokens,
 )
 from exp.common.models import ConnectionConfig
 from exp.runtime.models.credentials import (
     CredentialResolution,
     MissingModelCredentialError,
     ModelCredentialError,
+    describe_connection_credential,
     lookup_connection_credential,
     read_connection_api_key,
     resolve_or_prompt_connection_api_key,
@@ -389,3 +391,28 @@ def test_resolution_repr_never_includes_the_secret() -> None:
     assert _SECRET not in str(resolved)
     assert resolved.value == _SECRET
     assert resolved.source == "stored"
+
+
+def test_subscription_connection_reports_its_sign_in_state(tmp_path: Path) -> None:
+    """A plan connection is signed_in, missing, or mismatched; it never resolves as a key."""
+    plan = ConnectionConfig(provider="openai", subscription="chatgpt")
+    store = ProviderAuthStore(tmp_path / "auth.json")
+
+    assert describe_connection_credential(plan, connection_id="plan", store=store).source == (
+        "missing"
+    )
+    assert lookup_connection_credential(plan, connection_id="plan", store=store) is None
+    store.put_oauth(
+        "plan",
+        StoredOAuthTokens(access_token="a", refresh_token="r", expires_at_ms=1),
+        binding=_binding(plan),
+    )
+    assert describe_connection_credential(plan, connection_id="plan", store=store).source == (
+        "signed_in"
+    )
+    store.put("plan", "sk-key-instead")
+    assert describe_connection_credential(plan, connection_id="plan", store=store).source == (
+        "mismatch"
+    )
+    with pytest.raises(ModelCredentialError, match="plan sign-in and has no API key"):
+        read_connection_api_key(plan, connection_id="plan", store=store)

--- a/exp/runtime/models/providers/azure.py
+++ b/exp/runtime/models/providers/azure.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 from urllib.parse import urlsplit, urlunsplit
 
 from exp.common.models import ChatMaxTokensField, ModelSnapshot
-from exp.common.models.catalog import (
+from exp.common.models.connection import (
     AzureApiSurface,
     infer_azure_api_surface,
     strip_model_inference_root,

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -244,6 +244,13 @@ class GatewayWireProfile:
     pre-serialized body the data plane must send verbatim, and the resolved
     client exposes ``sign_gateway_dispatch``."""
 
+    omits_output_token_limit: bool = False
+    """Whether this rung's payload must carry no output-token ceiling.
+
+    The ChatGPT plan backend rejects ``max_output_tokens`` outright (400
+    "Unsupported parameter"), so a plan rung drops the caller's ceiling
+    structurally; every API-key rung forwards it unchanged."""
+
     embeddings_url: str | None = None
     """Full OpenAI-wire ``/embeddings`` endpoint for this connection, sharing
     ``headers``; ``None`` when the connection speaks no embeddings wire, so the

--- a/exp/runtime/models/providers/chatgpt_subscription.py
+++ b/exp/runtime/models/providers/chatgpt_subscription.py
@@ -1,0 +1,503 @@
+"""ChatGPT plan sign-in as a gateway upstream: the Codex Responses backend on rotating bearers.
+
+A ``subscription = "chatgpt"`` connection dispatches on a ChatGPT plan rather than an API
+key. The operator signs in once through the browser (the same OAuth client and loopback
+callback Codex itself uses, or an import of an existing Codex ``auth.json``); the tokens
+live in the user-only credential file under the connection ID. The gateway then mints a
+fresh bearer for every physical dispatch through the body-signing seam, refreshing ahead of
+expiry and persisting the rotated refresh token, so a long-running worker never dispatches
+on a stale token and never loses the sign-in to rotation.
+
+The backend is stricter than the public Responses API: it accepts only streaming requests
+with provider-side storage disabled, rejects ``max_output_tokens``, and answers every
+request with ``x-codex-*`` headers describing the plan's rolling usage windows. Those
+headers are what let a pool of plans rotate: an exhausted window suppresses its rung for
+exactly the reset the provider stated.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+import httpx
+
+from exp.common.auth import ProviderAuthStore, StoredCredentialBinding, StoredOAuthTokens
+from exp.common.core.artifacts import ContractModel, JsonObject
+from exp.common.models import ModelRequest, ModelResponse, ModelSnapshot
+from exp.runtime.models.credentials import ModelCredentialError
+from exp.runtime.models.providers.async_transport import AsyncJsonHttpTransport, RequestDeadline
+from exp.runtime.models.providers.base import DEFAULT_TIMEOUT_SECONDS, GatewayWireProfile
+from exp.runtime.models.providers.errors import ProviderCapabilityError
+from exp.runtime.models.providers.openai import OpenAIClient
+from exp.runtime.models.providers.transport import JsonHttpTransport
+
+logger = logging.getLogger(__name__)
+
+CHATGPT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+"""Fixed Responses backend a ChatGPT plan dispatches to; never operator-chosen."""
+CHATGPT_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+"""The public OAuth client Codex signs in with; a plan sign-in is only valid for it."""
+CHATGPT_OAUTH_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+CHATGPT_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CHATGPT_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback"
+"""The loopback callback registered for the client; the sign-in listener must bind it."""
+CHATGPT_OAUTH_SCOPE = "openid profile email offline_access"
+ACCESS_TOKEN_REFRESH_AHEAD_SECONDS = 300.0
+"""Refresh when the access token has this little life left, so no dispatch rides an expiry."""
+_TOKEN_ENDPOINT_TIMEOUT_SECONDS = 30.0
+_AUTH_CLAIMS_KEY = "https://api.openai.com/auth"
+_ORIGINATOR = "experiential"
+
+TokenEndpoint = Callable[[JsonObject], JsonObject]
+"""One JSON POST to the OAuth token endpoint, injectable for deterministic tests."""
+
+
+class ChatGptSignInError(ModelCredentialError):
+    """A plan sign-in could not be established, read, or refreshed."""
+
+
+class ChatGptAccountClaims(ContractModel):
+    """Content-free plan identity read from a sign-in token."""
+
+    account_id: str
+    plan_type: str | None = None
+
+
+def chatgpt_account_claims(token: str) -> ChatGptAccountClaims:
+    """Read the ChatGPT account identity a sign-in token carries.
+
+    The claims are read, not verified: the token arrived from the provider over TLS in
+    direct answer to this process's own request, and the identity is used only to address
+    the account on dispatch and to label it, never to grant anything.
+
+    Args:
+        token: An OpenAI id token or access token.
+
+    Returns:
+        The account identifier and plan type.
+
+    Raises:
+        ChatGptSignInError: The token is not a JWT or carries no ChatGPT account claims.
+    """
+    claims = _jwt_claims(token)
+    auth = claims.get(_AUTH_CLAIMS_KEY)
+    account_id = auth.get("chatgpt_account_id") if isinstance(auth, dict) else None
+    if not isinstance(account_id, str) or not account_id:
+        raise ChatGptSignInError("the sign-in token carries no ChatGPT account; sign in again")
+    plan_type = auth.get("chatgpt_plan_type") if isinstance(auth, dict) else None
+    return ChatGptAccountClaims(
+        account_id=account_id,
+        plan_type=plan_type if isinstance(plan_type, str) and plan_type else None,
+    )
+
+
+def jwt_expiry_ms(token: str) -> int:
+    """Return one JWT's ``exp`` claim as unix milliseconds.
+
+    Args:
+        token: A JWT whose payload carries ``exp`` in unix seconds.
+
+    Returns:
+        The expiry in unix milliseconds.
+
+    Raises:
+        ChatGptSignInError: The token is not a JWT or carries no integer ``exp``.
+    """
+    expiry = _jwt_claims(token).get("exp")
+    if isinstance(expiry, bool) or not isinstance(expiry, int) or expiry <= 0:
+        raise ChatGptSignInError("the sign-in token carries no expiry; sign in again")
+    return expiry * 1_000
+
+
+def _jwt_claims(token: str) -> dict[str, object]:
+    """Decode one JWT payload segment without verifying its signature.
+
+    Args:
+        token: Compact JWT.
+
+    Returns:
+        The payload object.
+
+    Raises:
+        ChatGptSignInError: The token is not a three-segment JWT with an object payload.
+    """
+    segments = token.split(".")
+    if len(segments) != 3:
+        raise ChatGptSignInError("the sign-in token is not a JWT; sign in again")
+    payload = segments[1]
+    try:
+        decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+        claims = json.loads(decoded)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ChatGptSignInError("the sign-in token payload is unreadable; sign in again") from exc
+    if not isinstance(claims, dict):
+        raise ChatGptSignInError("the sign-in token payload is not an object; sign in again")
+    return {str(name): value for name, value in claims.items()}
+
+
+def tokens_from_token_response(payload: JsonObject) -> StoredOAuthTokens:
+    """Build the stored sign-in from one OAuth token endpoint response.
+
+    Args:
+        payload: Decoded ``access_token``, ``refresh_token``, and ``id_token`` response.
+
+    Returns:
+        Tokens whose expiry comes from the access token and whose account comes from the
+        id token.
+
+    Raises:
+        ChatGptSignInError: A required token is missing or unreadable.
+    """
+    access = payload.get("access_token")
+    refresh = payload.get("refresh_token")
+    id_token = payload.get("id_token")
+    if not isinstance(access, str) or not access or not isinstance(refresh, str) or not refresh:
+        raise ChatGptSignInError("the sign-in response carried no token pair; sign in again")
+    identity_token = id_token if isinstance(id_token, str) and id_token else access
+    return StoredOAuthTokens(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at_ms=jwt_expiry_ms(access),
+        account_id=chatgpt_account_claims(identity_token).account_id,
+    )
+
+
+def tokens_from_codex_auth_file(path: Path) -> StoredOAuthTokens:
+    """Import an existing Codex ``auth.json`` sign-in.
+
+    Only the token fields are read. The file is never modified: Codex keeps its own copy,
+    and the two refresh independently from this point on.
+
+    Args:
+        path: Codex ``auth.json`` path (``~/.codex/auth.json`` by default).
+
+    Returns:
+        The imported sign-in.
+
+    Raises:
+        ChatGptSignInError: The file is missing, unreadable, or not a ChatGPT sign-in.
+    """
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ChatGptSignInError(f"could not read the Codex auth file at {path}") from exc
+    tokens = document.get("tokens") if isinstance(document, dict) else None
+    if not isinstance(tokens, dict):
+        raise ChatGptSignInError(
+            f"the Codex auth file at {path} holds no ChatGPT sign-in; run 'codex login' first"
+        )
+    return tokens_from_token_response(
+        {
+            "access_token": tokens.get("access_token"),
+            "refresh_token": tokens.get("refresh_token"),
+            "id_token": tokens.get("id_token"),
+        }
+    )
+
+
+def post_token_request(payload: JsonObject) -> JsonObject:
+    """POST one JSON request to the ChatGPT OAuth token endpoint.
+
+    Args:
+        payload: Grant parameters.
+
+    Returns:
+        The decoded token response.
+
+    Raises:
+        ChatGptSignInError: The endpoint refused the grant or was unreachable. The message
+            names the OAuth error code only, never a token.
+    """
+    try:
+        response = httpx.post(
+            CHATGPT_OAUTH_TOKEN_URL,
+            json=payload,
+            timeout=_TOKEN_ENDPOINT_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        raise ChatGptSignInError("the ChatGPT sign-in service was unreachable") from exc
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+    if response.status_code >= 400 or not isinstance(body, dict):
+        code = body.get("error") if isinstance(body, dict) else None
+        detail = f" ({code})" if isinstance(code, str) and code else ""
+        raise ChatGptSignInError(
+            f"the ChatGPT sign-in service refused the request with status "
+            f"{response.status_code}{detail}; sign in again"
+        )
+    return {str(name): value for name, value in body.items()}
+
+
+def exchange_authorization_code(
+    *,
+    code: str,
+    code_verifier: str,
+    token_endpoint: TokenEndpoint = post_token_request,
+) -> StoredOAuthTokens:
+    """Redeem one PKCE authorization code for a stored sign-in.
+
+    Args:
+        code: Authorization code from the loopback callback.
+        code_verifier: The PKCE verifier whose challenge opened the authorization.
+        token_endpoint: Token endpoint POST, injectable for deterministic tests.
+
+    Returns:
+        The new sign-in.
+    """
+    return tokens_from_token_response(
+        token_endpoint(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": CHATGPT_OAUTH_REDIRECT_URI,
+                "client_id": CHATGPT_OAUTH_CLIENT_ID,
+                "code_verifier": code_verifier,
+            }
+        )
+    )
+
+
+def refresh_sign_in(
+    tokens: StoredOAuthTokens,
+    *,
+    token_endpoint: TokenEndpoint = post_token_request,
+) -> StoredOAuthTokens:
+    """Rotate one sign-in through the refresh grant.
+
+    The provider rotates the refresh token on every use, so the returned pair must
+    replace the stored one; the old refresh token is spent.
+
+    Args:
+        tokens: The sign-in to refresh.
+        token_endpoint: Token endpoint POST, injectable for deterministic tests.
+
+    Returns:
+        The rotated sign-in.
+    """
+    response = token_endpoint(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": tokens.refresh_token,
+            "client_id": CHATGPT_OAUTH_CLIENT_ID,
+            "scope": "openid profile email",
+        }
+    )
+    if "refresh_token" not in response:
+        # A refresh answer may omit the refresh token when it is not rotated.
+        response = {**response, "refresh_token": tokens.refresh_token}
+    return tokens_from_token_response(response)
+
+
+class ChatGptTokenSource:
+    """Mint fresh bearers for one connection from its stored sign-in.
+
+    Every read goes to the credential file, so a sign-in refreshed by another process (a
+    second worker, the CLI) is picked up immediately. A refresh happens ahead of expiry
+    under one lock, and the rotated pair is persisted before any dispatch uses it, so a
+    concurrent burst of dispatches spends the refresh token exactly once.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: ProviderAuthStore,
+        connection_id: str,
+        binding: StoredCredentialBinding,
+        token_endpoint: TokenEndpoint = post_token_request,
+        clock_ms: Callable[[], int] | None = None,
+    ) -> None:
+        """Bind one connection's stored sign-in.
+
+        Args:
+            store: Credential store holding the sign-in.
+            connection_id: Exact gateway connection name used as the store key.
+            binding: Endpoint identity the stored sign-in must match.
+            token_endpoint: Token endpoint POST, injectable for deterministic tests.
+            clock_ms: Unix-millisecond clock, injectable for deterministic tests.
+        """
+        self._store = store
+        self._connection_id = connection_id
+        self._binding = binding
+        self._token_endpoint = token_endpoint
+        self._clock_ms = clock_ms if clock_ms is not None else _unix_ms
+        self._lock = threading.Lock()
+
+    @property
+    def connection_id(self) -> str:
+        """Return the connection this source mints for."""
+        return self._connection_id
+
+    def current(self) -> StoredOAuthTokens:
+        """Return a sign-in whose access token is good for at least the refresh-ahead window.
+
+        Returns:
+            The stored sign-in, refreshed and persisted first when it was about to expire.
+
+        Raises:
+            ChatGptSignInError: No sign-in is stored, or the refresh was refused.
+        """
+        with self._lock:
+            tokens = self._store.get_oauth(self._connection_id, binding=self._binding)
+            if tokens is None:
+                raise ChatGptSignInError(
+                    f"no ChatGPT sign-in is stored for connection {self._connection_id!r}; "
+                    f"run 'exp config gateway provider add {self._connection_id} "
+                    "--provider openai --subscription chatgpt --replace'"
+                )
+            if not tokens.expires_within(
+                ACCESS_TOKEN_REFRESH_AHEAD_SECONDS, now_ms=self._clock_ms()
+            ):
+                return tokens
+            refreshed = refresh_sign_in(tokens, token_endpoint=self._token_endpoint)
+            self._store.put_oauth(self._connection_id, refreshed, binding=self._binding)
+            logger.info("refreshed the ChatGPT sign-in for connection %r", self._connection_id)
+            return refreshed
+
+    def account_id(self) -> str:
+        """Return the account the stored sign-in belongs to.
+
+        Raises:
+            ChatGptSignInError: No sign-in is stored or it carries no account.
+        """
+        tokens = self.current()
+        if tokens.account_id is None:
+            raise ChatGptSignInError(
+                f"the stored sign-in for connection {self._connection_id!r} names no account; "
+                "sign in again"
+            )
+        return tokens.account_id
+
+
+def _unix_ms() -> int:
+    """Return the current unix time in milliseconds."""
+    return int(time.time() * 1_000)
+
+
+class ChatGptSubscriptionClient(OpenAIClient):
+    """Dispatch to the Codex Responses backend on a ChatGPT plan's rotating bearer."""
+
+    def __init__(
+        self,
+        *,
+        model: ModelSnapshot,
+        tokens: ChatGptTokenSource,
+        transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        supports_temperature: bool = True,
+        supports_top_p: bool | None = None,
+        supports_reasoning: bool = False,
+        reasoning_effort: str | None = None,
+        sampling_requires_reasoning_none: bool = False,
+    ) -> None:
+        """Create a client whose credential is minted per request from the token source.
+
+        Args:
+            model: Resolved catalog identity for every request.
+            tokens: Store-backed bearer source for the connection.
+            transport: Optional injected JSON transport for deterministic tests.
+            timeout_seconds: Positive per-attempt timeout floor.
+            supports_temperature: Catalog declaration that the model accepts temperature.
+            supports_top_p: Catalog declaration for nucleus sampling.
+            supports_reasoning: Catalog declaration that the model accepts ``reasoning``.
+            reasoning_effort: Optional catalog-pinned reasoning-effort level.
+            sampling_requires_reasoning_none: Whether sampling controls need reasoning off.
+        """
+        # The base client requires a non-empty static credential; this client never sends
+        # it. Every request reads the current bearer from the token source instead.
+        super().__init__(
+            model=model,
+            api_key="chatgpt-subscription",
+            base_url=CHATGPT_CODEX_BASE_URL,
+            transport=transport,
+            timeout_seconds=timeout_seconds,
+            supports_temperature=supports_temperature,
+            supports_top_p=supports_top_p,
+            supports_reasoning=supports_reasoning,
+            reasoning_effort=reasoning_effort,
+            sampling_requires_reasoning_none=sampling_requires_reasoning_none,
+        )
+        self._tokens = tokens
+
+    def _static_headers(self) -> dict[str, str]:
+        """Return the per-connection headers that carry no secret."""
+        return {
+            "Content-Type": "application/json",
+            "chatgpt-account-id": self._tokens.account_id(),
+            "OpenAI-Beta": "responses=experimental",
+            "originator": _ORIGINATOR,
+        }
+
+    def _headers(self) -> dict[str, str]:
+        """Return the static headers plus a bearer minted now."""
+        return {**self._static_headers(), **self.sign_gateway_dispatch(url="", body="")}
+
+    def sign_gateway_dispatch(self, *, url: str, body: str) -> Mapping[str, str]:
+        """Mint the bearer for one physical dispatch immediately before the provider POST.
+
+        The body-signing seam is reused for its timing: it runs after the data plane's
+        dispatch permit, so queue time never ages the token, and every redial or failover
+        mints afresh. The body itself is not covered by any signature.
+
+        Args:
+            url: Exact endpoint the data plane will POST to (unused).
+            body: Exact frozen body (unused).
+
+        Returns:
+            The ``Authorization`` header for this dispatch.
+        """
+        del url, body
+        return {"Authorization": f"Bearer {self._tokens.current().access_token}"}
+
+    def gateway_wire_profile(self) -> GatewayWireProfile:
+        """Return the Codex backend wire profile: streaming Responses on a per-dispatch bearer."""
+        base = super().gateway_wire_profile()
+        return GatewayWireProfile(
+            dialect=base.dialect,
+            url=f"{CHATGPT_CODEX_BASE_URL}/responses",
+            headers=self._static_headers(),
+            model_id=base.model_id,
+            timeout_seconds=base.timeout_seconds,
+            supports_temperature=base.supports_temperature,
+            supports_top_p=base.supports_top_p,
+            supports_reasoning=base.supports_reasoning,
+            reasoning_wire_format=base.reasoning_wire_format,
+            reasoning_effort=base.reasoning_effort,
+            sampling_requires_reasoning_none=base.sampling_requires_reasoning_none,
+            forwards_prompt_cache_key=True,
+            signs_request_body=True,
+            omits_output_token_limit=True,
+        )
+
+    def complete(self, request: ModelRequest) -> ModelResponse:
+        """Refuse the non-streaming completion path the backend does not offer.
+
+        Raises:
+            ProviderCapabilityError: Always; a plan connection serves through the gateway
+                data plane only, which streams.
+        """
+        del request
+        raise ProviderCapabilityError(capability="non_streaming_completion")
+
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Refuse the non-streaming completion path the backend does not offer.
+
+        Raises:
+            ProviderCapabilityError: Always; see :meth:`complete`.
+        """
+        del request, deadline, idempotency_key
+        raise ProviderCapabilityError(capability="non_streaming_completion")

--- a/exp/runtime/models/providers/chatgpt_subscription_test.py
+++ b/exp/runtime/models/providers/chatgpt_subscription_test.py
@@ -1,0 +1,320 @@
+"""Tests for the ChatGPT plan upstream: sign-in tokens, refresh, bearer minting, and wire."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from exp.common.auth import ProviderAuthStore, StoredCredentialBinding, StoredOAuthTokens
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import BillingSource, ModelMessage, ModelRequest, ModelSnapshot
+from exp.runtime.models.providers.chatgpt_subscription import (
+    ACCESS_TOKEN_REFRESH_AHEAD_SECONDS,
+    CHATGPT_CODEX_BASE_URL,
+    CHATGPT_OAUTH_CLIENT_ID,
+    CHATGPT_OAUTH_REDIRECT_URI,
+    ChatGptSignInError,
+    ChatGptSubscriptionClient,
+    ChatGptTokenSource,
+    chatgpt_account_claims,
+    exchange_authorization_code,
+    jwt_expiry_ms,
+    refresh_sign_in,
+    tokens_from_codex_auth_file,
+    tokens_from_token_response,
+)
+from exp.runtime.models.providers.errors import ProviderCapabilityError
+
+_BINDING = StoredCredentialBinding(provider="openai", endpoint_sha256="e" * 64)
+_NOW_MS = 1_800_000_000_000
+
+
+def _jwt(claims: JsonObject) -> str:
+    """Return an unsigned compact JWT carrying ``claims``.
+
+    Args:
+        claims: Payload object.
+
+    Returns:
+        Three-segment token whose signature segment is a fixed placeholder.
+    """
+
+    def _segment(value: JsonObject) -> str:
+        return base64.urlsafe_b64encode(json.dumps(value).encode()).rstrip(b"=").decode()
+
+    return f"{_segment({'alg': 'none'})}.{_segment(claims)}.signature"
+
+
+def _access(exp_seconds: int, *, account: str = "acct-1") -> str:
+    """Return an access-token JWT expiring at ``exp_seconds`` for ``account``."""
+    return _jwt(
+        {
+            "exp": exp_seconds,
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account,
+                "chatgpt_plan_type": "team",
+            },
+        }
+    )
+
+
+def _tokens(
+    *, expires_at_ms: int = _NOW_MS + 3_600_000, refresh: str = "refresh-1"
+) -> StoredOAuthTokens:
+    """Return a stored sign-in whose access token expires at ``expires_at_ms``."""
+    return StoredOAuthTokens(
+        access_token=_access(expires_at_ms // 1_000),
+        refresh_token=refresh,
+        expires_at_ms=expires_at_ms,
+        account_id="acct-1",
+    )
+
+
+def _snapshot() -> ModelSnapshot:
+    """Return one plan model snapshot."""
+    return ModelSnapshot(
+        billing_source=BillingSource.CUSTOMER_MANAGED,
+        provider="openai",
+        model_id="gpt-5.6-sol",
+        capabilities_sha256="a" * 64,
+        connection_sha256="b" * 64,
+    )
+
+
+class TestTokenParsing:
+    """Sign-in tokens yield the account identity and expiry without signature checks."""
+
+    def test_claims_and_expiry_read_from_the_jwt_payload(self) -> None:
+        """The ChatGPT account and plan type come from the auth claim; exp becomes ms."""
+        token = _access(1_800_000_000)
+
+        claims = chatgpt_account_claims(token)
+        assert (claims.account_id, claims.plan_type) == ("acct-1", "team")
+        assert jwt_expiry_ms(token) == 1_800_000_000_000
+
+    @pytest.mark.parametrize("token", ["not-a-jwt", "a.b", _jwt({"exp": 5})])
+    def test_tokens_without_an_account_or_shape_are_refused(self, token: str) -> None:
+        """A malformed token or one with no ChatGPT account fails with a sign-in error."""
+        with pytest.raises(ChatGptSignInError):
+            chatgpt_account_claims(token)
+
+    def test_token_response_binds_expiry_to_access_and_account_to_id_token(self) -> None:
+        """The access token's exp and the id token's account make the stored record."""
+        tokens = tokens_from_token_response(
+            {
+                "access_token": _access(1_800_000_000, account="from-access"),
+                "refresh_token": "refresh-x",
+                "id_token": _jwt(
+                    {"https://api.openai.com/auth": {"chatgpt_account_id": "from-id"}}
+                ),
+            }
+        )
+
+        assert tokens.account_id == "from-id"
+        assert tokens.expires_at_ms == 1_800_000_000_000
+        assert tokens.refresh_token == "refresh-x"
+
+    def test_token_response_without_a_pair_is_refused(self) -> None:
+        """A response missing either token never becomes a partial sign-in."""
+        with pytest.raises(ChatGptSignInError, match="no token pair"):
+            tokens_from_token_response({"access_token": _access(1_800_000_000)})
+
+    def test_codex_auth_file_import_reads_only_the_token_fields(self, tmp_path: Path) -> None:
+        """An existing Codex sign-in imports without touching the file."""
+        path = tmp_path / "auth.json"
+        original = json.dumps(
+            {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": _access(1_800_000_000),
+                    "refresh_token": "codex-refresh",
+                    "id_token": _access(1_800_000_000, account="acct-codex"),
+                    "account_id": "acct-codex",
+                },
+                "last_refresh": "2026-09-07T00:00:00Z",
+            }
+        )
+        path.write_text(original, encoding="utf-8")
+
+        tokens = tokens_from_codex_auth_file(path)
+
+        assert tokens.account_id == "acct-codex"
+        assert tokens.refresh_token == "codex-refresh"
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_codex_auth_file_without_a_sign_in_names_the_fix(self, tmp_path: Path) -> None:
+        """An API-key Codex login or a missing file points at codex login."""
+        path = tmp_path / "auth.json"
+        with pytest.raises(ChatGptSignInError, match="could not read"):
+            tokens_from_codex_auth_file(path)
+        path.write_text(json.dumps({"OPENAI_API_KEY": "sk-x"}), encoding="utf-8")
+        with pytest.raises(ChatGptSignInError, match="codex login"):
+            tokens_from_codex_auth_file(path)
+
+
+class TestGrants:
+    """Code exchange and refresh send the public client's grants and read the pair back."""
+
+    def test_code_exchange_sends_pkce_grant_for_the_registered_callback(self) -> None:
+        """The authorization-code grant names the client, callback, and verifier."""
+        seen: list[JsonObject] = []
+
+        def endpoint(payload: JsonObject) -> JsonObject:
+            seen.append(payload)
+            return {
+                "access_token": _access(1_800_000_000),
+                "refresh_token": "refresh-new",
+                "id_token": _access(1_800_000_000),
+            }
+
+        tokens = exchange_authorization_code(
+            code="code-1", code_verifier="verifier-1", token_endpoint=endpoint
+        )
+
+        assert seen == [
+            {
+                "grant_type": "authorization_code",
+                "code": "code-1",
+                "redirect_uri": CHATGPT_OAUTH_REDIRECT_URI,
+                "client_id": CHATGPT_OAUTH_CLIENT_ID,
+                "code_verifier": "verifier-1",
+            }
+        ]
+        assert tokens.refresh_token == "refresh-new"
+
+    def test_refresh_rotates_the_pair_and_keeps_the_old_refresh_when_not_reissued(self) -> None:
+        """A refresh answer without a refresh token keeps the one that was spent to get it."""
+        seen: list[JsonObject] = []
+
+        def endpoint(payload: JsonObject) -> JsonObject:
+            seen.append(payload)
+            return {"access_token": _access(1_900_000_000), "id_token": _access(1_900_000_000)}
+
+        refreshed = refresh_sign_in(_tokens(refresh="refresh-old"), token_endpoint=endpoint)
+
+        assert seen[0]["grant_type"] == "refresh_token"
+        assert seen[0]["refresh_token"] == "refresh-old"
+        assert seen[0]["client_id"] == CHATGPT_OAUTH_CLIENT_ID
+        assert refreshed.refresh_token == "refresh-old"
+        assert refreshed.expires_at_ms == 1_900_000_000_000
+
+
+class TestTokenSource:
+    """The token source serves the stored sign-in and refreshes ahead of expiry, once."""
+
+    def _source(
+        self,
+        tmp_path: Path,
+        tokens: StoredOAuthTokens | None,
+        *,
+        endpoint_calls: list[JsonObject],
+    ) -> tuple[ChatGptTokenSource, ProviderAuthStore]:
+        """Return a source over a temporary store seeded with ``tokens``."""
+        store = ProviderAuthStore(tmp_path / "auth.json")
+        if tokens is not None:
+            store.put_oauth("plan", tokens, binding=_BINDING)
+
+        def endpoint(payload: JsonObject) -> JsonObject:
+            endpoint_calls.append(payload)
+            return {
+                "access_token": _access((_NOW_MS + 7_200_000) // 1_000),
+                "refresh_token": f"refresh-{len(endpoint_calls)}",
+                "id_token": _access((_NOW_MS + 7_200_000) // 1_000),
+            }
+
+        source = ChatGptTokenSource(
+            store=store,
+            connection_id="plan",
+            binding=_BINDING,
+            token_endpoint=endpoint,
+            clock_ms=lambda: _NOW_MS,
+        )
+        return source, store
+
+    def test_a_fresh_sign_in_is_served_without_a_refresh(self, tmp_path: Path) -> None:
+        """No token endpoint call happens while the access token has life left."""
+        calls: list[JsonObject] = []
+        source, _store = self._source(tmp_path, _tokens(), endpoint_calls=calls)
+
+        assert source.current().refresh_token == "refresh-1"
+        assert source.account_id() == "acct-1"
+        assert calls == []
+
+    def test_a_near_expiry_sign_in_is_refreshed_and_persisted(self, tmp_path: Path) -> None:
+        """The rotated pair replaces the stored one before the bearer is handed out."""
+        calls: list[JsonObject] = []
+        near = _tokens(expires_at_ms=_NOW_MS + int(ACCESS_TOKEN_REFRESH_AHEAD_SECONDS * 1_000) - 1)
+        source, store = self._source(tmp_path, near, endpoint_calls=calls)
+
+        first = source.current()
+        second = source.current()
+
+        assert len(calls) == 1
+        assert first.refresh_token == "refresh-1"
+        assert second == first
+        assert store.get_oauth("plan", binding=_BINDING) == first
+
+    def test_a_missing_sign_in_names_the_command_that_creates_one(self, tmp_path: Path) -> None:
+        """An unsigned connection fails with the exact re-add command."""
+        source, _store = self._source(tmp_path, None, endpoint_calls=[])
+
+        with pytest.raises(ChatGptSignInError, match="provider add plan --provider openai"):
+            source.current()
+
+
+class TestClient:
+    """The client dispatches to the plan backend on a bearer minted per attempt."""
+
+    def _client(self, tmp_path: Path) -> ChatGptSubscriptionClient:
+        """Return a client over a store holding a fresh sign-in."""
+        store = ProviderAuthStore(tmp_path / "auth.json")
+        store.put_oauth("plan", _tokens(), binding=_BINDING)
+        return ChatGptSubscriptionClient(
+            model=_snapshot(),
+            tokens=ChatGptTokenSource(
+                store=store,
+                connection_id="plan",
+                binding=_BINDING,
+                token_endpoint=lambda payload: {},
+                clock_ms=lambda: _NOW_MS,
+            ),
+        )
+
+    def test_wire_profile_targets_the_plan_backend_and_mints_per_dispatch(
+        self, tmp_path: Path
+    ) -> None:
+        """Static headers carry the account, never a bearer; the profile signs and drops limits."""
+        client = self._client(tmp_path)
+
+        profile = client.gateway_wire_profile()
+
+        assert profile.dialect == "openai_responses"
+        assert profile.url == f"{CHATGPT_CODEX_BASE_URL}/responses"
+        assert profile.headers["chatgpt-account-id"] == "acct-1"
+        assert profile.headers["OpenAI-Beta"] == "responses=experimental"
+        assert "Authorization" not in profile.headers
+        assert profile.signs_request_body
+        assert profile.omits_output_token_limit
+        assert profile.forwards_prompt_cache_key
+        assert profile.embeddings_url is None
+        assert profile.images_url is None
+
+    def test_sign_gateway_dispatch_returns_the_current_bearer(self, tmp_path: Path) -> None:
+        """The signer mints the access token as a bearer regardless of url or body."""
+        client = self._client(tmp_path)
+
+        headers = client.sign_gateway_dispatch(url="https://x", body="{}")
+
+        assert headers == {"Authorization": f"Bearer {_tokens().access_token}"}
+        assert "Authorization" in client._headers()
+
+    def test_non_streaming_completion_is_refused(self, tmp_path: Path) -> None:
+        """The backend streams only, so the completion path fails closed."""
+        client = self._client(tmp_path)
+        request = ModelRequest(messages=(ModelMessage(role="user", content="hi"),))
+
+        with pytest.raises(ProviderCapabilityError):
+            client.complete(request)

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -126,6 +126,7 @@ def dialect_stream_payload(
             sampling_requires_reasoning_none=profile.sampling_requires_reasoning_none,
             forwards_service_tier=profile.forwards_tier(provider_request.service_tier),
             forwards_prompt_cache_key=profile.forwards_prompt_cache_key,
+            omits_output_token_limit=profile.omits_output_token_limit,
         )
     if profile.dialect == "anthropic_messages":
         return anthropic_messages_stream_payload(

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -70,6 +70,7 @@ def openai_responses_stream_payload(
     sampling_requires_reasoning_none: bool = False,
     forwards_service_tier: bool = False,
     forwards_prompt_cache_key: bool = False,
+    omits_output_token_limit: bool = False,
 ) -> JsonObject:
     """Translate one canonical request to native streaming Responses JSON.
 
@@ -79,6 +80,8 @@ def openai_responses_stream_payload(
         supports_temperature: Whether this exact model accepts explicit temperature.
         supports_reasoning: Whether this exact model accepts the reasoning parameter.
         reasoning_effort: Optional catalog-pinned reasoning effort.
+        omits_output_token_limit: Whether the wire rejects ``max_output_tokens`` (the
+            ChatGPT plan backend), so the caller's ceiling is dropped structurally.
 
     Returns:
         Native Responses request with storage disabled and streaming enabled.
@@ -153,7 +156,7 @@ def openai_responses_stream_payload(
         text_payload["format"] = format_payload
     if text_payload:
         payload["text"] = text_payload
-    if request.maximum_output_tokens is not None:
+    if request.maximum_output_tokens is not None and not omits_output_token_limit:
         payload["max_output_tokens"] = request.maximum_output_tokens
     effective_reasoning_effort = request.reasoning_effort or reasoning_effort
     require_sampling_reasoning_compatibility(

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Literal, Protocol
 
+from exp.common.auth import ProviderAuthStore
 from exp.common.core.artifacts import JsonObject, sha256_json
 from exp.common.models import (
     EmbeddingClient,
@@ -17,7 +18,7 @@ from exp.common.models import (
     ReasoningEffort,
     known_model_metadata,
 )
-from exp.runtime.models.credentials import read_connection_api_key
+from exp.runtime.models.credentials import connection_credential_binding, read_connection_api_key
 from exp.runtime.models.preflight import CapabilityRequirement, preflight_capabilities
 from exp.runtime.models.providers.anthropic import ANTHROPIC_BASE_URL, AnthropicClient
 from exp.runtime.models.providers.async_transport import (
@@ -34,6 +35,12 @@ from exp.runtime.models.providers.bedrock import (
     BedrockClient,
     BedrockRuntimeFactory,
     BoundedBedrockClient,
+)
+from exp.runtime.models.providers.chatgpt_subscription import (
+    ChatGptSubscriptionClient,
+    ChatGptTokenSource,
+    TokenEndpoint,
+    post_token_request,
 )
 from exp.runtime.models.providers.gemini import GEMINI_BASE_URL, GeminiClient
 from exp.runtime.models.providers.openai import OPENAI_BASE_URL, OpenAIClient
@@ -132,12 +139,18 @@ class RuntimeModelCatalog:
         tinker_sampler_factory: TinkerSamplerFactory | None = None,
         bedrock_runtime_factory: BedrockRuntimeFactory | None = None,
         vertex_token_provider_factory: VertexTokenProviderFactory | None = None,
+        auth_store: ProviderAuthStore | None = None,
+        chatgpt_token_endpoint: TokenEndpoint = post_token_request,
     ) -> None:
         """Create a local resolver without importing SDK registries or contacting providers.
 
         Args:
             catalog: Parsed `.exp/models.toml` aliases and connections.
             environment: Credential mapping, injectable for deterministic tests.
+            auth_store: Credential store holding subscription sign-ins. Omit it to use the
+                platform user-data file.
+            chatgpt_token_endpoint: ChatGPT OAuth token POST used to refresh plan sign-ins,
+                injectable for deterministic tests.
             transport_factory: Explicit transport construction for HTTP-backed providers.
             tinker_sampler_factory: Optional deterministic test override for completed-handle
                 sampling. Omit it to use the runtime-owned Tinker SDK construction seam.
@@ -151,6 +164,8 @@ class RuntimeModelCatalog:
         self._tinker_sampler_factory = tinker_sampler_factory
         self._bedrock_runtime_factory = bedrock_runtime_factory
         self._vertex_token_provider_factory = vertex_token_provider_factory
+        self._auth_store = auth_store
+        self._chatgpt_token_endpoint = chatgpt_token_endpoint
 
     def snapshot(self, alias: str) -> tuple[ModelSnapshot, ModelCapabilities]:
         """Resolve static identity and exact capability evidence without provider access.
@@ -228,6 +243,8 @@ class RuntimeModelCatalog:
                 current_connection["aws_access_key_id_env"] = connection.aws_access_key_id_env
             if connection.bedrock_auth_mode is not None:
                 current_connection["bedrock_auth_mode"] = connection.bedrock_auth_mode
+            if connection.subscription is not None:
+                current_connection["subscription"] = connection.subscription
             current_connection_sha256 = sha256_json(current_connection)
             if provenance.connection_config_sha256 != current_connection_sha256:
                 raise ModelConnectionError(
@@ -235,6 +252,30 @@ class RuntimeModelCatalog:
                     "verified SFT provenance"
                 )
         provider = connection.provider
+        if connection.subscription == "chatgpt":
+            subscription_client = ChatGptSubscriptionClient(
+                model=snapshot,
+                tokens=ChatGptTokenSource(
+                    store=self._auth_store if self._auth_store is not None else ProviderAuthStore(),
+                    connection_id=record.connection,
+                    binding=connection_credential_binding(connection),
+                    token_endpoint=self._chatgpt_token_endpoint,
+                ),
+                transport=self._transport_factory(),
+                supports_temperature=capabilities.supports_temperature,
+                supports_top_p=_supports_top_p(capabilities),
+                supports_reasoning=capabilities.supports_reasoning,
+                reasoning_effort=capabilities.reasoning_effort,
+                sampling_requires_reasoning_none=capabilities.sampling_requires_reasoning_none,
+            )
+            return ResolvedModel(
+                alias,
+                snapshot,
+                capabilities,
+                subscription_client,
+                None,
+                served_model_id=record.served_model_id,
+            )
         if provider == "bedrock":
             bearer_token = None
             access_key_id = (

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import base64
+import json
+from pathlib import Path
 from typing import Literal
 
 import pytest
 
+from exp.common.auth import ProviderAuthStore, StoredCredentialBinding, StoredOAuthTokens
 from exp.common.core.artifacts import sha256_json
 from exp.common.models import (
     AssistantAction,
@@ -24,6 +28,7 @@ from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.preflight import CapabilityRequirement, ModelCapabilityError
 from exp.runtime.models.providers.anthropic import AnthropicClient
 from exp.runtime.models.providers.azure import AzureClient
+from exp.runtime.models.providers.chatgpt_subscription import ChatGptSubscriptionClient
 from exp.runtime.models.providers.tinker_sampling import (
     TinkerOptionalDependencyError,
     TinkerSample,
@@ -524,3 +529,60 @@ def test_tinker_resolution_reports_a_missing_optional_dependency(
 
     with pytest.raises(ModelConnectionError, match="uv sync --extra sft"):
         catalog.resolve("fixture-model")
+
+
+def test_subscription_connection_resolves_to_a_plan_client_that_signs_each_dispatch(
+    tmp_path: Path,
+) -> None:
+    """A chatgpt plan connection needs no environment key; its client mints bearers itself."""
+    store = ProviderAuthStore(tmp_path / "auth.json")
+    plan = ConnectionConfig(provider="openai", subscription="chatgpt")
+    access = _plan_jwt(exp_seconds=4_000_000_000, account="acct-plan")
+    store.put_oauth(
+        "plan",
+        StoredOAuthTokens(
+            access_token=access,
+            refresh_token="refresh",
+            expires_at_ms=4_000_000_000_000,
+            account_id="acct-plan",
+        ),
+        binding=StoredCredentialBinding(provider="openai", endpoint_sha256=plan.identity_sha256()),
+    )
+    catalog = ModelCatalog(
+        connections={"plan": plan},
+        models={
+            "codex": ModelRecord(
+                connection="plan",
+                model="gpt-5.6-sol",
+                billing_source=BillingSource.CUSTOMER_MANAGED,
+                capabilities=_DEFAULT_CAPABILITIES,
+            )
+        },
+        roles=ModelRoles(candidates=("codex",), incumbent="codex"),
+    )
+
+    resolved = RuntimeModelCatalog(
+        catalog,
+        environment={},
+        transport_factory=lambda: ScriptedJsonTransport([]),
+        auth_store=store,
+        chatgpt_token_endpoint=lambda payload: {},
+    ).resolve("codex")
+
+    assert isinstance(resolved.client, ChatGptSubscriptionClient)
+    profile = resolved.client.gateway_wire_profile()
+    assert profile.url == "https://chatgpt.com/backend-api/codex/responses"
+    assert profile.headers["chatgpt-account-id"] == "acct-plan"
+    assert resolved.client.sign_gateway_dispatch(url=profile.url, body="{}") == {
+        "Authorization": f"Bearer {access}"
+    }
+    assert resolved.embedding_client is None
+
+
+def _plan_jwt(*, exp_seconds: int, account: str) -> str:
+    """Return an unsigned JWT carrying a ChatGPT account claim and ``exp``."""
+    payload = json.dumps(
+        {"exp": exp_seconds, "https://api.openai.com/auth": {"chatgpt_account_id": account}}
+    ).encode()
+    segment = base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+    return f"header.{segment}.signature"


### PR DESCRIPTION
## What

A gateway connection may now dispatch on a **ChatGPT plan** instead of an API key: `ConnectionConfig.subscription = "chatgpt"`. This is the first "subscription account pool" primitive: several plan connections certified into one exact-model pool rotate on their usage windows, and a conversation stays on one plan (existing sticky affinity) while it has room.

Design source is sub2api (Wei-Shaw/sub2api): subscription-to-API relay, per-account usage windows read from the provider's own response headers, rotation before the first 429, sticky sessions per account. sub2api is LGPL-3.0 on a Go/Vue stack, so nothing was copied; the design was reimplemented on the engine's existing seams.

## How it fits the engine

- **Credential**: OpenCode-shaped `type = "oauth"` records in the user-only `auth.json` beside API keys (`get_oauth` / `put_oauth`, kind-mismatch fails closed). The connection itself stays secret-free and its identity digest covers the kind.
- **Per-dispatch bearer**: the client sets `signs_request_body=True` and implements `sign_gateway_dispatch`, so the Rust plane calls the existing `sign_dispatch` hook right before the POST (the Bedrock SigV4 timing). Zero Rust dispatch changes; the token is never aged by queue time and every redial mints afresh. `ChatGptTokenSource` refreshes 5 minutes ahead of expiry under a lock and persists the rotated refresh token before handing out the bearer.
- **Wire**: Codex Responses backend (`https://chatgpt.com/backend-api/codex/responses`), dialect `openai_responses`, headers `chatgpt-account-id` / `OpenAI-Beta: responses=experimental` / `originator: experiential`. The backend requires `stream: true` and `store: false` (already how the stream payload is built) and rejects `max_output_tokens`; a new `GatewayWireProfile.omits_output_token_limit` drops it structurally.
- **Rotation**: the Rust rate-limit header allowlist gains the six `x-codex-{primary,secondary}-{used-percent,reset-after-seconds,window-minutes}` headers (numbers only; never `x-codex-turn-state`). `RateLimitObservation.subscription_windows` types them; `DeploymentHealthRegistry.exhausted()` throttles a rung whose window hit 100 percent until the stated reset (clamped like Retry-After), success or not; a throttled settlement with no Retry-After takes the exhausted window's reset.
- **Ledger**: schema v20 adds `plan_primary_used_percent`, `plan_primary_reset_after_seconds`, `plan_secondary_used_percent`, `plan_secondary_reset_after_seconds` on `gateway_attempts`; v21 adds `provider_connection_revisions.subscription` so the revision digest round-trips.
- **CLI** (options on the existing locked commands, no new command): `exp config gateway provider add NAME --provider openai --subscription chatgpt` opens the PKCE browser sign-in on the client's registered loopback callback (`localhost:1455`); `--codex-auth-file ~/.codex/auth.json` imports an existing Codex sign-in without touching Codex's file. `provider list` shows the kind; `update` never re-authenticates.
- **Module split**: `ConnectionConfig` and its endpoint helpers moved to `exp/common/models/connection.py` because `catalog.py` sat at exactly 999 lines; `record_dead_admission_rungs` moved to `native_admission.py` for the same reason. Public import path `exp.common.models.ConnectionConfig` is unchanged; three direct importers were repointed (no shim).

## Deliberately not built

- **Anthropic Claude plans.** Anthropic restricts plan OAuth tokens to Claude Code, and sub2api makes them work by impersonating Claude Code (fixed client headers, `metadata.user_id` rewriting, Node.js TLS fingerprint). That is detection evasion of a provider's terms and is not in this PR; `providers.md` states the exclusion. Using a ChatGPT plan through a gateway is likewise subject to OpenAI's terms for that plan; the engine sends its own `originator` and never impersonates another client.
- Non-streaming `complete()` on a plan client fails closed (`ProviderCapabilityError`): the backend streams only, so plan connections are gateway-only (build/optimize keep using API keys).
- `UpsertProviderConnectionCommand` (the platform command shape) is untouched; the hosted platform's plan-account UI is the next PR and will thread the kind through when it lands.

## Evidence

- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`: clean.
- `uv run pytest -q`: 4040 passed, 6 skipped (two release-evidence tests require a clean checkout and pass after commit).
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --no-default-features`: clean.
- **Live**: on a fresh local gateway (`exp config gateway init`, `provider add plan-main --subscription chatgpt --codex-auth-file ~/.codex/auth.json`, `alias create codex --deployment plan-main:gpt-5.6-sol`), `exp --root ROOT --port 8765` served `/v1/models`, a non-streaming chat completion ("pool ok"), a streamed chat completion, and a `/v1/responses` call on a Team plan. The attempt ledger recorded `plan_primary_used_percent=43, plan_primary_reset_after_seconds=6212, plan_secondary_used_percent=7, plan_secondary_reset_after_seconds=593012` on every attempt. The throwaway root and its imported tokens were deleted afterwards.
- Backend contract probed directly beforehand: `store` omitted or `true` → 400 "Store must be set to false"; `stream: false` → 400 "Stream must be set to true"; `max_output_tokens` → 400 "Unsupported parameter"; `input` must be a list.

## AGENTS.md notes

- Schema moves v19 → v21 through additive `ALTER TABLE`s (forward migration of existing local databases, no data change). No legacy path, alias, or compatibility shim was added.
- README unchanged. No em dashes in added lines.
- `/ready-for-merge` not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
