### PR TITLE
Release 0.7.61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.60"
+version = "0.7.61"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.60"
+version = "0.7.61"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bumps `experiential` to 0.7.61 to release #887: on DeepSeek's own origin (`api.deepseek.com`), the Chat wire builder now replays caller-supplied `reasoning_content` verbatim on every assistant turn and backfills `reasoning_content: ""` on assistant tool-call turns that lack it, so DeepSeek's thinking mode (on by default) stops answering HTTP 400 `The `reasoning_content` in the thinking mode must be passed back to the API.` on every turn of a coding-agent loop whose history started on another provider or whose SDK strips the field; no exposure stamp is required and no other origin changes. Python-only: the native crate is unchanged at `exp-gateway-native` 0.3.47, so no new native wheels are published. This PR changes only `pyproject.toml` `version` and the matching `uv.lock` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
