### PR TITLE
release: bump experiential to 0.7.60 (promptCacheKey alias + tokenizer-based reservation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.59"
+version = "0.7.60"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.59"
+version = "0.7.60"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Release train for two merged changes:
- #874: promptCacheKey accepted as an alias of prompt_cache_key on chat + Responses.
- #877: input-token reservation from an o200k tokenizer estimate (+15% headroom) instead of the byte bound; the encoding table ships in the wheel (no runtime egress). Adds runtime dep tiktoken>=0.9,<1.

Native crate unchanged at 0.3.47. Mirrors #875: pyproject version + uv.lock only. The tag targets this PR's merge commit, which sits after b214b54af (#877) on main.

After merge: `gh release create v0.7.60 --target <merge sha>` publishes to PyPI; platform repin follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)