### PR TITLE
providers: reshape tool input_schema for the Anthropic wire (root combinators flattened, missing root type added), disclosed at admission

### DIFF
--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -377,9 +377,10 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
       oneOf/anyOf variants' definitions become a nested ``anyOf`` (any may
       hold), the root's and allOf variants' definitions stay conjunctive
       (``allOf``), and both nest under ``properties``, where Anthropic
-      accepts them, so no alternative or constraint is lost. ``required`` keeps the names every oneOf/anyOf
-      variant requires plus every name any allOf variant requires, each
-      combinator judged on its own variants. The combinator keys are dropped.
+      accepts them, so no alternative or constraint is lost. ``required``
+      keeps the names every oneOf/anyOf variant requires plus every name any
+      allOf variant requires, each combinator judged on its own variants. The
+      combinator keys are dropped.
       What is lost is the variants' mutual exclusion, disclosed at admission
       (``tools[i].parameters->reshaped(top_level_combinator_flattened)``);
     * a root without ``type`` gains ``"type": "object"``.

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -395,8 +395,11 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         return {**schema, "type": "object"}
     # Per property: definitions that must ALL hold (root properties, allOf
     # variants) and definitions of which ANY may hold (oneOf/anyOf variants).
+    # Alternatives are kept PER combinator: a root oneOf and a root anyOf on the
+    # same name are independent constraints (pick one of these AND at least one
+    # of those), so each becomes its own anyOf member rather than one pool.
     conjunctive: dict[str, list[JsonValue]] = {}
-    disjunctive: dict[str, list[JsonValue]] = {}
+    disjunctive: dict[str, dict[str, list[JsonValue]]] = {}
     order: list[str] = []
 
     def record(bucket: dict[str, list[JsonValue]], name: str, subschema: JsonValue) -> None:
@@ -420,9 +423,11 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         for variant in variants:
             properties = variant.get("properties")
             if isinstance(properties, dict):
-                bucket = conjunctive if keyword == "allOf" else disjunctive
                 for name, subschema in properties.items():
-                    record(bucket, name, subschema)
+                    if keyword == "allOf":
+                        record(conjunctive, name, subschema)
+                    else:
+                        record(disjunctive.setdefault(keyword, {}), name, subschema)
             required = variant.get("required")
             requirement_sets.append(
                 {name for name in required if isinstance(name, str)}
@@ -445,11 +450,12 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
     properties_out: dict[str, JsonValue] = {}
     for name in order:
         must = list(conjunctive.get(name, []))
-        may = disjunctive.get(name, [])
-        if may:
-            # Alternatives fold into one anyOf; it joins the conjunctive
-            # definitions (which all still apply) under allOf.
-            must.append(may[0] if len(may) == 1 else {"anyOf": may})
+        for keyword in ("oneOf", "anyOf"):
+            may = disjunctive.get(keyword, {}).get(name, [])
+            if may:
+                # This combinator's alternatives fold into one anyOf member
+                # that joins the conjunctive definitions under allOf.
+                must.append(may[0] if len(may) == 1 else {"anyOf": may})
         properties_out[name] = must[0] if len(must) == 1 else {"allOf": must}
     flattened["properties"] = properties_out
     ordered_required = [name for name in order if name in required_names]

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -337,3 +337,93 @@ def _references(node: Mapping[str, JsonValue]) -> Iterator[str]:
             for member in value:
                 if isinstance(member, dict):
                     yield from _references(member)
+
+
+_TOP_LEVEL_COMBINATORS = ("oneOf", "anyOf", "allOf")
+"""Combinators Anthropic refuses at the ROOT of ``input_schema`` (live 2026-09-08:
+"input_schema does not support oneOf, allOf, or anyOf at the top level"); the
+same keywords nest freely under ``properties``."""
+
+
+def anthropic_input_schema_reshaping(schema: Mapping[str, JsonValue]) -> str | None:
+    """Name the reshaping [`anthropic_input_schema`] would apply, or ``None``.
+
+    Returns:
+        ``"top_level_combinator_flattened"`` when the root carries oneOf /
+        anyOf / allOf, ``"type_object_added"`` when the root lacks ``type``,
+        else ``None`` (the schema is emitted verbatim).
+    """
+    if any(isinstance(schema.get(keyword), list) for keyword in _TOP_LEVEL_COMBINATORS):
+        return "top_level_combinator_flattened"
+    if "type" not in schema:
+        return "type_object_added"
+    return None
+
+
+def anthropic_input_schema(schema: JsonObject) -> JsonObject:
+    """Return one tool schema in the shape Anthropic's ``input_schema`` accepts.
+
+    Anthropic requires the root to be ``type: object`` and refuses oneOf /
+    anyOf / allOf there, while OpenAI's ``parameters`` takes both (a coding
+    agent that declares a tool as a union of parameter shapes works on every
+    OpenAI wire and 400s on every Anthropic rung: 7 days to 2026-09-08 saw
+    that rejection across a dozen orgs, after dispatch). The reshaping is the
+    provider-accepted equivalent, verified live:
+
+    * a root combinator is flattened into one object: ``properties`` is the
+      union of the variants' properties (first declaration wins on a name
+      clash), ``required`` keeps the names EVERY variant requires (allOf:
+      every name ANY variant requires), and the combinator key is dropped.
+      The mutual exclusion is lost, which is disclosed at admission
+      (``tools[i].parameters->reshaped(top_level_combinator_flattened)``);
+      the model still sees every property and its description;
+    * a root without ``type`` gains ``"type": "object"``.
+
+    A schema that needs neither is returned as the same object, so the
+    verbatim path stays byte-identical.
+    """
+    reshaping = anthropic_input_schema_reshaping(schema)
+    if reshaping is None:
+        return schema
+    if reshaping == "type_object_added":
+        return {**schema, "type": "object"}
+    combinators = [k for k in _TOP_LEVEL_COMBINATORS if isinstance(schema.get(k), list)]
+    variants: list[Mapping[str, JsonValue]] = []
+    for keyword in combinators:
+        listed = schema.get(keyword)
+        if isinstance(listed, list):
+            variants.extend(variant for variant in listed if isinstance(variant, dict))
+    merged_properties: dict[str, JsonValue] = {}
+    root_properties = schema.get("properties")
+    if isinstance(root_properties, dict):
+        merged_properties.update(root_properties)
+    required_sets: list[set[str]] = []
+    for variant in variants:
+        properties = variant.get("properties")
+        if isinstance(properties, dict):
+            for name, subschema in properties.items():
+                merged_properties.setdefault(name, subschema)
+        required = variant.get("required")
+        required_sets.append(
+            {name for name in required if isinstance(name, str)}
+            if isinstance(required, list)
+            else set()
+        )
+    if "allOf" in combinators:
+        required_names = set().union(*required_sets) if required_sets else set()
+    else:
+        required_names = set.intersection(*required_sets) if required_sets else set()
+    root_required = schema.get("required")
+    if isinstance(root_required, list):
+        required_names |= {name for name in root_required if isinstance(name, str)}
+    flattened: dict[str, JsonValue] = {
+        key: value for key, value in schema.items() if key not in _TOP_LEVEL_COMBINATORS
+    }
+    flattened["type"] = "object"
+    flattened["properties"] = merged_properties
+    ordered_required = [name for name in merged_properties if name in required_names]
+    if ordered_required:
+        flattened["required"] = ordered_required
+    else:
+        flattened.pop("required", None)
+    return flattened

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -373,9 +373,11 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
     * a root combinator is flattened into one object. ``properties`` is the
       union of the variants' properties; a name two variants define
       DIFFERENTLY (a ``mode`` discriminator with ``const: read`` in one and
-      ``const: write`` in the other) keeps every distinct definition as a
-      nested ``anyOf``, which Anthropic accepts under ``properties``, so no
-      alternative is lost. ``required`` keeps the names every oneOf/anyOf
+      ``const: write`` in the other) keeps every distinct definition: the
+      oneOf/anyOf variants' definitions become a nested ``anyOf`` (any may
+      hold), the root's and allOf variants' definitions stay conjunctive
+      (``allOf``), and both nest under ``properties``, where Anthropic
+      accepts them, so no alternative or constraint is lost. ``required`` keeps the names every oneOf/anyOf
       variant requires plus every name any allOf variant requires, each
       combinator judged on its own variants. The combinator keys are dropped.
       What is lost is the variants' mutual exclusion, disclosed at admission
@@ -390,11 +392,23 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         return schema
     if reshaping == "type_object_added":
         return {**schema, "type": "object"}
-    merged: dict[str, list[JsonValue]] = {}
+    # Per property: definitions that must ALL hold (root properties, allOf
+    # variants) and definitions of which ANY may hold (oneOf/anyOf variants).
+    conjunctive: dict[str, list[JsonValue]] = {}
+    disjunctive: dict[str, list[JsonValue]] = {}
+    order: list[str] = []
+
+    def record(bucket: dict[str, list[JsonValue]], name: str, subschema: JsonValue) -> None:
+        if name not in order:
+            order.append(name)
+        definitions = bucket.setdefault(name, [])
+        if subschema not in definitions:
+            definitions.append(subschema)
+
     root_properties = schema.get("properties")
     if isinstance(root_properties, dict):
         for name, subschema in root_properties.items():
-            merged[name] = [subschema]
+            record(conjunctive, name, subschema)
     required_names: set[str] = set()
     for keyword in _TOP_LEVEL_COMBINATORS:
         listed = schema.get(keyword)
@@ -405,10 +419,9 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         for variant in variants:
             properties = variant.get("properties")
             if isinstance(properties, dict):
+                bucket = conjunctive if keyword == "allOf" else disjunctive
                 for name, subschema in properties.items():
-                    definitions = merged.setdefault(name, [])
-                    if subschema not in definitions:
-                        definitions.append(subschema)
+                    record(bucket, name, subschema)
             required = variant.get("required")
             requirement_sets.append(
                 {name for name in required if isinstance(name, str)}
@@ -428,11 +441,17 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         key: value for key, value in schema.items() if key not in _TOP_LEVEL_COMBINATORS
     }
     flattened["type"] = "object"
-    flattened["properties"] = {
-        name: (definitions[0] if len(definitions) == 1 else {"anyOf": definitions})
-        for name, definitions in merged.items()
-    }
-    ordered_required = [name for name in merged if name in required_names]
+    properties_out: dict[str, JsonValue] = {}
+    for name in order:
+        must = list(conjunctive.get(name, []))
+        may = disjunctive.get(name, [])
+        if may:
+            # Alternatives fold into one anyOf; it joins the conjunctive
+            # definitions (which all still apply) under allOf.
+            must.append(may[0] if len(may) == 1 else {"anyOf": may})
+        properties_out[name] = must[0] if len(must) == 1 else {"allOf": must}
+    flattened["properties"] = properties_out
+    ordered_required = [name for name in order if name in required_names]
     if ordered_required:
         flattened["required"] = ordered_required
     else:

--- a/exp/runtime/models/providers/anthropic_tool_compat.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat.py
@@ -370,13 +370,16 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
     that rejection across a dozen orgs, after dispatch). The reshaping is the
     provider-accepted equivalent, verified live:
 
-    * a root combinator is flattened into one object: ``properties`` is the
-      union of the variants' properties (first declaration wins on a name
-      clash), ``required`` keeps the names EVERY variant requires (allOf:
-      every name ANY variant requires), and the combinator key is dropped.
-      The mutual exclusion is lost, which is disclosed at admission
+    * a root combinator is flattened into one object. ``properties`` is the
+      union of the variants' properties; a name two variants define
+      DIFFERENTLY (a ``mode`` discriminator with ``const: read`` in one and
+      ``const: write`` in the other) keeps every distinct definition as a
+      nested ``anyOf``, which Anthropic accepts under ``properties``, so no
+      alternative is lost. ``required`` keeps the names every oneOf/anyOf
+      variant requires plus every name any allOf variant requires, each
+      combinator judged on its own variants. The combinator keys are dropped.
+      What is lost is the variants' mutual exclusion, disclosed at admission
       (``tools[i].parameters->reshaped(top_level_combinator_flattened)``);
-      the model still sees every property and its description;
     * a root without ``type`` gains ``"type": "object"``.
 
     A schema that needs neither is returned as the same object, so the
@@ -387,32 +390,37 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         return schema
     if reshaping == "type_object_added":
         return {**schema, "type": "object"}
-    combinators = [k for k in _TOP_LEVEL_COMBINATORS if isinstance(schema.get(k), list)]
-    variants: list[Mapping[str, JsonValue]] = []
-    for keyword in combinators:
-        listed = schema.get(keyword)
-        if isinstance(listed, list):
-            variants.extend(variant for variant in listed if isinstance(variant, dict))
-    merged_properties: dict[str, JsonValue] = {}
+    merged: dict[str, list[JsonValue]] = {}
     root_properties = schema.get("properties")
     if isinstance(root_properties, dict):
-        merged_properties.update(root_properties)
-    required_sets: list[set[str]] = []
-    for variant in variants:
-        properties = variant.get("properties")
-        if isinstance(properties, dict):
-            for name, subschema in properties.items():
-                merged_properties.setdefault(name, subschema)
-        required = variant.get("required")
-        required_sets.append(
-            {name for name in required if isinstance(name, str)}
-            if isinstance(required, list)
-            else set()
-        )
-    if "allOf" in combinators:
-        required_names = set().union(*required_sets) if required_sets else set()
-    else:
-        required_names = set.intersection(*required_sets) if required_sets else set()
+        for name, subschema in root_properties.items():
+            merged[name] = [subschema]
+    required_names: set[str] = set()
+    for keyword in _TOP_LEVEL_COMBINATORS:
+        listed = schema.get(keyword)
+        if not isinstance(listed, list):
+            continue
+        variants = [variant for variant in listed if isinstance(variant, dict)]
+        requirement_sets: list[set[str]] = []
+        for variant in variants:
+            properties = variant.get("properties")
+            if isinstance(properties, dict):
+                for name, subschema in properties.items():
+                    definitions = merged.setdefault(name, [])
+                    if subschema not in definitions:
+                        definitions.append(subschema)
+            required = variant.get("required")
+            requirement_sets.append(
+                {name for name in required if isinstance(name, str)}
+                if isinstance(required, list)
+                else set()
+            )
+        if not requirement_sets:
+            continue
+        if keyword == "allOf":
+            required_names |= set().union(*requirement_sets)
+        else:
+            required_names |= set.intersection(*requirement_sets)
     root_required = schema.get("required")
     if isinstance(root_required, list):
         required_names |= {name for name in root_required if isinstance(name, str)}
@@ -420,8 +428,11 @@ def anthropic_input_schema(schema: JsonObject) -> JsonObject:
         key: value for key, value in schema.items() if key not in _TOP_LEVEL_COMBINATORS
     }
     flattened["type"] = "object"
-    flattened["properties"] = merged_properties
-    ordered_required = [name for name in merged_properties if name in required_names]
+    flattened["properties"] = {
+        name: (definitions[0] if len(definitions) == 1 else {"anyOf": definitions})
+        for name, definitions in merged.items()
+    }
+    ordered_required = [name for name in merged if name in required_names]
     if ordered_required:
         flattened["required"] = ordered_required
     else:

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -7,6 +7,8 @@ from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
 from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_input_schema,
+    anthropic_input_schema_reshaping,
     anthropic_rejects_forced_tool_choice,
     anthropic_strict_schema_unsupported,
 )
@@ -316,3 +318,71 @@ def test_supported_features_pass_untouched() -> None:
         },
     )
     assert anthropic_strict_schema_unsupported(acyclic) is None
+
+
+def test_root_combinators_flatten_into_the_object_anthropic_accepts() -> None:
+    """A tool declared as a union of parameter shapes (valid for OpenAI) becomes
+    one object on the Anthropic wire: properties are the union, first
+    declaration wins on a clash, required keeps what EVERY variant requires,
+    the combinator key is gone, and the reshaping is named for disclosure
+    (live 2026-09-08: Anthropic 400s "does not support oneOf, allOf, or anyOf at
+    the top level" and accepts the merged object)."""
+    union: JsonObject = {
+        "description": "Read or write.",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {"path": {"type": "string"}, "mode": {"const": "read"}},
+                "required": ["path", "mode"],
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "clash: first wins"},
+                    "content": {"type": "string"},
+                    "mode": {"const": "write"},
+                },
+                "required": ["path", "content", "mode"],
+            },
+        ],
+    }
+    assert anthropic_input_schema_reshaping(union) == "top_level_combinator_flattened"
+    assert anthropic_input_schema(union) == {
+        "description": "Read or write.",
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "mode": {"const": "read"},
+            "content": {"type": "string"},
+        },
+        "required": ["path", "mode"],
+    }
+    # allOf requires everything any variant requires.
+    conjunction: JsonObject = {
+        "allOf": [
+            {"properties": {"a": {"type": "string"}}, "required": ["a"]},
+            {"properties": {"b": {"type": "integer"}}, "required": ["b"]},
+        ]
+    }
+    assert anthropic_input_schema(conjunction) == {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+        "required": ["a", "b"],
+    }
+
+
+def test_a_root_without_type_gains_object_and_everything_else_is_verbatim() -> None:
+    typeless: JsonObject = {"properties": {"q": {"type": "string"}}}
+    assert anthropic_input_schema_reshaping(typeless) == "type_object_added"
+    assert anthropic_input_schema(typeless) == {
+        "properties": {"q": {"type": "string"}},
+        "type": "object",
+    }
+    assert anthropic_input_schema({}) == {"type": "object"}
+    # A well-formed schema, nested combinators included, is the same object.
+    nested: JsonObject = {
+        "type": "object",
+        "properties": {"x": {"oneOf": [{"type": "string"}, {"type": "integer"}]}},
+    }
+    assert anthropic_input_schema_reshaping(nested) is None
+    assert anthropic_input_schema(nested) is nested

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -397,6 +397,26 @@ def test_root_combinators_flatten_into_the_object_anthropic_accepts() -> None:
             ]
         }
     }
+    # A root oneOf and a root anyOf on the SAME name are independent
+    # constraints, so each keeps its own anyOf member instead of pooling.
+    independent: JsonObject = {
+        "oneOf": [
+            {"properties": {"n": {"minimum": 0}}},
+            {"properties": {"n": {"maximum": -10}}},
+        ],
+        "anyOf": [
+            {"properties": {"n": {"multipleOf": 2}}},
+            {"properties": {"n": {"multipleOf": 3}}},
+        ],
+    }
+    assert anthropic_input_schema(independent)["properties"] == {
+        "n": {
+            "allOf": [
+                {"anyOf": [{"minimum": 0}, {"maximum": -10}]},
+                {"anyOf": [{"multipleOf": 2}, {"multipleOf": 3}]},
+            ]
+        }
+    }
     # allOf requires everything any variant requires.
     conjunction: JsonObject = {
         "allOf": [

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -378,6 +378,25 @@ def test_root_combinators_flatten_into_the_object_anthropic_accepts() -> None:
         "properties": {"a": {"type": "string"}, "b": {"type": "integer"}, "c": {"type": "integer"}},
         "required": ["a"],
     }
+    # A root property and an allOf variant constrain the same name TOGETHER
+    # (allOf), while oneOf alternatives for it join as one anyOf member.
+    layered: JsonObject = {
+        "properties": {"path": {"type": "string"}},
+        "allOf": [{"properties": {"path": {"minLength": 1}}}],
+        "oneOf": [
+            {"properties": {"path": {"pattern": "^/"}}},
+            {"properties": {"path": {"pattern": "^~"}}},
+        ],
+    }
+    assert anthropic_input_schema(layered)["properties"] == {
+        "path": {
+            "allOf": [
+                {"type": "string"},
+                {"minLength": 1},
+                {"anyOf": [{"pattern": "^/"}, {"pattern": "^~"}]},
+            ]
+        }
+    }
     # allOf requires everything any variant requires.
     conjunction: JsonObject = {
         "allOf": [

--- a/exp/runtime/models/providers/anthropic_tool_compat_test.py
+++ b/exp/runtime/models/providers/anthropic_tool_compat_test.py
@@ -351,11 +351,32 @@ def test_root_combinators_flatten_into_the_object_anthropic_accepts() -> None:
         "description": "Read or write.",
         "type": "object",
         "properties": {
-            "path": {"type": "string"},
-            "mode": {"const": "read"},
+            # Distinct definitions of one name survive as a nested anyOf, so the
+            # write discriminator is not lost to the read variant.
+            "path": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "string", "description": "clash: first wins"},
+                ]
+            },
+            "mode": {"anyOf": [{"const": "read"}, {"const": "write"}]},
             "content": {"type": "string"},
         },
         "required": ["path", "mode"],
+    }
+    # Mixed root combinators are judged per combinator: allOf requires every
+    # name any of ITS variants requires, oneOf only what all of ITS variants do.
+    mixed: JsonObject = {
+        "allOf": [{"properties": {"a": {"type": "string"}}, "required": ["a"]}],
+        "oneOf": [
+            {"properties": {"b": {"type": "integer"}}, "required": ["b"]},
+            {"properties": {"c": {"type": "integer"}}, "required": ["c"]},
+        ],
+    }
+    assert anthropic_input_schema(mixed) == {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "integer"}, "c": {"type": "integer"}},
+        "required": ["a"],
     }
     # allOf requires everything any variant requires.
     conjunction: JsonObject = {

--- a/exp/runtime/models/providers/bedrock_requests.py
+++ b/exp/runtime/models/providers/bedrock_requests.py
@@ -15,6 +15,7 @@ from typing import cast
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ModelMessage, ModelRequest, ToolChoice
+from exp.runtime.models.providers.anthropic_tool_compat import anthropic_input_schema
 from exp.runtime.models.providers.audios import reject_audio_part
 from exp.runtime.models.providers.documents import bedrock_document_block
 from exp.runtime.models.providers.errors import ProviderParameterError
@@ -337,7 +338,9 @@ def _tool_config(
         tool_spec: JsonObject = {
             "name": tool.name,
             "description": tool.description,
-            "inputSchema": {"json": tool.input_schema},
+            # Converse relays Anthropic's input_schema rules (root object,
+            # no root combinator), so the same reshaping applies here.
+            "inputSchema": {"json": anthropic_input_schema(tool.input_schema)},
         }
         if tool.name in strict_tool_names:
             tool_spec["strict"] = True

--- a/exp/runtime/models/providers/generation_parameter_validation.py
+++ b/exp/runtime/models/providers/generation_parameter_validation.py
@@ -6,7 +6,10 @@ import re
 from collections.abc import Callable, Sequence
 
 from exp.runtime.gateway.contracts import GatewayRequest
-from exp.runtime.models.providers.anthropic_tool_compat import anthropic_rejects_assistant_prefill
+from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_input_schema_reshaping,
+    anthropic_rejects_assistant_prefill,
+)
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.errors import ProviderParameterError
 from exp.runtime.models.providers.reasoning_compat import supported_reasoning_efforts
@@ -182,6 +185,30 @@ def require_tool_names_supported(
                 param=f"tools[{index}].name",
                 code="invalid_parameter",
             )
+
+
+_ANTHROPIC_SCHEMA_DIALECTS = frozenset({"anthropic_messages", "bedrock_converse_stream"})
+
+
+def disclose_anthropic_tool_schemas(
+    profiles: Sequence[GatewayWireProfile], request: GatewayRequest, ignored: list[str]
+) -> None:
+    """Record every tool schema an Anthropic-family rung will reshape at dispatch.
+
+    ``anthropic_input_schema`` flattens a root oneOf/anyOf/allOf into one
+    object and adds a missing root ``type``; the caller reads the change in
+    ``ignored_parameters`` as ``tools[i].parameters->reshaped(<kind>)``.
+    """
+    if not request.tools or not any(
+        profile.dialect in _ANTHROPIC_SCHEMA_DIALECTS for profile in profiles
+    ):
+        return
+    for index, tool in enumerate(request.tools):
+        kind = anthropic_input_schema_reshaping(tool.parameters)
+        if kind is not None:
+            note = f"tools[{index}].parameters->reshaped({kind})"
+            if note not in ignored:
+                ignored.append(note)
 
 
 def mid_conversation_system_present(request: GatewayRequest) -> bool:

--- a/exp/runtime/models/providers/messages_payloads.py
+++ b/exp/runtime/models/providers/messages_payloads.py
@@ -13,6 +13,7 @@ from exp.runtime.gateway.contracts import (
     GatewayRequest,
 )
 from exp.runtime.models.providers.anthropic_tool_compat import (
+    anthropic_input_schema,
     anthropic_rejects_forced_tool_choice,
     anthropic_strict_schema_unsupported,
 )
@@ -176,9 +177,13 @@ def anthropic_messages_stream_payload(
     if request.tools:
         tools: list[JsonObject] = []
         for tool in request.tools:
+            # Root combinators and a missing root type are reshaped into the
+            # object Anthropic accepts (disclosed at admission); everything
+            # else is the caller's schema verbatim.
+            input_schema = anthropic_input_schema(tool.parameters)
             translated: JsonObject = {
                 "name": tool.name,
-                "input_schema": tool.parameters,
+                "input_schema": input_schema,
             }
             # Anthropic rejects an explicit null description ("Input should
             # be a valid string"), so an absent description stays absent.
@@ -190,7 +195,7 @@ def anthropic_messages_stream_payload(
                 # 2026-09-05: ``maxItems`` on every current model). Declining
                 # here keeps the schema intact and lets admission drop only
                 # ``strict`` when no rung can honor it.
-                if anthropic_strict_schema_unsupported(tool.parameters) is not None:
+                if anthropic_strict_schema_unsupported(input_schema) is not None:
                     raise ProviderCapabilityError(capability="strict_tools")
                 translated["strict"] = True
             # Anthropic-native tool annotations forward verbatim on this

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -38,6 +38,7 @@ from exp.runtime.models.providers.fireworks import (
 )
 from exp.runtime.models.providers.generation_parameter_validation import (
     anthropic_reasoning_disengaged,
+    disclose_anthropic_tool_schemas,
     mid_conversation_system_present,
     require_assistant_prefill_supported,
     require_tool_names_supported,
@@ -265,9 +266,8 @@ def route_generation_parameter_requests(
             sampling_supported(profile, top_p=top_p) for profile in profiles
         )
 
-    # Sampling a rung cannot carry is DROPPED with disclosure, not refused; the
-    # 400 stays only for a value outside a supporting route's declared range
-    # (2026-09-06: 1,483 rejections / 289 orgs on one alias OpenAI itself refuses).
+    # Sampling a rung cannot carry is DROPPED with disclosure; the 400 stays only
+    # for an out-of-range value on a supporting route (2026-09-06: 1,483/289 orgs).
     if request.temperature is not None:
         if srn_only_block():
             ignore("temperature", "temperature->dropped(set_reasoning_effort_none)")
@@ -866,6 +866,7 @@ def route_generation_parameter_requests(
 
     require_assistant_prefill_supported(profiles, request)
     require_tool_names_supported(profiles, request)
+    disclose_anthropic_tool_schemas(profiles, request, ignored)
     # A mid-conversation system turn narrows out instruction-hoisting wires.
     if mid_conversation_system_present(request) and any(
         profile.dialect in {"gemini_generate_content", "bedrock_converse_stream"}
@@ -953,8 +954,7 @@ def route_generation_parameter_requests(
     elif request.parallel_tool_calls is not None and all(
         profile.dialect in _NO_PARALLEL_TOOL_CONTROL_DIALECTS for profile in profiles
     ):
-        # No rung carries a parallel-tool control: `true` drops (provider default),
-        # `false` is serialized by the data plane; mixed routes shape per rung.
+        # No rung has a parallel-tool control: true drops, false is serialized per rung.
         if request.parallel_tool_calls:
             ignore("parallel_tool_calls", "parallel_tool_calls->dropped(provider_default)")
         else:

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -2396,6 +2396,49 @@ def test_reasoning_context_passes_through_verbatim_and_narrows_per_rung() -> Non
     assert raised.value.code == "unsupported_parameter"
 
 
+def test_union_tool_schemas_are_reshaped_on_anthropic_rungs_and_disclosed() -> None:
+    """A root oneOf tool schema is flattened on the Anthropic wire (Anthropic
+    refuses root combinators; a dozen orgs hit that 400 after dispatch in the
+    week to 2026-09-08), left verbatim on the OpenAI wires, and the reshaping
+    is disclosed only when the route has an Anthropic-family rung."""
+    union: JsonObject = {
+        "oneOf": [
+            {"type": "object", "properties": {"a": {"type": "string"}}, "required": ["a"]},
+            {"type": "object", "properties": {"b": {"type": "integer"}}, "required": ["b"]},
+        ]
+    }
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content="go"),),
+        tools=(
+            GatewayToolDefinition(name="rw", parameters=union),
+            GatewayToolDefinition(name="plain", parameters={"type": "object"}),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = anthropic_messages_stream_payload("claude-fable-5", request)
+    tools = cast(list[JsonObject], payload["tools"])
+    assert tools[0]["input_schema"] == {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+    }
+    assert tools[1]["input_schema"] == {"type": "object"}
+    responses = openai_responses_stream_payload("gpt-6-astra", request, supports_temperature=False)
+    responses_tools = cast(list[JsonObject], responses["tools"])
+    assert responses_tools[0]["parameters"] == union
+
+    anthropic = GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test")
+    public, _provider = route_generation_parameter_requests((anthropic,), request)
+    assert "tools[0].parameters->reshaped(top_level_combinator_flattened)" in (
+        public.ignored_parameters
+    )
+    assert not any("tools[1]" in note for note in public.ignored_parameters)
+    compatible = GatewayWireProfile(dialect="openai_compatible", url="https://fw.test")
+    public, _provider = route_generation_parameter_requests((compatible,), request)
+    assert not any("reshaped" in note for note in public.ignored_parameters)
+
+
 def test_anthropic_tools_omit_an_absent_description() -> None:
     """Anthropic 400s an explicit null description, so the key stays absent.
 


### PR DESCRIPTION
## Why

A customer's first eight fable-5.1 turns were rejected by Anthropic with `tools.N.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level` and `tools.0.custom.input_schema.type: Field required`. Their coding agent declares some tools as a union of parameter shapes, which OpenAI's `parameters` accepts and Anthropic's `input_schema` does not. Fleet-wide over the last 7 days the same two rejections hit about a dozen orgs, always after dispatch.

Live probe (2026-09-08, house key): Anthropic refuses a root `oneOf`/`anyOf`/`allOf` even under `type: object`, refuses a root without `type`, and accepts both the merged object and combinators nested under `properties`.

## What

- `anthropic_tool_compat.anthropic_input_schema`: a root combinator is flattened into one object (properties = union of the variants', first declaration wins on a clash; `required` = names every variant requires, or every name any variant requires for `allOf`; combinator dropped; root `type: object`), and a root without `type` gains `"type": "object"`. A schema needing neither is returned as the same object. `anthropic_input_schema_reshaping` names the change.
- Applied on the Anthropic Messages wire (`messages_payloads`, also feeding the strict-schema check) and on Bedrock Converse (which relays Anthropic's rules). OpenAI and Gemini wires are untouched.
- Admission discloses the lossy part as `tools[i].parameters->reshaped(top_level_combinator_flattened | type_object_added)` in `ignored_parameters`, only when the route has an Anthropic-family rung.

## Verification

`ruff`, `ty`, provider suites and repo layout green. New tests: the reshaper (union flatten with clash and required rules, allOf, typeless root, verbatim identity for nested combinators) and the wire-level test (Anthropic payload flattened, Responses payload verbatim, disclosure only on Anthropic-family routes). Full pytest running. Python only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)