### PR TITLE
gateway: accept Copilot image media type hints

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -333,6 +333,12 @@ Responses have separate allowlist decoders and field-specific OpenAI error respo
 convert to one canonical gateway request without conflating their wire contracts. The package also
 owns headers, response assembly, SSE framing, tool-call reconstruction, and official SDK
 compatibility.
+Chat image references accept Copilot's optional `image_url.media_type` MIME hint
+(`image/png`, `image/jpeg`, `image/gif`, or `image/webp`). The hint is validated and
+discarded before provider dispatch and canonical replay identity; the `url` and
+`detail` remain authoritative. A data URL keeps its embedded MIME type, and a
+remote URL is forwarded for the provider to fetch. Unknown image fields and
+malformed URLs or base64 remain rejected.
 Chat streaming emits valid completion chunks and one `[DONE]`. Responses streaming emits the
 created, in-progress, output, and exactly one terminal lifecycle. Provider tool-argument fragments
 are accumulated in original order and validated only at the complete-call boundary.

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -1044,6 +1044,7 @@ def _configured_gateway(
     *,
     base_url: str = "http://127.0.0.1:9/v1",
     capabilities: ModelCapabilities | None = None,
+    gateway_capabilities: GatewayDeploymentCapabilities | None = None,
     provider: str = "openai-compatible",
 ) -> tuple[GatewayManagement, str]:
     """Create one explicit direct alias, identity, grant, and key in real SQLite."""
@@ -1068,7 +1069,8 @@ def _configured_gateway(
         exact_model_id="model-revision-exact",
         revision=None,
         capabilities=capabilities or ModelCapabilities(),
-        gateway_capabilities=GatewayDeploymentCapabilities(
+        gateway_capabilities=gateway_capabilities
+        or GatewayDeploymentCapabilities(
             supports_streaming=True,
             supports_streaming_tool_arguments=True,
         ),

--- a/exp/runtime/gateway/lifecycle_test.py
+++ b/exp/runtime/gateway/lifecycle_test.py
@@ -1046,6 +1046,7 @@ def _configured_gateway(
     capabilities: ModelCapabilities | None = None,
     gateway_capabilities: GatewayDeploymentCapabilities | None = None,
     provider: str = "openai-compatible",
+    api_version: str | None = None,
 ) -> tuple[GatewayManagement, str]:
     """Create one explicit direct alias, identity, grant, and key in real SQLite."""
     manager = GatewayManagement(root)
@@ -1057,6 +1058,7 @@ def _configured_gateway(
             provider=provider,
             # Fixed-origin providers (anthropic and friends) reject a base_url.
             base_url=None if provider == "anthropic" else base_url,
+            api_version=api_version,
             api_key_env="TEST_PROVIDER_KEY",
         ),
         replace=False,

--- a/exp/runtime/gateway/tests/native_chat_images_test.py
+++ b/exp/runtime/gateway/tests/native_chat_images_test.py
@@ -74,6 +74,8 @@ def test_copilot_image_mime_hint_serves_without_leaking_to_the_provider(
     _manager, raw_key = _configured_gateway(
         tmp_path,
         base_url=f"http://127.0.0.1:{provider.server_port}/v1",
+        provider="azure",
+        api_version="2024-10-21",
         gateway_capabilities=GatewayDeploymentCapabilities(
             supports_streaming=True, supports_image_input=True, supports_image_url_input=True
         ),

--- a/exp/runtime/gateway/tests/native_chat_images_test.py
+++ b/exp/runtime/gateway/tests/native_chat_images_test.py
@@ -1,0 +1,128 @@
+"""Copilot image references survive the served gateway and reach the provider intact."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import cast
+
+import httpx
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models import GatewayDeploymentCapabilities
+from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.tests.launch_test import _provider_frame, _ServedGateway, _unused_port
+
+_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8"
+    "z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize(
+    "url",
+    ["https://example.test/attachment", f"data:image/png;base64,{_PNG_BASE64}"],
+    ids=["remote", "inline"],
+)
+def test_copilot_image_mime_hint_serves_without_leaking_to_the_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stream: bool, url: str
+) -> None:
+    """The reported fourth-message image reaches a vision route without its client hint."""
+    received: list[JsonObject] = []
+
+    class Provider(BaseHTTPRequestHandler):
+        """Capture the image request and return a finite completion with usage."""
+
+        def do_POST(self) -> None:  # noqa: N802
+            """Record the provider-bound payload before returning an answer."""
+            received.append(json.loads(self.rfile.read(int(self.headers["content-length"]))))
+            frames = (
+                _provider_frame(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"role": "assistant", "content": "A screenshot."},
+                                "finish_reason": "stop",
+                            }
+                        ]
+                    }
+                )
+                + _provider_frame(
+                    {"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 2}}
+                )
+                + b"data: [DONE]\n\n"
+            )
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(frames)))
+            self.end_headers()
+            self.wfile.write(frames)
+
+        def log_message(self, format: str, *args: object) -> None:
+            """Keep synthetic request traffic out of test logs."""
+            del format, args
+
+    provider = ThreadingHTTPServer(("127.0.0.1", 0), Provider)
+    thread = threading.Thread(target=provider.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("TEST_PROVIDER_KEY", "synthetic-provider-key")
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url=f"http://127.0.0.1:{provider.server_port}/v1",
+        gateway_capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True, supports_image_input=True, supports_image_url_input=True
+        ),
+    )
+    gateway = _ServedGateway(tmp_path, _unused_port())
+    try:
+        gateway.start()
+        response = httpx.post(
+            f"http://127.0.0.1:{gateway.port}/v1/chat/completions",
+            headers={"Authorization": f"Bearer {raw_key}"},
+            json={
+                "model": "coding",
+                "stream": stream,
+                "messages": [
+                    {"role": "system", "content": "Help with screenshots."},
+                    {"role": "user", "content": "Hello."},
+                    {"role": "assistant", "content": "Send the screenshot."},
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": url,
+                                    "detail": "high",
+                                    "media_type": "image/png",
+                                },
+                            },
+                            {"type": "text", "text": "What is this?"},
+                        ],
+                    },
+                ],
+            },
+            timeout=10,
+        )
+        assert response.status_code == 200, response.text
+        if stream:
+            assert "A screenshot." in response.text
+            assert response.text.endswith("data: [DONE]\n\n")
+        else:
+            assert response.json()["choices"][0]["message"]["content"] == "A screenshot."
+        assert len(received) == 1
+        messages = cast(list[JsonObject], received[0]["messages"])
+        assert messages[3]["content"] == [
+            {"type": "image_url", "image_url": {"url": url, "detail": "high"}},
+            {"type": "text", "text": "What is this?"},
+        ]
+    finally:
+        gateway.stop()
+        provider.shutdown()
+        provider.server_close()
+        thread.join(timeout=5)

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -1969,6 +1969,78 @@ def test_chat_decoder_retains_image_parts_in_caller_order() -> None:
     assert image.detail == "high"
 
 
+@pytest.mark.parametrize("media_type", ["image/png", "image/jpeg", "image/gif", "image/webp", None])
+@pytest.mark.parametrize(
+    "url", ["https://example.test/attachment", f"data:image/png;base64,{_PNG_BASE64}"]
+)
+def test_chat_image_media_type_hint_preserves_the_url_contract(
+    media_type: str | None, url: str
+) -> None:
+    """Copilot's MIME hint changes neither the image nor canonical replay identity.
+
+    The fourth message reproduces the reported field path. The URL remains
+    authoritative, including when its embedded MIME type differs from the hint.
+    """
+    image_url: JsonObject = {"url": url, "detail": "high"}
+    body: JsonObject = {
+        "model": "coding",
+        "messages": [
+            {"role": "system", "content": "Help with screenshots."},
+            {"role": "user", "content": "Hello."},
+            {"role": "assistant", "content": "Send the screenshot."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": image_url},
+                    {"type": "text", "text": "What is this?"},
+                ],
+            },
+        ],
+    }
+    expected = decode_chat(body).request
+    image_url["media_type"] = media_type
+
+    actual = decode_chat(body).request
+
+    assert actual == expected
+    assert sha256_json(actual) == sha256_json(expected)
+    assert actual.images[0].data_url() == url
+    assert actual.images[0].detail == "high"
+    assert image_url["media_type"] == media_type
+
+
+@pytest.mark.parametrize(
+    ("image_url", "param"),
+    [
+        ({"url": "https://example.test/image", "media_type": 42}, "media_type"),
+        ({"url": "https://example.test/image", "media_type": {}}, "media_type"),
+        ({"url": "https://example.test/image", "media_type": "image/svg+xml"}, "media_type"),
+        ({"url": "https://example.test/image", "media_type": ""}, "media_type"),
+        (
+            {"url": "https://example.test/image", "media_type": "image/png", "unknown": True},
+            "unknown",
+        ),
+        ({"url": "ftp://example.test/image", "media_type": "image/png"}, None),
+        ({"url": "data:image/png;base64,%%%", "media_type": "image/png"}, None),
+    ],
+)
+def test_chat_image_media_type_hint_keeps_image_validation_strict(
+    image_url: JsonObject, param: str | None
+) -> None:
+    """The MIME hint cannot admit malformed images, unsupported hints, or unknown fields."""
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [
+                    {"role": "user", "content": [{"type": "image_url", "image_url": image_url}]}
+                ],
+            }
+        )
+    location = "messages.0.content.0.image_url"
+    assert raised.value.detail.param == (f"{location}.{param}" if param else location)
+
+
 def test_an_empty_text_part_beside_an_image_drops() -> None:
     """A client's empty text part never reaches a wire that rejects one."""
     decoded = decode_chat(

--- a/exp/runtime/openai_protocol/wire_models.py
+++ b/exp/runtime/openai_protocol/wire_models.py
@@ -19,6 +19,7 @@ from exp.common.models.content import (
     MAXIMUM_DOCUMENT_NAME_CHARACTERS,
     MAXIMUM_IMAGE_BASE64_BYTES,
     MAXIMUM_VIDEO_BASE64_BYTES,
+    ImageMediaType,
 )
 from exp.common.models.model import MAXIMUM_TOOL_CALL_ID_CHARACTERS, ReasoningEffort
 from exp.runtime.gateway.reasoning_carrier import MAXIMUM_REASONING_CARRIER_BYTES
@@ -72,10 +73,16 @@ _MAXIMUM_IMAGE_URL_CHARACTERS = MAXIMUM_IMAGE_BASE64_BYTES + 128
 
 
 class _ChatImageUrl(_WireModel):
-    """Chat Completions image reference: a remote URL or a base64 data URL."""
+    """Chat Completions image reference: a remote URL or a base64 data URL.
+
+    Copilot includes ``media_type`` as a MIME hint for uploaded images. It
+    is validated and discarded: the URL or its embedded data-URL media type
+    defines the image, so the hint never rewrites content or replay identity.
+    """
 
     url: str = Field(min_length=1, max_length=_MAXIMUM_IMAGE_URL_CHARACTERS)
     detail: _ImageDetail | None = None
+    media_type: ImageMediaType | None = None
 
 
 class _ChatImagePart(_WireModel):


### PR DESCRIPTION
Copilot image requests fail before provider dispatch because its `image_url.media_type` annotation is rejected as an unknown field. A synthetic fourth-message image reproduces the reported error exactly: `Invalid value for 'messages.3.content.0.image_url.media_type'.` Microsoft's [Copilot serializer](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/networking/common/openai.ts#L173-L181) emits this field, and its [OpenAI endpoint](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/extension/byok/node/openAIEndpoint.ts#L262) uses that serializer.

Accept the optional MIME hint using the existing PNG/JPEG/GIF/WebP type contract, then discard it during canonical conversion. The image URL, embedded data-URL MIME type, bytes, detail, provider payload, and replay identity stay unchanged. Unknown fields, unsupported MIME hints, and malformed images remain rejected. This is a narrowly scoped extension for the current Copilot client; it adds no generic unknown-field fallback.

Validation:
- Reproduced the exact 400 on the base revision; all 17 new decoder cases now pass.
- Four real-socket tests return 200 through the Rust gateway and a URL-capable Azure OpenAI configuration for remote/inline images and streaming/non-streaming responses, and assert the exact provider-bound image content.
- Broad non-live suite: 3,962 passed, one skipped (Python 3.12, `TERM=xterm-256color`, `pytest -n 4 --dist loadfile` to preserve module-scoped test ordering). Seven Tinker adapter tests pass separately.
- Whole-repository Ruff, format, and ty checks pass. CI is green, including Rust checks/tests, native parity, the non-live suite, macOS evidence, all five wheel builds, and the installed-package smoke. Greptile: 5/5; the review finding is resolved.

The customer request body was not available, so the MIME value and selected model have not been confirmed. This fixes the reproduced schema rejection. Hosted rollout requires an Experiential release and a Platform dependency-pin update; this PR does not deploy it.
