### PR TITLE
release: bump experiential to 0.7.59 (native 0.3.47)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.58"
+version = "0.7.59"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.58"
+version = "0.7.59"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the v0.7.59 release, shipping #873: tool `input_schema` reshaped for the Anthropic and Bedrock wires (root oneOf/anyOf/allOf flattened into the object Anthropic accepts, missing root type added), disclosed at admission. Publishing: merge, then `gh release create v0.7.59 --target <merge sha>`, then the platform repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)