### PR TITLE
gateway: withhold and reconcile bytes streamed after a tool-argument object closes (Foundry DeepSeek `{}""`)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -43,6 +43,18 @@ Output guardrail byte limits count the complete serialized completion, including
 tool IDs, tool names, arguments, and JSON framing.
 Provider-specific wire restrictions still apply when routing to a different API dialect.
 
+Streamed function-call arguments must assemble to one JSON object. On OpenAI-compatible
+Chat streams the gateway stops relaying argument deltas at the byte that closes that object:
+whatever the provider streams after it is withheld and judged at completion. A tail that is
+only whitespace, an exact repetition of the whole object, or (after a zero-argument `{}`)
+empty literals such as `""` is dropped and the call completes — Azure Foundry's DeepSeek shim
+streams `{}` then `""` for every zero-argument call — so the deltas a client receives always
+concatenate to the completed call's bytes. Any other tail, and any syntax error inside the
+object, keeps the strict contract: the attempt fails as `malformed_response` (a provider
+fault, eligible to fail over to a later deployment), the ledger names the parse position and
+byte count, and the operator log names the tool; argument bytes are never logged or repaired
+by guessing.
+
 ## The data plane
 
 The gateway has exactly one data plane: a native Rust HTTP server compiled as

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.47"
+version = "0.3.48"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.47"
+version = "0.3.48"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.47"
+version = "0.3.48"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects.rs
+++ b/exp/runtime/gateway/native/src/dialects.rs
@@ -290,14 +290,15 @@ fn complete_streamed_tool(
         // invites dictionary guessing): the operator line carries only the
         // tool name, the size, and the parse reason, which together
         // correlate identical unparsable shapes across requests.
+        let bytes = tool.raw_arguments.len() + tool.withheld_tail.len();
         let line = serde_json::json!({
             "event": "malformed_tool_arguments",
             "name": tool.name,
-            "bytes": tool.raw_arguments.len(),
+            "bytes": bytes,
             "reason": message,
         });
         eprintln!("exp-gateway-native: {line}");
-        malformed(&format!("{message} ({} bytes)", tool.raw_arguments.len()))
+        malformed(&format!("{message} ({bytes} bytes)"))
     })?;
     events.push(if tool.server {
         Event::ServerToolUseCompleted { index, call }

--- a/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/compatible.rs
@@ -202,11 +202,15 @@ impl Normalizer {
                             };
                             self.reserve_tool_bytes(raw_fragment.len())?;
                             let tool = self.tools.get_mut(&index).expect("tool just ensured");
-                            tool.raw_arguments.push_str(&raw_fragment);
-                            events.push(Event::ToolArgumentsDelta {
-                                index,
-                                delta: raw_fragment,
-                            });
+                            // Bytes after the argument object closes are
+                            // withheld, never relayed: Azure Foundry's
+                            // DeepSeek shim streams `{}` then `""` for a
+                            // zero-argument call (live 2026-09-10), and a
+                            // client that concatenates deltas must end up
+                            // with exactly the completed call's bytes.
+                            if let Some(delta) = tool.push_arguments(&raw_fragment) {
+                                events.push(Event::ToolArgumentsDelta { index, delta });
+                            }
                         }
                     }
                 }

--- a/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
+++ b/exp/runtime/gateway/native/src/dialects/openai/normalizer_tests.rs
@@ -883,3 +883,116 @@ fn responses_error_frames_keep_numeric_codes() {
             && failure.provider_detail.as_deref() == Some("429: Slow down.")
     ));
 }
+
+#[test]
+fn foundry_deepseek_zero_argument_call_streams_a_stray_empty_string_delta() {
+    // Azure Foundry serving DeepSeek-V4-Flash, captured live 2026-09-10 (ids
+    // redacted): a zero-argument call opens with `arguments: ""`, streams
+    // `{}`, then one more delta whose text is `""` (two quote characters),
+    // then finishes `tool_calls`. Verbatim assembly gave `{}""` and failed
+    // every such call as malformed_response ("trailing characters at line 1
+    // column 3 (4 bytes)"; 222 production attempts on 2026-09-10 alone). The
+    // stray delta is withheld from the caller and the call completes as `{}`.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    let frames = [
+        serde_json::json!({"reasoning_content": null, "role": "assistant", "content": ""}),
+        serde_json::json!({"role": null, "content": "\n\n", "reasoning_content": null, "tool_calls": null}),
+        serde_json::json!({"role": null, "content": null, "reasoning_content": null, "tool_calls": [{
+            "id": "call_1ec818a39da5408bb7b383a9", "index": 0, "type": "function",
+            "function": {"name": "view_agent_graph", "arguments": ""},
+        }]}),
+        serde_json::json!({"role": null, "content": null, "reasoning_content": null, "tool_calls": [{
+            "id": null, "index": 0, "type": "function",
+            "function": {"name": null, "arguments": "{}"},
+        }]}),
+        serde_json::json!({"role": null, "content": null, "reasoning_content": null, "tool_calls": [{
+            "id": null, "index": 0, "type": "function",
+            "function": {"name": null, "arguments": "\"\""},
+        }]}),
+    ];
+    let mut events = Vec::new();
+    for frame in &frames {
+        events.extend(
+            normalizer
+                .feed(&compatible_chunk(frame.clone(), None))
+                .expect("every Foundry frame must normalize"),
+        );
+    }
+    events.extend(
+        normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"reasoning_content": null}),
+                Some("tool_calls"),
+            ))
+            .expect("finish chunk must normalize"),
+    );
+    events.extend(
+        normalizer
+            .feed(&SseEvent {
+                event: None,
+                data: "[DONE]".to_string(),
+            })
+            .expect("the stream must complete"),
+    );
+    let shown: String = events
+        .iter()
+        .filter_map(|event| match event {
+            Event::ToolArgumentsDelta { delta, .. } => Some(delta.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(shown, "{}", "the stray delta never reaches the caller");
+    assert!(matches!(
+        events.as_slice(),
+        [
+            Event::TextDelta(text),
+            Event::ToolCallStarted { call_id, name, .. },
+            Event::ToolArgumentsDelta { delta: opening, .. },
+            Event::ToolArgumentsDelta { delta, .. },
+            Event::ToolCallCompleted { call, .. },
+            Event::Completed,
+        ] if text == "\n\n"
+            && call_id == "call_1ec818a39da5408bb7b383a9"
+            && name == "view_agent_graph"
+            && opening.is_empty()
+            && delta == "{}"
+            && call.raw_arguments == "{}"
+    ));
+}
+
+#[test]
+fn compatible_stream_still_rejects_argument_content_after_the_object_closed() {
+    // The hold-back drops NOISE only: a second object after a complete one
+    // is two candidate parses, and the stream stays malformed, reporting
+    // the position in the bytes the provider actually sent.
+    let mut normalizer = Normalizer::new(Dialect::OpenAiCompatible);
+    for arguments in ["{\"a\":1}", "{\"b\":2}"] {
+        normalizer
+            .feed(&compatible_chunk(
+                serde_json::json!({"tool_calls": [{
+                    "index": 0, "id": "call_1", "type": "function",
+                    "function": {"name": "lookup", "arguments": arguments},
+                }]}),
+                None,
+            ))
+            .expect("fragments normalize until completion");
+    }
+    let failure = normalizer
+        .feed(&SseEvent {
+            event: None,
+            data: "[DONE]".to_string(),
+        })
+        .expect_err("content after a closed object stays malformed");
+    assert_eq!(failure.failure_class, FailureClass::MalformedResponse);
+    assert!(
+        failure
+            .safe_message
+            .ends_with("trailing characters at line 1 column 8 (14 bytes)"),
+        "{}",
+        failure.safe_message
+    );
+    assert!(
+        failure.failover_eligible,
+        "a provider fault may fail over to a later rung"
+    );
+}

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -678,6 +678,130 @@ pub fn require_json_object_text(raw: &str) -> Result<(), String> {
     }
 }
 
+/// Incremental scan of one JSON-argument accumulation that knows the byte at
+/// which the top-level value closed.
+///
+/// A tool call's arguments are one JSON object, so nothing a provider streams
+/// after the byte that closes it can be argument content: it is either an
+/// extra delta the shim never should have sent or noise. The scan is a
+/// constant-time-per-byte bracket/string tracker (never a re-parse of the
+/// whole accumulation), exact for any well-formed prefix; a malformed prefix
+/// simply never closes and keeps the strict parse at completion.
+#[derive(Debug, Clone, Default)]
+pub struct JsonValueScan {
+    depth: u32,
+    in_string: bool,
+    escaped: bool,
+    /// Whether the top-level value has closed (depth returned to zero after
+    /// a container opened).
+    pub closed: bool,
+}
+
+impl JsonValueScan {
+    /// Feed one fragment; returns the byte offset within it at which the
+    /// top-level value closed (exclusive, i.e. the first byte of the tail),
+    /// or `None` when the fragment left the value open. Only ASCII
+    /// structural bytes advance the scan, so the offset is always a char
+    /// boundary.
+    pub fn feed(&mut self, fragment: &str) -> Option<usize> {
+        if self.closed {
+            return Some(0);
+        }
+        for (offset, byte) in fragment.bytes().enumerate() {
+            if self.in_string {
+                if self.escaped {
+                    self.escaped = false;
+                } else if byte == b'\\' {
+                    self.escaped = true;
+                } else if byte == b'"' {
+                    self.in_string = false;
+                }
+                continue;
+            }
+            match byte {
+                b'"' => self.in_string = true,
+                b'{' | b'[' => self.depth += 1,
+                b'}' | b']' if self.depth > 0 => {
+                    self.depth -= 1;
+                    if self.depth == 0 {
+                        self.closed = true;
+                        return Some(offset + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+/// Why a tail streamed after a complete argument object was dropped rather
+/// than failing the call. Each shape reproduces exactly one parse, so no
+/// argument content is ever invented or chosen between alternatives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedundantTail {
+    /// Only whitespace (a pretty-printed buffer's trailing newline).
+    Whitespace,
+    /// One or more exact repetitions of the complete value (`{}{}`, a
+    /// duplicated whole-object delta).
+    DuplicateValue,
+    /// Empty JSON literals after a zero-argument call (`{}""`: Azure
+    /// Foundry's DeepSeek shim, live 2026-09-10, 222 attempts in one day).
+    EmptyLiterals,
+}
+
+impl RedundantTail {
+    fn as_str(self) -> &'static str {
+        match self {
+            RedundantTail::Whitespace => "whitespace",
+            RedundantTail::DuplicateValue => "duplicate_value",
+            RedundantTail::EmptyLiterals => "empty_literals",
+        }
+    }
+}
+
+/// Classify the bytes a provider streamed AFTER its argument object closed.
+///
+/// Accepts only tails whose removal is unambiguous: whitespace; exact
+/// repetitions of the whole value; and, after a zero-argument `{}` only,
+/// empty literals (`""`, `{}`, `[]`) that carry no argument content. A tail
+/// that is merely a suffix of the value (`{"a":1}}`) is NOT accepted: the same
+/// bytes arise from a dropped inner delta (`{"a":1,"b":{` lost from
+/// `{"a":1,"b":{"c":2}}`), so the parse would be a guess.
+pub fn redundant_tail(value: &str, tail: &str) -> Option<RedundantTail> {
+    let value = value.trim();
+    let tail = tail.trim();
+    if tail.is_empty() {
+        return Some(RedundantTail::Whitespace);
+    }
+    let mut rest = tail;
+    let mut duplicates = true;
+    while !rest.is_empty() {
+        match rest.strip_prefix(value) {
+            Some(after) if !value.is_empty() => rest = after.trim_start(),
+            _ => {
+                duplicates = false;
+                break;
+            }
+        }
+    }
+    if duplicates {
+        return Some(RedundantTail::DuplicateValue);
+    }
+    if value != "{}" {
+        return None;
+    }
+    let mut rest = tail;
+    while !rest.is_empty() {
+        rest = rest
+            .strip_prefix("\"\"")
+            .or_else(|| rest.strip_prefix("{}"))
+            .or_else(|| rest.strip_prefix("[]"))?
+            .trim_start();
+    }
+    Some(RedundantTail::EmptyLiterals)
+}
+
 /// Accumulated per-stream state for one incrementally emitted function call.
 #[derive(Debug, Clone)]
 pub struct ToolAccumulator {
@@ -696,6 +820,13 @@ pub struct ToolAccumulator {
     /// (`server_tool_use`), whose lifecycle events stay on the dedicated
     /// server-tool variants and never count toward the tool-use stop reason.
     pub server: bool,
+    /// Scan of `raw_arguments` for dialects that accumulate through
+    /// [`ToolAccumulator::push_arguments`]; dialects that append directly
+    /// leave it untouched and never withhold anything.
+    scan: JsonValueScan,
+    /// Bytes streamed after the argument object closed, never emitted to the
+    /// caller; reconciled by [`ToolAccumulator::complete`].
+    pub withheld_tail: String,
 }
 
 /// Opaque tool IDs share the Python model bound, including signature carriers.
@@ -714,11 +845,62 @@ impl ToolAccumulator {
             completed: false,
             custom: false,
             server: false,
+            scan: JsonValueScan::default(),
+            withheld_tail: String::new(),
+        }
+    }
+
+    /// Append one streamed argument fragment, returning the part the caller
+    /// may see: everything up to and including the byte that closes the
+    /// argument object. Whatever follows that byte is withheld (never
+    /// emitted) and judged at completion, so the deltas a client receives
+    /// always concatenate to the completed call's bytes. Custom (freeform)
+    /// input is opaque text and passes through whole.
+    pub fn push_arguments(&mut self, fragment: &str) -> Option<String> {
+        if self.custom {
+            self.raw_arguments.push_str(fragment);
+            return Some(fragment.to_string());
+        }
+        match self.scan.feed(fragment) {
+            None => {
+                self.raw_arguments.push_str(fragment);
+                Some(fragment.to_string())
+            }
+            Some(closed_at) => {
+                let (value, tail) = fragment.split_at(closed_at);
+                self.raw_arguments.push_str(value);
+                self.withheld_tail.push_str(tail);
+                (!value.is_empty()).then(|| value.to_string())
+            }
         }
     }
 
     pub fn complete(&self) -> Result<CompletedToolCall, String> {
         if !self.custom {
+            if !self.withheld_tail.is_empty() {
+                // A provider streamed bytes after its argument object closed.
+                // Only a content-free tail is dropped (its shape reaches the
+                // operator log; never its bytes); anything else is validated
+                // as the concatenation the provider actually sent, so the
+                // failure names the same parse position it always did.
+                match redundant_tail(&self.raw_arguments, &self.withheld_tail) {
+                    Some(RedundantTail::Whitespace) => {}
+                    Some(shape) => {
+                        let line = serde_json::json!({
+                            "event": "tool_arguments_tail_dropped",
+                            "name": self.name,
+                            "shape": shape.as_str(),
+                            "tail_bytes": self.withheld_tail.len(),
+                        });
+                        eprintln!("exp-gateway-native: {line}");
+                    }
+                    None => {
+                        let mut streamed = self.raw_arguments.clone();
+                        streamed.push_str(&self.withheld_tail);
+                        require_json_object_text(&streamed)?;
+                    }
+                }
+            }
             // Custom (freeform) tool input is opaque text by contract; only
             // function arguments must parse as one JSON object.
             require_json_object_text(&self.raw_arguments)?;

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -384,3 +384,163 @@ fn tool_id_bound_counts_characters_and_preserves_opaque_signatures() {
         assert!(tool.complete().is_err());
     }
 }
+
+/// Push fragments through the hold-back path and return what a client would
+/// have been shown.
+fn push_all(tool: &mut ToolAccumulator, fragments: &[&str]) -> Vec<String> {
+    fragments
+        .iter()
+        .filter_map(|fragment| tool.push_arguments(fragment))
+        .collect()
+}
+
+#[test]
+fn zero_argument_tail_of_empty_literals_is_dropped_after_the_object_closes() {
+    // Azure Foundry's DeepSeek-V4-Flash shim (captured live 2026-09-10):
+    // a zero-argument call streams `""` (arguments start), `{}`, then a
+    // stray `""` delta. Verbatim concatenation is `{}""`, the exact
+    // "trailing characters at line 1 column 3 (4 bytes)" seen on 222
+    // production attempts in one day. The stray delta carries no argument
+    // content, so it is withheld from the caller and the call completes.
+    let mut tool = ToolAccumulator::new("call_1".into(), "view_agent_graph".into());
+    let shown = push_all(&mut tool, &["", "{}", "\"\""]);
+    // The empty opening delta is shown as before (unchanged wire behaviour);
+    // only the bytes after the closing brace are withheld.
+    assert_eq!(shown, vec![String::new(), "{}".to_string()]);
+    assert_eq!(tool.withheld_tail, "\"\"");
+    let call = tool.complete().expect("a content-free tail completes");
+    assert_eq!(call.raw_arguments, "{}");
+    // The same verdict for every empty literal, in any mix, with whitespace;
+    // a bare `{}` after `{}` is first of all a duplicated whole value.
+    for tail in ["[]", "\"\"{}", " \"\" \n[] {}"] {
+        assert_eq!(
+            redundant_tail("{}", tail),
+            Some(RedundantTail::EmptyLiterals)
+        );
+    }
+    assert_eq!(
+        redundant_tail("{}", "{}"),
+        Some(RedundantTail::DuplicateValue)
+    );
+}
+
+#[test]
+fn duplicated_whole_object_deltas_collapse_to_one_value() {
+    // A delta re-sent whole (`{}{}`, or a non-empty object twice) adds no
+    // information: the first copy is the call, the repetition is dropped.
+    let mut tool = ToolAccumulator::new("call_1".into(), "lookup".into());
+    assert_eq!(push_all(&mut tool, &["{}", "{}"]), vec!["{}".to_string()]);
+    assert_eq!(tool.complete().expect("duplicate").raw_arguments, "{}");
+
+    let mut tool = ToolAccumulator::new("call_2".into(), "lookup".into());
+    // The repetition straddles a fragment boundary with the closing byte.
+    let shown = push_all(&mut tool, &["{\"a\":", "1}{\"a\"", ":1}"]);
+    assert_eq!(shown.concat(), "{\"a\":1}");
+    assert_eq!(tool.withheld_tail, "{\"a\":1}");
+    assert_eq!(
+        tool.complete().expect("duplicate").raw_arguments,
+        "{\"a\":1}"
+    );
+    assert_eq!(
+        redundant_tail("{\"a\":1}", " {\"a\":1}\n{\"a\":1}"),
+        Some(RedundantTail::DuplicateValue)
+    );
+}
+
+#[test]
+fn pretty_printed_arguments_with_a_trailing_newline_complete() {
+    let mut tool = ToolAccumulator::new("call_1".into(), "lookup".into());
+    let shown = push_all(
+        &mut tool,
+        &["{\n  \"a\": [1, 2],\n", "  \"b\": {}\n}", "\n"],
+    );
+    assert_eq!(shown.concat(), "{\n  \"a\": [1, 2],\n  \"b\": {}\n}");
+    assert_eq!(tool.withheld_tail, "\n");
+    assert_eq!(
+        redundant_tail("{}", " \n\t"),
+        Some(RedundantTail::Whitespace)
+    );
+    tool.complete()
+        .expect("whitespace after the object is not content");
+}
+
+#[test]
+fn a_tail_carrying_content_or_a_bare_suffix_stays_malformed() {
+    // Anything whose removal would pick one parse over another fails closed
+    // with the parse position of the bytes the provider actually sent.
+    for (fragments, position) in [
+        (vec!["{\"a\":1}", "{\"b\":2}"], "line 1 column 8"),
+        // A bare `}` is also what a dropped inner delta leaves behind.
+        (vec!["{\"a\":1}", "}"], "line 1 column 8"),
+        (vec!["{}", "\"x\""], "line 1 column 3"),
+        (vec!["{}", "null"], "line 1 column 3"),
+        (vec!["{\"a\":1}", "\"\""], "line 1 column 8"),
+    ] {
+        let mut tool = ToolAccumulator::new("call_1".into(), "lookup".into());
+        push_all(&mut tool, &fragments);
+        let error = tool
+            .complete()
+            .expect_err("content after the object is malformed");
+        assert!(
+            error
+                .starts_with("streamed tool arguments are not valid JSON: trailing characters at ")
+                && error.contains(position),
+            "{fragments:?} -> {error}"
+        );
+    }
+    assert_eq!(redundant_tail("{\"a\":1}", "}"), None);
+    assert_eq!(redundant_tail("{\"a\":1}", "\"\""), None);
+    assert_eq!(redundant_tail("{}", "{\"a\":1}"), None);
+}
+
+#[test]
+fn the_scan_ignores_structural_bytes_inside_strings_and_never_closes_a_scalar() {
+    let mut tool = ToolAccumulator::new("call_1".into(), "terminal".into());
+    let shown = push_all(
+        &mut tool,
+        &[
+            "{\"command\":\"echo }\\\"{ ]\"",
+            ", \"n\": [1, {\"x\": \"}\"}]}",
+            "{}",
+        ],
+    );
+    assert_eq!(
+        shown.concat(),
+        "{\"command\":\"echo }\\\"{ ]\", \"n\": [1, {\"x\": \"}\"}]}"
+    );
+    assert_eq!(tool.withheld_tail, "{}");
+    // `{}` after a non-empty object is content-bearing ambiguity, not noise.
+    assert!(tool.complete().is_err());
+
+    // A top-level scalar never closes, so every byte is shown and the strict
+    // object contract rejects it at completion exactly as before.
+    let mut tool = ToolAccumulator::new("call_2".into(), "lookup".into());
+    assert_eq!(
+        push_all(&mut tool, &["\"just", " text\""]).concat(),
+        "\"just text\""
+    );
+    assert!(tool.withheld_tail.is_empty());
+    assert_eq!(
+        tool.complete().expect_err("a string is not an object"),
+        "streamed tool arguments must decode to an object"
+    );
+
+    // An open object stays open: no tail, and the usual EOF parse error.
+    let mut tool = ToolAccumulator::new("call_3".into(), "lookup".into());
+    push_all(&mut tool, &["{\"a\": [1, 2"]);
+    assert!(tool.withheld_tail.is_empty());
+    assert!(tool.complete().is_err());
+}
+
+#[test]
+fn custom_tool_input_passes_through_the_hold_back_untouched() {
+    let mut tool = ToolAccumulator::new("call_1".into(), "shell".into());
+    tool.custom = true;
+    let shown = push_all(&mut tool, &["{}", "\"\"", " ls -la"]);
+    assert_eq!(shown.concat(), "{}\"\" ls -la");
+    assert!(tool.withheld_tail.is_empty());
+    assert_eq!(
+        tool.complete().expect("freeform").raw_arguments,
+        "{}\"\" ls -la"
+    );
+}

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5299,3 +5299,57 @@ def test_affinity_pool_routes_each_session_deterministically(tmp_path: Path) -> 
             (str(started["attempt_id"]),),
         ).fetchone()
     assert row == ("affinity", None)
+
+
+def test_foundry_deepseek_zero_argument_call_with_a_stray_empty_string_delta_completes() -> None:
+    """The captured Azure Foundry DeepSeek zero-argument tool stream completes as ``{}``.
+
+    Live wire of 2026-09-10 (ids redacted): after ``arguments: ""`` and ``{}`` the
+    shim streams one more argument delta whose text is two quote characters. Verbatim
+    assembly is ``{}""`` and failed 222 production attempts in one day as
+    ``malformed_response`` ("trailing characters at line 1 column 3 (4 bytes)"). The
+    stray delta is content-free, so it is withheld from the caller and the call
+    completes; the deltas a client sees concatenate to exactly the completed bytes.
+    """
+    native = pytest.importorskip("exp_gateway_native")
+    head = (
+        '{"id":"chatcmpl-redacted","object":"chat.completion.chunk","created":1789000000,'
+        '"model":"DeepSeek-V4-Flash","choices":[{"index":0,"delta":'
+    )
+    tail = ',"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}'
+    tool = '{"id":null,"index":0,"type":"function","function":{"name":null,"arguments":%s}}'
+    deltas = [
+        '{"reasoning_content":null,"role":"assistant","content":""}',
+        '{"role":null,"content":"\\n\\n","reasoning_content":null,"tool_calls":null}',
+        '{"role":null,"content":null,"reasoning_content":null,"tool_calls":[{"id":"call_redacted",'
+        '"index":0,"type":"function","function":{"name":"view_agent_graph","arguments":""}}]}',
+        '{"role":null,"content":null,"reasoning_content":null,"tool_calls":['
+        + tool % '"{}"'
+        + "]}",
+        '{"role":null,"content":null,"reasoning_content":null,"tool_calls":['
+        + tool % '"\\"\\""'
+        + "]}",
+    ]
+    frames = [f"data: {head}{delta}{tail}\n\n" for delta in deltas]
+    frames.append(
+        'data: {"id":"chatcmpl-redacted","object":"chat.completion.chunk","created":1789000000,'
+        '"model":"DeepSeek-V4-Flash","choices":[{"index":0,"delta":{"reasoning_content":null},'
+        '"logprobs":null,"finish_reason":"tool_calls","matched_stop":1}]}\n\n'
+    )
+    frames.append("data: [DONE]\n\n")
+    # The fixture boundary carries raw stream bytes as latin-1 code points.
+    normalized = json.loads(
+        native.normalize_stream_fixture(
+            "openai_compatible",
+            json.dumps([frame.encode().decode("latin-1") for frame in frames]),
+        )
+    )
+    assert normalized["failure"] is None
+    events = normalized["events"]
+    shown = "".join(event["text"] for event in events if event["kind"] == "tool_arguments_delta")
+    assert shown == "{}"
+    completed = [event for event in events if event["kind"] == "tool_call_completed"]
+    assert [(event["name"], event["raw_arguments"]) for event in completed] == [
+        ("view_agent_graph", "{}")
+    ]
+    assert events[-1]["kind"] == "completed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.62"
+version = "0.7.63"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.47,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.48,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.47"
+version = "0.3.48"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.62"
+version = "0.7.63"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Defect

Streamed `tool_calls[i].function.arguments` deltas were appended verbatim per index and parsed once at completion, so any byte a provider streams after the argument object closed failed the attempt as `malformed_response` ("streamed tool arguments are not valid JSON: trailing characters …").

Production evidence (platform ledger, 24h to 2026-09-10 15:30Z): ~350 such attempts; **222 of them are the exact 4-byte shape** `trailing characters at line 1 column 3 (4 bytes)`, all on the `azure_openai` DeepSeek lanes (`deepseek-v4-flash` 211, `deepseek-v3.2` 11), 55 organizations, appearing the day the Foundry DeepSeek lane went live (09-07: 4, 09-08: 89, 09-09: 318, 09-10: 146+). Example: platform request `request-d5d0d57c5a8e4ff9bed3ba7a290c44bd`.

Reproduced live 2/2 against Azure Foundry `DeepSeek-V4-Flash` with a zero-argument tool: the shim streams `arguments: ""`, then `{}`, then one more delta whose text is `""` (two quote characters) — verbatim assembly `{}""`. Non-empty argument calls on the same lane stream clean. DeepSeek's own API (`deepseek-flash`, thinking on and off) did not reproduce (8/8 clean); the direct lane's remaining shapes (`expected \`,\` or \`]\`` mid-object, control characters, invalid escapes) are corruption inside the object and cannot be repaired without guessing — they keep failing closed.

## Fix

- `ToolAccumulator::push_arguments` (events.rs): a constant-time bracket/string scan (`JsonValueScan`) that stops relaying argument deltas at the byte closing the top-level value and withholds everything after it (`withheld_tail`). The OpenAI-compatible normalizer routes fragments through it; other dialects append directly and are unchanged.
- `ToolAccumulator::complete`: a withheld tail is dropped only when its removal is unambiguous — `redundant_tail`: whitespace (pretty-printed buffers), exact repetitions of the whole object (`{}{}`, duplicated whole-object deltas), or empty literals `""` / `{}` / `[]` after a zero-argument `{}` (the Foundry shape). A dropped non-whitespace tail logs a content-free operator line `tool_arguments_tail_dropped` (tool name, shape, byte count).
- Any other tail (a second object, a bare `}` — the same bytes a dropped inner delta leaves behind, so a guess) is validated as the concatenation the provider actually sent: same `malformed_response` class, same parse position, byte count now includes the tail. No argument content is ever invented.
- Failure class unchanged on purpose: `malformed_response` is the provider-fault class and already carries `failover_eligible = true` (`dialects.rs::malformed`), so a later certified rung may serve it; the ledger detail names the parse position and byte count and the operator line names the tool.
- Because withheld bytes are never emitted, the deltas a client receives still concatenate to the completed call's bytes (the Chat encoder asserts exactly this).

## Tests

- `events/tests.rs`: Foundry `{}""` shape; `{}{}` and `{"a":1}{"a":1}` (including a repetition straddling the closing fragment); pretty-printed trailing newline; content-bearing tails and bare-suffix tails stay malformed with the expected positions; structural bytes inside strings/escapes; scalars never close; custom tools pass through.
- `dialects/openai/normalizer_tests.rs`: replay of the captured Foundry frame sequence (ids redacted) → `ToolCallCompleted` with `{}`, shown deltas concatenate to `{}`; a second object after a closed one stays `malformed_response` and `failover_eligible`.
- `native_bridge_test.py`: the captured wire replayed byte-for-byte through `normalize_stream_fixture("openai_compatible", …)`.
- docs/reference/gateway-architecture.md documents the contract.

## Validation

```
cargo fmt --check                                   ok
cargo clippy --no-default-features --all-targets -- -D warnings   clean
cargo test --no-default-features                    278 passed
pytest native_bridge_test.py native_dialect_parity_test.py   153 passed (rebuilt wheel 0.3.48)
ruff check / ruff format --check                    clean
```

Crate `0.3.47 → 0.3.48`, `experiential 0.7.62 → 0.7.63` (bump included so the release can be cut from this squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
