### PR TITLE
openai_protocol: accept promptCacheKey as an alias of prompt_cache_key (AI SDK clients)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -339,6 +339,11 @@ discarded before provider dispatch and canonical replay identity; the `url` and
 `detail` remain authoritative. A data URL keeps its embedded MIME type, and a
 remote URL is forwarded for the provider to fetch. Unknown image fields and
 malformed URLs or base64 remain rejected.
+Both OpenAI surfaces accept the Vercel AI SDK's camelCase `promptCacheKey` (sent verbatim by
+opencode and other `ai-sdk` coding clients) as an alias of `prompt_cache_key`: it is renamed
+before manifest validation and decodes exactly as the documented field. When both spellings
+arrive, `prompt_cache_key` wins and the dropped alias is disclosed through `ignored_parameters`.
+It is the only camelCase spelling admitted; every other unknown top-level field stays a named 400.
 Chat streaming emits valid completion chunks and one `[DONE]`. Responses streaming emits the
 created, in-progress, output, and exactly one terminal lifecycle. Provider tool-argument fragments
 are accumulated in original order and validated only at the complete-call boundary.

--- a/exp/runtime/openai_protocol/prompt_cache_key_alias.py
+++ b/exp/runtime/openai_protocol/prompt_cache_key_alias.py
@@ -1,0 +1,43 @@
+"""Fold the camelCase ``promptCacheKey`` alias onto ``prompt_cache_key``.
+
+Coding clients built on the Vercel AI SDK (opencode, mimocode) place the
+provider option ``promptCacheKey`` verbatim in the OpenAI request body instead
+of the documented snake_case wire field. The alias is renamed here, before the
+compatibility manifest sees the body, so the request proceeds exactly as if
+``prompt_cache_key`` had been sent. This is the one camelCase spelling the
+OpenAI surfaces admit; every other unknown top-level field stays rejected by
+name.
+"""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject
+
+PROMPT_CACHE_KEY_ALIAS = "promptCacheKey"
+"""Vercel AI SDK spelling of the OpenAI ``prompt_cache_key`` wire field."""
+
+PROMPT_CACHE_KEY_ALIAS_IGNORED = f"{PROMPT_CACHE_KEY_ALIAS}->ignored(explicit_prompt_cache_key)"
+"""Disclosure emitted when both spellings arrive and the alias is dropped."""
+
+_CANONICAL = "prompt_cache_key"
+
+
+def fold_prompt_cache_key_alias(payload: JsonObject) -> tuple[JsonObject, tuple[str, ...]]:
+    """Rename a top-level ``promptCacheKey`` to ``prompt_cache_key``.
+
+    Args:
+        payload: Parsed Chat Completions or Responses body.
+
+    Returns:
+        The original payload when the alias is absent; otherwise a shallow copy
+        without the alias, carrying its value under ``prompt_cache_key`` unless
+        the canonical field was already present, in which case the canonical
+        value wins and the dropped alias is named in the returned disclosures.
+    """
+    if PROMPT_CACHE_KEY_ALIAS not in payload:
+        return payload, ()
+    folded = {key: value for key, value in payload.items() if key != PROMPT_CACHE_KEY_ALIAS}
+    if _CANONICAL in payload:
+        return folded, (PROMPT_CACHE_KEY_ALIAS_IGNORED,)
+    folded[_CANONICAL] = payload[PROMPT_CACHE_KEY_ALIAS]
+    return folded, ()

--- a/exp/runtime/openai_protocol/prompt_cache_key_alias_test.py
+++ b/exp/runtime/openai_protocol/prompt_cache_key_alias_test.py
@@ -1,0 +1,46 @@
+"""Tests for folding the camelCase ``promptCacheKey`` alias onto ``prompt_cache_key``."""
+
+from __future__ import annotations
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.openai_protocol.prompt_cache_key_alias import (
+    PROMPT_CACHE_KEY_ALIAS_IGNORED,
+    fold_prompt_cache_key_alias,
+)
+
+
+def test_payload_without_the_alias_is_returned_unchanged() -> None:
+    """No alias means no copy and no disclosure, even when the canonical field is set."""
+    payload: JsonObject = {"model": "coding", "prompt_cache_key": "pck"}
+    folded, disclosures = fold_prompt_cache_key_alias(payload)
+    assert folded is payload
+    assert disclosures == ()
+
+
+def test_alias_alone_is_renamed_to_the_canonical_field() -> None:
+    """The camelCase value lands under ``prompt_cache_key`` with nothing to disclose."""
+    payload: JsonObject = {"model": "coding", "promptCacheKey": "sess-1"}
+    folded, disclosures = fold_prompt_cache_key_alias(payload)
+    assert folded == {"model": "coding", "prompt_cache_key": "sess-1"}
+    assert disclosures == ()
+    # The caller's object is never mutated.
+    assert payload == {"model": "coding", "promptCacheKey": "sess-1"}
+
+
+def test_canonical_field_wins_over_the_alias_and_the_drop_is_disclosed() -> None:
+    """Both spellings present: snake_case is kept and the alias is named as ignored."""
+    payload: JsonObject = {
+        "model": "coding",
+        "prompt_cache_key": "snake",
+        "promptCacheKey": "camel",
+    }
+    folded, disclosures = fold_prompt_cache_key_alias(payload)
+    assert folded == {"model": "coding", "prompt_cache_key": "snake"}
+    assert disclosures == (PROMPT_CACHE_KEY_ALIAS_IGNORED,)
+    assert PROMPT_CACHE_KEY_ALIAS_IGNORED == "promptCacheKey->ignored(explicit_prompt_cache_key)"
+
+
+def test_alias_value_is_carried_verbatim_for_downstream_validation() -> None:
+    """The fold renames only; a non-string value reaches the wire model as sent."""
+    folded, _ = fold_prompt_cache_key_alias({"promptCacheKey": 7})
+    assert folded == {"prompt_cache_key": 7}

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -47,6 +47,7 @@ from exp.runtime.openai_protocol.manifest import (
     disposition_map,
 )
 from exp.runtime.openai_protocol.media_parts import message_content
+from exp.runtime.openai_protocol.prompt_cache_key_alias import fold_prompt_cache_key_alias
 from exp.runtime.openai_protocol.responses_input import (
     ReplayedFunctionCall,
     ReplayedFunctionOutput,
@@ -158,7 +159,9 @@ def decode_chat(
     OpenCode may attach an Anthropic-style ``cache_control`` annotation on
     Chat messages and on text content parts. Supported ephemeral forms are
     validated and removed before official OpenAI validation and before
-    canonical conversion. Other unknown nested fields stay rejected.
+    canonical conversion. Other unknown nested fields stay rejected. The
+    Vercel AI SDK's camelCase ``promptCacheKey`` is folded onto
+    ``prompt_cache_key`` first, so it decodes as the documented wire field.
 
     Args:
         payload: Parsed JSON request body.
@@ -171,6 +174,7 @@ def decode_chat(
     Raises:
         OpenAIProtocolError: The body is invalid, unknown, or unsupported.
     """
+    payload, alias_disclosures = fold_prompt_cache_key_alias(payload)
     payload = drop_opencode_cache_control(payload)
     _validate_manifest(payload, CHAT_MANIFEST)
     # The installed SDK's effort literal lags the newest provider tier
@@ -206,7 +210,11 @@ def decode_chat(
             tool_choice=_chat_tool_choice(request.tool_choice),
             parallel_tool_calls=request.parallel_tool_calls,
             structured_text=chat_structured_text(request.response_format),
-            ignored_parameters=(*json_object_disclosure, *thinking.disclosures),
+            ignored_parameters=(
+                *alias_disclosures,
+                *json_object_disclosure,
+                *thinking.disclosures,
+            ),
             maximum_output_tokens=maximum,
             maximum_output_tokens_parameter=(
                 "max_completion_tokens"
@@ -293,6 +301,7 @@ def decode_responses(
     Raises:
         OpenAIProtocolError: The body is invalid, unknown, or unsupported.
     """
+    payload, alias_disclosures = fold_prompt_cache_key_alias(payload)
     _validate_manifest(payload, RESPONSES_MANIFEST)
     # The installed SDK's effort literal lags the newest provider tier
     # ("ultra"), so the strict wire model owns reasoning validation.
@@ -376,6 +385,7 @@ def decode_responses(
             tool_choice=_responses_tool_choice(request.tool_choice),
             parallel_tool_calls=request.parallel_tool_calls,
             structured_text=responses_structured_text(request.text),
+            ignored_parameters=alias_disclosures,
             maximum_output_tokens=request.max_output_tokens,
             maximum_output_tokens_parameter=(
                 "max_output_tokens" if request.max_output_tokens is not None else None

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -972,6 +972,90 @@ def test_responses_decoder_captures_end_user_attribution() -> None:
     assert request.attribution_label == "sid-9"
 
 
+def test_chat_decoder_folds_the_ai_sdk_prompt_cache_key_alias() -> None:
+    """A camelCase-only ``promptCacheKey`` (Vercel AI SDK) decodes as ``prompt_cache_key``."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "promptCacheKey": "opencode-session-1",
+        }
+    )
+    request = decoded.request
+    assert request.prompt_cache_key == "opencode-session-1"
+    assert request.attribution_label is None
+    assert request.ignored_parameters == ()
+
+
+def test_chat_decoder_prefers_snake_case_over_the_alias_and_discloses_the_drop() -> None:
+    """Both spellings present: the documented wire field wins and the alias is disclosed."""
+    decoded = decode_chat(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt_cache_key": "snake",
+            "promptCacheKey": "camel",
+        }
+    )
+    request = decoded.request
+    assert request.prompt_cache_key == "snake"
+    assert request.ignored_parameters == ("promptCacheKey->ignored(explicit_prompt_cache_key)",)
+
+
+def test_chat_decoder_validates_the_alias_value_as_prompt_cache_key() -> None:
+    """The alias is renamed, not trusted: its value meets the canonical field's contract."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "promptCacheKey": ["not", "a", "string"],
+            }
+        )
+    assert captured.value.status_code == 400
+    assert captured.value.detail.param == "prompt_cache_key"
+
+
+@pytest.mark.parametrize("field", ["safetyIdentifier", "maxTokens", "serviceTier"])
+def test_chat_decoder_still_rejects_other_camel_case_fields(field: str) -> None:
+    """Only ``promptCacheKey`` is aliased; every other camelCase field stays a named 400."""
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                field: "value",
+            }
+        )
+    assert captured.value.status_code == 400
+    assert captured.value.detail.code == "unsupported_parameter"
+    assert captured.value.detail.param == field
+
+
+def test_responses_decoder_folds_the_ai_sdk_prompt_cache_key_alias() -> None:
+    """The Responses surface folds ``promptCacheKey`` the same way as Chat."""
+    decoded = decode_responses(
+        {"model": "coding", "input": "hi", "promptCacheKey": "opencode-session-2"}
+    )
+    assert decoded.request.prompt_cache_key == "opencode-session-2"
+    assert decoded.request.ignored_parameters == ()
+    both = decode_responses(
+        {
+            "model": "coding",
+            "input": "hi",
+            "prompt_cache_key": "snake",
+            "promptCacheKey": "camel",
+        }
+    )
+    assert both.request.prompt_cache_key == "snake"
+    assert both.request.ignored_parameters == (
+        "promptCacheKey->ignored(explicit_prompt_cache_key)",
+    )
+    with pytest.raises(OpenAIProtocolError) as captured:
+        decode_responses({"model": "coding", "input": "hi", "safetyIdentifier": "x"})
+    assert captured.value.detail.param == "safetyIdentifier"
+
+
 def test_responses_decoder_accepts_the_codex_request_shape() -> None:
     """store:false, include, ultra effort, and replayed reasoning all decode."""
     decoded = decode_responses(


### PR DESCRIPTION
## Problem (production, 2026-09-08)

Coding clients built on the Vercel AI SDK send the camelCase provider option `promptCacheKey` verbatim in the OpenAI chat-completions body. The engine's manifest validation treats it as an unknown top-level field and answers:

```
400 unsupported_parameter, param "promptCacheKey"
"The parameter 'promptCacheKey' is not supported by this gateway profile. Remove the field and resend the request."
```

Every request from those clients fails before admission and billing.

- 13 rejections today from 3 user agents, all AI SDK on Bun: `mimocode/local ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14` and `opencode/1.18.x ai-sdk/...`.
- A paying customer hit it 8 times tonight and concluded "none of the models are working".
- OpenAI's real wire field is `prompt_cache_key`, which both the Chat and Responses manifests already admit as `CONDITIONALLY_SUPPORTED`.

## Change

- New `exp/runtime/openai_protocol/prompt_cache_key_alias.py`: `fold_prompt_cache_key_alias` renames a top-level `promptCacheKey` to `prompt_cache_key` and returns the folded payload plus disclosures. Pure rename, no value coercion: the alias value still meets the canonical field's wire-model contract.
- `decode_chat` and `decode_responses` call the fold before `_validate_manifest`, so the request proceeds exactly as if `prompt_cache_key` had been sent (affinity digest, official SDK probe, and canonical request all see the snake_case field).
- Both present: `prompt_cache_key` wins and the dropped alias is disclosed as `promptCacheKey->ignored(explicit_prompt_cache_key)` through the existing `ignored_parameters` mechanism (same `path->action(reason)` vocabulary as `enable_thinking`). Responses previously passed no `ignored_parameters`; it now carries this one disclosure.
- Scope: only this one camelCase spelling is admitted. Every other unknown or camelCase top-level field (`safetyIdentifier`, `maxTokens`, `serviceTier`, ...) still 400s by name; the tests pin that. Silently ignoring unknown fields in general remains a separate product decision.
- Docs: one paragraph in `docs/reference/gateway-architecture.md` next to the Copilot image-hint note.

Rule 14 note: this is a client-compatibility alias for a live wire spelling that two shipping coding agents send, not a shim for a retired contract of ours. Flagging it explicitly per AGENTS.md so it is an approved, not silent, alias.

## Tests

- `prompt_cache_key_alias_test.py`: unchanged passthrough, alias-only rename, both-present preference + disclosure, non-string value carried verbatim for downstream validation.
- `requests_test.py`: chat camelCase-only lands as `prompt_cache_key` with empty `ignored_parameters`; both present prefers snake_case and discloses; alias with a non-string value 400s under `prompt_cache_key`; `safetyIdentifier`/`maxTokens`/`serviceTier` still rejected as `unsupported_parameter` with their own param; Responses surface folds the alias the same way and still rejects other camelCase fields.

Results:

| Suite | Result |
| --- | --- |
| `exp/runtime/openai_protocol` | 314 passed |
| `exp/runtime/gateway` + `exp/tests` | 994 passed, 3 skipped (1 xdist flake in `native_images_test`, passes alone) |
| full `exp` suite (`-n auto`) | 4026 passed, 6 skipped, 3 failed, 1 error |
| `ruff check .`, `ruff format --check .`, `ty check` | all pass |

The four full-suite non-passes are not from this change: `comparison_evidence_test` passes serially (xdist flake); `terminal_tasks_happy_path_test` errored only because I ran with `-p no:cacheprovider`, passes without it; `composition_evidence_test` requires a checkout with no staged changes; `native_waterfall_test::test_ledger_conserves_every_admitted_request` fails identically on a clean `origin/main` worktree (`assert 1 == 12`, pre-existing).

## Known limitation

An invalid alias value (for example a non-string `promptCacheKey`) is reported under param `prompt_cache_key`, not the spelling the caller used. The AI SDK always sends a string, so this only affects hand-built bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
