### PR TITLE
openai_protocol: name the constraint in every rejection instead of a bare field path

### DIFF
--- a/exp/runtime/openai_protocol/rejections.py
+++ b/exp/runtime/openai_protocol/rejections.py
@@ -1,0 +1,299 @@
+"""Public rejection shaping for the OpenAI-protocol request decoders.
+
+Every strict wire model in :mod:`exp.runtime.openai_protocol.wire_models` is
+validated through this module, so a caller that sends a value the gateway
+cannot serve reads a message that names the field, the constraint it violated,
+and what arrived. Only structural facts appear: expectations come from this
+gateway's own wire models, and the arrived side is the JSON type of the
+caller's value, never the value itself and never provider prose.
+
+Two rejection families are shaped here:
+
+- Shape and bound failures (a wrong JSON type, an out-of-range number, an
+  over-long string, a list of the wrong length) name the constraint and the
+  arriving shape, so the caller never has to bisect a ceiling out of a bare
+  field path.
+- Discriminated-union failures name the offending tag and the accepted ones.
+  Pydantic reports a bad tag at the union's own location and then adds
+  speculative complaints from the arm it tried first (a ``missing`` sibling
+  field); those arm complaints are dropped in favor of the tag diagnosis,
+  because the caller's actual mistake is the tag.
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+from pydantic_core import ErrorDetails
+
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field
+from exp.runtime.openai_protocol.wire_models import (
+    HOSTED_TOOL_ITEM_TYPES_ASSISTANT,
+    HOSTED_TOOL_ITEM_TYPES_TOOL,
+)
+
+_LOCATION_NOISE = {"body", "non-streaming", "streaming"}
+_UNION_BRANCH_TYPES = {"str", "int", "float", "bool", "list", "tuple", "dict", "NoneType"}
+_OUTPUT_ITEM_VARIANTS = {
+    "message",
+    "function_call",
+    "function_call_output",
+    "reasoning",
+    "additional_tools",
+    "custom_tool_call",
+    "custom_tool_call_output",
+    # Hosted-tool echo variants share the same union-branch label shape.
+    *HOSTED_TOOL_ITEM_TYPES_TOOL,
+    *HOSTED_TOOL_ITEM_TYPES_ASSISTANT,
+}
+
+_WIRE_TYPE_NAMES = {
+    "str": "a string",
+    "int": "an integer",
+    "float": "a number",
+    "bool": "a boolean",
+    "list": "an array",
+    "tuple": "an array",
+    "dict": "an object",
+    "NoneType": "null",
+}
+"""JSON-shape names for python input types, used in expected/got messages."""
+
+_EXPECTED_BY_ERROR_TYPE = {
+    "string_type": "a string",
+    "string_too_short": "a non-empty string",
+    "int_type": "an integer",
+    "int_parsing": "an integer",
+    "float_type": "a number",
+    "float_parsing": "a number",
+    "bool_type": "a boolean",
+    "bool_parsing": "a boolean",
+    "list_type": "an array",
+    "tuple_type": "an array",
+    "dict_type": "an object",
+    "model_type": "an object",
+    "model_attributes_type": "an object",
+    "missing": "a value",
+    "none_required": "null",
+}
+"""Shape-level expectations for the pydantic error types worth naming."""
+
+_BOUND_ERROR_TYPES = {
+    "less_than": ("lt", "less than"),
+    "less_than_equal": ("le", "at most"),
+    "greater_than": ("gt", "greater than"),
+    "greater_than_equal": ("ge", "at least"),
+}
+"""Numeric-bound error types mapped to their context key and comparison phrase.
+
+Each pydantic comparison error carries its own limit in ``ctx`` under this key,
+so the message can state the exact bound instead of only the field path. The
+numeric limits are this gateway's own wire-model constraints, so stating them
+leaks nothing about the caller's value.
+"""
+
+
+def _format_bound(value: object) -> str:
+    """Render one numeric limit without a trailing ``.0`` on whole floats."""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _cleaned_location(location: tuple[str | int, ...]) -> tuple[str, ...]:
+    """Drop pydantic union-branch labels so the path names request fields."""
+    cleaned: list[str] = []
+    for part in location:
+        text = str(part)
+        if text in _LOCATION_NOISE:
+            continue
+        # Typed-dict union branches are labeled with their class name, which
+        # no request field ever shares: every public field is lower case.
+        if isinstance(part, str) and (
+            part.startswith("_") or "[" in text or text in _UNION_BRANCH_TYPES or text[:1].isupper()
+        ):
+            continue
+        if text in _OUTPUT_ITEM_VARIANTS and cleaned and cleaned[-1].isdigit():
+            continue
+        # A discriminated part whose tag is also its payload field name
+        # (``file.file``, ``image_url.image_url``) reports the tag once.
+        if cleaned and cleaned[-1] == text and not text.isdigit():
+            continue
+        cleaned.append(text)
+    return tuple(cleaned)
+
+
+def _tag_message(param: str, detail: ErrorDetails) -> tuple[str, str]:
+    """Name the missing or rejected union tag and the accepted tags there.
+
+    Returns the field path (the union location plus its discriminator) and the
+    message together, so a caller's path and prose can never disagree.
+
+    Pydantic supplies the discriminator's property name and the accepted tag
+    list, both of which are this gateway's own vocabulary. The arriving tag is
+    deliberately not echoed, exactly like every other value in these messages:
+    the caller learns which field is wrong and which selectors are valid, which
+    is what the rejection has to say.
+    """
+    context = detail.get("ctx") or {}
+    discriminator = context.get("discriminator")
+    tag_field = discriminator.strip("'\"") if isinstance(discriminator, str) else None
+    field = f"{param}.{tag_field}" if tag_field else param
+    expected = context.get("expected_tags")
+    if isinstance(expected, str) and expected:
+        return field, f"Invalid value for '{field}': expected one of {expected}."
+    return field, f"Invalid value for '{field}': a type selector is required here."
+
+
+def _tag_rejection(
+    reported: list[ErrorDetails],
+    selected: list[ErrorDetails],
+    param: str,
+) -> tuple[str, str] | None:
+    """Prefer a bad-discriminator tag over a union arm's speculative complaint.
+
+    A caller that sends an unknown item or content-part ``type`` gets pydantic's
+    ``union_tag_invalid`` at the union's own location plus complaints from the
+    arm it happened to try first (typically a ``missing`` field of a sibling
+    shape). Reporting the arm complaint names a field the caller never sent, so
+    when the selected detail is speculative and a tag rejection exists, the tag
+    diagnosis wins. When the selected detail *is* the tag rejection, its own
+    location becomes the param so the path and the message agree.
+    """
+    tag_types = {"union_tag_invalid", "union_tag_not_found"}
+    chosen: ErrorDetails | None = None
+    if any(detail["type"] in tag_types for detail in selected):
+        chosen = next(detail for detail in selected if detail["type"] in tag_types)
+    elif selected and all(detail["type"] == "missing" for detail in selected):
+        chosen = next(
+            (detail for detail in reported if detail["type"] == "union_tag_invalid"),
+            None,
+        )
+    if chosen is None:
+        return None
+    location = _cleaned_location(chosen["loc"])
+    return _tag_message(".".join(location) or param, chosen)
+
+
+def _shape_message(param: str, details: list[ErrorDetails]) -> str | None:
+    """Describe what shape a field expected versus what arrived.
+
+    Only structural facts appear: expectations come from this gateway's own
+    wire models and the got side is the JSON type of the caller's value,
+    never the value itself and never provider prose.
+    """
+    expected: list[str] = []
+    got: str | None = None
+    for detail in details:
+        if detail["type"] == "string_too_long":
+            # The bound and the arriving LENGTH are both display-safe facts
+            # (the value itself is never echoed); stating them saves the
+            # caller from bisecting the ceiling out of a bare rejection.
+            context = detail.get("ctx") or {}
+            maximum = context.get("max_length")
+            value = detail.get("input")
+            if isinstance(maximum, int) and isinstance(value, str):
+                return (
+                    f"Invalid value for '{param}': expected at most "
+                    f"{maximum:,} characters, but got {len(value):,}."
+                )
+        bound = _BOUND_ERROR_TYPES.get(detail["type"])
+        if bound is not None:
+            key, phrase = bound
+            limit = (detail.get("ctx") or {}).get(key)
+            if limit is not None:
+                return f"Invalid value for '{param}': expected {phrase} {_format_bound(limit)}."
+        if detail["type"] == "too_short":
+            shortage = _shortage_message(param, detail)
+            if shortage is not None:
+                return shortage
+        if detail["type"] == "extra_forbidden":
+            # An undeclared key inside a nested object (a tool entry, a text
+            # block) is the same rejection the manifest already names at the
+            # top level: state it consistently instead of leaving a bare path.
+            return f"Unknown parameter '{param}'. Remove the field and resend the request."
+        phrase = _EXPECTED_BY_ERROR_TYPE.get(detail["type"])
+        if detail["type"] in {"literal_error", "enum"}:
+            context = detail.get("ctx") or {}
+            allowed = context.get("expected")
+            if isinstance(allowed, str):
+                phrase = f"one of {allowed}"
+        if phrase is not None and phrase not in expected:
+            expected.append(phrase)
+        # A missing-field complaint carries the parent object as its input,
+        # so it contributes no honest "got" type.
+        if detail["type"] != "missing" and "input" in detail:
+            got = _WIRE_TYPE_NAMES.get(type(detail["input"]).__name__, got)
+    if not expected:
+        return None
+    description = " or ".join(expected)
+    if got is not None:
+        return f"Invalid value for '{param}': expected {description}, but got {got} instead."
+    return f"Invalid value for '{param}': expected {description}."
+
+
+def _shortage_message(param: str, detail: ErrorDetails) -> str | None:
+    """Name a list too short for its declared minimum, with both counts."""
+    context = detail.get("ctx") or {}
+    minimum = context.get("min_length")
+    actual = context.get("actual_length")
+    if isinstance(minimum, int) and isinstance(actual, int):
+        return (
+            f"Invalid value for '{param}': expected at least {minimum:,} "
+            f"{'entry' if minimum == 1 else 'entries'}, but got {actual:,}."
+        )
+    return None
+
+
+def _validation_protocol_error(error: ValidationError) -> OpenAIProtocolError:
+    """Convert Pydantic locations into stable dotted OpenAI ``param`` paths.
+
+    Union validation reports every branch's complaints. Errors group by
+    their branch (the location minus its final field segment); among the
+    most field-specific groups, the branch the caller actually meant is the
+    one with the fewest complaints, so its deepest cleaned location names
+    the real field (an echoed item's ``input.1.caller``), never a union
+    branch label such as ``input.str``. The chosen field's own complaints
+    then name the expected shape against the arriving JSON type.
+    """
+    reported = error.errors(include_url=False)
+    groups: dict[tuple[str | int, ...], list[tuple[tuple[str, ...], ErrorDetails]]] = {}
+    for detail in reported:
+        groups.setdefault(tuple(detail["loc"][:-1]), []).append(
+            (_cleaned_location(detail["loc"]), detail)
+        )
+    if not groups:
+        return invalid_field("body")
+    deepest = max(len(location) for members in groups.values() for location, _ in members)
+    candidates = [
+        members
+        for members in groups.values()
+        if any(len(location) == deepest for location, _ in members)
+    ]
+    best = min(candidates, key=len)
+    location = max((cleaned for cleaned, _ in best), key=len, default=())
+    param = ".".join(location) or "body"
+    details = [detail for cleaned, detail in best if cleaned == location]
+    # A tag rejection can carry the field itself as its location, so it may
+    # rename the param; the message and the path are returned together so the
+    # two never disagree.
+    tag = _tag_rejection(reported, details, param)
+    if tag is not None:
+        return invalid_field(tag[0], tag[1])
+    if param == "body":
+        # A whole-request rule (such as the attachment count ceiling) has no
+        # field of its own, so its own wording is the only useful message.
+        for detail in details:
+            if detail["type"] == "value_error":
+                return invalid_field(param, detail["msg"].removeprefix("Value error, ") + ".")
+    for detail in details:
+        # A field validator's own wording states this gateway's exact value
+        # constraint (only our wire models raise these, so the text is
+        # display-safe and never echoes the caller's value).
+        if detail["type"] == "value_error":
+            return invalid_field(
+                param,
+                f"Invalid value for {param!r}: "
+                + detail["msg"].removeprefix("Value error, ")
+                + ".",
+            )
+    return invalid_field(param, _shape_message(param, details))

--- a/exp/runtime/openai_protocol/requests.py
+++ b/exp/runtime/openai_protocol/requests.py
@@ -10,7 +10,6 @@ from openai.types import EmbeddingCreateParams
 from openai.types.chat.completion_create_params import CompletionCreateParams
 from openai.types.responses.response_create_params import ResponseCreateParams
 from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
-from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import ContractModel, JsonObject
 from exp.common.models.model import ToolCall
@@ -39,7 +38,7 @@ from exp.runtime.openai_protocol.cache_control import (
     drop_opencode_cache_control,
 )
 from exp.runtime.openai_protocol.enable_thinking import translate_enable_thinking
-from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
+from exp.runtime.openai_protocol.errors import invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import (
     CHAT_MANIFEST,
     EMBEDDINGS_MANIFEST,
@@ -48,6 +47,7 @@ from exp.runtime.openai_protocol.manifest import (
 )
 from exp.runtime.openai_protocol.media_parts import message_content
 from exp.runtime.openai_protocol.prompt_cache_key_alias import fold_prompt_cache_key_alias
+from exp.runtime.openai_protocol.rejections import _validation_protocol_error
 from exp.runtime.openai_protocol.responses_input import (
     ReplayedFunctionCall,
     ReplayedFunctionOutput,
@@ -63,7 +63,6 @@ from exp.runtime.openai_protocol.structured_text import (
     responses_structured_text,
 )
 from exp.runtime.openai_protocol.wire_models import (
-    HOSTED_TOOL_ITEM_TYPES_ASSISTANT,
     HOSTED_TOOL_ITEM_TYPES_TOOL,
     _AdditionalToolsItem,
     _AssistantToolCall,
@@ -510,166 +509,6 @@ def _validate_wire[ModelT: BaseModel](model: type[ModelT], payload: JsonObject) 
         return model.model_validate(payload)
     except ValidationError as exc:
         raise _validation_protocol_error(exc) from exc
-
-
-_LOCATION_NOISE = {"body", "non-streaming", "streaming"}
-_UNION_BRANCH_TYPES = {"str", "int", "float", "bool", "list", "tuple", "dict", "NoneType"}
-_OUTPUT_ITEM_VARIANTS = {
-    "message",
-    "function_call",
-    "function_call_output",
-    "reasoning",
-    "additional_tools",
-    "custom_tool_call",
-    "custom_tool_call_output",
-    # Hosted-tool echo variants share the same union-branch label shape.
-    *HOSTED_TOOL_ITEM_TYPES_TOOL,
-    *HOSTED_TOOL_ITEM_TYPES_ASSISTANT,
-}
-
-
-def _cleaned_location(location: tuple[str | int, ...]) -> tuple[str, ...]:
-    """Drop pydantic union-branch labels so the path names request fields."""
-    cleaned: list[str] = []
-    for part in location:
-        text = str(part)
-        if text in _LOCATION_NOISE:
-            continue
-        # Typed-dict union branches are labeled with their class name, which
-        # no request field ever shares: every public field is lower case.
-        if isinstance(part, str) and (
-            part.startswith("_") or "[" in text or text in _UNION_BRANCH_TYPES or text[:1].isupper()
-        ):
-            continue
-        if text in _OUTPUT_ITEM_VARIANTS and cleaned and cleaned[-1].isdigit():
-            continue
-        # A discriminated part whose tag is also its payload field name
-        # (``file.file``, ``image_url.image_url``) reports the tag once.
-        if cleaned and cleaned[-1] == text and not text.isdigit():
-            continue
-        cleaned.append(text)
-    return tuple(cleaned)
-
-
-_WIRE_TYPE_NAMES = {
-    "str": "a string",
-    "int": "an integer",
-    "float": "a number",
-    "bool": "a boolean",
-    "list": "an array",
-    "tuple": "an array",
-    "dict": "an object",
-    "NoneType": "null",
-}
-"""JSON-shape names for python input types, used in expected/got messages."""
-
-_EXPECTED_BY_ERROR_TYPE = {
-    "string_type": "a string",
-    "string_too_short": "a non-empty string",
-    "int_type": "an integer",
-    "int_parsing": "an integer",
-    "float_type": "a number",
-    "float_parsing": "a number",
-    "bool_type": "a boolean",
-    "list_type": "an array",
-    "tuple_type": "an array",
-    "dict_type": "an object",
-    "model_type": "an object",
-    "model_attributes_type": "an object",
-    "missing": "a value",
-    "none_required": "null",
-}
-"""Shape-level expectations for the pydantic error types worth naming."""
-
-
-def _shape_message(param: str, details: list[ErrorDetails]) -> str | None:
-    """Describe what shape a field expected versus what arrived.
-
-    Only structural facts appear: expectations come from this gateway's own
-    wire models and the got side is the JSON type of the caller's value,
-    never the value itself and never provider prose.
-    """
-    expected: list[str] = []
-    got: str | None = None
-    for detail in details:
-        if detail["type"] == "string_too_long":
-            # The bound and the arriving LENGTH are both display-safe facts
-            # (the value itself is never echoed); stating them saves the
-            # caller from bisecting the ceiling out of a bare rejection.
-            context = detail.get("ctx") or {}
-            maximum = context.get("max_length")
-            value = detail.get("input")
-            if isinstance(maximum, int) and isinstance(value, str):
-                return (
-                    f"Invalid value for '{param}': expected at most "
-                    f"{maximum:,} characters, but got {len(value):,}."
-                )
-        phrase = _EXPECTED_BY_ERROR_TYPE.get(detail["type"])
-        if detail["type"] in {"literal_error", "enum"}:
-            context = detail.get("ctx") or {}
-            allowed = context.get("expected")
-            if isinstance(allowed, str):
-                phrase = f"one of {allowed}"
-        if phrase is not None and phrase not in expected:
-            expected.append(phrase)
-        # A missing-field complaint carries the parent object as its input,
-        # so it contributes no honest "got" type.
-        if detail["type"] != "missing" and "input" in detail:
-            got = _WIRE_TYPE_NAMES.get(type(detail["input"]).__name__, got)
-    if not expected:
-        return None
-    description = " or ".join(expected)
-    if got is not None:
-        return f"Invalid value for '{param}': expected {description}, but got {got} instead."
-    return f"Invalid value for '{param}': expected {description}."
-
-
-def _validation_protocol_error(error: ValidationError) -> OpenAIProtocolError:
-    """Convert Pydantic locations into stable dotted OpenAI ``param`` paths.
-
-    Union validation reports every branch's complaints. Errors group by
-    their branch (the location minus its final field segment); among the
-    most field-specific groups, the branch the caller actually meant is the
-    one with the fewest complaints, so its deepest cleaned location names
-    the real field (an echoed item's ``input.1.caller``), never a union
-    branch label such as ``input.str``. The chosen field's own complaints
-    then name the expected shape against the arriving JSON type.
-    """
-    groups: dict[tuple[str | int, ...], list[tuple[tuple[str, ...], ErrorDetails]]] = {}
-    for detail in error.errors(include_url=False):
-        groups.setdefault(tuple(detail["loc"][:-1]), []).append(
-            (_cleaned_location(detail["loc"]), detail)
-        )
-    if not groups:
-        return invalid_field("body")
-    deepest = max(len(location) for members in groups.values() for location, _ in members)
-    candidates = [
-        members
-        for members in groups.values()
-        if any(len(location) == deepest for location, _ in members)
-    ]
-    best = min(candidates, key=len)
-    location = max((cleaned for cleaned, _ in best), key=len, default=())
-    param = ".".join(location) or "body"
-    details = [detail for cleaned, detail in best if cleaned == location]
-    if param == "body":
-        # A whole-request rule (such as the attachment count ceiling) has no
-        # field of its own, so its own wording is the only useful message.
-        for detail in details:
-            if detail["type"] == "value_error":
-                return invalid_field(param, detail["msg"].removeprefix("Value error, ") + ".")
-    for detail in details:
-        # A field validator's own wording states this gateway's exact value
-        # constraint (only our wire models raise these, so the text is
-        # display-safe and never echoes the caller's value).
-        if detail["type"] == "value_error":
-            return invalid_field(
-                param,
-                f"Invalid value for {param!r}: "
-                + detail["msg"].removeprefix("Value error, ")
-                + ".",
-            )
-    return invalid_field(param, _shape_message(param, details))
 
 
 def _validated_operation_headers(

--- a/exp/runtime/openai_protocol/requests_test.py
+++ b/exp/runtime/openai_protocol/requests_test.py
@@ -1972,6 +1972,143 @@ def test_the_captured_codex_reasoning_echo_with_null_content_decodes() -> None:
     assert carrier[0].encrypted_content == "gAAAAABfixture"
 
 
+def _named(param: str, message: str) -> tuple[str, str]:
+    """Build the (param, message) pair one rejection is expected to carry."""
+    return param, message
+
+
+def test_numeric_bound_rejections_state_the_bound_not_only_the_field() -> None:
+    """An out-of-range control names its limit instead of a bare field path.
+
+    Customer-facing surfaces read these messages directly, and a bare
+    ``Invalid value for 'temperature'.`` forces the caller to bisect the
+    ceiling out of the rejection (the same problem the over-long description
+    bound was fixed for).
+    """
+    for decoder, payload, expected in (
+        (
+            decode_chat,
+            {"model": "coding", "messages": [{"role": "user", "content": "hi"}], "temperature": 5},
+            _named("temperature", "Invalid value for 'temperature': expected at most 2."),
+        ),
+        (
+            decode_chat,
+            {"model": "coding", "messages": [{"role": "user", "content": "hi"}], "top_p": 3},
+            _named("top_p", "Invalid value for 'top_p': expected at most 1."),
+        ),
+        (
+            decode_chat,
+            {"model": "coding", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 0},
+            _named("max_tokens", "Invalid value for 'max_tokens': expected greater than 0."),
+        ),
+        (
+            decode_chat,
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "presence_penalty": -9,
+            },
+            _named(
+                "presence_penalty",
+                "Invalid value for 'presence_penalty': expected at least -2.",
+            ),
+        ),
+        (
+            decode_responses,
+            {"model": "coding", "input": "hi", "max_output_tokens": 0},
+            _named(
+                "max_output_tokens",
+                "Invalid value for 'max_output_tokens': expected greater than 0.",
+            ),
+        ),
+        (
+            decode_responses,
+            {"model": "coding", "input": "hi", "top_k": -1},
+            _named("top_k", "Invalid value for 'top_k': expected at least 0."),
+        ),
+    ):
+        with pytest.raises(OpenAIProtocolError) as raised:
+            decoder(payload)
+        assert (raised.value.detail.param, raised.value.detail.message) == expected
+
+
+def test_boolean_and_short_list_rejections_name_the_expected_shape() -> None:
+    """A wrong boolean and an empty message list state what was expected."""
+    with pytest.raises(OpenAIProtocolError) as boolean:
+        decode_responses({"model": "coding", "input": "hi", "store": "x"})
+    assert boolean.value.detail.param == "store"
+    assert boolean.value.detail.message == (
+        "Invalid value for 'store': expected a boolean, but got a string instead."
+    )
+
+    with pytest.raises(OpenAIProtocolError) as empty:
+        decode_chat({"model": "coding", "messages": []})
+    assert empty.value.detail.param == "messages"
+    assert empty.value.detail.message == (
+        "Invalid value for 'messages': expected at least 1 entry, but got 0."
+    )
+
+
+def test_unknown_item_type_names_the_type_selector_not_a_sibling_field() -> None:
+    """An unknown item ``type`` names the tag field and the accepted tags.
+
+    Pydantic reports the union miss at the item's own location and then adds a
+    speculative complaint from the arm it tried first (``input.0.role``), naming
+    a field the caller never sent. The tag diagnosis is the caller's real
+    mistake, so it wins and its path names the ``type`` selector itself.
+    """
+    with pytest.raises(OpenAIProtocolError) as raised:
+        decode_responses({"model": "coding", "input": [{"type": "bogus"}]})
+    assert raised.value.detail.param == "input.0.type"
+    assert raised.value.detail.message.startswith(
+        "Invalid value for 'input.0.type': expected one of 'function_call', 'function_call_output'"
+    )
+
+
+def test_unknown_content_part_type_names_the_part_selector() -> None:
+    """A bad content-part ``type`` names that part's selector and its options."""
+    with pytest.raises(OpenAIProtocolError) as chat:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": [{"type": "image", "image_url": "u"}]}],
+            }
+        )
+    assert chat.value.detail.param == "messages.0.content.0.type"
+    assert chat.value.detail.message == (
+        "Invalid value for 'messages.0.content.0.type': expected one of 'text', "
+        "'input_text', 'output_text', 'image_url', 'input_image', 'video_url', "
+        "'input_audio', 'file', 'input_file'."
+    )
+
+    with pytest.raises(OpenAIProtocolError) as missing:
+        decode_chat(
+            {"model": "coding", "messages": [{"role": "user", "content": [{"image_url": "u"}]}]}
+        )
+    assert missing.value.detail.param == "messages.0.content.0.type"
+    assert missing.value.detail.message == (
+        "Invalid value for 'messages.0.content.0.type': a type selector is required here."
+    )
+
+
+def test_undeclared_nested_keys_use_the_unknown_parameter_phrasing() -> None:
+    """A stray key inside a tool entry reads like the top-level rejection."""
+    with pytest.raises(OpenAIProtocolError) as chat:
+        decode_chat(
+            {
+                "model": "coding",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {"type": "function", "function": {"name": "t", "parameters": {}, "bogus": 1}}
+                ],
+            }
+        )
+    assert chat.value.detail.param == "tools.0.function.bogus"
+    assert chat.value.detail.message == (
+        "Unknown parameter 'tools.0.function.bogus'. Remove the field and resend the request."
+    )
+
+
 def test_decode_errors_name_the_expected_shape_against_the_arriving_type() -> None:
     """Union rejections say what shape the field expected and what arrived,
     at type level only, matching the provider's own error style."""


### PR DESCRIPTION
## Problem

Validation rejections on the Chat and Responses surfaces degraded to a content-free `Invalid value for 'X'.` whenever the failing pydantic error type was not one of the fourteen the shaper recognized. Verified against current `main`:

```
temperature: 5        -> Invalid value for 'temperature'.        (constraint le=2, unstated)
top_p: 3              -> Invalid value for 'top_p'.              (constraint le=1, unstated)
max_tokens: 0         -> Invalid value for 'max_tokens'.         (constraint gt=0, unstated)
presence_penalty: -9  -> Invalid value for 'presence_penalty'.   (constraint ge=-2, unstated)
store: "x"            -> Invalid value for 'store'.
max_output_tokens: 0  -> Invalid value for 'max_output_tokens'.
top_k: -1             -> Invalid value for 'top_k'.
messages: []          -> Invalid value for 'messages'.
```

A caller reading these has to bisect the constraint out of a bare field path. This is the same class of problem the over-long description bound was fixed for in #817, which states both the limit and the arriving length; the numeric-bound and list-length paths were simply never mapped, so they fell through to `invalid_field(param, None)` and its default message.

Two rejection families were worse than terse:

**A union miss blamed a field the caller never sent.** An unknown item `type` on `/v1/responses` returned

```
Invalid value for 'input.0.role': expected a value.
```

Pydantic reports the union miss at the item's own location, then adds a speculative complaint (`missing` on `role`) from the arm it happened to try first. The shaper selected the arm complaint, so the message named a field that was never in the request and never named the tag that was actually wrong. The same shape produced `input.0.content` for a message item and a bare `input.0.content.0` for a bad content part.

**An undeclared nested key was terser than its top-level twin.** `tools.0.function.bogus` returned a bare path, while the identical mistake at the top level already read `Unknown parameter 'bogus'. Remove the field and resend the request.`

## Fix

| Rejection | Before | After |
|---|---|---|
| `temperature: 5` | `Invalid value for 'temperature'.` | `Invalid value for 'temperature': expected at most 2.` |
| `max_tokens: 0` | `Invalid value for 'max_tokens'.` | `Invalid value for 'max_tokens': expected greater than 0.` |
| `presence_penalty: -9` | `Invalid value for 'presence_penalty'.` | `Invalid value for 'presence_penalty': expected at least -2.` |
| `store: "x"` | `Invalid value for 'store'.` | `Invalid value for 'store': expected a boolean, but got a string instead.` |
| `messages: []` | `Invalid value for 'messages'.` | `Invalid value for 'messages': expected at least 1 entry, but got 0.` |
| `input: [{"type": "bogus"}]` | `Invalid value for 'input.0.role': expected a value.` | `Invalid value for 'input.0.type': expected one of 'function_call', 'function_call_output', ...` |
| a content part with no `type` | `Invalid value for 'messages.0.content.0'.` | `Invalid value for 'messages.0.content.0.type': a type selector is required here.` |
| `tools.0.function.bogus` | `Invalid value for 'tools.0.function.bogus'.` | `Unknown parameter 'tools.0.function.bogus'. Remove the field and resend the request.` |

Bounds come from the error's own `ctx`, so every number stated is this gateway's wire-model constraint, never the caller's value. The tag field is reported as the caller's own `type` selector so the path and the message agree. Arriving tag values are deliberately **not** echoed, matching every other message here: these report structure, not caller content or provider prose.

The union change is what makes the `input.0.role` misdirection go away; it only overrides a **purely speculative** selection (every selected detail is a `missing` field) and only when a real tag rejection exists, so the existing union-path resolution that names `input.1.caller` and `input.0.content` is unchanged (see the tests it already has).

## Placement

The shaping moves to `exp/runtime/openai_protocol/rejections.py`. `requests.py` was at **994 of the 999-physical-line gate** before this change and had no room for it, so a sibling module was the only way to satisfy the repository's own size rule. `_validation_protocol_error` is re-exported from `requests.py` under its original name, so the existing importer (`images_requests.py`) is untouched.

## Verification

- `uv run ruff check .` and `uv run ruff format --check .`: clean.
- `uv run ty check`: `All checks passed!`
- `uv run pytest -q`: **4070 passed, 6 skipped**. The only two failures on a dirty tree were `composition_evidence_test.py` and `comparison_evidence_test.py`, which fail closed with `release evidence requires a checkout with no tracked source changes`; both pass on this commit. Baseline on unmodified `main` was 4072 passed, 6 skipped, so this is the same suite with no regressions.
- New regression coverage in `requests_test.py`: numeric bounds, boolean and short-list messages, the item-tag and content-part-tag diagnoses (including the missing-selector case), and the nested unknown-key phrasing.

Python-only: no change under `exp/runtime/gateway/native`, so the crate version is untouched and no native wheels are republished.

## Note

The `cache_control` rejection (`messages.0.cache_control`) still returns its bare message. That one is a deliberate, separately-tested contract raised from `cache_control.py`'s `require_supported_cache_control` rather than the wire-model shaper, so it is out of scope here; happy to give it the same treatment in a follow-up if that is wanted.
