### PR TITLE
release: bump experiential to 0.7.58

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.57"
+version = "0.7.58"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.57"
+version = "0.7.58"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only (pyproject + uv.lock). Carries #871 (541a002df): Vertex Model Garden MaaS ids (`<publisher>/<model>`) served over Vertex's OpenAI-compatible `endpoints/openapi` route under the service-account OAuth bearer (`VertexOpenAIClient`, `vertex_wire_for_model`). Native crate unchanged (exp-gateway-native stays 0.3.47).

Platform consumer: experientiallabs/platform pin bump to `experiential==0.7.58` turns the Vertex MaaS lanes (#1573) from dark to live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)