### PR TITLE
Release 0.7.62

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.61"
+version = "0.7.62"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.61"
+version = "0.7.62"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bumps `experiential` to 0.7.62 to release #890: on DeepSeek's own origin (`api.deepseek.com`) the Chat wire builders now backfill `reasoning_content: ""` on every assistant message that lacks a string value (explicit `null` included), not only tool-call turns, on both the streaming path (`openai_chat_message`) and the buffered `RouterRuntime.complete` path (`openai_compatible_request`). DeepSeek's thinking mode requires the field on every assistant message of the current turn, a text-only message that precedes a tool-call message included, and accepts an empty string everywhere, so the "text message, then tool-call message" agent shape that still 400'd after 0.7.61 (verified directly against api.deepseek.com and through the production gateway) is now accepted; caller-supplied strings keep forwarding verbatim and no other origin changes. Python-only: the native crate is unchanged at `exp-gateway-native` 0.3.47, so no new native wheels are published. This PR changes only `pyproject.toml` `version` and the matching `uv.lock` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
