### PR TITLE
providers: preserve Gemini listing page tokens

### DIFF
--- a/exp/runtime/models/providers/listing.py
+++ b/exp/runtime/models/providers/listing.py
@@ -11,6 +11,7 @@ import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, cast
+from urllib.parse import urlencode
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ReasoningEffort
@@ -204,9 +205,10 @@ class HttpProviderModelLister:
         models = []
         page_token: str | None = None
         for _ in range(_MAXIMUM_GEMINI_PAGES):
-            url = f"{base_url}/models?pageSize=200"
+            query_parameters = {"pageSize": "200"}
             if page_token is not None:
-                url = f"{url}&pageToken={page_token}"
+                query_parameters["pageToken"] = page_token
+            url = f"{base_url}/models?{urlencode(query_parameters)}"
             body = self._read(endpoint, url, headers)
             for entry in _entries(endpoint.provider, body.get("models")):
                 identity = _text(entry.get("name"))

--- a/exp/runtime/models/providers/listing_test.py
+++ b/exp/runtime/models/providers/listing_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib.parse import parse_qs, urlsplit
+
 import pytest
 
 from exp.common.core.artifacts import JsonObject
@@ -369,6 +371,20 @@ def test_gemini_listing_follows_pages_and_drops_the_resource_prefix() -> None:
     assert models[1].supports_embeddings is True
     assert transport.requests[0].headers["x-goog-api-key"] == "secret-key"
     assert transport.requests[1].url.endswith("&pageToken=page-2")
+
+
+def test_gemini_listing_preserves_an_opaque_page_token() -> None:
+    """Gemini pagination must encode reserved characters without changing the cursor."""
+    page_token = "page+2&cursor=%23fragment#tail"
+    transport = _transport(
+        _ok({"models": [], "nextPageToken": page_token}),
+        _ok({"models": []}),
+    )
+
+    _lister(transport).list_models(ProviderEndpoint(provider="gemini", api_key="secret-key"))
+
+    query = parse_qs(urlsplit(transport.requests[1].url).query)
+    assert query["pageToken"] == [page_token]
 
 
 def test_listing_rejects_an_invalid_credential_without_retrying() -> None:


### PR DESCRIPTION
## Why

Gemini model discovery inserted an opaque `nextPageToken` directly into the next request URL.
Reserved characters were interpreted as query or fragment syntax, so a token such as
`page+2&cursor=%23fragment#tail` reached the transport as only `page 2`.

Closes #866.

## What

- Build Gemini model-listing query strings with `urllib.parse.urlencode`.
- Add a transport-level regression test covering `+`, `&`, `%`, `=`, and `#` in one opaque token.
- Decode the recorded request in the test and require an exact token round trip.

## Validation

- `.venv/bin/pytest -q exp/runtime/models/providers/listing_test.py exp/cli/providers/setup_test.py`
  - 41 passed
- `.venv/bin/ruff check .`
  - passed
- `.venv/bin/ruff format --check .`
  - 821 files passed
- `.venv/bin/ty check`
  - passed
- `timeout 180 .venv/bin/pytest -q -x`
  - 108 passed before the unrelated gateway socket test hit the workspace sandbox restriction:
    `PermissionError: [Errno 1] Operation not permitted`
