### PR TITLE
DeepSeek: replay and backfill reasoning_content on assistant tool-call turns (thinking-mode 400 fix)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -520,6 +520,22 @@ including routes with no exposing rung. Gateway-issued carriers are recognized b
 scheme prefix and retain strict parsing, authentication, and route binding; malformed carriers
 never become plaintext history.
 
+DeepSeek's own origin (`https://api.deepseek.com`, `is_deepseek_base_url`) is a reasoning-HISTORY
+route by origin, independent of the exposure stamp (`GatewayWireProfile.deepseek_reasoning_history`).
+Its thinking mode, on by default, rejects a request that carries `tools` unless every assistant
+message with `tool_calls` in the history carries `reasoning_content` (HTTP 400 ``The
+`reasoning_content` in the thinking mode must be passed back to the API.``), while accepting an
+empty string exactly like real reasoning (verified live 2026-09-10). On that rung the Chat builder
+forwards caller plaintext `reasoning_content` verbatim on plain and tool-call turns alike, and a
+tool-call turn that arrives without the field (a history started on another provider, or an
+OpenAI-compatible SDK that strips the extension) is backfilled with `reasoning_content: ""`;
+non-tool turns are never backfilled and no other origin is touched. The rung counts as a carrying
+rung for narrowing and disclosure (`replays_plaintext_reasoning`), so no drop is disclosed there.
+`reasoning_output_exposed` keeps its one meaning on DeepSeek: whether the caller SEES the reasoning
+deltas on output. Unstamped, the caller never receives reasoning to replay and the empty backfill
+is what keeps agent loops alive; stamped, the caller replays the real text and the backfill only
+covers turns minted elsewhere.
+
 Route admission preserves caller capabilities in three verbatim-preference layers before any
 coercion: operationally dead rungs are skipped (`dispatchable_route_profiles`), generation
 controls narrow the waterfall to the rungs that preserve every exact value

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -232,6 +232,17 @@ class GatewayWireProfile:
     category (Tencent/DeepSeek/Anthropic) so the caller sees the model's thinking
     it is already billed for; the round-trip token stays the sealed carrier."""
 
+    deepseek_reasoning_history: bool = False
+    """Whether this rung is DeepSeek's own API, whose thinking mode enforces
+    ``reasoning_content`` on every assistant tool-call turn in the history.
+
+    Origin-derived (``is_deepseek_base_url``), never a catalog stamp: the Chat
+    wire builder replays caller plaintext ``reasoning_content`` verbatim on
+    this rung and backfills an empty string on a tool-call turn that lacks it
+    (DeepSeek validates presence, not content; verified live 2026-09-10).
+    Independent of ``reasoning_output_exposed``, which still decides alone
+    whether the caller SEES the reasoning deltas on output."""
+
     token_limit_key: ChatMaxTokensField = "max_tokens"
     """Wire field carrying the output-token ceiling on Chat Completions."""
 
@@ -252,6 +263,17 @@ class GatewayWireProfile:
     images_url: str | None = None
     """Full OpenAI-wire ``/images/generations`` endpoint for this connection,
     sharing ``headers``; ``None`` when the connection speaks no images wire."""
+
+    @property
+    def replays_plaintext_reasoning(self) -> bool:
+        """Whether this rung forwards caller plaintext ``reasoning_content`` verbatim.
+
+        True on an exposure-stamped rung (the caller replays what that rung
+        itself returned) and on DeepSeek's origin, which REQUIRES the field on
+        tool-call history regardless of whether its output is exposed. Route
+        narrowing and the disclosure gate read this, never the two flags apart.
+        """
+        return self.reasoning_output_exposed or self.deepseek_reasoning_history
 
     def __post_init__(self) -> None:
         """Reject malformed operator wire contracts before admission."""

--- a/exp/runtime/models/providers/deepseek.py
+++ b/exp/runtime/models/providers/deepseek.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""DeepSeek first-party origin detection.
+
+DeepSeek's own API (``https://api.deepseek.com``) serves an OpenAI-compatible
+Chat Completions endpoint whose thinking mode is ON by default and enforced on
+the wire (verified live 2026-09-10): in a request that carries ``tools``, every
+assistant message in the history that has ``tool_calls`` must carry a
+``reasoning_content`` field, unless DeepSeek itself minted that call earlier in
+the same session. Otherwise it answers HTTP 400 ``"The `reasoning_content` in
+the thinking mode must be passed back to the API."`` The value is not
+validated: an empty string is accepted exactly like real reasoning text.
+
+Recognizing the origin here lets the Chat wire builder replay caller-supplied
+``reasoning_content`` verbatim and backfill an empty one on tool-call turns
+that lack it, so agent loops whose history started on another provider (or
+whose SDK strips the field) keep working. Nothing about OUTPUT exposure is
+decided here: whether the caller sees DeepSeek's reasoning deltas stays the
+catalog's ``reasoning_output_exposed`` stamp.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+# DeepSeek documents two equivalent OpenAI-compatible roots: the bare origin
+# and its ``/v1`` alias (the path the platform's house lane dispatches to).
+# The ``/beta`` root is a different feature surface and is deliberately not
+# matched until a lane dispatches through it.
+_DEEPSEEK_HOST = "api.deepseek.com"
+_DEEPSEEK_ROOT_PATHS = frozenset({"", "/v1"})
+
+
+def is_deepseek_base_url(base_url: str) -> bool:
+    """Return whether one endpoint is DeepSeek's own OpenAI-compatible root.
+
+    Matches ``https://api.deepseek.com`` and ``https://api.deepseek.com/v1`` on
+    the default port with no credentials, query, or fragment. Third-party hosts
+    that serve DeepSeek weights (OpenRouter, Fireworks, Azure AI Foundry) are
+    NOT DeepSeek's origin: they enforce no thinking-mode replay rule and may
+    reject an unknown ``reasoning_content`` field, so they never match.
+    """
+    parsed = urlsplit(base_url)
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname == _DEEPSEEK_HOST
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.port in {None, 443}
+        and parsed.path.rstrip("/") in _DEEPSEEK_ROOT_PATHS
+        and not parsed.query
+        and not parsed.fragment
+    )

--- a/exp/runtime/models/providers/deepseek_test.py
+++ b/exp/runtime/models/providers/deepseek_test.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Experiential Labs. All rights reserved.
+"""DeepSeek first-party origin detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.runtime.models.providers.deepseek import is_deepseek_base_url
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        # The ``/v1`` alias the platform's house lane dispatches to.
+        "https://api.deepseek.com/v1",
+        "https://api.deepseek.com/v1/",
+        # DeepSeek's documented bare root, equivalent to ``/v1``.
+        "https://api.deepseek.com",
+        "https://api.deepseek.com/",
+    ],
+)
+def test_matches_deepseeks_documented_roots(base_url: str) -> None:
+    """Both documented OpenAI-compatible roots are DeepSeek's origin."""
+    assert is_deepseek_base_url(base_url)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        # Plaintext, credential-bearing, ported, or path-shifted variants.
+        "http://api.deepseek.com/v1",
+        "https://user:pass@api.deepseek.com/v1",
+        "https://api.deepseek.com:8443/v1",
+        "https://api.deepseek.com/v1/chat/completions",
+        "https://api.deepseek.com/v1?x=1",
+        # The beta feature root is a different surface.
+        "https://api.deepseek.com/beta",
+        # A look-alike host must not match.
+        "https://api.deepseek.com.evil.test/v1",
+        # Third-party hosts serving DeepSeek weights enforce no replay rule.
+        "https://openrouter.ai/api/v1",
+        "https://api.fireworks.ai/inference/v1",
+        "https://example.services.ai.azure.com/openai/v1",
+    ],
+)
+def test_rejects_non_canonical_endpoints(base_url: str) -> None:
+    """Only the exact scheme/host/root with no extras is DeepSeek's origin."""
+    assert not is_deepseek_base_url(base_url)

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -194,6 +194,7 @@ def dialect_stream_payload(
             fireworks_reasoning_route_sha256=profile.fireworks_reasoning_route_sha256,
             hunyuan_reasoning_route_sha256=profile.hunyuan_reasoning_route_sha256,
             reasoning_output_exposed=profile.reasoning_output_exposed,
+            deepseek_reasoning_history=profile.deepseek_reasoning_history,
             forwards_service_tier=profile.forwards_tier(provider_request.service_tier),
             forwards_prompt_cache_key=profile.forwards_prompt_cache_key,
         )

--- a/exp/runtime/models/providers/generation_route_compat.py
+++ b/exp/runtime/models/providers/generation_route_compat.py
@@ -83,11 +83,11 @@ def _carries_exposed_reasoning(profile: GatewayWireProfile, request: GatewayRequ
     """Return whether a rung forwards the request's plaintext reasoning history.
 
     Replayed plaintext ``reasoning_content`` reaches the provider only on an
-    exposure-gated rung; any other rung serves the turn by dropping it (a
-    disclosed drop), so it is only a fallback behind a rung that carries it —
-    the same preference rule sampling controls follow.
+    exposure-gated rung or DeepSeek's own origin; any other rung serves the
+    turn by dropping it (a disclosed drop), so it is only a fallback behind a
+    rung that carries it — the same preference rule sampling controls follow.
     """
-    if profile.reasoning_output_exposed:
+    if profile.replays_plaintext_reasoning:
         return True
     return not any(
         block.kind == "exposed_reasoning_content"

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -34,6 +34,7 @@ from exp.runtime.models.providers.base import (
     ProviderHttpClient,
     ReasoningWireFormat,
 )
+from exp.runtime.models.providers.deepseek import is_deepseek_base_url
 from exp.runtime.models.providers.errors import (
     ProviderRefusalError,
     ProviderRefusalSignal,
@@ -514,6 +515,12 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             reasoning_output_exposed=(
                 self._reasoning_output_exposed and self._hunyuan_reasoning_route_sha256 is not None
             ),
+            # DeepSeek's own API enforces reasoning_content on assistant
+            # tool-call history in thinking mode (400 otherwise), so its rung
+            # replays caller plaintext and backfills the field WITHOUT the
+            # exposure stamp: a house lane that fails every agent loop by
+            # default is wrong, and the stamp only governs output exposure.
+            deepseek_reasoning_history=is_deepseek_base_url(self._base_url),
             # Tencent's prefix cache is per node behind its load balancer;
             # prompt_cache_key pins a session to one node (verified live
             # 2026-09-05). Other compatible servers may reject unknown fields,

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -524,3 +524,36 @@ def test_tokenhub_intl_rung_resolves_a_carrier_route_and_exposes_when_declared()
     ).gateway_wire_profile()
     assert profile.hunyuan_reasoning_route_sha256 is not None
     assert profile.reasoning_output_exposed is True
+
+
+def test_deepseek_origin_replays_reasoning_history_without_the_exposure_stamp() -> None:
+    """DeepSeek's own API is a reasoning-HISTORY route by origin, not by catalog stamp.
+
+    Its thinking mode requires ``reasoning_content`` on every assistant tool-call
+    turn (400 otherwise), so the flag is derived from the base URL alone. Output
+    exposure stays the catalog's decision: an unstamped rung still hides the
+    deltas, and the rung is not a sealed-carrier route either.
+    """
+    for base_url in ("https://api.deepseek.com/v1", "https://api.deepseek.com"):
+        profile = OpenAICompatibleClient(
+            model=_snapshot(model_id="deepseek-flash"),
+            base_url=base_url,
+            api_key="fake-key",
+        ).gateway_wire_profile()
+        assert profile.deepseek_reasoning_history is True
+        assert profile.replays_plaintext_reasoning is True
+        assert profile.reasoning_output_exposed is False
+        assert profile.hunyuan_reasoning_route_sha256 is None
+        assert profile.fireworks_reasoning_route_sha256 is None
+
+
+def test_deepseek_reasoning_history_is_off_for_every_other_compatible_origin() -> None:
+    """Hunyuan and generic shims never backfill: an unknown field is a 400 on strict servers."""
+    for base_url in (_HUNYUAN_BASE_URL, "https://openrouter.ai/api/v1", "https://example.test/v1"):
+        profile = OpenAICompatibleClient(
+            model=_snapshot(model_id="deepseek-v4-flash"),
+            base_url=base_url,
+            api_key="fake-key",
+        ).gateway_wire_profile()
+        assert profile.deepseek_reasoning_history is False
+        assert profile.replays_plaintext_reasoning is False

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -214,6 +214,7 @@ def openai_compatible_stream_payload(
     fireworks_reasoning_route_sha256: str | None = None,
     hunyuan_reasoning_route_sha256: str | None = None,
     reasoning_output_exposed: bool = False,
+    deepseek_reasoning_history: bool = False,
     forwards_service_tier: bool = False,
     forwards_prompt_cache_key: bool = False,
 ) -> JsonObject:
@@ -231,6 +232,10 @@ def openai_compatible_stream_payload(
         reasoning_effort: Optional catalog-pinned reasoning effort.
         reasoning_output_exposed: Whether this rung replays the caller's plaintext
             ``reasoning_content`` history verbatim (exposure-gated Tencent/DeepSeek rung).
+        deepseek_reasoning_history: Whether this rung is DeepSeek's own origin,
+            which replays caller plaintext regardless of exposure and requires
+            ``reasoning_content`` on every assistant tool-call turn (an absent one
+            is backfilled empty); see ``openai_chat_message``.
 
     Returns:
         Chat Completions request that always asks the provider for terminal usage.
@@ -250,6 +255,7 @@ def openai_compatible_stream_payload(
                 message,
                 reasoning_route_sha256=reasoning_route_sha256,
                 reasoning_output_exposed=reasoning_output_exposed,
+                deepseek_reasoning_history=deepseek_reasoning_history,
             )
             for message in messages
         ],

--- a/exp/runtime/models/providers/openai_payloads_test.py
+++ b/exp/runtime/models/providers/openai_payloads_test.py
@@ -3,8 +3,17 @@ are exercised in streaming_requests_test.py."""
 
 from __future__ import annotations
 
+from typing import cast
+
 from exp.common.core.artifacts import JsonObject
-from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.common.models.model import ToolCall
+from exp.runtime.gateway.contracts import (
+    ExposedReasoningContentBlock,
+    GatewayApiSurface,
+    GatewayMessage,
+    GatewayRequest,
+    GatewayToolDefinition,
+)
 from exp.runtime.models.providers.openai_payloads import (
     openai_compatible_stream_payload,
     openai_responses_stream_payload,
@@ -139,3 +148,125 @@ def test_replayed_items_with_foreign_ids_are_repaired_for_the_openai_wire() -> N
     assert {key: value for key, value in foreign_call.items() if key != "id"} in items
     assert own_reasoning in items
     assert all("item_" not in str(item.get("id", "")) for item in items if isinstance(item, dict))
+
+
+def _agent_loop(*, reasoning: tuple[str | None, ...]) -> GatewayRequest:
+    """One tools request whose history holds two assistant tool-call turns and a final text turn.
+
+    ``reasoning`` gives the ``reasoning_content`` each assistant turn replays
+    (``None`` = the field was absent, the shape an OpenAI-compatible SDK or a
+    history started on another provider produces).
+    """
+    turns: tuple[tuple[str | None, tuple[str, JsonObject] | None], ...] = (
+        ("", ("call-1", {"path": "a.txt"})),
+        (None, ("call-2", {"path": "b.txt"})),
+        ("Done reading.", None),
+    )
+    messages: list[GatewayMessage] = [GatewayMessage(role="user", content="read a and b")]
+    for (content, call), replayed in zip(turns, reasoning, strict=True):
+        blocks = (ExposedReasoningContentBlock(content=replayed),) if replayed is not None else ()
+        if call is None:
+            messages.append(
+                GatewayMessage(role="assistant", content=content, provider_reasoning=blocks)
+            )
+            continue
+        call_id, arguments = call
+        messages.append(
+            GatewayMessage(
+                role="assistant",
+                content=content or None,
+                tool_calls=(ToolCall(call_id=call_id, name="read_file", arguments=arguments),),
+                provider_reasoning=blocks,
+            )
+        )
+        messages.append(GatewayMessage(role="tool", content="ok", tool_call_id=call_id))
+    messages.append(GatewayMessage(role="user", content="now summarize"))
+    return GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=tuple(messages),
+        tools=(
+            GatewayToolDefinition(
+                name="read_file",
+                description="Read one file.",
+                parameters={"type": "object", "properties": {"path": {"type": "string"}}},
+            ),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+
+
+def _assistant_turns(payload: JsonObject) -> list[JsonObject]:
+    messages = cast("list[JsonObject]", payload["messages"])
+    return [message for message in messages if message["role"] == "assistant"]
+
+
+def test_deepseek_origin_backfills_empty_reasoning_on_tool_call_turns_only() -> None:
+    """A tool-call turn with no reasoning gets ``reasoning_content: ""``; text turns do not.
+
+    DeepSeek's thinking mode 400s a tools request unless every assistant
+    tool-call turn carries the field (``The `reasoning_content` in the thinking
+    mode must be passed back to the API.``) and accepts an empty string exactly
+    like real reasoning (verified live 2026-09-10). The final text turn is left
+    alone: the provider does not require the field there and the wire stays
+    minimal.
+    """
+    payload = openai_compatible_stream_payload(
+        "deepseek-flash", _agent_loop(reasoning=(None, None, None)), deepseek_reasoning_history=True
+    )
+    first_call, second_call, final_text = _assistant_turns(payload)
+    assert first_call["tool_calls"] and first_call["reasoning_content"] == ""
+    assert second_call["tool_calls"] and second_call["reasoning_content"] == ""
+    assert "tool_calls" not in final_text
+    assert "reasoning_content" not in final_text
+
+
+def test_deepseek_origin_forwards_caller_reasoning_verbatim_without_the_exposure_stamp() -> None:
+    """Caller plaintext replays byte-for-byte on plain AND tool-call turns, empty included.
+
+    No ``reasoning_output_exposed`` stamp is involved: the platform's DeepSeek
+    lane is not stamped, and replay is what the provider REQUIRES, not what the
+    catalog chose to expose.
+    """
+    payload = openai_compatible_stream_payload(
+        "deepseek-flash",
+        _agent_loop(reasoning=("", "I should read b next.", "Both files are read.")),
+        deepseek_reasoning_history=True,
+    )
+    first_call, second_call, final_text = _assistant_turns(payload)
+    assert first_call["reasoning_content"] == ""
+    assert second_call["reasoning_content"] == "I should read b next."
+    assert final_text["reasoning_content"] == "Both files are read."
+
+
+def test_deepseek_origin_leaves_a_history_with_no_tool_calls_untouched() -> None:
+    """A plain conversation on the DeepSeek origin gets no injected field at all."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            GatewayMessage(role="assistant", content="hello"),
+            GatewayMessage(role="user", content="again"),
+        ),
+        stream=True,
+        include_usage=True,
+    )
+    payload = openai_compatible_stream_payload(
+        "deepseek-flash", request, deepseek_reasoning_history=True
+    )
+    (assistant,) = _assistant_turns(payload)
+    assert assistant == {"role": "assistant", "content": "hello"}
+
+
+def test_other_compatible_origins_keep_the_exposure_gated_behaviour() -> None:
+    """Off the DeepSeek origin nothing changes: no backfill, plaintext still exposure-gated."""
+    request = _agent_loop(reasoning=("", "I should read b next.", None))
+    stripped = openai_compatible_stream_payload("deepseek-v4-flash", request)
+    assert all("reasoning_content" not in turn for turn in _assistant_turns(stripped))
+    exposed = openai_compatible_stream_payload(
+        "hy4-preview", request, reasoning_output_exposed=True
+    )
+    first_call, second_call, final_text = _assistant_turns(exposed)
+    assert first_call["reasoning_content"] == ""
+    assert second_call["reasoning_content"] == "I should read b next."
+    assert "reasoning_content" not in final_text

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -666,17 +666,18 @@ def route_generation_parameter_requests(
     # Opaque provider-reasoning carriers replay only on the one wire that
     # issued them, so a mixed waterfall is rejected instead of dropping them.
     # Plaintext reasoning an exposure-gated rung itself returned (Tencent/
-    # DeepSeek) replays only to rungs that expose their reasoning: the
-    # provider's wire accepts it verbatim there, and nowhere else was it ever
-    # issued. A route with no exposing rung rejects by name; a mixed waterfall
-    # keeps it on the exposing rungs and discloses the drop on the others.
+    # DeepSeek) replays only to rungs that replay plaintext: an exposing rung
+    # (the provider's wire accepts back what it issued) or DeepSeek's own
+    # origin, which requires the field on tool-call history whether or not
+    # its output is exposed. A mixed waterfall keeps it on those rungs and
+    # discloses the drop on the others.
     exposed_reasoning_present = any(
         block.kind == "exposed_reasoning_content"
         for message in request.messages
         for block in message.provider_reasoning
     )
     if exposed_reasoning_present and not all(
-        profile.reasoning_output_exposed for profile in profiles
+        profile.replays_plaintext_reasoning for profile in profiles
     ):
         # Plaintext reasoning is baked into the caller's transcript (an
         # earlier turn on a reasoning-exposed rung, or a client-side AI-SDK

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4316,6 +4316,78 @@ def test_plaintext_reasoning_route_gate_discloses_or_forwards() -> None:
     assert public.ignored_parameters == ()
 
 
+def _deepseek_profile() -> GatewayWireProfile:
+    """The platform's DeepSeek house lane: DeepSeek's origin, no exposure stamp."""
+    return GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://api.deepseek.com/v1/chat/completions",
+        model_id="deepseek-flash",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+        deepseek_reasoning_history=True,
+    )
+
+
+def test_deepseek_rung_carries_plaintext_reasoning_without_disclosure_or_stamp() -> None:
+    """An unstamped DeepSeek rung is a carrying rung: no drop disclosure, verbatim replay.
+
+    Before this, the DeepSeek house lane disclosed
+    ``messages.reasoning_content->dropped`` and stripped the field, and DeepSeek
+    then 400'd the whole request in thinking mode.
+    """
+    request = _exposed_reasoning_request()
+    public, provider = route_generation_parameter_requests((_deepseek_profile(),), request)
+    assert public.ignored_parameters == ()
+    payload = dialect_stream_payload(_deepseek_profile(), provider)
+    payload_messages = cast("list[JsonObject]", payload["messages"])
+    assert payload_messages[1]["reasoning_content"] == "The user wants a directory listing."
+    # On a mixed waterfall the DeepSeek rung is exact and a stripping rung is a fallback.
+    assert compatible_generation_parameter_profile_indexes(
+        (_exposed_profile(exposed=False, url="https://openrouter.test/v1"), _deepseek_profile()),
+        request,
+    ) == (1,)
+
+
+def test_deepseek_rung_backfills_tool_call_history_through_dialect_dispatch() -> None:
+    """The resolved profile alone (no builder kwargs) yields the accepted wire shape.
+
+    A 296-message coding-agent history whose tool calls were minted elsewhere
+    arrives with bare ``tool_calls`` turns; every one of them leaves with
+    ``reasoning_content: ""`` on the DeepSeek rung and untouched on any other.
+    """
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(role="user", content="read it"),
+            GatewayMessage(
+                role="assistant",
+                content=None,
+                tool_calls=(
+                    ToolCall(call_id="call_other_provider", name="read_file", arguments={}),
+                ),
+            ),
+            GatewayMessage(role="tool", content="contents", tool_call_id="call_other_provider"),
+        ),
+        tools=(
+            GatewayToolDefinition(
+                name="read_file", description="Read.", parameters={"type": "object"}
+            ),
+        ),
+        stream=True,
+    )
+    deepseek = cast(
+        "list[JsonObject]", dialect_stream_payload(_deepseek_profile(), request)["messages"]
+    )
+    assert deepseek[1]["tool_calls"] and deepseek[1]["reasoning_content"] == ""
+    generic = cast(
+        "list[JsonObject]",
+        dialect_stream_payload(
+            _exposed_profile(exposed=False, url="https://openrouter.test/v1"), request
+        )["messages"],
+    )
+    assert generic[1]["tool_calls"] and "reasoning_content" not in generic[1]
+
+
 def test_plaintext_reasoning_prefers_the_exposing_rung_on_a_mixed_waterfall() -> None:
     """A rung that carries the reasoning is exact; a rung that would drop it is a fallback."""
     request = _exposed_reasoning_request()

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -495,6 +495,7 @@ def openai_chat_message(
     *,
     reasoning_route_sha256: str | None = None,
     reasoning_output_exposed: bool = False,
+    deepseek_reasoning_history: bool = False,
 ) -> JsonObject:
     """Translate one gateway message to OpenAI Chat wire JSON.
 
@@ -517,6 +518,13 @@ def openai_chat_message(
     ``reasoning_output_exposed`` marks a rung whose plaintext reasoning the
     caller may replay verbatim (an ``exposed_reasoning_content`` block); any
     other rung omits that block, which route narrowing already disclosed.
+    ``deepseek_reasoning_history`` marks DeepSeek's own origin, whose thinking
+    mode 400s a tools request unless every assistant tool-call turn in the
+    history carries ``reasoning_content`` (presence checked, content not;
+    verified live 2026-09-10): caller plaintext forwards verbatim there without
+    the exposure stamp, and a tool-call turn with no reasoning block is
+    backfilled with an empty string. Non-tool turns are never backfilled (the
+    provider does not require it) and no other origin is touched.
     """
     if message.role == "tool":
         tool_payload: JsonObject = {
@@ -563,7 +571,7 @@ def openai_chat_message(
             raise ProviderResponseError("Chat reasoning history requires exactly one carrier")
         block = message.provider_reasoning[0]
         if block.kind == "exposed_reasoning_content":
-            if reasoning_output_exposed:
+            if reasoning_output_exposed or deepseek_reasoning_history:
                 payload["reasoning_content"] = block.content
             return payload
         if (
@@ -573,6 +581,13 @@ def openai_chat_message(
         ):
             raise ProviderResponseError("reasoning carrier belongs to a different Chat route")
         payload["reasoning_content"] = block.content
+    elif deepseek_reasoning_history and message.role == "assistant" and message.tool_calls:
+        # DeepSeek's thinking mode rejects the whole request when a tool-call
+        # turn arrives without the field, and accepts an empty one exactly like
+        # real reasoning. Histories that started on another provider, or that
+        # an OpenAI-compatible SDK re-serialized without the extension field,
+        # arrive this way on every turn of an agent loop.
+        payload["reasoning_content"] = ""
     return payload
 
 


### PR DESCRIPTION
## Problem

The platform serves DeepSeek's own API (`https://api.deepseek.com/v1`, wire id `deepseek-flash`, provider family `openai-compatible`) as a house lane. DeepSeek's thinking mode is ON by default and enforced on the wire: in a request that carries `tools`, every assistant message in the history that has `tool_calls` must carry a `reasoning_content` field, unless DeepSeek itself minted that call earlier in the same session. Otherwise it answers:

```
HTTP 400 {"error":{"message":"The `reasoning_content` in the thinking mode must be passed back to the API.","type":"invalid_request_error","code":"invalid_request_error"}}
```

Reproduced 2026-09-10 against production:

| Assistant tool-call turn in history | Direct to DeepSeek | Through the gateway (before) |
|---|---|---|
| `content: "" / null / omitted`, `tool_calls`, no `reasoning_content` | 400 | 400 |
| `content: "Let me read it."`, `tool_calls`, no `reasoning_content` | 400 | 400 |
| same turn with `reasoning_content: ""` | 200 | 400 (field stripped: rung not stamped `reasoning_output_exposed`) |
| same turn with any reasoning text | 200 (content not validated) | 400 (stripped for the same reason) |
| any of the above with `thinking: {type: disabled}` / `reasoning_effort: "none"` | 200 | n/a |

Real impact: coding-agent loops (296-message histories, assistant tool-call turns with empty content) failed on every turn once the history contained a tool call not minted by DeepSeek in the same session (e.g. the conversation started on another provider), and most OpenAI-compatible SDKs strip the field anyway. Since 0.7.34 (#790) plaintext `reasoning_content` replays only on a rung stamped `reasoning_output_exposed`; the platform's DeepSeek lane is not stamped, and a lane that fails every agent loop by default is wrong.

## Fix (Python only, provider-scoped)

- **`exp/runtime/models/providers/deepseek.py`** — `is_deepseek_base_url` recognizes DeepSeek's two documented OpenAI-compatible roots (`https://api.deepseek.com` and `/v1`), the way `hunyuan.py` recognizes TokenHub. Third-party hosts serving DeepSeek weights (OpenRouter, Fireworks, Foundry) never match: they enforce no replay rule and may 400 on an unknown field.
- **`GatewayWireProfile.deepseek_reasoning_history`** — origin-derived in `OpenAICompatibleClient.gateway_wire_profile`, never a catalog stamp. A shared `replays_plaintext_reasoning` property (`reasoning_output_exposed or deepseek_reasoning_history`) is what route narrowing (`_carries_exposed_reasoning`) and the `messages.reasoning_content->dropped` disclosure gate now read, so a DeepSeek rung is a carrying rung.
- **`openai_chat_message`** on that rung: (a) forwards a caller-supplied `reasoning_content` VERBATIM on plain and tool-call turns alike (empty string preserved); (b) when an assistant message carries `tool_calls` and no reasoning block, injects `"reasoning_content": ""`; (c) never injects on non-tool assistant turns; (d) no other origin and no sealed-carrier (Fireworks/Hunyuan) behaviour is touched.
- **Interaction with the stamp**, documented in `docs/reference/gateway-architecture.md` and the field docstrings: `reasoning_output_exposed` keeps its one meaning on DeepSeek — whether the caller SEES the reasoning deltas on output (`native_execution` still passes it to the Rust encoder unchanged). Unstamped, the caller never receives reasoning to replay and the empty backfill keeps agent loops alive; stamped, the caller replays real text and the backfill covers only turns minted elsewhere. Replay on DeepSeek works in both modes.

## Tests

- `deepseek_test.py`: matcher accepts both documented roots; rejects http/credentials/port/path-shifted/`/beta`/look-alike/third-party hosts.
- `openai_payloads_test.py`: builder-level, on a tools request with two tool-call turns and a final text turn — backfilled `""` on tool turns only; caller text forwarded verbatim (empty included) without the stamp; plain history untouched; other origins unchanged (generic strips, Hunyuan stays exposure-gated).
- `openai_compatible_test.py`: the resolved profile derives the flag from the origin (`/v1` and bare root), stays `reasoning_output_exposed=False` and carrier-route-free; off for Hunyuan/OpenRouter/generic.
- `streaming_requests_test.py`: route gate — an unstamped DeepSeek rung carries plaintext with `ignored_parameters == ()`, is preferred over a stripping rung on a mixed waterfall, and `dialect_stream_payload(profile, request)` from the profile alone yields the backfilled shape (the closest thing the repo has to a request-shape golden for this dialect; the committed goldens are stream fixtures).

## Validation

- `ruff format` / `ruff check` / `ty check`: clean (baseline `origin/main` is ty-clean; verified by stashing).
- `uv run --python 3.13 python -m pytest` on the provider suites (291 passed, 1 skipped) and on `openai_protocol/requests_test`, `native_admission_test`, `native_execution_test`, `execution_resolution_test`, `reasoning_carrier_test`, `native_dispatch_test`, `capability_parity_test`, `reasoning_compat_test`, `native_bridge_test` (434 passed).
- **No change under `exp/runtime/gateway/native`**: the Chat payload is built in Python, so no crate version bump is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
