### PR TITLE
fix(gateway/batch): handle UnicodeDecodeError in parse_input_jsonl and render 400 error

### DIFF
--- a/exp/runtime/gateway/batch/contracts.py
+++ b/exp/runtime/gateway/batch/contracts.py
@@ -356,8 +356,12 @@ def parse_input_jsonl(payload: bytes) -> list[tuple[int, JsonObject]]:
         raise BatchSubmitError(
             f"batch input exceeds {MAXIMUM_INPUT_FILE_BYTES} bytes; split the job"
         )
+    try:
+        decoded = payload.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise BatchSubmitError(f"batch input is not valid UTF-8: {exc.reason}") from exc
     lines: list[tuple[int, JsonObject]] = []
-    for line_number, raw in enumerate(payload.decode("utf-8", errors="strict").splitlines(), 1):
+    for line_number, raw in enumerate(decoded.splitlines(), 1):
         text = raw.strip()
         if not text:
             continue

--- a/exp/runtime/gateway/batch/contracts_test.py
+++ b/exp/runtime/gateway/batch/contracts_test.py
@@ -64,6 +64,12 @@ def test_parse_input_jsonl_rejects_empty_payload() -> None:
         parse_input_jsonl(b"\n\n")
 
 
+def test_parse_input_jsonl_rejects_non_utf8_payload() -> None:
+    """A payload containing non-UTF-8 bytes is refused with a clear error."""
+    with pytest.raises(BatchSubmitError, match="not valid UTF-8"):
+        parse_input_jsonl(b"\x80\x81\x82")
+
+
 def test_parse_input_jsonl_enforces_the_line_budget() -> None:
     """One line above the product cap refuses the whole payload."""
     payload = b"\n".join(b'{"custom_id": "x"}' for _ in range(MAXIMUM_BATCH_LINES + 1))

--- a/exp/runtime/gateway/batch/plane_test.py
+++ b/exp/runtime/gateway/batch/plane_test.py
@@ -184,6 +184,13 @@ def test_malformed_payloads_and_bad_base64_are_client_errors() -> None:
     assert parsed["status"] == 400
     status, body = _call(plane, "file_create", purpose="batch", content_b64="@@@")
     assert status == 400 and "base64" in body["error"]["message"]
+    status, body = _call(
+        plane,
+        "file_create",
+        purpose="batch",
+        content_b64=base64.b64encode(b"\x80\x81\x82").decode("ascii"),
+    )
+    assert status == 400 and "UTF-8" in body["error"]["message"]
 
 
 def test_unknown_ids_map_to_404() -> None:


### PR DESCRIPTION
Closes #878

### Summary
In `exp.runtime.gateway.batch.contracts.parse_input_jsonl`, calling `payload.decode("utf-8", errors="strict")` directly without exception handling allowed non-UTF-8 payloads to raise an unhandled `UnicodeDecodeError`. 

Because `BatchControlPlane.file_create` only catches `BatchSubmitError`, unhandled decoding errors bubbled out to the data plane, rendering a 500 error instead of the documented 400 client error envelope.

### Changes
1. **`contracts.py`**: Wrapped `payload.decode("utf-8", errors="strict")` in a `try...except UnicodeDecodeError` block to raise `BatchSubmitError(f"batch input is not valid UTF-8: {exc.reason}")`.
2. **`contracts_test.py`**: Added `test_parse_input_jsonl_rejects_non_utf8_payload` asserting `BatchSubmitError` is raised on non-UTF-8 bytes.
3. **`plane_test.py`**: Added an assertion to `test_malformed_payloads_and_bad_base64_are_client_errors` ensuring non-UTF-8 file uploads produce an HTTP 400 response.

### Verification
- `uv run ruff check .` (passed)
- `uv run ruff format --check .` (passed)
- `uv run ty check` (passed)
- `uv run pytest exp/runtime/gateway/batch/` (113 passed, 3 skipped)
