### PR TITLE
DeepSeek: backfill reasoning_content on every assistant turn (text-then-tool-call 400)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -523,13 +523,16 @@ never become plaintext history.
 DeepSeek's own origin (`https://api.deepseek.com`, `is_deepseek_base_url`) is a reasoning-HISTORY
 route by origin, independent of the exposure stamp (`GatewayWireProfile.deepseek_reasoning_history`).
 Its thinking mode, on by default, rejects a request that carries `tools` unless every assistant
-message with `tool_calls` in the history carries `reasoning_content` (HTTP 400 ``The
-`reasoning_content` in the thinking mode must be passed back to the API.``), while accepting an
-empty string exactly like real reasoning (verified live 2026-09-10). On that rung the Chat builder
-forwards caller plaintext `reasoning_content` verbatim on plain and tool-call turns alike, and a
-tool-call turn that arrives without the field (a history started on another provider, or an
-OpenAI-compatible SDK that strips the extension) is backfilled with `reasoning_content: ""`;
-non-tool turns are never backfilled and no other origin is touched. The rung counts as a carrying
+message of the current turn (after the last user message, text-only messages that precede a tool
+call included) carries `reasoning_content` (HTTP 400 ``The `reasoning_content` in the thinking
+mode must be passed back to the API.``), while accepting an empty string exactly like real
+reasoning anywhere, exempt messages included (verified live 2026-09-10). On that rung the Chat
+builder forwards caller plaintext `reasoning_content` verbatim on plain and tool-call turns alike,
+and every assistant message that arrives without the field or with an explicit `null` (a history
+started on another provider, or an OpenAI-compatible SDK that strips the extension) is backfilled
+with `reasoning_content: ""` — tool-call and text-only messages alike, since backfilling only
+tool-call turns left the "text message, then tool-call message" agent shape 400ing in production;
+no other origin is touched. The rung counts as a carrying
 rung for narrowing and disclosure (`replays_plaintext_reasoning`), so no drop is disclosed there.
 `reasoning_output_exposed` keeps its one meaning on DeepSeek: whether the caller SEES the reasoning
 deltas on output. Unstamped, the caller never receives reasoning to replay and the empty backfill

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -238,8 +238,11 @@ class GatewayWireProfile:
 
     Origin-derived (``is_deepseek_base_url``), never a catalog stamp: the Chat
     wire builder replays caller plaintext ``reasoning_content`` verbatim on
-    this rung and backfills an empty string on a tool-call turn that lacks it
-    (DeepSeek validates presence, not content; verified live 2026-09-10).
+    this rung and backfills an empty string on every assistant message that
+    lacks it — the provider requires the field on each assistant message of
+    the current turn, text-only ones included, and accepts an empty one
+    anywhere (DeepSeek validates presence, not content; verified live
+    2026-09-10).
     Independent of ``reasoning_output_exposed``, which still decides alone
     whether the caller SEES the reasoning deltas on output."""
 

--- a/exp/runtime/models/providers/deepseek.py
+++ b/exp/runtime/models/providers/deepseek.py
@@ -4,16 +4,18 @@
 DeepSeek's own API (``https://api.deepseek.com``) serves an OpenAI-compatible
 Chat Completions endpoint whose thinking mode is ON by default and enforced on
 the wire (verified live 2026-09-10): in a request that carries ``tools``, every
-assistant message in the history that has ``tool_calls`` must carry a
-``reasoning_content`` field, unless DeepSeek itself minted that call earlier in
-the same session. Otherwise it answers HTTP 400 ``"The `reasoning_content` in
-the thinking mode must be passed back to the API."`` The value is not
-validated: an empty string is accepted exactly like real reasoning text.
+assistant message of the current turn (after the last user message, text-only
+messages that precede a tool call included) must carry a ``reasoning_content``
+field, unless DeepSeek itself minted the tool call earlier in the same
+session. Otherwise it answers HTTP 400 ``"The `reasoning_content` in the
+thinking mode must be passed back to the API."`` The value is not validated:
+an empty string is accepted exactly like real reasoning text, and is harmless
+on the messages the rule exempts (earlier turns, tool-less requests).
 
 Recognizing the origin here lets the Chat wire builder replay caller-supplied
-``reasoning_content`` verbatim and backfill an empty one on tool-call turns
-that lack it, so agent loops whose history started on another provider (or
-whose SDK strips the field) keep working. Nothing about OUTPUT exposure is
+``reasoning_content`` verbatim and backfill an empty one on every assistant
+message that lacks it, so agent loops whose history started on another
+provider (or whose SDK strips the field) keep working. Nothing about OUTPUT exposure is
 decided here: whether the caller sees DeepSeek's reasoning deltas stays the
 catalog's ``reasoning_output_exposed`` stamp.
 """

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -77,6 +77,7 @@ def openai_compatible_request(
     reasoning_effort: str | None = None,
     reasoning_wire_format: ReasoningWireFormat = "reasoning_effort",
     sampling_requires_reasoning_none: bool = False,
+    deepseek_reasoning_history: bool = False,
 ) -> JsonObject:
     """Convert a EXP request into one non-streaming Chat Completions payload.
 
@@ -96,6 +97,11 @@ def openai_compatible_request(
         supports_reasoning: Whether this exact model accepts a reasoning control.
         reasoning_effort: Optional catalog-pinned reasoning effort.
         reasoning_wire_format: Provider field used for normalized reasoning effort.
+        deepseek_reasoning_history: Whether this is DeepSeek's own origin, whose
+            thinking mode requires ``reasoning_content`` on every assistant message
+            of the current turn; every assistant message is backfilled with an
+            empty one (the typed request carries no reasoning to forward), the
+            same rule the streaming builder applies in ``openai_chat_message``.
 
     Returns:
         A JSON object for ``/chat/completions``.
@@ -105,7 +111,10 @@ def openai_compatible_request(
     """
     payload: JsonObject = {
         "model": model_id,
-        "messages": [_openai_message(message) for message in request.messages],
+        "messages": [
+            _openai_message(message, deepseek_reasoning_history=deepseek_reasoning_history)
+            for message in request.messages
+        ],
         "stream": False,
     }
     if request.tools:
@@ -484,6 +493,10 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         self._hunyuan_reasoning_route_sha256 = (
             reasoning_content_route_sha256(model) if is_hunyuan_base_url(self._base_url) else None
         )
+        # DeepSeek's own API enforces reasoning_content on every assistant
+        # message of the current turn in thinking mode (400 otherwise); both the
+        # streaming wire profile and the buffered request builder read this.
+        self._deepseek_reasoning_history = is_deepseek_base_url(self._base_url)
 
     def gateway_wire_profile(self) -> GatewayWireProfile:
         """Return the Chat Completions wire profile for this connection."""
@@ -515,12 +528,11 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             reasoning_output_exposed=(
                 self._reasoning_output_exposed and self._hunyuan_reasoning_route_sha256 is not None
             ),
-            # DeepSeek's own API enforces reasoning_content on every assistant
-            # message of the current turn in thinking mode (400 otherwise), so its rung
-            # replays caller plaintext and backfills the field WITHOUT the
-            # exposure stamp: a house lane that fails every agent loop by
-            # default is wrong, and the stamp only governs output exposure.
-            deepseek_reasoning_history=is_deepseek_base_url(self._base_url),
+            # The DeepSeek rung replays caller plaintext and backfills the
+            # field WITHOUT the exposure stamp: a house lane that fails every
+            # agent loop by default is wrong, and the stamp only governs
+            # output exposure.
+            deepseek_reasoning_history=self._deepseek_reasoning_history,
             # Tencent's prefix cache is per node behind its load balancer;
             # prompt_cache_key pins a session to one node (verified live
             # 2026-09-05). Other compatible servers may reject unknown fields,
@@ -546,6 +558,7 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             reasoning_effort=self._reasoning_effort,
             reasoning_wire_format=self.reasoning_wire_format,
             sampling_requires_reasoning_none=self._sampling_requires_reasoning_none,
+            deepseek_reasoning_history=self._deepseek_reasoning_history,
         )
 
     def _parse_response(self, payload: JsonObject, *, latency_seconds: float) -> ModelResponse:
@@ -565,8 +578,16 @@ class OpenRouterClient(OpenAICompatibleClient):
     reasoning_wire_format: ClassVar[ReasoningWireFormat] = "reasoning"
 
 
-def _openai_message(message: ModelMessage) -> JsonObject:
-    """Convert one EXP message while retaining assistant tool history."""
+def _openai_message(
+    message: ModelMessage, *, deepseek_reasoning_history: bool = False
+) -> JsonObject:
+    """Convert one EXP message while retaining assistant tool history.
+
+    On DeepSeek's own origin every assistant message gains ``reasoning_content: ""``:
+    the provider 400s a tools request when any assistant message of the current
+    turn lacks the field and accepts an empty one everywhere (see
+    ``openai_chat_message`` for the streaming twin of this rule).
+    """
     if message.role == "tool":
         return {
             "role": "tool",
@@ -591,6 +612,8 @@ def _openai_message(message: ModelMessage) -> JsonObject:
             }
             for call in action.tool_calls
         ]
+    if deepseek_reasoning_history:
+        payload["reasoning_content"] = ""
     return payload
 
 

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -515,8 +515,8 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             reasoning_output_exposed=(
                 self._reasoning_output_exposed and self._hunyuan_reasoning_route_sha256 is not None
             ),
-            # DeepSeek's own API enforces reasoning_content on assistant
-            # tool-call history in thinking mode (400 otherwise), so its rung
+            # DeepSeek's own API enforces reasoning_content on every assistant
+            # message of the current turn in thinking mode (400 otherwise), so its rung
             # replays caller plaintext and backfills the field WITHOUT the
             # exposure stamp: a house lane that fails every agent loop by
             # default is wrong, and the stamp only governs output exposure.

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import math
 import os
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 
+from exp.common.core.artifacts import JsonObject
 from exp.common.models import (
     AssistantAction,
     BillingSource,
@@ -557,3 +558,57 @@ def test_deepseek_reasoning_history_is_off_for_every_other_compatible_origin() -
         ).gateway_wire_profile()
         assert profile.deepseek_reasoning_history is False
         assert profile.replays_plaintext_reasoning is False
+
+
+def test_buffered_request_backfills_reasoning_content_on_deepseek_assistant_turns() -> None:
+    """The non-streaming builder applies the DeepSeek rule too, tool-call and text turns alike.
+
+    ``RouterRuntime.complete`` serializes through ``openai_compatible_request``,
+    not the streaming ``openai_chat_message``; a text-then-tool-call history on
+    this path would otherwise still draw DeepSeek's thinking-mode 400. The
+    typed request carries no reasoning to forward, so the rule here is the
+    backfill alone; system, user, and tool messages are untouched.
+    """
+    request = ModelRequest(
+        messages=(
+            ModelMessage(role="system", content="You are precise."),
+            ModelMessage(role="user", content="read a.txt"),
+            ModelMessage(role="assistant", content="Let me read it."),
+            ModelMessage(
+                role="assistant",
+                assistant_action=AssistantAction(
+                    tool_calls=(ToolCall(call_id="call_foreign_1", name="read_file", arguments={}),)
+                ),
+            ),
+            ModelMessage(role="tool", content="hello", tool_call_id="call_foreign_1"),
+        ),
+        tools=(ToolSchema(name="read_file", description="Read.", input_schema={"type": "object"}),),
+    )
+    payload = openai_compatible_request("deepseek-flash", request, deepseek_reasoning_history=True)
+    system, user, text_turn, tool_call_turn, tool = cast("list[JsonObject]", payload["messages"])
+    assert text_turn == {"role": "assistant", "content": "Let me read it.", "reasoning_content": ""}
+    assert tool_call_turn["tool_calls"] and tool_call_turn["reasoning_content"] == ""
+    assert all("reasoning_content" not in message for message in (system, user, tool))
+    # Off the DeepSeek origin the buffered wire is byte-identical to before.
+    generic = cast(
+        "list[JsonObject]", openai_compatible_request("deepseek-flash", request)["messages"]
+    )
+    assert all("reasoning_content" not in message for message in generic)
+
+
+def test_deepseek_client_builds_buffered_requests_with_the_backfill_from_its_origin() -> None:
+    """The client derives the buffered-path backfill from its base URL, like the wire profile."""
+    deepseek = OpenAICompatibleClient(
+        model=_snapshot(model_id="deepseek-flash"),
+        base_url="https://api.deepseek.com/v1",
+        api_key="fake-key",
+    )
+    messages = cast("list[JsonObject]", deepseek._build_request(_request())["messages"])
+    assert messages[2]["tool_calls"] and messages[2]["reasoning_content"] == ""
+    generic = OpenAICompatibleClient(
+        model=_snapshot(model_id="deepseek-flash"),
+        base_url="https://example.test/v1",
+        api_key="fake-key",
+    )
+    generic_messages = cast("list[JsonObject]", generic._build_request(_request())["messages"])
+    assert "reasoning_content" not in generic_messages[2]

--- a/exp/runtime/models/providers/openai_payloads.py
+++ b/exp/runtime/models/providers/openai_payloads.py
@@ -234,8 +234,9 @@ def openai_compatible_stream_payload(
             ``reasoning_content`` history verbatim (exposure-gated Tencent/DeepSeek rung).
         deepseek_reasoning_history: Whether this rung is DeepSeek's own origin,
             which replays caller plaintext regardless of exposure and requires
-            ``reasoning_content`` on every assistant tool-call turn (an absent one
-            is backfilled empty); see ``openai_chat_message``.
+            ``reasoning_content`` on every assistant message of the current turn
+            (an absent one is backfilled empty on every assistant message); see
+            ``openai_chat_message``.
 
     Returns:
         Chat Completions request that always asks the provider for terminal usage.

--- a/exp/runtime/models/providers/openai_payloads_test.py
+++ b/exp/runtime/models/providers/openai_payloads_test.py
@@ -18,6 +18,7 @@ from exp.runtime.models.providers.openai_payloads import (
     openai_compatible_stream_payload,
     openai_responses_stream_payload,
 )
+from exp.runtime.openai_protocol.requests import decode_chat
 
 
 def _developer_conversation() -> GatewayRequest:
@@ -201,15 +202,15 @@ def _assistant_turns(payload: JsonObject) -> list[JsonObject]:
     return [message for message in messages if message["role"] == "assistant"]
 
 
-def test_deepseek_origin_backfills_empty_reasoning_on_tool_call_turns_only() -> None:
-    """A tool-call turn with no reasoning gets ``reasoning_content: ""``; text turns do not.
+def test_deepseek_origin_backfills_empty_reasoning_on_every_assistant_turn() -> None:
+    """Every assistant message with no reasoning gets ``reasoning_content: ""``, text turns too.
 
     DeepSeek's thinking mode 400s a tools request unless every assistant
-    tool-call turn carries the field (``The `reasoning_content` in the thinking
-    mode must be passed back to the API.``) and accepts an empty string exactly
-    like real reasoning (verified live 2026-09-10). The final text turn is left
-    alone: the provider does not require the field there and the wire stays
-    minimal.
+    message of the current turn carries the field (``The `reasoning_content`
+    in the thinking mode must be passed back to the API.``) and accepts an
+    empty string exactly like real reasoning, on exempt turns included
+    (verified live 2026-09-10). The builder does not track turn boundaries:
+    the empty string is harmless where the provider does not require it.
     """
     payload = openai_compatible_stream_payload(
         "deepseek-flash", _agent_loop(reasoning=(None, None, None)), deepseek_reasoning_history=True
@@ -218,7 +219,62 @@ def test_deepseek_origin_backfills_empty_reasoning_on_tool_call_turns_only() -> 
     assert first_call["tool_calls"] and first_call["reasoning_content"] == ""
     assert second_call["tool_calls"] and second_call["reasoning_content"] == ""
     assert "tool_calls" not in final_text
-    assert "reasoning_content" not in final_text
+    assert final_text["reasoning_content"] == ""
+
+
+def test_deepseek_origin_backfills_a_text_message_before_a_tool_call_and_an_explicit_null() -> None:
+    """The residual production shape: a text-only assistant message, then a tool-call one.
+
+    0.7.61 backfilled tool-call turns alone; DeepSeek still 400'd
+    ``text-asst(no rc) + toolcall-asst(rc "") + tool`` (org cc2023new's agent
+    emits a text message and then a tool-call message in one turn). An
+    explicit ``reasoning_content: null`` on the wire decodes to no block and
+    is backfilled exactly like an absent field.
+    """
+    decoded = decode_chat(
+        {
+            "model": "deepseek-flash",
+            "messages": [
+                {"role": "user", "content": "read a.txt"},
+                {"role": "assistant", "content": "Let me read it.", "reasoning_content": None},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_foreign_1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_foreign_1", "content": "hello"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "Read one file.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        }
+    )
+    payload = openai_compatible_stream_payload(
+        "deepseek-flash", decoded.request, deepseek_reasoning_history=True
+    )
+    text_message, tool_call_message = _assistant_turns(payload)
+    assert text_message["content"] == "Let me read it."
+    assert text_message["reasoning_content"] == ""
+    assert tool_call_message["tool_calls"] and tool_call_message["reasoning_content"] == ""
+    # Off the DeepSeek origin the same request is untouched.
+    generic = openai_compatible_stream_payload("deepseek-v4-flash", decoded.request)
+    assert all("reasoning_content" not in turn for turn in _assistant_turns(generic))
 
 
 def test_deepseek_origin_forwards_caller_reasoning_verbatim_without_the_exposure_stamp() -> None:
@@ -239,8 +295,13 @@ def test_deepseek_origin_forwards_caller_reasoning_verbatim_without_the_exposure
     assert final_text["reasoning_content"] == "Both files are read."
 
 
-def test_deepseek_origin_leaves_a_history_with_no_tool_calls_untouched() -> None:
-    """A plain conversation on the DeepSeek origin gets no injected field at all."""
+def test_deepseek_origin_backfills_a_tool_less_conversation_harmlessly() -> None:
+    """A plain conversation on the DeepSeek origin is backfilled too.
+
+    DeepSeek accepts ``reasoning_content: ""`` on a request with no tools
+    (verified live), so one rule covers every shape and the builder never has
+    to know whether a later turn will add tools.
+    """
     request = GatewayRequest(
         surface=GatewayApiSurface.CHAT_COMPLETIONS,
         messages=(
@@ -255,7 +316,7 @@ def test_deepseek_origin_leaves_a_history_with_no_tool_calls_untouched() -> None
         "deepseek-flash", request, deepseek_reasoning_history=True
     )
     (assistant,) = _assistant_turns(payload)
-    assert assistant == {"role": "assistant", "content": "hello"}
+    assert assistant == {"role": "assistant", "content": "hello", "reasoning_content": ""}
 
 
 def test_other_compatible_origins_keep_the_exposure_gated_behaviour() -> None:

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -519,12 +519,15 @@ def openai_chat_message(
     caller may replay verbatim (an ``exposed_reasoning_content`` block); any
     other rung omits that block, which route narrowing already disclosed.
     ``deepseek_reasoning_history`` marks DeepSeek's own origin, whose thinking
-    mode 400s a tools request unless every assistant tool-call turn in the
-    history carries ``reasoning_content`` (presence checked, content not;
-    verified live 2026-09-10): caller plaintext forwards verbatim there without
-    the exposure stamp, and a tool-call turn with no reasoning block is
-    backfilled with an empty string. Non-tool turns are never backfilled (the
-    provider does not require it) and no other origin is touched.
+    mode 400s a tools request unless every assistant message of the CURRENT
+    turn (after the last user message, text-only messages that precede a
+    tool call included) carries ``reasoning_content`` (presence checked,
+    content not; verified live 2026-09-10): caller plaintext forwards verbatim
+    there without the exposure stamp, and EVERY assistant message with no
+    reasoning block (an absent field or an explicit null) is backfilled with
+    an empty string. An empty string is harmless on the turns the provider
+    exempts (earlier turns, tool-less requests), so the builder does not track
+    turn boundaries; no other origin is touched.
     """
     if message.role == "tool":
         tool_payload: JsonObject = {
@@ -581,12 +584,15 @@ def openai_chat_message(
         ):
             raise ProviderResponseError("reasoning carrier belongs to a different Chat route")
         payload["reasoning_content"] = block.content
-    elif deepseek_reasoning_history and message.role == "assistant" and message.tool_calls:
-        # DeepSeek's thinking mode rejects the whole request when a tool-call
-        # turn arrives without the field, and accepts an empty one exactly like
-        # real reasoning. Histories that started on another provider, or that
-        # an OpenAI-compatible SDK re-serialized without the extension field,
-        # arrive this way on every turn of an agent loop.
+    elif deepseek_reasoning_history and message.role == "assistant":
+        # DeepSeek's thinking mode rejects the whole request when any assistant
+        # message of the current turn arrives without the field — a text-only
+        # message before the tool call included (0.7.61 backfilled tool-call
+        # turns alone and the "text turn, then tool-call turn" agent shape
+        # still 400'd in production) — and accepts an empty one exactly like
+        # real reasoning, on exempt turns too. Histories that started on
+        # another provider, or that an OpenAI-compatible SDK re-serialized
+        # without the extension field, arrive this way on every turn.
         payload["reasoning_content"] = ""
     return payload
 


### PR DESCRIPTION
## Problem

0.7.61 (#887) backfills `reasoning_content: ""` on assistant **tool-call** turns only. In production it eliminated most DeepSeek thinking-mode refusals (34/h → 2/h) but one shape still 400s. Verified directly against `api.deepseek.com` with foreign call ids (no in-session cache) and through the production gateway, DeepSeek's actual rule is: with `tools` present, **every assistant message of the current turn** (after the last user message) must carry `reasoning_content`, including text-only assistant messages that precede a tool-call assistant message in that turn; earlier turns are exempt; an empty string is accepted everywhere and is harmless on messages that do not need it (also without tools).

Direct evidence (tools present):

| History shape | DeepSeek |
|---|---|
| text-asst (no rc) + toolcall-asst (rc `""`) + tool | **400** ← the residual (org cc2023new: agent emits a text turn, then a tool-call turn) |
| text-asst (rc `""`) + toolcall-asst (rc `""`) + tool | 200 |
| text-asst (rc `""`) + toolcall-asst (no rc) + tool | 400 |
| prev-turn text-asst (no rc), user, toolcall-asst (rc `""`) + tool | 200 |
| prev-turn text-asst (no rc), user, toolcall-asst (no rc) + tool | 400 |
| toolcall-asst (rc `""`) + tool + text-asst (no rc) + new user | 200 (previous turn, exempt) |
| no tools, prior assistant with rc `""` | 200 (harmless) |

Through the gateway on 0.7.61: `toolcall-asst content null` → 200 (fixed), explicit `reasoning_content: null` → 200, but `text-asst then toolcall-asst` → **400**.

## Fix (Python only)

On a DeepSeek origin (`deepseek_reasoning_history`, unchanged detection from #887), `openai_chat_message` now injects `"reasoning_content": ""` on **every** assistant message that lacks a string `reasoning_content`, not just tool-call turns. An explicit `null` on the wire already decodes to no reasoning block, so it is backfilled exactly like an absent field. Caller-supplied strings keep forwarding verbatim. The builder does not track turn boundaries: the empty string is harmless on exempt messages, so the simplest rule is the correct one. No other origin and no Hunyuan/Fireworks carrier behaviour changes. Docstrings and `docs/reference/gateway-architecture.md` updated.

## Tests (`openai_payloads_test.py`)

- New: the residual shape decoded from the wire with `decode_chat` — text assistant message with explicit `reasoning_content: null`, then a tool-call assistant message with the field absent, plus `tools` — both leave with `""`; the same request off the DeepSeek origin is untouched.
- Updated: every-assistant-turn backfill (final text turn now `""`), tool-less conversation backfilled harmlessly, verbatim forwarding and other-origin tests unchanged.

## Validation

- `ruff format` / `ruff check` / `ty check`: clean.
- `uv run --python 3.13 python -m pytest` on `openai_payloads_test`, `deepseek_test`, `openai_compatible_test`, `streaming_requests_test`, `wire_messages_test`, `openai_protocol/requests_test`, `native_admission_test`, `native_execution_test`: 448 passed, 1 skipped. Full suite running.
- **No change under `exp/runtime/gateway/native`**: no crate version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
