### PR TITLE
release: 0.7.57

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.56"
+version = "0.7.57"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.56"
+version = "0.7.57"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bump `experiential` from 0.7.56 to 0.7.57 to release the merged Copilot image MIME-hint fix in #869. The diff changes only the package version in `pyproject.toml` and `uv.lock`; native remains 0.3.47 and all dependency requirements match the published 0.7.56 wheel.

Validation:
- Wheel and source distribution build successfully; installed and built-wheel metadata report 0.7.57.
- 183 targeted release, protocol, and served-image tests passed.
- Whole-repository Ruff, formatting, ty, and `uv lock --check` pass.
- The optional archive-contract check exposes an existing assertion that rejects the Anthropic dev extra as a forbidden dependency. The identical dev requirement is present in published 0.7.56; this bump does not change it.
- CI and Greptile review are pending.

This prepares the version bump. Publishing the release and updating the Platform pin remain separate steps.
