### PR TITLE
cli: report invalid dotenv files without tracebacks

### DIFF
--- a/exp/cli/app.py
+++ b/exp/cli/app.py
@@ -126,10 +126,19 @@ def _quiet_http_logs() -> None:
 def main() -> None:
     """Load local environment settings, quiet HTTP logs, and dispatch the CLI.
 
-    The explicit entrypoint keeps environment loading out of import time, so library imports
-    cannot mutate an operator's process environment.
+    The explicit entrypoint keeps environment loading out of import time while retaining its
+    pre-parse timing for CLI option environment variables. Invalid environment files are rendered
+    through Typer's standard usage-error type before command parsing begins.
+
+    Raises:
+        SystemExit: The local environment file cannot be read safely.
     """
-    load_env_file()
+    try:
+        load_env_file()
+    except ValueError as exc:
+        error = typer.BadParameter(str(exc), param_hint=".env")
+        error.show()
+        raise SystemExit(error.exit_code) from None
     _quiet_http_logs()
     app()
 

--- a/exp/cli/app_test.py
+++ b/exp/cli/app_test.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 from typer import Context
 from typer.core import TyperGroup
 from typer.main import get_group
 
-from exp.cli.app import app
+from exp.cli.app import app, main
 
 EXPECTED_SUBCOMMANDS = {
     "config": {"budget", "gateway", "judge", "providers", "telemetry"},
@@ -29,3 +32,23 @@ def test_root_cli_and_subgroups_are_exact() -> None:
         assert isinstance(command, TyperGroup)
         context = Context(command, parent=root_context, info_name=name)
         assert set(command.list_commands(context)) == expected
+
+
+def test_main_reports_an_invalid_dotenv_before_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CLI startup should frame an invalid environment file without dispatch or traceback."""
+    (tmp_path / ".env").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as captured:
+        main()
+
+    assert captured.value.code == 2
+    output = capsys.readouterr()
+    assert "Invalid value for .env" in output.err
+    assert "regular UTF-8 text file: .env" in output.err
+    assert "remove it" in output.err
+    assert "Traceback" not in output.err

--- a/exp/common/config/dotenv.py
+++ b/exp/common/config/dotenv.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import os
+import stat
 from pathlib import Path
 
 ENV_FILE = ".env"
+_INVALID_ENV_FILE = (
+    "environment file must be a readable regular UTF-8 text file: {path}; "
+    "repair or replace it, or remove it to continue without one"
+)
 
 
 def load_env_file(path: str | Path = ENV_FILE) -> None:
@@ -13,11 +18,29 @@ def load_env_file(path: str | Path = ENV_FILE) -> None:
 
     Args:
         path: File containing ``KEY=VALUE`` lines.
+
+    Raises:
+        ValueError: The existing path is not a readable regular UTF-8 text file.
     """
     env_path = Path(path)
-    if not env_path.exists():
+    try:
+        descriptor = os.open(env_path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
+    except FileNotFoundError:
         return
-    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+    except OSError as exc:
+        raise ValueError(_INVALID_ENV_FILE.format(path=env_path)) from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError(_INVALID_ENV_FILE.format(path=env_path))
+        with os.fdopen(descriptor, encoding="utf-8") as handle:
+            descriptor = -1
+            contents = handle.read()
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(_INVALID_ENV_FILE.format(path=env_path)) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    for raw_line in contents.splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue

--- a/exp/common/config/dotenv_test.py
+++ b/exp/common/config/dotenv_test.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+
+import pytest
 
 from exp.common.config.dotenv import load_env_file
+
+
+def test_load_env_file_ignores_a_missing_path(tmp_path: Path) -> None:
+    """An absent environment file remains an intentional no-op."""
+    load_env_file(tmp_path / "missing.env")
 
 
 def test_load_env_file_sets_only_unset_vars(tmp_path, monkeypatch) -> None:  # noqa: ANN001
@@ -23,3 +31,42 @@ def test_load_env_file_sets_only_unset_vars(tmp_path, monkeypatch) -> None:  # n
     assert os.environ["EXP_TEST_SET"] == "from-env"  # not overridden
     monkeypatch.delenv("EXP_TEST_NEW")
     monkeypatch.delenv("EXP_TEST_KEPT")
+
+
+def test_load_env_file_rejects_a_directory_with_actionable_context(tmp_path: Path) -> None:
+    """A directory path should become a configuration error that identifies the path."""
+    env_path = tmp_path / ".env"
+    env_path.mkdir()
+
+    with pytest.raises(ValueError) as captured:
+        load_env_file(env_path)
+
+    message = str(captured.value)
+    assert str(env_path) in message
+    assert "regular UTF-8 text file" in message
+    assert "remove it" in message
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO files are not portable")
+def test_load_env_file_rejects_a_fifo_without_blocking(tmp_path: Path) -> None:
+    """The opened descriptor must be validated before a special file can block a read."""
+    env_path = tmp_path / ".env"
+    os.mkfifo(env_path)
+
+    with pytest.raises(ValueError, match="regular UTF-8 text file"):
+        load_env_file(env_path)
+
+
+def test_load_env_file_rejects_non_utf8_content_with_actionable_context(tmp_path: Path) -> None:
+    """Invalid UTF-8 should become a configuration error that identifies remediation."""
+    env_path = tmp_path / ".env"
+    env_path.write_bytes(b"EXP_TEST_SECRET=\xff\n")
+
+    with pytest.raises(ValueError) as captured:
+        load_env_file(env_path)
+
+    message = str(captured.value)
+    assert str(env_path) in message
+    assert "regular UTF-8 text file" in message
+    assert "remove it" in message
+    assert isinstance(captured.value.__cause__, UnicodeDecodeError)


### PR DESCRIPTION
## Why

CLI startup read `.env` after checking only that the path existed. A directory raised raw
`IsADirectoryError`, and non-UTF-8 content raised a decoder error without identifying the
configuration contract or recovery action.

Closes #882.

## What

- Preserve the missing-file no-op while requiring an existing `.env` to be a regular file.
- Open the path once with a nonblocking descriptor, validate that descriptor as a regular file,
  and read through the same descriptor so a replacement race cannot introduce a blocking FIFO.
- Convert narrow open, descriptor, read, and UTF-8 decoding failures into an actionable
  `ValueError` that names the path and tells the user to repair, replace, or remove it.
- Preserve underlying I/O and decoding errors as exception causes.
- Render the configuration failure through Typer before command parsing while retaining the
  original pre-parse environment-loading behavior.
- Add loader regressions for missing, directory, FIFO, and non-UTF-8 paths, plus a CLI regression
  proving exit code 2 with no traceback.

## Validation

- `.venv/bin/pytest -q exp/common/config exp/cli/app_test.py`
  - 26 passed
- `.venv/bin/ruff check .`
  - passed
- `.venv/bin/ruff format --check .`
  - 827 files passed
- `.venv/bin/ty check`
  - passed
- `timeout 180 .venv/bin/pytest -q -x`
  - 109 passed before the unrelated gateway socket test hit the workspace sandbox restriction:
    `PermissionError: [Errno 1] Operation not permitted`
