### PR TITLE
vertex: serve Model Garden MaaS ids over Vertex's OpenAI-compatible route

### DIFF
--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -209,10 +209,24 @@ JSON itself never travels on the wire, and the endpoint host is pinned to HTTPS
 Requests use the same `generateContent` wire protocol as the Gemini provider on
 `publishers/google/models/` routes.
 
+The model id spelling picks the wire. A bare id (`gemini-2.5-pro`) or a Google resource path
+(`publishers/google/models/gemini-2.5-pro`) is a Google-published model on the Gemini wire. A
+`<publisher>/<model>` id (`deepseek-ai/deepseek-v3.2-maas`, `xai/grok-4.20-reasoning`,
+`qwen/qwen3-coder-480b-a35b-instruct-maas`) is a Model Garden model served as a managed API
+(MaaS), which Vertex serves only over its OpenAI-compatible route
+`{base_url}/endpoints/openapi/chat/completions` (dialect `openai_compatible`, the same
+Chat Completions request and stream handling as `openai-compatible`), still under the OAuth
+bearer. Most MaaS models are addressed through the `global` location
+(`https://aiplatform.googleapis.com/v1/projects/PROJECT/locations/global`); a listing-style
+`publishers/<publisher>/models/<model>` spelling is collapsed onto the `<publisher>/<model>`
+form the route accepts.
+
 Vertex is catalog-and-API configuration only: the interactive `exp config providers` picker
 does not offer it. Like Azure and Bedrock, provider names do not imply protocol support or
 prices, so every Vertex alias declares explicit capabilities. Embeddings are not supported on
-Vertex connections; use a `gemini` connection for Gemini embeddings.
+the Gemini-wire Vertex aliases; use a `gemini` connection for Gemini embeddings. MaaS aliases
+expose the compatible embeddings route (`endpoints/openapi/embeddings`) when their
+capabilities declare `supports_embeddings`.
 
 ```toml
 [connections.vertex]

--- a/docs/reference/providers.md
+++ b/docs/reference/providers.md
@@ -219,7 +219,10 @@ Chat Completions request and stream handling as `openai-compatible`), still unde
 bearer. Most MaaS models are addressed through the `global` location
 (`https://aiplatform.googleapis.com/v1/projects/PROJECT/locations/global`); a listing-style
 `publishers/<publisher>/models/<model>` spelling is collapsed onto the `<publisher>/<model>`
-form the route accepts.
+form the route accepts. Google's own managed endpoints share the Gemini resource path in
+the listing (`publishers/google/models/gemma-4-26b-a4b-it-maas`) and are told apart by
+Vertex's `-maas` endpoint suffix, so both that spelling and `google/gemma-4-26b-a4b-it-maas`
+take the MaaS route.
 
 Vertex is catalog-and-API configuration only: the interactive `exp config providers` picker
 does not offer it. Like Azure and Bedrock, provider names do not imply protocol support or

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -359,6 +359,15 @@ def openai_embedding_response_raw(payload: JsonObject, *, expected_count: int) -
 class OpenAIEmbeddingMixin(ProviderHttpClient):
     """Adds the shared OpenAI-wire embeddings endpoint to one HTTP provider client."""
 
+    def _embedding_model_id(self) -> str:
+        """Return the model id placed on the embeddings wire.
+
+        The configured identity by default; a client whose provider spells the wire id
+        differently from the catalog record (Vertex MaaS collapses a resource path onto
+        ``<publisher>/<model>``) overrides this so both routes name the same model.
+        """
+        return self._model.model_id
+
     def embed(self, texts: Sequence[str]) -> tuple[Embedding, ...]:
         """Embed ordered text through the configured model without making empty requests.
 
@@ -370,7 +379,9 @@ class OpenAIEmbeddingMixin(ProviderHttpClient):
         """
         if not texts:
             return ()
-        response = self._post("embeddings", openai_embedding_request(self._model.model_id, texts))
+        response = self._post(
+            "embeddings", openai_embedding_request(self._embedding_model_id(), texts)
+        )
         return openai_embedding_response(response, expected_count=len(texts))
 
     def embed_raw(
@@ -406,7 +417,7 @@ class OpenAIEmbeddingMixin(ProviderHttpClient):
         response = self._post(
             "embeddings",
             openai_embedding_request(
-                self._model.model_id,
+                self._embedding_model_id(),
                 texts,
                 dimensions=dimensions,
                 encoding_format=encoding_format,

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -495,11 +495,44 @@ class VertexOpenAIClient(OpenAICompatibleClient):
         """Name the MaaS id on the embeddings wire too, never the resource-path spelling."""
         return self._wire_model_id
 
+    async def _post_async(
+        self,
+        path: str,
+        payload: JsonObject,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> JsonObject:
+        """Warm the bearer token off the event loop before the shared JSON post.
+
+        The embeddings routes reach ``_headers`` through this path, so the same bounded
+        off-loop mint the completion flow performs happens here too: a blocking token
+        refresh never runs inline on the event loop, and a stalled token endpoint fails
+        the request at its deadline instead of outliving it.
+
+        Args:
+            path: Provider route below the configured base URL.
+            payload: Complete JSON request object.
+            deadline: Optional request-wide deadline.
+            idempotency_key: Optional stable identity for same-endpoint retries.
+
+        Returns:
+            The first successful decoded provider body.
+        """
+        request_deadline = deadline or RequestDeadline.after(self._timeout_seconds)
+        await _warm_vertex_bearer_token(
+            self._token_provider, request_deadline, self._timeout_seconds
+        )
+        return await super()._post_async(
+            path, payload, deadline=request_deadline, idempotency_key=idempotency_key
+        )
+
     def _headers(self) -> dict[str, str]:
         """Build headers carrying the provider's current bearer token (never the credential).
 
-        The async completion entry point warms the provider off the event loop first, so
-        this call returns the cached token without blocking in the ordinary case.
+        Every async entry point (completions and the embeddings post) warms the provider
+        off the event loop first, so this call returns the cached token without blocking
+        in the ordinary case.
         """
         return _vertex_bearer_headers(self._token_provider)
 

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -55,10 +55,13 @@ VertexWire = Literal["gemini_generate_content", "openai_compatible"]
 """The two wire dialects one Vertex connection serves, chosen per model id."""
 
 _MODEL_PATH_PREFIX = "publishers/google/models/"
-# Catalog spellings that name a Google-published model and therefore ride the Gemini wire:
-# a bare id (``gemini-2.5-pro``) or a Google resource path. Any OTHER ``<publisher>/<model>``
-# spelling is a Model Garden MaaS id for the OpenAI-compatible route.
-_GOOGLE_RESOURCE_PREFIXES = (_MODEL_PATH_PREFIX, "models/")
+# A bare id (``gemini-2.5-pro``) or a Google resource path names a Google-published model
+# on the Gemini wire; any OTHER ``<publisher>/<model>`` spelling is a Model Garden MaaS id
+# for the OpenAI-compatible route (see ``vertex_wire_for_model``).
+# Google's OWN Model Garden managed endpoints (``gemma-4-26b-a4b-it-maas``) carry this
+# suffix in Vertex's listing; it is what separates them from the Gemini models that share
+# the ``publishers/google/models/`` resource path.
+_MAAS_SUFFIX = "-maas"
 _PUBLISHER_RESOURCE_PATH = re.compile(r"^publishers/([^/]+)/models/(.+)$")
 _VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
 
@@ -71,8 +74,10 @@ def vertex_wire_for_model(model_id: str) -> VertexWire:
     publisher-qualified id (``deepseek-ai/deepseek-v3.2-maas``, ``xai/grok-4.20-reasoning``,
     ``publishers/qwen/models/qwen3-coder-480b-a35b-instruct-maas``) names a Model Garden
     MaaS model, which Vertex serves only over its OpenAI-compatible route. Google's own
-    MaaS-served open models (``google/gemma-4-26b-a4b-it-maas``) follow the same rule: the
-    ``<publisher>/<model>`` spelling IS the OpenAI-route address.
+    MaaS-served open models follow the same rule under either spelling: the listing's
+    ``publishers/google/models/gemma-4-26b-a4b-it-maas`` is recognized by Vertex's
+    ``-maas`` endpoint suffix, and ``google/gemma-4-26b-a4b-it-maas`` IS the OpenAI-route
+    address.
 
     Args:
         model_id: Catalog model identifier as spelled on the deployment record.
@@ -80,7 +85,9 @@ def vertex_wire_for_model(model_id: str) -> VertexWire:
     Returns:
         The dialect the resolved client speaks for this model.
     """
-    if model_id.startswith(_GOOGLE_RESOURCE_PREFIXES) or "/" not in model_id:
+    if model_id.startswith(_MODEL_PATH_PREFIX):
+        return "openai_compatible" if model_id.endswith(_MAAS_SUFFIX) else "gemini_generate_content"
+    if model_id.startswith("models/") or "/" not in model_id:
         return "gemini_generate_content"
     return "openai_compatible"
 
@@ -475,11 +482,25 @@ class VertexOpenAIClient(OpenAICompatibleClient):
         )
 
     def gateway_wire_profile(self) -> GatewayWireProfile:
-        """Return the compatible client's profile addressed with the MaaS wire id."""
+        """Return the compatible client's profile addressed with the MaaS wire id.
+
+        Profile resolution runs on the native bridge's blocking callback thread,
+        exactly like :meth:`VertexClient.gateway_wire_profile`, so the roughly-hourly
+        OAuth refresh never blocks Rust's async dispatcher; the resulting bearer token
+        is frozen only for this admitted request.
+        """
         return replace(super().gateway_wire_profile(), model_id=self._wire_model_id)
 
+    def _embedding_model_id(self) -> str:
+        """Name the MaaS id on the embeddings wire too, never the resource-path spelling."""
+        return self._wire_model_id
+
     def _headers(self) -> dict[str, str]:
-        """Build headers carrying the provider's current bearer token (never the credential)."""
+        """Build headers carrying the provider's current bearer token (never the credential).
+
+        The async completion entry point warms the provider off the event loop first, so
+        this call returns the cached token without blocking in the ordinary case.
+        """
         return _vertex_bearer_headers(self._token_provider)
 
     def _request_path(self, path: str) -> str:

--- a/exp/runtime/models/providers/vertex.py
+++ b/exp/runtime/models/providers/vertex.py
@@ -1,10 +1,14 @@
-"""Native Vertex AI adapter for Google-published models over the Gemini wire protocol.
+"""Native Vertex AI adapter: Gemini wire for Google models, OpenAI wire for Model Garden MaaS.
 
-Vertex serves the same ``generateContent`` and ``streamGenerateContent`` protocol as the
-Gemini API, so request and response conversion is shared with the Gemini adapter. What
-differs is identity: the endpoint root names one project and location, model routes live
-under ``publishers/google/models/``, and authentication uses short-lived OAuth bearer
-tokens minted from a service-account JSON credential instead of a static API key.
+Vertex serves Google-published models over the same ``generateContent`` and
+``streamGenerateContent`` protocol as the Gemini API, so request and response conversion
+is shared with the Gemini adapter. Third-party Model Garden models served as a managed API
+(MaaS: DeepSeek, Qwen, Kimi, Grok, Llama, ...) are instead served over Vertex's
+OpenAI-compatible ``endpoints/openapi/chat/completions`` route, addressed by a
+``<publisher>/<model>`` id. Both wires share identity and authentication: the endpoint
+root names one project and location, and every request carries a short-lived OAuth bearer
+token minted from a service-account JSON credential instead of a static API key. The
+catalog model id spelling picks the wire (:func:`vertex_wire_for_model`).
 """
 
 from __future__ import annotations
@@ -13,11 +17,12 @@ import asyncio
 import json
 import re
 import threading
-from typing import Protocol
+from dataclasses import replace
+from typing import Literal, Protocol
 from urllib.parse import urlsplit
 
 from exp.common.core.artifacts import JsonObject
-from exp.common.models import ModelRequest, ModelResponse, ModelSnapshot
+from exp.common.models import ChatMaxTokensField, ModelRequest, ModelResponse, ModelSnapshot
 from exp.runtime.models.providers.async_transport import (
     AsyncJsonHttpTransport,
     ProviderDeadlineExceeded,
@@ -34,13 +39,69 @@ from exp.runtime.models.providers.gemini import (
     gemini_generate_request,
     gemini_generate_response,
 )
+from exp.runtime.models.providers.openai_compatible import (
+    OpenAICompatibleClient,
+    openai_compatible_request,
+)
 from exp.runtime.models.providers.transport import JsonHttpTransport, RetryPolicy
 
 VERTEX_TOKEN_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 """OAuth scope requested for every Vertex access token."""
 
+VERTEX_OPENAPI_PATH_PREFIX = "endpoints/openapi/"
+"""Route prefix, below the project-and-location root, of Vertex's OpenAI-compatible surface."""
+
+VertexWire = Literal["gemini_generate_content", "openai_compatible"]
+"""The two wire dialects one Vertex connection serves, chosen per model id."""
+
 _MODEL_PATH_PREFIX = "publishers/google/models/"
+# Catalog spellings that name a Google-published model and therefore ride the Gemini wire:
+# a bare id (``gemini-2.5-pro``) or a Google resource path. Any OTHER ``<publisher>/<model>``
+# spelling is a Model Garden MaaS id for the OpenAI-compatible route.
+_GOOGLE_RESOURCE_PREFIXES = (_MODEL_PATH_PREFIX, "models/")
+_PUBLISHER_RESOURCE_PATH = re.compile(r"^publishers/([^/]+)/models/(.+)$")
 _VERTEX_HOST = re.compile(r"(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?-)?aiplatform\.googleapis\.com")
+
+
+def vertex_wire_for_model(model_id: str) -> VertexWire:
+    """Choose the wire dialect one Vertex catalog model id is served over.
+
+    Google-published models (``gemini-2.5-pro``, ``models/gemini-2.5-pro``,
+    ``publishers/google/models/gemini-2.5-pro``) ride the native Gemini wire. A
+    publisher-qualified id (``deepseek-ai/deepseek-v3.2-maas``, ``xai/grok-4.20-reasoning``,
+    ``publishers/qwen/models/qwen3-coder-480b-a35b-instruct-maas``) names a Model Garden
+    MaaS model, which Vertex serves only over its OpenAI-compatible route. Google's own
+    MaaS-served open models (``google/gemma-4-26b-a4b-it-maas``) follow the same rule: the
+    ``<publisher>/<model>`` spelling IS the OpenAI-route address.
+
+    Args:
+        model_id: Catalog model identifier as spelled on the deployment record.
+
+    Returns:
+        The dialect the resolved client speaks for this model.
+    """
+    if model_id.startswith(_GOOGLE_RESOURCE_PREFIXES) or "/" not in model_id:
+        return "gemini_generate_content"
+    return "openai_compatible"
+
+
+def vertex_openapi_model_id(model_id: str) -> str:
+    """Return the ``<publisher>/<model>`` id Vertex's OpenAI-compatible route accepts.
+
+    The route rejects the resource-path spelling (``publishers/X/models/Y``) with 400
+    "expected '<publisher>/<model>'", so a catalog carrying the listing's resource path is
+    collapsed onto the accepted form; an id already in that form passes through verbatim.
+
+    Args:
+        model_id: Catalog model identifier for a MaaS model.
+
+    Returns:
+        The publisher-qualified id to place on the wire.
+    """
+    match = _PUBLISHER_RESOURCE_PATH.match(model_id)
+    if match is None:
+        return model_id
+    return f"{match.group(1)}/{match.group(2)}"
 
 
 class VertexCredentialError(ValueError):
@@ -237,35 +298,12 @@ class VertexClient(ProviderHttpClient):
         request_deadline = deadline or RequestDeadline.after(
             completion_timeout_seconds(self._timeout_seconds, request.maximum_output_tokens)
         )
-        await self._warm_bearer_token(request_deadline)
+        await _warm_vertex_bearer_token(
+            self._token_provider, request_deadline, self._timeout_seconds
+        )
         return await super().complete_async(
             request, deadline=request_deadline, idempotency_key=idempotency_key
         )
-
-    async def _warm_bearer_token(self, deadline: RequestDeadline) -> str:
-        """Mint or read the bearer token off the event loop, bounded by the request deadline.
-
-        Token minting is one blocking HTTPS call to Google's token endpoint. It runs on a
-        worker thread so the gateway event loop stays responsive, and the wait is bounded by
-        the smaller of the remaining request budget and the per-attempt timeout floor.
-
-        Args:
-            deadline: Immutable request-wide deadline shared with the provider dispatch.
-
-        Returns:
-            A currently valid bearer token.
-
-        Raises:
-            ProviderDeadlineExceeded: The deadline expired before a token was available.
-        """
-        timeout_seconds = deadline.attempt_timeout(self._timeout_seconds)
-        try:
-            async with asyncio.timeout(timeout_seconds):
-                return await asyncio.to_thread(self._token_provider)
-        except TimeoutError as exc:
-            raise ProviderDeadlineExceeded(
-                "Vertex token refresh exhausted the provider request deadline"
-            ) from exc
 
     def _headers(self) -> dict[str, str]:
         """Build native Vertex headers carrying the provider's current bearer token.
@@ -273,10 +311,7 @@ class VertexClient(ProviderHttpClient):
         The async entry points warm the provider off the event loop first, so this call
         returns the cached token without blocking in the ordinary case.
         """
-        return {
-            "authorization": f"Bearer {self._token_provider()}",
-            "content-type": "application/json",
-        }
+        return _vertex_bearer_headers(self._token_provider)
 
     def gateway_wire_profile(self) -> GatewayWireProfile:
         """Return the native Gemini-dialect profile for this Vertex connection.
@@ -331,6 +366,179 @@ class VertexClient(ProviderHttpClient):
         return gemini_generate_response(
             payload, configured_model=self._model, latency_seconds=latency_seconds
         )
+
+
+class VertexOpenAIClient(OpenAICompatibleClient):
+    """Calls one Model Garden MaaS model through Vertex's OpenAI-compatible route.
+
+    The Chat Completions request and response conversion, the embeddings route, and the
+    native ``openai_compatible`` wire profile are the compatible client's; this class only
+    changes identity and authentication: every route sits below
+    ``endpoints/openapi/`` on the project-and-location root, the model travels as its
+    ``<publisher>/<model>`` id, and the bearer token is minted from the service-account
+    credential exactly like :class:`VertexClient`.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: ModelSnapshot,
+        api_key: str,
+        base_url: str,
+        transport: AsyncJsonHttpTransport | JsonHttpTransport | None = None,
+        retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        token_provider: VertexTokenProvider | None = None,
+        supports_temperature: bool = True,
+        supports_top_p: bool | None = None,
+        supports_top_k: bool = False,
+        supports_logprobs: bool = False,
+        supports_frequency_penalty: bool = False,
+        supports_presence_penalty: bool = False,
+        supports_reasoning: bool = False,
+        reasoning_effort: str | None = None,
+        chat_max_tokens_field: ChatMaxTokensField | None = None,
+        sampling_requires_reasoning_none: bool = False,
+    ) -> None:
+        """Create one MaaS client with explicit generation gates for one Vertex endpoint root.
+
+        Args:
+            model: Resolved configured model identity (a ``<publisher>/<model>`` MaaS id).
+            api_key: Service-account JSON credential read from the connection's environment
+                variable. It never travels on the wire; it mints each request's bearer token.
+            base_url: Project-and-location endpoint root, such as
+                ``https://aiplatform.googleapis.com/v1/projects/PROJECT/locations/global``.
+            transport: Optional deterministic transport used by tests.
+            retry_policy: Bounded same-endpoint retry policy.
+            timeout_seconds: Per-attempt timeout floor.
+            token_provider: Optional deterministic bearer-token seam for tests and callers
+                that own credential refresh themselves.
+            supports_temperature: Whether the exact model accepts temperature.
+            supports_top_p: Whether the exact model accepts top-p sampling.
+            supports_top_k: Whether the exact model accepts top-k sampling.
+            supports_logprobs: Whether the catalog reports logprob support.
+            supports_frequency_penalty: Whether the exact model accepts frequency_penalty.
+            supports_presence_penalty: Whether the exact model accepts presence_penalty.
+            supports_reasoning: Whether the exact model accepts ``reasoning_effort``.
+            reasoning_effort: Optional catalog-pinned reasoning effort.
+            chat_max_tokens_field: Wire field carrying the output-token ceiling.
+            sampling_requires_reasoning_none: Whether sampling controls are only accepted
+                with reasoning disabled.
+        """
+        _require_vertex_host(base_url)
+        super().__init__(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            transport=transport,
+            retry_policy=retry_policy,
+            timeout_seconds=timeout_seconds,
+            supports_temperature=supports_temperature,
+            supports_top_p=supports_top_p,
+            supports_top_k=supports_top_k,
+            supports_logprobs=supports_logprobs,
+            supports_frequency_penalty=supports_frequency_penalty,
+            supports_presence_penalty=supports_presence_penalty,
+            supports_reasoning=supports_reasoning,
+            reasoning_effort=reasoning_effort,
+            chat_max_tokens_field=chat_max_tokens_field,
+            sampling_requires_reasoning_none=sampling_requires_reasoning_none,
+        )
+        self._token_provider = token_provider or ServiceAccountTokenProvider(api_key)
+        self._wire_model_id = vertex_openapi_model_id(model.model_id)
+
+    async def complete_async(
+        self,
+        request: ModelRequest,
+        *,
+        deadline: RequestDeadline | None = None,
+        idempotency_key: str | None = None,
+    ) -> ModelResponse:
+        """Warm the bearer token off the event loop, then run the shared completion flow.
+
+        Args:
+            request: Visible messages, tool schemas, and sampling controls to send.
+            deadline: Optional request-wide deadline supplied by gateway execution.
+            idempotency_key: Optional stable caller or gateway attempt identity.
+
+        Returns:
+            The typed completed response with observed request economics.
+        """
+        request_deadline = deadline or RequestDeadline.after(
+            completion_timeout_seconds(self._timeout_seconds, request.maximum_output_tokens)
+        )
+        await _warm_vertex_bearer_token(
+            self._token_provider, request_deadline, self._timeout_seconds
+        )
+        return await super().complete_async(
+            request, deadline=request_deadline, idempotency_key=idempotency_key
+        )
+
+    def gateway_wire_profile(self) -> GatewayWireProfile:
+        """Return the compatible client's profile addressed with the MaaS wire id."""
+        return replace(super().gateway_wire_profile(), model_id=self._wire_model_id)
+
+    def _headers(self) -> dict[str, str]:
+        """Build headers carrying the provider's current bearer token (never the credential)."""
+        return _vertex_bearer_headers(self._token_provider)
+
+    def _request_path(self, path: str) -> str:
+        """Place every OpenAI-compatible route below Vertex's ``endpoints/openapi/`` prefix."""
+        return f"{VERTEX_OPENAPI_PATH_PREFIX}{path}"
+
+    def _build_request(self, request: ModelRequest) -> JsonObject:
+        """Convert one typed request into a Chat Completions payload naming the MaaS id."""
+        return openai_compatible_request(
+            self._wire_model_id,
+            request,
+            token_limit_key=self._token_limit_key,
+            supports_temperature=self._supports_temperature,
+            supports_top_p=self._supports_top_p,
+            supports_top_k=self._supports_top_k,
+            supports_logprobs=self._supports_logprobs,
+            supports_reasoning=self._supports_reasoning,
+            reasoning_effort=self._reasoning_effort,
+            reasoning_wire_format=self.reasoning_wire_format,
+            sampling_requires_reasoning_none=self._sampling_requires_reasoning_none,
+        )
+
+
+async def _warm_vertex_bearer_token(
+    token_provider: VertexTokenProvider, deadline: RequestDeadline, timeout_seconds: float
+) -> str:
+    """Mint or read the bearer token off the event loop, bounded by the request deadline.
+
+    Token minting is one blocking HTTPS call to Google's token endpoint. It runs on a
+    worker thread so the gateway event loop stays responsive, and the wait is bounded by
+    the smaller of the remaining request budget and the per-attempt timeout floor.
+
+    Args:
+        token_provider: The connection's cached token provider.
+        deadline: Immutable request-wide deadline shared with the provider dispatch.
+        timeout_seconds: The client's per-attempt timeout floor.
+
+    Returns:
+        A currently valid bearer token.
+
+    Raises:
+        ProviderDeadlineExceeded: The deadline expired before a token was available.
+    """
+    attempt_timeout = deadline.attempt_timeout(timeout_seconds)
+    try:
+        async with asyncio.timeout(attempt_timeout):
+            return await asyncio.to_thread(token_provider)
+    except TimeoutError as exc:
+        raise ProviderDeadlineExceeded(
+            "Vertex token refresh exhausted the provider request deadline"
+        ) from exc
+
+
+def _vertex_bearer_headers(token_provider: VertexTokenProvider) -> dict[str, str]:
+    """Authenticated JSON headers carrying the current bearer token, never the credential."""
+    return {
+        "authorization": f"Bearer {token_provider()}",
+        "content-type": "application/json",
+    }
 
 
 def _require_vertex_host(base_url: str) -> None:

--- a/exp/runtime/models/providers/vertex_test.py
+++ b/exp/runtime/models/providers/vertex_test.py
@@ -31,8 +31,11 @@ from exp.runtime.models.providers.vertex import (
     ServiceAccountTokenProvider,
     VertexClient,
     VertexCredentialError,
+    VertexOpenAIClient,
     VertexTokenProvider,
     _vertex_model_id,
+    vertex_openapi_model_id,
+    vertex_wire_for_model,
 )
 from exp.runtime.models.registry import RuntimeModelCatalog
 from exp.runtime.openai_protocol.model_adapter import model_request
@@ -443,3 +446,234 @@ def test_vertex_error_status_surfaces_after_bounded_retries() -> None:
 
     with pytest.raises(Exception, match="403"):
         client.complete(_request())
+
+
+_GLOBAL_BASE_URL = "https://aiplatform.googleapis.com/v1/projects/fixture-project/locations/global"
+
+
+def _chat_completion_response() -> JsonObject:
+    """Return one minimal Chat Completions payload as Vertex's MaaS route shapes it.
+
+    ``prompt_tokens_details`` is ``null`` and ``usage`` carries Google's
+    ``extra_properties`` on the live wire (2026-09-08), so the fixture keeps both.
+    """
+    return {
+        "id": "04aa73bb-2800-4f51-985b-a6ef5b3b2ca9",
+        "object": "chat.completion",
+        "model": "deepseek-ai/deepseek-v3.2-maas",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Working.", "tool_calls": None},
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 6,
+            "total_tokens": 18,
+            "prompt_tokens_details": None,
+            "extra_properties": {"google": {"traffic_type": "ON_DEMAND"}},
+        },
+    }
+
+
+def test_vertex_wire_follows_the_model_id_spelling() -> None:
+    """Google ids ride the Gemini wire; any other publisher-qualified id is a MaaS route."""
+    for google_id in (
+        "gemini-2.5-pro",
+        "models/gemini-2.5-pro",
+        "publishers/google/models/gemini-2.5-flash",
+    ):
+        assert vertex_wire_for_model(google_id) == "gemini_generate_content"
+    for maas_id in (
+        "deepseek-ai/deepseek-v3.2-maas",
+        "xai/grok-4.20-reasoning",
+        "google/gemma-4-26b-a4b-it-maas",
+        "publishers/qwen/models/qwen3-coder-480b-a35b-instruct-maas",
+    ):
+        assert vertex_wire_for_model(maas_id) == "openai_compatible"
+
+
+def test_vertex_openapi_model_id_collapses_the_resource_path_spelling() -> None:
+    """The route accepts only ``<publisher>/<model>``; the listing's path form is collapsed."""
+    assert (
+        vertex_openapi_model_id("deepseek-ai/deepseek-v3.2-maas")
+        == "deepseek-ai/deepseek-v3.2-maas"
+    )
+    assert (
+        vertex_openapi_model_id("publishers/qwen/models/qwen3-coder-480b-a35b-instruct-maas")
+        == "qwen/qwen3-coder-480b-a35b-instruct-maas"
+    )
+
+
+def test_vertex_openapi_client_posts_chat_completions_with_a_bearer_token() -> None:
+    """A MaaS completion posts to the openapi route with OAuth auth and the publisher id."""
+    transport = ScriptedJsonTransport(
+        [JsonHttpResponse(status_code=200, body=_chat_completion_response())]
+    )
+    client = VertexOpenAIClient(
+        model=_snapshot("vertex", "deepseek-ai/deepseek-v3.2-maas"),
+        api_key='{"placeholder": true}',
+        base_url=_GLOBAL_BASE_URL,
+        transport=transport,
+        token_provider=lambda: "fixture-bearer-token",
+    )
+
+    response = client.complete(_request())
+
+    assert isinstance(client, ModelClient)
+    assert isinstance(client, EmbeddingClient)
+    assert response.output.content == "Working."
+    assert response.model.model_id == "deepseek-ai/deepseek-v3.2-maas"
+    assert response.economics.usage is not None
+    assert response.economics.usage.input_tokens == 12
+    assert response.economics.usage.cached_input_tokens is None
+    url, headers, payload = transport.requests[0]
+    assert url == f"{_GLOBAL_BASE_URL}/endpoints/openapi/chat/completions"
+    assert headers["authorization"] == "Bearer fixture-bearer-token"
+    assert "x-goog-api-key" not in headers
+    assert payload["model"] == "deepseek-ai/deepseek-v3.2-maas"
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    assert messages[0] == {"role": "system", "content": "You are precise."}
+    assert payload["stream"] is False
+
+
+def test_vertex_openapi_profile_is_the_compatible_dialect_on_the_vertex_host() -> None:
+    """The native profile speaks openai_compatible at the openapi route with the MaaS id."""
+    provider = _StatefulTokenProvider("token-first")
+    client = VertexOpenAIClient(
+        model=_snapshot("vertex", "publishers/xai/models/grok-4.20-reasoning"),
+        api_key='{"placeholder": true}',
+        base_url=_GLOBAL_BASE_URL,
+        transport=ScriptedJsonTransport(),
+        token_provider=provider,
+        supports_top_k=False,
+        supports_reasoning=True,
+    )
+
+    profile = client.gateway_wire_profile()
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="Preserve these controls."),),
+        maximum_output_tokens=128,
+        temperature=0.4,
+        top_k=32,
+        reasoning_effort="high",
+    )
+    native_payload = dialect_stream_payload(profile, request)
+    payload = client._build_request(model_request(request))
+
+    assert profile.dialect == "openai_compatible"
+    assert profile.url == f"{_GLOBAL_BASE_URL}/endpoints/openapi/chat/completions"
+    assert profile.embeddings_url == f"{_GLOBAL_BASE_URL}/endpoints/openapi/embeddings"
+    assert profile.headers == {
+        "authorization": "Bearer token-first",
+        "content-type": "application/json",
+    }
+    assert profile.model_id == "xai/grok-4.20-reasoning"
+    assert profile.reasoning_wire_format == "reasoning_effort"
+    assert profile.token_limit_key == "max_tokens"
+    assert native_payload["model"] == "xai/grok-4.20-reasoning"
+    assert native_payload["stream"] is True
+    assert native_payload["stream_options"] == {"include_usage": True}
+    assert native_payload["temperature"] == 0.4
+    assert "top_k" not in native_payload
+    assert native_payload["reasoning_effort"] == "high"
+    assert native_payload["max_tokens"] == 128
+    assert payload["model"] == "xai/grok-4.20-reasoning"
+    assert payload["reasoning_effort"] == "high"
+    # The token is re-read per profile so a renewed bearer reaches the wire.
+    provider.token = "token-second"
+    assert client.gateway_wire_profile().headers["authorization"] == "Bearer token-second"
+
+
+def test_vertex_openapi_client_refuses_non_google_hosts() -> None:
+    """The MaaS client fails closed before a bearer token could leave for a foreign host."""
+    with pytest.raises(ValueError, match="aiplatform.googleapis.com"):
+        VertexOpenAIClient(
+            model=_snapshot("vertex", "deepseek-ai/deepseek-v3.2-maas"),
+            api_key='{"placeholder": true}',
+            base_url="https://attacker.example.com/v1/projects/p/locations/global",
+            transport=ScriptedJsonTransport(),
+            token_provider=lambda: "fixture-bearer-token",
+        )
+
+
+def test_vertex_openapi_token_refresh_is_bounded_by_the_request_deadline() -> None:
+    """The MaaS client shares the Gemini-wire client's bounded off-loop token warm."""
+    provider = _StatefulTokenProvider("unused-token")
+    client = VertexOpenAIClient(
+        model=_snapshot("vertex", "deepseek-ai/deepseek-v3.2-maas"),
+        api_key='{"placeholder": true}',
+        base_url=_GLOBAL_BASE_URL,
+        transport=ScriptedJsonTransport(),
+        token_provider=provider,
+    )
+    spent = RequestDeadline.after(10.0, now_monotonic=0.0)
+
+    with pytest.raises(ProviderDeadlineExceeded):
+        asyncio.run(client.complete_async(_request(), deadline=spent))
+
+    assert provider.calls == 0
+
+
+def test_catalog_resolution_builds_the_openapi_client_for_model_garden_ids() -> None:
+    """One Vertex connection resolves Gemini ids and MaaS ids to their own clients."""
+    seen_credentials: list[str] = []
+
+    def factory(*, credentials_json: str) -> VertexTokenProvider:
+        """Record the routed credential and hand back a deterministic token provider."""
+        seen_credentials.append(credentials_json)
+        return lambda: "factory-token"
+
+    catalog = RuntimeModelCatalog(
+        ModelCatalog(
+            connections={
+                "vertex": ConnectionConfig(
+                    provider="vertex",
+                    base_url=_GLOBAL_BASE_URL,
+                    api_key_env="VERTEX_SERVICE_ACCOUNT_JSON",
+                )
+            },
+            models={
+                "deepseek": ModelRecord(
+                    billing_source=BillingSource.CUSTOMER_MANAGED,
+                    connection="vertex",
+                    model="deepseek-ai/deepseek-v3.2-maas",
+                    capabilities=ModelCapabilities(
+                        supports_tools=True,
+                        supports_completions=True,
+                        supports_embeddings=False,
+                    ),
+                ),
+                "gemini-pro": ModelRecord(
+                    billing_source=BillingSource.CUSTOMER_MANAGED,
+                    connection="vertex",
+                    model="gemini-2.5-pro",
+                    capabilities=ModelCapabilities(
+                        supports_tools=True,
+                        supports_completions=True,
+                        supports_embeddings=False,
+                    ),
+                ),
+            },
+        ),
+        environment={"VERTEX_SERVICE_ACCOUNT_JSON": '{"type": "service_account"}'},
+        transport_factory=lambda: ScriptedJsonTransport(
+            [JsonHttpResponse(status_code=200, body=_chat_completion_response())]
+        ),
+        vertex_token_provider_factory=factory,
+    )
+
+    maas = catalog.resolve("deepseek")
+    gemini = catalog.resolve("gemini-pro")
+    response = maas.client.complete(_request())
+
+    assert isinstance(maas.client, VertexOpenAIClient)
+    assert maas.embedding_client is None
+    assert type(gemini.client) is VertexClient
+    assert response.finish_reason == ModelFinishReason.COMPLETED
+    assert response.output.content == "Working."
+    assert seen_credentials == ['{"type": "service_account"}', '{"type": "service_account"}']

--- a/exp/runtime/models/providers/vertex_test.py
+++ b/exp/runtime/models/providers/vertex_test.py
@@ -714,3 +714,35 @@ def test_catalog_resolution_builds_the_openapi_client_for_model_garden_ids() -> 
     assert response.finish_reason == ModelFinishReason.COMPLETED
     assert response.output.content == "Working."
     assert seen_credentials == ['{"type": "service_account"}', '{"type": "service_account"}']
+
+
+def test_vertex_openapi_embeddings_bound_the_token_mint_by_the_request_deadline() -> None:
+    """The embeddings post warms the token off the loop and fails at the request deadline."""
+
+    def stalled_provider() -> str:
+        """Simulate a token endpoint that answers far too late."""
+        time.sleep(0.5)
+        return "too-late-token"
+
+    client = VertexOpenAIClient(
+        model=_snapshot("vertex", "e5/multilingual-e5-large-instruct-maas"),
+        api_key='{"placeholder": true}',
+        base_url=_GLOBAL_BASE_URL,
+        transport=ScriptedJsonTransport(),
+        token_provider=stalled_provider,
+    )
+
+    async def scenario() -> float:
+        """Time how quickly the deadline error reaches the caller inside the loop."""
+        started = time.monotonic()
+        with pytest.raises(ProviderDeadlineExceeded, match="token refresh"):
+            await client._post_async(
+                "embeddings",
+                {"model": "e5/multilingual-e5-large-instruct-maas", "input": ["hello"]},
+                deadline=RequestDeadline.after(0.05),
+            )
+        return time.monotonic() - started
+
+    # asyncio.run may wait for the orphaned worker thread at loop shutdown; the bound
+    # under test is how quickly the caller inside the loop sees the deadline error.
+    assert asyncio.run(scenario()) < 0.4

--- a/exp/runtime/models/providers/vertex_test.py
+++ b/exp/runtime/models/providers/vertex_test.py
@@ -490,6 +490,9 @@ def test_vertex_wire_follows_the_model_id_spelling() -> None:
         "deepseek-ai/deepseek-v3.2-maas",
         "xai/grok-4.20-reasoning",
         "google/gemma-4-26b-a4b-it-maas",
+        # Google's own managed endpoint under the listing's resource path: the
+        # ``-maas`` suffix is what separates it from the Gemini models sharing it.
+        "publishers/google/models/gemma-4-26b-a4b-it-maas",
         "publishers/qwen/models/qwen3-coder-480b-a35b-instruct-maas",
     ):
         assert vertex_wire_for_model(maas_id) == "openai_compatible"
@@ -505,6 +508,40 @@ def test_vertex_openapi_model_id_collapses_the_resource_path_spelling() -> None:
         vertex_openapi_model_id("publishers/qwen/models/qwen3-coder-480b-a35b-instruct-maas")
         == "qwen/qwen3-coder-480b-a35b-instruct-maas"
     )
+    assert (
+        vertex_openapi_model_id("publishers/google/models/gemma-4-26b-a4b-it-maas")
+        == "google/gemma-4-26b-a4b-it-maas"
+    )
+
+
+def test_vertex_openapi_embeddings_name_the_collapsed_maas_id() -> None:
+    """The embeddings route carries the same ``<publisher>/<model>`` id as completions."""
+    transport = ScriptedJsonTransport(
+        [
+            JsonHttpResponse(
+                status_code=200,
+                body={
+                    "data": [{"index": 0, "embedding": [0.6, 0.8]}],
+                    "usage": {"prompt_tokens": 3},
+                },
+            )
+        ]
+    )
+    client = VertexOpenAIClient(
+        model=_snapshot("vertex", "publishers/e5/models/multilingual-e5-large-instruct-maas"),
+        api_key='{"placeholder": true}',
+        base_url=_GLOBAL_BASE_URL,
+        transport=transport,
+        token_provider=lambda: "fixture-bearer-token",
+    )
+
+    embeddings = client.embed(["hello"])
+
+    assert len(embeddings) == 1
+    url, headers, payload = transport.requests[0]
+    assert url == f"{_GLOBAL_BASE_URL}/endpoints/openapi/embeddings"
+    assert headers["authorization"] == "Bearer fixture-bearer-token"
+    assert payload["model"] == "e5/multilingual-e5-large-instruct-maas"
 
 
 def test_vertex_openapi_client_posts_chat_completions_with_a_bearer_token() -> None:

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -49,7 +49,12 @@ from exp.runtime.models.providers.tinker_sampling import (
     create_tinker_sampler,
 )
 from exp.runtime.models.providers.transport import JsonHttpTransport
-from exp.runtime.models.providers.vertex import VertexClient, VertexTokenProviderFactory
+from exp.runtime.models.providers.vertex import (
+    VertexClient,
+    VertexOpenAIClient,
+    VertexTokenProviderFactory,
+    vertex_wire_for_model,
+)
 
 ProviderTransport = AsyncJsonHttpTransport | JsonHttpTransport
 
@@ -300,6 +305,39 @@ class RuntimeModelCatalog:
                 if self._vertex_token_provider_factory is None
                 else self._vertex_token_provider_factory(credentials_json=api_key)
             )
+            if vertex_wire_for_model(snapshot.model_id) == "openai_compatible":
+                # A Model Garden MaaS id: Vertex serves it only over its
+                # OpenAI-compatible route, so the compatible client's wire and
+                # embeddings surface apply, under the same OAuth bearer.
+                maas_client = VertexOpenAIClient(
+                    model=snapshot,
+                    api_key=api_key,
+                    base_url=connection.base_url,
+                    transport=self._transport_factory(),
+                    token_provider=token_provider,
+                    supports_temperature=capabilities.supports_temperature,
+                    supports_top_p=_supports_top_p(capabilities),
+                    supports_top_k=_supports_flag(capabilities, "supports_top_k"),
+                    supports_logprobs=_supports_flag(capabilities, "supports_logprobs"),
+                    supports_frequency_penalty=_supports_flag(
+                        capabilities, "supports_frequency_penalty"
+                    ),
+                    supports_presence_penalty=_supports_flag(
+                        capabilities, "supports_presence_penalty"
+                    ),
+                    supports_reasoning=capabilities.supports_reasoning,
+                    reasoning_effort=capabilities.reasoning_effort,
+                    chat_max_tokens_field=capabilities.chat_max_tokens_field,
+                    sampling_requires_reasoning_none=capabilities.sampling_requires_reasoning_none,
+                )
+                return ResolvedModel(
+                    alias,
+                    snapshot,
+                    capabilities,
+                    maas_client,
+                    maas_client if capabilities.supports_embeddings is not False else None,
+                    served_model_id=record.served_model_id,
+                )
             vertex_client = VertexClient(
                 model=snapshot,
                 api_key=api_key,


### PR DESCRIPTION
## Why

Vertex AI serves third-party Model Garden models as a managed API (MaaS: DeepSeek, Qwen, Kimi, MiniMax, GLM, gpt-oss, Grok, Llama) ONLY over its OpenAI-compatible route `{project-and-location root}/endpoints/openapi/chat/completions`, addressed by a `<publisher>/<model>` id, with the same service-account OAuth bearer the Gemini wire uses. `VertexClient` routed every id over `publishers/google/models/…:streamGenerateContent`, so a MaaS id could not be served at all. The platform's openai-compatible provider only carries a static bearer, so this is engine work.

## What

- `vertex_wire_for_model(model_id)`: a bare id (`gemini-2.5-pro`) or a Google resource path stays on `gemini_generate_content`; any other publisher-qualified id (`deepseek-ai/deepseek-v3.2-maas`, `xai/grok-4.20-reasoning`, `google/gemma-4-26b-a4b-it-maas`) is `openai_compatible`.
- `VertexOpenAIClient(OpenAICompatibleClient)`: Vertex bearer headers (token minted by the shared `ServiceAccountTokenProvider`, warmed off the event loop under the request deadline exactly like `VertexClient`), every route below `endpoints/openapi/`, the MaaS id on the wire (`vertex_openapi_model_id` collapses the listing's `publishers/x/models/y` spelling, which the route rejects with 400 "expected '<publisher>/<model>'"), the same host pin (`*.aiplatform.googleapis.com`, HTTPS only). The native profile is the existing `openai_compatible` dialect, so the Rust crate is untouched.
- `RuntimeModelCatalog.resolve` picks the client per model id on a `vertex` connection; the MaaS client also exposes the compatible embeddings route.
- Docs: `docs/reference/providers.md` Vertex section.

## Evidence

- Live wire facts (2026-09-08, project evident-catcher-501816-u4, global endpoint): 15 MaaS ids serve plain + SSE (with `stream_options.include_usage` honored) + tool calls; `usage.prompt_tokens_details` is `null` and `usage` carries Google's `extra_properties`; Grok returns `completion_tokens_details.reasoning_tokens` and `prompt_tokens_details.cached_tokens`.
- Captured SSE from gpt-oss-120b (reasoning_content deltas), grok-4.20-reasoning (usage w/ reasoning + cached), grok-4.20-non-reasoning tool call, kimi-k2-thinking tool call, qwen3-coder tool call all replay cleanly through `exp_gateway_native.normalize_stream_fixture("openai_compatible", …)` on the current crate.
- `ruff check`/`ruff format`/`ty check` clean; `pytest exp/runtime/models exp/common/models`: 923 passed, 1 skipped.

Platform consumer: the Experiential Labs platform's Vertex MaaS lanes (house `vertex` connection on the `global` location) — gated on the pin that carries this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)