### PR TITLE
Harbor/Hy4 gap program (engine): host-independent Hunyuan carrier, `reasoning` on Messages, preserved thinking on Messages

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -422,8 +422,11 @@ an identical prompt hits but the same stem with a new tail (every turn of an age
 routed by the whole prompt and usually misses (Tencent TokenHub, measured 2026-09-05: 2 of 8
 shared-stem turns hit with no hint, 10 of 10 with one). The gateway therefore dispatches a
 `prompt_cache_key` on rungs whose wire profile says the provider routes by it (OpenAI, Tencent
-TokenHub; other OpenAI-compatible servers may reject unknown fields, so they never receive it,
-BYOK or not): never the caller's raw value, which shares a house account across tenants, but a
+TokenHub, and OpenRouter, whose documented sticky routing falls back to that field as the session
+key and forwards it upstream, so a provider's own node pin rides along; other OpenAI-compatible
+servers may reject unknown fields, so they never receive it, BYOK or not, and a vLLM origin
+ignores the field because its prefix cache is per engine process and content-addressed): never
+the caller's raw value, which shares a house account across tenants, but a
 digest namespaced by organization and identity (`exp/runtime/gateway/prompt_cache_affinity.py`).
 A caller `prompt_cache_key` is the material when present; otherwise the conversation stem (the
 leading system/developer messages, which every turn of a session and every request sharing that

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -525,9 +525,10 @@ Exposure-gated reasoning rungs (Tencent Hunyuan and DeepSeek, rows stamped
 history, including tool-call turns. A rung becomes a preserved-thinking carrier route either by
 host recognition (Tencent's two OpenAI-compatible origins) or by declaring the rung capability
 `reasoning_content_native`, which says the origin returns the standard `reasoning_content` field
-and accepts it back (a self-hosted vLLM origin started with a reasoning parser); the declaration
-also forwards `prompt_cache_key` to that origin. It is off by default and fails closed: an
-undeclared origin has no carrier route, and exposure still requires `reasoning_output_exposed`. The decoder preserves the text verbatim, including an
+and accepts it back (a self-hosted vLLM origin started with a reasoning parser). It is off by
+default and fails closed: an undeclared origin has no carrier route, and exposure still requires
+`reasoning_output_exposed`. The `prompt_cache_key` node pin stays keyed on Tencent's hosts, since the
+declaration says nothing about whether an origin tolerates unknown request fields. The decoder preserves the text verbatim, including an
 explicitly empty string: a provider can require the field even when the turn performed no
 reasoning. Missing or null values remain absent. Plaintext is bounded to 8,388,608 characters;
 values exceeding that limit receive a named error with the limit and a retry instruction.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -522,7 +522,12 @@ ceiling is an `incomplete` answer.
 
 Exposure-gated reasoning rungs (Tencent Hunyuan and DeepSeek, rows stamped
 `reasoning_output_exposed`) accept caller-owned plaintext `reasoning_content` on assistant
-history, including tool-call turns. The decoder preserves the text verbatim, including an
+history, including tool-call turns. A rung becomes a preserved-thinking carrier route either by
+host recognition (Tencent's two OpenAI-compatible origins) or by declaring the rung capability
+`reasoning_content_native`, which says the origin returns the standard `reasoning_content` field
+and accepts it back (a self-hosted vLLM origin started with a reasoning parser); the declaration
+also forwards `prompt_cache_key` to that origin. It is off by default and fails closed: an
+undeclared origin has no carrier route, and exposure still requires `reasoning_output_exposed`. The decoder preserves the text verbatim, including an
 explicitly empty string: a provider can require the field even when the turn performed no
 reasoning. Missing or null values remain absent. Plaintext is bounded to 8,388,608 characters;
 values exceeding that limit receive a named error with the limit and a retry instruction.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -435,8 +435,21 @@ the public request, its digests, and replay identity never carry it. LiteLLM mes
 echoed back verbatim: the object is dropped with a `messages.provider_specific_fields`
 disclosure and the empty forms are accepted like the SDK's own empty keys, while populated
 carriers stay rejected by name.
-Thinking carriers replay only on the Anthropic wire, so route admission requires every waterfall
-rung to speak the `anthropic_messages` dialect; on the Responses surface over Anthropic routes,
+Anthropic-signed thinking replays only on the Anthropic wire: a mixed waterfall's Anthropic rung
+re-emits the caller's blocks verbatim, while every foreign wire omits them at encoding and the
+route discloses `messages.thinking->dropped(unsupported_by_provider)` instead of rejecting (the
+blocks are baked into a framework-managed transcript, so a session that switches from a Claude
+model to any other keeps serving). The Messages surface also carries the gateway's OWN preserved
+thinking, mirroring the Chat surface's `reasoning_content` contract: an exposure-gated rung's
+(`reasoning_output_exposed`) plaintext reasoning streams and aggregates as one UNSIGNED `thinking`
+block (Anthropic signs every block it issues, so an unsigned block is recognizably the gateway's),
+and a tool turn's hidden reasoning leaves only as the sealed carrier, in one trailing
+`redacted_thinking` block (the carrier is known once every tool call completed, after the
+sequential thinking block closed; `redacted_thinking` is Anthropic's opaque replay-verbatim
+shape). On replay the decoder maps an unsigned block to the caller-owned plaintext an exposing
+rung forwards (dropped with disclosure elsewhere) and a carrier-prefixed `redacted_thinking`
+payload to the sealed carrier that admission authenticates and pins to its issuing rung,
+dropping the unsigned display duplicate beside it. On the Responses surface over Anthropic routes,
 thinking text is projected onto the reasoning-summary channel (signatures deliberately dropped)
 so callers receive the reasoning they pay for, while the Chat surface has no reasoning
 representation and drops it like summary deltas. Streaming emits the Anthropic

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -179,7 +179,12 @@ possible billable dispatch is visible to the gateway ledger.
 First-party CLI compatibility is capture-driven: the fields real Claude Code and Codex send by
 default are accepted and preserved. On the Messages surface, `output_config` forwards verbatim on
 Anthropic rungs (a canonical `effort` also rides `reasoning_effort`, caller keys always win over
-engine-derived ones), mid-conversation `system` turns keep their position on wires that express
+engine-derived ones); OpenRouter's `reasoning` object (`effort`, or a `max_tokens` budget, plus
+`enabled` / `exclude`) is accepted as a second effort channel, mapped onto the same canonical
+effort (a budget becomes a budgeted `thinking` config on Anthropic rungs and the nearest tier
+elsewhere), and when it is present it wins: a `thinking` config beside it and a disagreeing
+`output_config.effort` drop with disclosure, `exclude` is disclosed rather than honored, and an
+effort the route cannot serve is rejected as `reasoning.effort`; mid-conversation `system` turns keep their position on wires that express
 them (instruction-hoisting rungs narrow out), and `thinking.display` rides the verbatim thinking
 config. The conditional Claude Code fields `diagnostics` and `speed` forward verbatim on
 Anthropic rungs with their required `anthropic-beta` tokens and drop with disclosure elsewhere.

--- a/exp/common/models/model.py
+++ b/exp/common/models/model.py
@@ -473,6 +473,18 @@ class ModelCapabilities(ContractModel):
     wire on a carrier-route identity, so an absent capability fails closed and
     reasoning stays stripped even on an otherwise-exposable endpoint.
     """
+    reasoning_content_native: bool = False
+    """Whether this OpenAI-compatible rung speaks the native ``reasoning_content`` contract.
+
+    The origin returns the model's chain-of-thought in the standard
+    ``reasoning_content`` response field and accepts it back on assistant turns
+    (Tencent Hunyuan's contract, and a self-hosted vLLM origin started with a
+    reasoning parser). Declaring it makes the rung a preserved-thinking carrier
+    route regardless of its hostname, so the same model self-hosted keeps the
+    contract Tencent's own origins carry by recognition. Off by default: an
+    undeclared origin never gets a carrier route, and exposure still requires
+    ``reasoning_output_exposed`` on top.
+    """
     chat_max_tokens_field: ChatMaxTokensField | None = None
     minimum_temperature: float | None = Field(default=None, ge=0, le=2)
     maximum_temperature: float | None = Field(default=None, ge=0, le=2)
@@ -566,6 +578,7 @@ class ModelCapabilities(ContractModel):
             "reasoning_effort",
             "sampling_requires_reasoning_none",
             "reasoning_output_exposed",
+            "reasoning_content_native",
             "chat_max_tokens_field",
             "minimum_temperature",
             "maximum_temperature",

--- a/exp/common/models/model_test.py
+++ b/exp/common/models/model_test.py
@@ -118,6 +118,7 @@ def test_model_request_keeps_tool_contract_and_capabilities_deterministic() -> N
         "reasoning_effort": None,
         "sampling_requires_reasoning_none": False,
         "reasoning_output_exposed": False,
+        "reasoning_content_native": False,
         "chat_max_tokens_field": None,
         "minimum_temperature": None,
         "maximum_temperature": None,
@@ -434,3 +435,12 @@ def test_generation_parameter_contract_rejects_inverted_ranges() -> None:
         ModelCapabilities(minimum_top_k=10, maximum_top_k=5)
     with pytest.raises(ValidationError, match="conditional sampling requires reasoning support"):
         ModelCapabilities(sampling_requires_reasoning_none=True)
+
+
+def test_reasoning_content_native_is_a_gateway_flag_outside_the_frozen_identity() -> None:
+    """The native reasoning_content declaration defaults off and never re-digests a catalog."""
+    assert ModelCapabilities().reasoning_content_native is False
+    assert (
+        ModelCapabilities(reasoning_content_native=True).identity_sha256()
+        == ModelCapabilities().identity_sha256()
+    )

--- a/exp/runtime/anthropic_protocol/gateway_reasoning.py
+++ b/exp/runtime/anthropic_protocol/gateway_reasoning.py
@@ -1,0 +1,88 @@
+"""Thinking-shaped Messages blocks the gateway itself issued.
+
+The Messages surface returns an exposure-gated rung's (Tencent/DeepSeek)
+plaintext reasoning as an UNSIGNED ``thinking`` block, and a tool turn's
+hidden reasoning as one ``redacted_thinking`` block holding the sealed
+carrier. Anthropic signs every thinking block it issues and its redacted
+payloads never carry a gateway prefix, so both shapes are unambiguous on
+replay: an unsigned block is caller-owned plaintext history (the Chat wire's
+plaintext ``reasoning_content``, forwarded to exposing rungs and dropped with
+disclosure elsewhere), a carrier-prefixed payload is the sealed carrier (the
+Chat wire's carrier, authenticated at admission). Everything else is
+Anthropic's own block, carried verbatim for its wire.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from pydantic import ValidationError
+
+from exp.runtime.gateway.contracts import (
+    ExposedReasoningContentBlock,
+    SealedReasoningContentBlock,
+)
+from exp.runtime.gateway.reasoning_carrier import (
+    parse_reasoning_content_carrier,
+    scheme_for_carrier,
+)
+from exp.runtime.openai_protocol.errors import invalid_field
+
+EMPTY_GATEWAY_BLOCK = ExposedReasoningContentBlock(content="")
+"""Sentinel for an unsigned thinking block with no text: nothing to replay."""
+
+
+class ThinkingShapedBlock(Protocol):
+    """The two wire block shapes this module classifies (duck-typed on purpose:
+    the decoder's private wire models stay private)."""
+
+    @property
+    def type(self) -> str:
+        """The wire block type: ``thinking`` or ``redacted_thinking``."""
+        ...
+
+
+def gateway_reasoning_block(
+    block: ThinkingShapedBlock, param: str
+) -> ExposedReasoningContentBlock | SealedReasoningContentBlock | None:
+    """Recognize a thinking-shaped block the GATEWAY issued, or None for Anthropic's.
+
+    Args:
+        block: A decoded ``thinking`` or ``redacted_thinking`` wire block.
+        param: Public field path of the block, for the rejection.
+
+    Returns:
+        The gateway block to replay (``EMPTY_GATEWAY_BLOCK`` when an unsigned
+        block carries no text), or ``None`` for a genuine Anthropic block.
+
+    Raises:
+        OpenAIProtocolError: An oversized unsigned block, or a carrier-prefixed
+            payload that is not a complete gateway carrier.
+    """
+    if block.type == "thinking":
+        signature = getattr(block, "signature", None)
+        text = getattr(block, "thinking", "")
+        if signature:
+            return None
+        if not text:
+            return EMPTY_GATEWAY_BLOCK
+        try:
+            return ExposedReasoningContentBlock(content=text)
+        except ValidationError as exc:
+            raise invalid_field(
+                param,
+                "unsigned thinking text exceeds 8,388,608 characters. Shorten the "
+                "replayed thinking block and retry.",
+            ) from exc
+    data = getattr(block, "data", "")
+    scheme = scheme_for_carrier(data)
+    if scheme is None:
+        return None
+    try:
+        return parse_reasoning_content_carrier(data, scheme=scheme)
+    except ValueError as exc:
+        raise invalid_field(
+            param,
+            "redacted_thinking data is not a complete gateway reasoning carrier. Replay "
+            "the block exactly as the gateway returned it.",
+        ) from exc

--- a/exp/runtime/anthropic_protocol/gateway_reasoning_test.py
+++ b/exp/runtime/anthropic_protocol/gateway_reasoning_test.py
@@ -1,0 +1,55 @@
+"""Tests for recognizing the gateway's own thinking-shaped Messages blocks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from exp.runtime.anthropic_protocol.gateway_reasoning import (
+    EMPTY_GATEWAY_BLOCK,
+    gateway_reasoning_block,
+)
+from exp.runtime.gateway.contracts import (
+    ExposedReasoningContentBlock,
+    SealedReasoningContentBlock,
+)
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+_CARRIER = "x-experiential-hunyuan-reasoning-v1:ZGVwbG95bWVudC0x:c2VhbGVkLWVudmVsb3Bl"
+
+
+@dataclass(frozen=True)
+class _Thinking:
+    type: str = "thinking"
+    thinking: str = ""
+    signature: str | None = None
+
+
+@dataclass(frozen=True)
+class _Redacted:
+    type: str = "redacted_thinking"
+    data: str = ""
+
+
+def test_unsigned_thinking_is_exposed_plaintext_and_signed_thinking_is_anthropics() -> None:
+    """Anthropic signs every block it issues; an unsigned one is the gateway's."""
+    exposed = gateway_reasoning_block(_Thinking(thinking="the plan"), "messages.1.content.0")
+    assert isinstance(exposed, ExposedReasoningContentBlock)
+    assert exposed.content == "the plan"
+    assert gateway_reasoning_block(_Thinking(thinking=""), "p") is EMPTY_GATEWAY_BLOCK
+    assert gateway_reasoning_block(_Thinking(thinking="x", signature="sig=="), "p") is None
+    with pytest.raises(OpenAIProtocolError, match="8,388,608"):
+        gateway_reasoning_block(_Thinking(thinking="x" * (8 * 1024 * 1024 + 1)), "p")
+
+
+def test_carrier_prefixed_redacted_thinking_is_the_sealed_carrier() -> None:
+    """A gateway-prefixed payload parses as the sealed carrier; any other payload is Anthropic's."""
+    sealed = gateway_reasoning_block(_Redacted(data=_CARRIER), "p")
+    assert isinstance(sealed, SealedReasoningContentBlock)
+    assert sealed.deployment_hint == "deployment-1"
+    assert gateway_reasoning_block(_Redacted(data="opaque=="), "p") is None
+    with pytest.raises(OpenAIProtocolError, match="complete gateway reasoning carrier"):
+        gateway_reasoning_block(
+            _Redacted(data="x-experiential-hunyuan-reasoning-v1:broken"), "messages.1.content.2"
+        )

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -40,6 +40,12 @@ MESSAGES_MANIFEST = CompatibilityManifest(
         _field("tools", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
         _field("tool_choice", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
         _field("thinking", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "extended_thinking"),
+        # OpenRouter's Anthropic-compatible Messages endpoint accepts its
+        # ``reasoning`` object (effort / max_tokens / enabled / exclude) on
+        # this surface, and agents built against it send the field verbatim.
+        # Not an official SDK field: an installed extension, decoded closed and
+        # mapped onto the canonical effort channel (see requests.py).
+        _field("reasoning", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
         _field(
             "context_management",
             CompatibilityDisposition.CONDITIONALLY_SUPPORTED,

--- a/exp/runtime/anthropic_protocol/manifest_test.py
+++ b/exp/runtime/anthropic_protocol/manifest_test.py
@@ -142,3 +142,9 @@ def test_every_official_sdk_tool_type_is_consciously_classified() -> None:
         sdk_types - MESSAGES_SERVER_TOOL_TYPES_ACCEPTED - MESSAGES_SERVER_TOOL_TYPES_REJECTED
     )
     assert not undecided, _decided(undecided, "Anthropic-defined tool")
+
+
+def test_openrouter_reasoning_extension_is_conditionally_supported() -> None:
+    """The OpenRouter ``reasoning`` object is an installed extension, not an SDK field."""
+    decisions = {field.field_path: field.disposition for field in MESSAGES_MANIFEST.fields}
+    assert decisions["reasoning"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED

--- a/exp/runtime/anthropic_protocol/reasoning_channels.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels.py
@@ -20,6 +20,7 @@ from exp.common.core.artifacts import JsonObject
 from exp.common.models.model import ReasoningEffort
 from exp.runtime.anthropic_protocol.media_blocks import AnthropicWireModel
 from exp.runtime.models.providers.reasoning_compat import (
+    MINIMUM_THINKING_BUDGET_TOKENS,
     REASONING_EFFORTS,
     thinking_config_reasoning_effort,
 )
@@ -46,6 +47,8 @@ carry no reasoning on this surface."""
 
 # OpenRouter documents ``enabled: true`` as its default depth (medium).
 _REASONING_ENABLED_DEFAULT_EFFORT: ReasoningEffort = "medium"
+# The one "no reasoning" form every route honors (see resolve_reasoning_channels).
+_THINKING_DISABLED: JsonObject = {"type": "disabled"}
 
 
 class ReasoningConfig(AnthropicWireModel):
@@ -57,7 +60,9 @@ class ReasoningConfig(AnthropicWireModel):
     """
 
     effort: ReasoningEffort | None = None
-    max_tokens: int | None = Field(default=None, gt=0)
+    max_tokens: int | None = Field(default=None, ge=MINIMUM_THINKING_BUDGET_TOKENS)
+    """A thinking budget; Anthropic's floor applies (1024), so a smaller budget
+    is a named 400 here instead of a provider rejection downstream."""
     exclude: bool | None = None
     enabled: bool | None = None
 
@@ -116,9 +121,16 @@ def resolve_reasoning_channels(
 
     * ``effort`` is the canonical tier; ``max_tokens`` is a thinking budget
       (forwarded as a budgeted ``enabled`` config on Anthropic rungs, mapped to
-      the nearest tier elsewhere); ``enabled: false`` is ``none`` and wins over
-      any depth sent beside it; a bare or ``enabled: true`` object is
+      the nearest tier elsewhere); a bare or ``enabled: true`` object is
       OpenRouter's default depth.
+    * ``enabled: false`` (which wins over any depth sent beside it) and
+      ``effort: none`` both mean "no reasoning" and become the one off form
+      every route already honors, ``thinking: {type: disabled}``: Anthropic
+      rungs forward it (an adaptive-only model drops it with disclosure), and
+      effort ladders translate it to their ``none`` without ever snapping to an
+      active tier. Anthropic's own effort ladder has no ``none``, so the effort
+      channel is left empty rather than carrying a tier no Anthropic rung
+      accepts.
     * A ``thinking`` config beside it is dropped with disclosure, and an
       ``output_config.effort`` that disagrees is dropped with disclosure (an
       agreeing one stays, so the caller's forwarded object is untouched).
@@ -144,11 +156,12 @@ def resolve_reasoning_channels(
             disclosures=(),
         )
     disclosures: list[str] = []
-    if reasoning.enabled is False:
-        # An explicit off switch wins over any depth beside it (effort or a
-        # budget): the caller asked for no reasoning, so none is configured.
-        effort: ReasoningEffort = "none"
-        resolved_thinking: JsonObject | None = None
+    effort: ReasoningEffort | None
+    if reasoning.enabled is False or reasoning.effort == "none":
+        # The off switch wins over any depth beside it: the caller asked for
+        # no reasoning, so the request carries the disabled thinking form.
+        effort = None
+        resolved_thinking: JsonObject | None = _THINKING_DISABLED
     elif reasoning.max_tokens is not None:
         if reasoning.max_tokens >= max_tokens:
             raise invalid_field(
@@ -174,7 +187,7 @@ def resolve_reasoning_channels(
         disclosures.append(REASONING_EXCLUDE_DISCLOSURE)
     return ReasoningChannels(
         effort=effort,
-        effort_parameter="reasoning.effort",
+        effort_parameter="reasoning.effort" if effort is not None else None,
         thinking_config=resolved_thinking,
         output_config=output_config,
         disclosures=tuple(disclosures),

--- a/exp/runtime/anthropic_protocol/reasoning_channels.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels.py
@@ -116,8 +116,9 @@ def resolve_reasoning_channels(
 
     * ``effort`` is the canonical tier; ``max_tokens`` is a thinking budget
       (forwarded as a budgeted ``enabled`` config on Anthropic rungs, mapped to
-      the nearest tier elsewhere); ``enabled: false`` is ``none``; a bare or
-      ``enabled: true`` object is OpenRouter's default depth.
+      the nearest tier elsewhere); ``enabled: false`` is ``none`` and wins over
+      any depth sent beside it; a bare or ``enabled: true`` object is
+      OpenRouter's default depth.
     * A ``thinking`` config beside it is dropped with disclosure, and an
       ``output_config.effort`` that disagrees is dropped with disclosure (an
       agreeing one stays, so the caller's forwarded object is untouched).
@@ -143,7 +144,12 @@ def resolve_reasoning_channels(
             disclosures=(),
         )
     disclosures: list[str] = []
-    if reasoning.max_tokens is not None:
+    if reasoning.enabled is False:
+        # An explicit off switch wins over any depth beside it (effort or a
+        # budget): the caller asked for no reasoning, so none is configured.
+        effort: ReasoningEffort = "none"
+        resolved_thinking: JsonObject | None = None
+    elif reasoning.max_tokens is not None:
         if reasoning.max_tokens >= max_tokens:
             raise invalid_field(
                 "reasoning.max_tokens",
@@ -152,14 +158,11 @@ def resolve_reasoning_channels(
             )
         budget: JsonObject = {"type": "enabled", "budget_tokens": reasoning.max_tokens}
         effort = thinking_config_reasoning_effort(budget)
-        resolved_thinking: JsonObject | None = budget
+        resolved_thinking = budget
     else:
-        if reasoning.enabled is False:
-            effort = "none"
-        elif reasoning.effort is not None:
-            effort = reasoning.effort
-        else:
-            effort = _REASONING_ENABLED_DEFAULT_EFFORT
+        effort = (
+            reasoning.effort if reasoning.effort is not None else _REASONING_ENABLED_DEFAULT_EFFORT
+        )
         resolved_thinking = None
     if thinking is not None:
         disclosures.append(REASONING_SUPERSEDES_THINKING_DISCLOSURE)

--- a/exp/runtime/anthropic_protocol/reasoning_channels.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels.py
@@ -1,0 +1,178 @@
+"""Reasoning channels of the Anthropic Messages surface, collapsed onto one effort.
+
+Three caller channels can name a reasoning depth on ``POST /v1/messages``:
+Anthropic's ``thinking`` config, Anthropic's ``output_config.effort``, and
+OpenRouter's ``reasoning`` extension (its Anthropic-compatible Messages endpoint
+accepts the object next to ``thinking``, and agents built against it send the
+field verbatim). This module owns the closed wire model of that extension and
+the resolution rule that turns the three channels into the single canonical
+effort (plus the thinking config Anthropic rungs forward) every downstream seam
+reads: route narrowing, the coercion policy, and the payload builders.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models.model import ReasoningEffort
+from exp.runtime.anthropic_protocol.media_blocks import AnthropicWireModel
+from exp.runtime.models.providers.reasoning_compat import (
+    REASONING_EFFORTS,
+    thinking_config_reasoning_effort,
+)
+from exp.runtime.openai_protocol.errors import invalid_field
+
+REASONING_SUPERSEDES_THINKING_DISCLOSURE = "thinking->dropped(superseded_by_reasoning)"
+"""Disclosure recorded when the OpenRouter ``reasoning`` object and a
+``thinking`` config both name a depth: the explicit effort wins and the thinking
+config is dropped (Anthropic rungs still reason at that effort through the
+shared channel)."""
+
+REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE = (
+    "output_config.effort->dropped(superseded_by_reasoning)"
+)
+"""Disclosure recorded when ``output_config.effort`` disagrees with the
+OpenRouter ``reasoning`` effort: the explicit effort wins and the forwarded
+``output_config`` loses its ``effort`` key so the two cannot diverge."""
+
+REASONING_EXCLUDE_DISCLOSURE = "reasoning.exclude"
+"""Disclosure recorded when the caller asked to omit reasoning from the reply
+(``reasoning.exclude: true``), a rendering choice this gateway does not
+honor: Anthropic rungs stream their thinking blocks as always and other rungs
+carry no reasoning on this surface."""
+
+# OpenRouter documents ``enabled: true`` as its default depth (medium).
+_REASONING_ENABLED_DEFAULT_EFFORT: ReasoningEffort = "medium"
+
+
+class ReasoningConfig(AnthropicWireModel):
+    """OpenRouter's ``reasoning`` object, validated closed.
+
+    OpenRouter's own rule applies: ``effort`` and ``max_tokens`` are exclusive.
+    ``effort`` is the engine-owned ladder (OpenRouter's values are a subset),
+    so an unknown tier is a named 400 rather than a provider guess.
+    """
+
+    effort: ReasoningEffort | None = None
+    max_tokens: int | None = Field(default=None, gt=0)
+    exclude: bool | None = None
+    enabled: bool | None = None
+
+    @model_validator(mode="after")
+    def _effort_or_budget(self) -> ReasoningConfig:
+        """Enforce OpenRouter's exclusivity: one depth signal, not two."""
+        if self.effort is not None and self.max_tokens is not None:
+            raise ValueError("reasoning.effort and reasoning.max_tokens are exclusive; send one")
+        return self
+
+
+class ReasoningChannels(BaseModel):
+    """The canonical reasoning signals one Messages body resolves to."""
+
+    model_config = ConfigDict(frozen=True)
+
+    effort: ReasoningEffort | None
+    effort_parameter: Literal["reasoning.effort", "output_config.effort"] | None
+    """The caller field that named the effort, when the decoder must record it
+    (``None`` leaves the surface default, ``output_config.effort``)."""
+    thinking_config: JsonObject | None
+    output_config: JsonObject | None
+    disclosures: tuple[str, ...]
+
+
+def output_config_effort(config: JsonObject | None) -> ReasoningEffort | None:
+    """Map a canonical caller ``output_config.effort`` into the shared field.
+
+    A canonical ladder value rides ``reasoning_effort`` so route narrowing,
+    the coercion policy, and non-Anthropic rungs all see it; the raw object
+    still forwards verbatim on Anthropic rungs with the caller's keys
+    winning, so an unrecognized future effort value stays provider-decided
+    instead of gateway-rejected.
+    """
+    if config is None:
+        return None
+    effort = config.get("effort")
+    if isinstance(effort, str) and effort in REASONING_EFFORTS:
+        # The membership check above is the narrowing proof for this cast.
+        return cast("ReasoningEffort", effort)
+    return None
+
+
+def resolve_reasoning_channels(
+    reasoning: ReasoningConfig | None,
+    *,
+    max_tokens: int,
+    thinking: JsonObject | None,
+    output_config: JsonObject | None,
+) -> ReasoningChannels:
+    """Collapse the caller's reasoning channels onto the canonical effort.
+
+    Without the OpenRouter object, the surface behaves as Anthropic defines it:
+    ``thinking`` forwards byte-for-byte and a canonical ``output_config.effort``
+    rides ``reasoning_effort``. With it, the explicit OpenRouter signal wins:
+
+    * ``effort`` is the canonical tier; ``max_tokens`` is a thinking budget
+      (forwarded as a budgeted ``enabled`` config on Anthropic rungs, mapped to
+      the nearest tier elsewhere); ``enabled: false`` is ``none``; a bare or
+      ``enabled: true`` object is OpenRouter's default depth.
+    * A ``thinking`` config beside it is dropped with disclosure, and an
+      ``output_config.effort`` that disagrees is dropped with disclosure (an
+      agreeing one stays, so the caller's forwarded object is untouched).
+    * ``exclude: true`` is disclosed, never honored.
+
+    Args:
+        reasoning: The validated OpenRouter object, or ``None`` when absent.
+        max_tokens: The caller's reply ceiling, which a budget must stay below.
+        thinking: The caller's raw ``thinking`` object, byte-for-byte.
+        output_config: The caller's raw ``output_config`` object, byte-for-byte.
+
+    Raises:
+        OpenAIProtocolError: ``reasoning.max_tokens`` does not leave room for
+            the reply under ``max_tokens`` (both OpenRouter and Anthropic
+            require a strictly smaller budget).
+    """
+    if reasoning is None:
+        return ReasoningChannels(
+            effort=output_config_effort(output_config),
+            effort_parameter=None,
+            thinking_config=thinking,
+            output_config=output_config,
+            disclosures=(),
+        )
+    disclosures: list[str] = []
+    if reasoning.max_tokens is not None:
+        if reasoning.max_tokens >= max_tokens:
+            raise invalid_field(
+                "reasoning.max_tokens",
+                "reasoning.max_tokens must be below max_tokens so the reply has room "
+                "after thinking.",
+            )
+        budget: JsonObject = {"type": "enabled", "budget_tokens": reasoning.max_tokens}
+        effort = thinking_config_reasoning_effort(budget)
+        resolved_thinking: JsonObject | None = budget
+    else:
+        if reasoning.enabled is False:
+            effort = "none"
+        elif reasoning.effort is not None:
+            effort = reasoning.effort
+        else:
+            effort = _REASONING_ENABLED_DEFAULT_EFFORT
+        resolved_thinking = None
+    if thinking is not None:
+        disclosures.append(REASONING_SUPERSEDES_THINKING_DISCLOSURE)
+    if output_config is not None and output_config.get("effort", effort) != effort:
+        output_config = {key: value for key, value in output_config.items() if key != "effort"}
+        output_config = output_config or None
+        disclosures.append(REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE)
+    if reasoning.exclude:
+        disclosures.append(REASONING_EXCLUDE_DISCLOSURE)
+    return ReasoningChannels(
+        effort=effort,
+        effort_parameter="reasoning.effort",
+        thinking_config=resolved_thinking,
+        output_config=output_config,
+        disclosures=tuple(disclosures),
+    )

--- a/exp/runtime/anthropic_protocol/reasoning_channels_test.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels_test.py
@@ -38,6 +38,24 @@ def test_budget_form_becomes_a_budgeted_thinking_config_by_tier() -> None:
     )
     assert channels.thinking_config == {"type": "enabled", "budget_tokens": 4096}
     assert channels.effort == "low"
+    # An explicit off switch beside a budget (or an effort) configures nothing.
+    off = resolve_reasoning_channels(
+        ReasoningConfig(enabled=False, max_tokens=4096),
+        max_tokens=8192,
+        thinking=None,
+        output_config=None,
+    )
+    assert off.effort == "none"
+    assert off.thinking_config is None
+    assert (
+        resolve_reasoning_channels(
+            ReasoningConfig(enabled=False, effort="high"),
+            max_tokens=8192,
+            thinking=None,
+            output_config=None,
+        ).effort
+        == "none"
+    )
     with pytest.raises(OpenAIProtocolError) as oversized:
         resolve_reasoning_channels(
             ReasoningConfig(max_tokens=8192), max_tokens=8192, thinking=None, output_config=None

--- a/exp/runtime/anthropic_protocol/reasoning_channels_test.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from exp.runtime.anthropic_protocol.reasoning_channels import (
     REASONING_EXCLUDE_DISCLOSURE,
@@ -38,29 +39,37 @@ def test_budget_form_becomes_a_budgeted_thinking_config_by_tier() -> None:
     )
     assert channels.thinking_config == {"type": "enabled", "budget_tokens": 4096}
     assert channels.effort == "low"
-    # An explicit off switch beside a budget (or an effort) configures nothing.
-    off = resolve_reasoning_channels(
-        ReasoningConfig(enabled=False, max_tokens=4096),
-        max_tokens=8192,
-        thinking=None,
-        output_config=None,
-    )
-    assert off.effort == "none"
-    assert off.thinking_config is None
-    assert (
-        resolve_reasoning_channels(
-            ReasoningConfig(enabled=False, effort="high"),
-            max_tokens=8192,
-            thinking=None,
-            output_config=None,
-        ).effort
-        == "none"
-    )
+    # A budget under Anthropic's floor is a named 400 here, never a provider reject.
+    with pytest.raises(ValidationError):
+        ReasoningConfig(max_tokens=1023)
     with pytest.raises(OpenAIProtocolError) as oversized:
         resolve_reasoning_channels(
             ReasoningConfig(max_tokens=8192), max_tokens=8192, thinking=None, output_config=None
         )
     assert oversized.value.detail.param == "reasoning.max_tokens"
+
+
+def test_off_forms_become_the_disabled_thinking_config_on_every_route() -> None:
+    """``enabled: false`` (over any depth) and ``effort: none`` are ``thinking: disabled``.
+
+    Anthropic's effort ladder has no ``none``, so the off switch must not ride
+    the effort channel; the disabled thinking form is the one every route
+    already honors (forwarded on Anthropic rungs, translated to ``none`` on
+    effort ladders without snapping to an active tier).
+    """
+    for config in (
+        ReasoningConfig(enabled=False),
+        ReasoningConfig(enabled=False, max_tokens=4096),
+        ReasoningConfig(enabled=False, effort="high"),
+        ReasoningConfig(effort="none"),
+    ):
+        channels = resolve_reasoning_channels(
+            config, max_tokens=8192, thinking={"type": "adaptive"}, output_config=None
+        )
+        assert channels.effort is None
+        assert channels.effort_parameter is None
+        assert channels.thinking_config == {"type": "disabled"}
+        assert channels.disclosures == (REASONING_SUPERSEDES_THINKING_DISCLOSURE,)
 
 
 def test_explicit_effort_supersedes_the_anthropic_channels_with_disclosure() -> None:

--- a/exp/runtime/anthropic_protocol/reasoning_channels_test.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels_test.py
@@ -1,0 +1,72 @@
+"""Tests for the Messages reasoning-channel resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.runtime.anthropic_protocol.reasoning_channels import (
+    REASONING_EXCLUDE_DISCLOSURE,
+    REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE,
+    REASONING_SUPERSEDES_THINKING_DISCLOSURE,
+    ReasoningConfig,
+    output_config_effort,
+    resolve_reasoning_channels,
+)
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+
+def test_absent_reasoning_keeps_the_anthropic_channels_verbatim() -> None:
+    """Without the OpenRouter object the surface is exactly Anthropic's."""
+    channels = resolve_reasoning_channels(
+        None,
+        max_tokens=128,
+        thinking={"type": "enabled", "budget_tokens": 1024},
+        output_config={"effort": "low"},
+    )
+    assert channels.effort == "low"
+    assert channels.effort_parameter is None
+    assert channels.thinking_config == {"type": "enabled", "budget_tokens": 1024}
+    assert channels.output_config == {"effort": "low"}
+    assert channels.disclosures == ()
+    assert output_config_effort({"effort": "hyperdrive"}) is None
+
+
+def test_budget_form_becomes_a_budgeted_thinking_config_by_tier() -> None:
+    """A token budget forwards as ``enabled`` thinking and maps to the nearest tier."""
+    channels = resolve_reasoning_channels(
+        ReasoningConfig(max_tokens=4096), max_tokens=8192, thinking=None, output_config=None
+    )
+    assert channels.thinking_config == {"type": "enabled", "budget_tokens": 4096}
+    assert channels.effort == "low"
+    with pytest.raises(OpenAIProtocolError) as oversized:
+        resolve_reasoning_channels(
+            ReasoningConfig(max_tokens=8192), max_tokens=8192, thinking=None, output_config=None
+        )
+    assert oversized.value.detail.param == "reasoning.max_tokens"
+
+
+def test_explicit_effort_supersedes_the_anthropic_channels_with_disclosure() -> None:
+    """Both channels present: the OpenRouter effort wins and every drop is disclosed."""
+    channels = resolve_reasoning_channels(
+        ReasoningConfig(effort="high", exclude=True),
+        max_tokens=128,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "low", "format": {"type": "text"}},
+    )
+    assert channels.effort == "high"
+    assert channels.effort_parameter == "reasoning.effort"
+    assert channels.thinking_config is None
+    assert channels.output_config == {"format": {"type": "text"}}
+    assert channels.disclosures == (
+        REASONING_SUPERSEDES_THINKING_DISCLOSURE,
+        REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE,
+        REASONING_EXCLUDE_DISCLOSURE,
+    )
+    # An output_config reduced to its effort alone drops entirely.
+    alone = resolve_reasoning_channels(
+        ReasoningConfig(effort="high"),
+        max_tokens=128,
+        thinking=None,
+        output_config={"effort": "low"},
+    )
+    assert alone.output_config is None

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -37,6 +37,10 @@ from exp.common.models.content import (
     TextContentPart,
 )
 from exp.common.models.model import ToolCall
+from exp.runtime.anthropic_protocol.gateway_reasoning import (
+    EMPTY_GATEWAY_BLOCK,
+    gateway_reasoning_block,
+)
 from exp.runtime.anthropic_protocol.manifest import (
     MESSAGES_BETA_TOKENS_FORWARDED,
     MESSAGES_MANIFEST,
@@ -746,6 +750,19 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
         if content is None and not tool_calls and not reasoning and not attachments:
             ordered_blocks.clear()
             return
+        if any(block.kind == "sealed_reasoning_content" for block in reasoning):
+            # A gateway tool turn returned its reasoning twice: the unsigned
+            # display block that streamed live and the sealed carrier that
+            # holds the same text authenticated. Only the carrier replays.
+            reasoning[:] = [
+                block for block in reasoning if block.kind != "exposed_reasoning_content"
+            ]
+        # The verbatim block order exists for Anthropic-signed history, whose
+        # signatures the provider verifies in place; gateway-issued blocks
+        # (unsigned plaintext, sealed carriers) never replay on that wire.
+        anthropic_thinking = any(
+            block.kind in {"thinking", "redacted_thinking"} for block in reasoning
+        )
         out.append(
             GatewayMessage(
                 role=message.role,
@@ -757,7 +774,7 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                 # blocks are the same text in the same order, so a multimodal
                 # turn keeps its cache markers when it re-emits.
                 provider_text_blocks=_marked_text_blocks(tuple(text_parts)),
-                provider_anthropic_blocks=tuple(ordered_blocks) if reasoning else None,
+                provider_anthropic_blocks=tuple(ordered_blocks) if anthropic_thinking else None,
             )
         )
         text_parts.clear()
@@ -821,12 +838,16 @@ def _gateway_messages(message: _Message, index: int) -> list[GatewayMessage]:
                     f"{param}.content.{block_index}",
                     "thinking blocks are only valid in assistant messages.",
                 )
-            reasoning.append(
-                ThinkingBlock(text=block.thinking, signature=block.signature)
-                if isinstance(block, _ThinkingBlock)
-                else RedactedThinkingBlock(data=block.data)
-            )
-            ordered_blocks.append(block.model_dump(mode="json", exclude_none=True))
+            gateway_block = gateway_reasoning_block(block, f"{param}.content.{block_index}")
+            if gateway_block is None:
+                reasoning.append(
+                    ThinkingBlock(text=block.thinking, signature=block.signature)
+                    if isinstance(block, _ThinkingBlock)
+                    else RedactedThinkingBlock(data=block.data)
+                )
+                ordered_blocks.append(block.model_dump(mode="json", exclude_none=True))
+            elif gateway_block is not EMPTY_GATEWAY_BLOCK:
+                reasoning.append(gateway_block)
         elif isinstance(block, _ToolUseBlock):
             if message.role != "assistant":
                 raise invalid_field(

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -36,7 +36,7 @@ from exp.common.models.content import (
     MessageContentPart,
     TextContentPart,
 )
-from exp.common.models.model import ReasoningEffort, ToolCall
+from exp.common.models.model import ToolCall
 from exp.runtime.anthropic_protocol.manifest import (
     MESSAGES_BETA_TOKENS_FORWARDED,
     MESSAGES_MANIFEST,
@@ -50,6 +50,10 @@ from exp.runtime.anthropic_protocol.media_blocks import (
     document_part_from_block,
     image_part_from_block,
 )
+from exp.runtime.anthropic_protocol.reasoning_channels import (
+    ReasoningConfig,
+    resolve_reasoning_channels,
+)
 from exp.runtime.gateway.compatibility import CompatibilityDisposition
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
@@ -61,7 +65,6 @@ from exp.runtime.gateway.contracts import (
     RedactedThinkingBlock,
     ThinkingBlock,
 )
-from exp.runtime.models.providers.reasoning_compat import REASONING_EFFORTS
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import disposition_map
 from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
@@ -284,6 +287,7 @@ class _MessagesRequest(AnthropicWireModel):
     tool_choice: _ToolChoice | None = None
     metadata: _Metadata | None = None
     thinking: _ThinkingConfig | None = None
+    reasoning: ReasoningConfig | None = None
     context_management: JsonObject | None = None
     output_config: JsonObject | None = None
     diagnostics: JsonObject | None = None
@@ -359,6 +363,16 @@ def decode_messages(
     parallel_tool_calls: bool | None = None
     if request.tool_choice is not None and request.tool_choice.disable_parallel_tool_use:
         parallel_tool_calls = False
+    channels = resolve_reasoning_channels(
+        request.reasoning,
+        max_tokens=request.max_tokens,
+        thinking=cast(JsonObject, payload["thinking"]) if request.thinking is not None else None,
+        output_config=(
+            cast(JsonObject, payload["output_config"])
+            if request.output_config is not None
+            else None
+        ),
+    )
     try:
         canonical = GatewayRequest(
             surface=GatewayApiSurface.MESSAGES,
@@ -382,11 +396,7 @@ def decode_messages(
             stream=request.stream,
             include_usage=request.stream,
             metadata=_gateway_metadata(request.metadata),
-            # The raw payload value, not the re-serialized wire model, so the
-            # provider receives the caller's thinking config byte-for-byte.
-            provider_thinking_config=(
-                cast(JsonObject, payload["thinking"]) if request.thinking is not None else None
-            ),
+            provider_thinking_config=channels.thinking_config,
             context_management=_context_management(payload),
             diagnostics=_diagnostics(payload),
             speed=request.speed,
@@ -399,13 +409,10 @@ def decode_messages(
             ),
             inference_geo=request.inference_geo,
             provider_beta_tokens=forwarded_betas,
-            ignored_parameters=dropped_beta_disclosures,
-            reasoning_effort=_output_config_effort(request.output_config),
-            provider_output_config=(
-                cast(JsonObject, payload["output_config"])
-                if request.output_config is not None
-                else None
-            ),
+            ignored_parameters=(*dropped_beta_disclosures, *channels.disclosures),
+            reasoning_effort=channels.effort,
+            reasoning_effort_parameter=channels.effort_parameter,
+            provider_output_config=channels.output_config,
         )
     except ValidationError as exc:
         raise _validation_error(exc.errors(include_url=False)[0]) from exc
@@ -432,24 +439,6 @@ def _require_served_server_tool_types(tools: tuple[_Tool | _ServerTool, ...]) ->
                 f"Supported server tool types: {supported}. Remove the tool or use a "
                 "supported type.",
             )
-
-
-def _output_config_effort(config: JsonObject | None) -> ReasoningEffort | None:
-    """Map a canonical caller ``output_config.effort`` into the shared field.
-
-    A canonical ladder value rides ``reasoning_effort`` so route narrowing,
-    the coercion policy, and non-Anthropic rungs all see it; the raw object
-    still forwards verbatim on Anthropic rungs with the caller's keys
-    winning, so an unrecognized future effort value stays provider-decided
-    instead of gateway-rejected.
-    """
-    if config is None:
-        return None
-    effort = config.get("effort")
-    if isinstance(effort, str) and effort in REASONING_EFFORTS:
-        # The membership check above is the narrowing proof for this cast.
-        return cast("ReasoningEffort", effort)
-    return None
 
 
 def _context_management(payload: JsonObject) -> JsonObject | None:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1795,3 +1795,89 @@ def test_forced_tool_choice_decodes_to_the_canonical_forced_forms() -> None:
     assert decode_messages(
         _body(tool_choice={"type": "auto"}, tools=tools)
     ).request.tool_choice == ("auto")
+
+
+def test_openrouter_reasoning_effort_rides_the_canonical_effort_channel() -> None:
+    """OpenRouter's ``reasoning: {effort}`` is a second effort channel beside thinking.
+
+    Agents built against OpenRouter's Anthropic-compatible Messages endpoint
+    send it verbatim; the gateway maps it onto ``reasoning_effort`` so every
+    rung (native Anthropic through ``output_config`` or a budget, effort
+    ladders elsewhere) sees the same canonical tier.
+    """
+    decoded = decode_messages(_body(reasoning={"effort": "low"}))
+    assert decoded.request.reasoning_effort == "low"
+    assert decoded.request.provider_thinking_config is None
+    assert decoded.request.provider_output_config is None
+    assert decoded.request.reasoning_effort_parameter == "reasoning.effort"
+    assert decoded.request.ignored_parameters == ()
+    # The Anthropic channel alone keeps the surface default for rejections.
+    native = decode_messages(_body(output_config={"effort": "low"}))
+    assert native.request.reasoning_effort_parameter is None
+    assert decode_messages(_body(reasoning={"effort": "none"})).request.reasoning_effort == "none"
+    assert decode_messages(_body(reasoning={"effort": "max"})).request.reasoning_effort == "max"
+
+
+def test_openrouter_reasoning_enabled_and_budget_forms_translate() -> None:
+    """``enabled: true`` is OpenRouter's default depth; a token budget maps by tier."""
+    enabled = decode_messages(_body(reasoning={"enabled": True}))
+    assert enabled.request.reasoning_effort == "medium"
+    disabled = decode_messages(_body(reasoning={"enabled": False}))
+    assert disabled.request.reasoning_effort == "none"
+    # A budget becomes the budgeted thinking config Anthropic rungs forward and
+    # non-Anthropic rungs translate by tier (<=4096 low, <=16384 medium, else high).
+    budget = decode_messages(_body(max_tokens=64000, reasoning={"max_tokens": 32000}))
+    assert budget.request.provider_thinking_config == {"type": "enabled", "budget_tokens": 32000}
+    assert budget.request.reasoning_effort == "high"
+    # exclude only hides reasoning from the reply, which this gateway does not
+    # render for non-Anthropic rungs anyway; it is dropped with disclosure.
+    excluded = decode_messages(_body(reasoning={"effort": "high", "exclude": True}))
+    assert excluded.request.reasoning_effort == "high"
+    assert "reasoning.exclude" in excluded.request.ignored_parameters
+
+
+def test_openrouter_reasoning_rejects_conflicting_and_unknown_shapes() -> None:
+    """Closed validation: effort and max_tokens are exclusive; unknown keys 400."""
+    with pytest.raises(OpenAIProtocolError) as both:
+        decode_messages(_body(reasoning={"effort": "high", "max_tokens": 2000}))
+    assert both.value.detail.param == "reasoning"
+    with pytest.raises(OpenAIProtocolError) as unknown:
+        decode_messages(_body(reasoning={"effort": "high", "depth": 3}))
+    assert unknown.value.status_code == 400
+    with pytest.raises(OpenAIProtocolError) as bad_effort:
+        decode_messages(_body(reasoning={"effort": "hyperdrive"}))
+    assert bad_effort.value.detail.param == "reasoning.effort"
+    with pytest.raises(OpenAIProtocolError) as oversized:
+        decode_messages(_body(max_tokens=2000, reasoning={"max_tokens": 2000}))
+    assert oversized.value.detail.param == "reasoning.max_tokens"
+
+
+def test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosure() -> None:
+    """Two reasoning channels on one request: the explicit effort wins, disclosed.
+
+    ``thinking`` is dropped (Anthropic rungs still reason at the effort through
+    the shared channel) and an ``output_config.effort`` that disagrees is
+    dropped from the forwarded object so it and the routing decision cannot
+    diverge; the payload seam re-seeds the effort from the shared channel.
+    """
+    decoded = decode_messages(
+        _body(
+            reasoning={"effort": "high"},
+            thinking={"type": "enabled", "budget_tokens": 2048},
+            output_config={"effort": "low", "format": {"type": "text"}},
+        )
+    )
+    assert decoded.request.reasoning_effort == "high"
+    assert decoded.request.provider_thinking_config is None
+    assert decoded.request.provider_output_config == {"format": {"type": "text"}}
+    assert decoded.request.reasoning_effort_parameter == "reasoning.effort"
+    assert "thinking->dropped(superseded_by_reasoning)" in decoded.request.ignored_parameters
+    assert (
+        "output_config.effort->dropped(superseded_by_reasoning)"
+        in decoded.request.ignored_parameters
+    )
+    # An agreeing output_config.effort needs no disclosure.
+    agreeing = decode_messages(
+        _body(reasoning={"effort": "high"}, output_config={"effort": "high"})
+    )
+    assert agreeing.request.ignored_parameters == ()

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1821,7 +1821,9 @@ def test_openrouter_reasoning_effort_rides_the_canonical_effort_channel() -> Non
     # The Anthropic channel alone keeps the surface default for rejections.
     native = decode_messages(_body(output_config={"effort": "low"}))
     assert native.request.reasoning_effort_parameter is None
-    assert decode_messages(_body(reasoning={"effort": "none"})).request.reasoning_effort == "none"
+    off = decode_messages(_body(reasoning={"effort": "none"})).request
+    assert off.reasoning_effort is None
+    assert off.provider_thinking_config == {"type": "disabled"}
     assert decode_messages(_body(reasoning={"effort": "max"})).request.reasoning_effort == "max"
 
 
@@ -1830,7 +1832,8 @@ def test_openrouter_reasoning_enabled_and_budget_forms_translate() -> None:
     enabled = decode_messages(_body(reasoning={"enabled": True}))
     assert enabled.request.reasoning_effort == "medium"
     disabled = decode_messages(_body(reasoning={"enabled": False}))
-    assert disabled.request.reasoning_effort == "none"
+    assert disabled.request.reasoning_effort is None
+    assert disabled.request.provider_thinking_config == {"type": "disabled"}
     # A budget becomes the budgeted thinking config Anthropic rungs forward and
     # non-Anthropic rungs translate by tier (<=4096 low, <=16384 medium, else high).
     budget = decode_messages(_body(max_tokens=64000, reasoning={"max_tokens": 32000}))
@@ -1857,6 +1860,9 @@ def test_openrouter_reasoning_rejects_conflicting_and_unknown_shapes() -> None:
     with pytest.raises(OpenAIProtocolError) as oversized:
         decode_messages(_body(max_tokens=2000, reasoning={"max_tokens": 2000}))
     assert oversized.value.detail.param == "reasoning.max_tokens"
+    with pytest.raises(OpenAIProtocolError) as tiny:
+        decode_messages(_body(max_tokens=2000, reasoning={"max_tokens": 512}))
+    assert tiny.value.detail.param == "reasoning.max_tokens"
 
 
 def test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosure() -> None:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -11,9 +11,11 @@ from exp.common.core.artifacts import JsonObject
 from exp.common.models.content import MAXIMUM_DOCUMENTS_PER_REQUEST
 from exp.runtime.anthropic_protocol.requests import decode_messages
 from exp.runtime.gateway.contracts import (
+    ExposedReasoningContentBlock,
     GatewayApiSurface,
     GatewayNamedToolChoice,
     RedactedThinkingBlock,
+    SealedReasoningContentBlock,
     ThinkingBlock,
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
@@ -277,13 +279,18 @@ def test_thinking_history_blocks_ride_the_opaque_carrier_in_order() -> None:
     assert redacted.data == "opaque=="
 
     # A thinking-only assistant turn (cut off mid-thinking) is legal history.
+    # Anthropic signs the block even when max_tokens cuts it short; an
+    # UNSIGNED block is the gateway's own exposed reasoning (see
+    # test_unsigned_thinking_block_decodes_as_gateway_plaintext_reasoning).
     only = decode_messages(
         _body(
             messages=[
                 {"role": "user", "content": "go"},
                 {
                     "role": "assistant",
-                    "content": [{"type": "thinking", "thinking": "partial"}],
+                    "content": [
+                        {"type": "thinking", "thinking": "partial", "signature": "sig-cut"}
+                    ],
                 },
                 {"role": "user", "content": "continue"},
             ]
@@ -1881,3 +1888,152 @@ def test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosu
         _body(reasoning={"effort": "high"}, output_config={"effort": "high"})
     )
     assert agreeing.request.ignored_parameters == ()
+
+
+_CARRIER = "x-experiential-hunyuan-reasoning-v1:ZGVwbG95bWVudC0x:c2VhbGVkLWVudmVsb3Bl"
+"""One syntactically complete Hunyuan carrier (deployment hint + envelope)."""
+
+
+def test_unsigned_thinking_block_decodes_as_gateway_plaintext_reasoning() -> None:
+    """A thinking block with no signature is the gateway's own exposed reasoning.
+
+    Anthropic signs every thinking block it issues; the Messages surface
+    renders a Tencent/DeepSeek rung's plaintext reasoning as an UNSIGNED
+    thinking block, so on replay it decodes exactly like Chat's plaintext
+    ``reasoning_content``: caller-owned history that exposing rungs forward
+    and every other rung drops with disclosure. It is not an Anthropic block,
+    so no verbatim block order is retained for the Anthropic wire.
+    """
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "the user wants ls", "signature": ""},
+                        {"type": "text", "text": '{"command": "ls"}'},
+                    ],
+                },
+                {"role": "user", "content": "a.txt"},
+            ]
+        )
+    )
+    assistant = decoded.request.messages[1]
+    assert assistant.content == '{"command": "ls"}'
+    assert [block.kind for block in assistant.provider_reasoning] == ["exposed_reasoning_content"]
+    exposed = assistant.provider_reasoning[0]
+    assert isinstance(exposed, ExposedReasoningContentBlock)
+    assert exposed.content == "the user wants ls"
+    assert assistant.provider_anthropic_blocks is None
+
+    # An unsigned block with no text carries nothing worth replaying.
+    empty = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "", "signature": ""},
+                        {"type": "text", "text": "ok"},
+                    ],
+                },
+                {"role": "user", "content": "again"},
+            ]
+        )
+    )
+    assert empty.request.messages[1].provider_reasoning == ()
+
+
+def test_redacted_thinking_carrying_a_gateway_carrier_decodes_sealed() -> None:
+    """A redacted_thinking block whose data is a gateway carrier is the sealed carrier.
+
+    The Messages tool turn returns its reasoning as one trailing
+    redacted_thinking block holding the sealed carrier (Anthropic's opaque
+    replay-verbatim shape). On replay it decodes to the same sealed block the
+    Chat wire's carrier decodes to, and the unsigned display block that
+    streamed beside it is dropped: the carrier holds that text authenticated.
+    """
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "think privately", "signature": ""},
+                        {"type": "tool_use", "id": "call-1", "name": "lookup", "input": {}},
+                        {"type": "redacted_thinking", "data": _CARRIER},
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "call-1", "content": "done"}
+                    ],
+                },
+            ]
+        )
+    )
+    assistant = decoded.request.messages[1]
+    assert assistant.tool_calls[0].call_id == "call-1"
+    assert [block.kind for block in assistant.provider_reasoning] == ["sealed_reasoning_content"]
+    sealed = assistant.provider_reasoning[0]
+    assert isinstance(sealed, SealedReasoningContentBlock)
+    assert sealed.carrier == _CARRIER
+    assert sealed.deployment_hint == "deployment-1"
+    assert assistant.provider_anthropic_blocks is None
+
+    # A carrier-prefixed payload that is not a complete carrier names its block.
+    with pytest.raises(OpenAIProtocolError) as rejected:
+        decode_messages(
+            _body(
+                messages=[
+                    {"role": "user", "content": "go"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "tool_use", "id": "call-1", "name": "lookup", "input": {}},
+                            {
+                                "type": "redacted_thinking",
+                                "data": "x-experiential-hunyuan-reasoning-v1:broken",
+                            },
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "tool_use_id": "call-1", "content": "done"}
+                        ],
+                    },
+                ]
+            )
+        )
+    assert rejected.value.detail.param == "messages.1.content.1"
+
+
+def test_anthropic_signed_thinking_still_decodes_verbatim_beside_gateway_blocks() -> None:
+    """A provider-signed block keeps its Anthropic contract; only unsigned ones are ours."""
+    decoded = decode_messages(
+        _body(
+            messages=[
+                {"role": "user", "content": "go"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "private", "signature": "sig=="},
+                        {"type": "redacted_thinking", "data": "opaque=="},
+                        {"type": "text", "text": "done"},
+                    ],
+                },
+                {"role": "user", "content": "again"},
+            ]
+        )
+    )
+    assistant = decoded.request.messages[1]
+    assert [block.kind for block in assistant.provider_reasoning] == [
+        "thinking",
+        "redacted_thinking",
+    ]
+    assert assistant.provider_anthropic_blocks is not None

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -513,6 +513,15 @@ class GatewayRequest(ContractModel):
     logprobs: bool | None = None
     top_logprobs: int | None = Field(default=None, ge=0, le=20)
     reasoning_effort: ReasoningEffort | None = None
+    reasoning_effort_parameter: (
+        Literal["reasoning_effort", "reasoning.effort", "output_config.effort"] | None
+    ) = Field(default=None, exclude=True)
+    """Exact caller field normalized into ``reasoning_effort``, when a surface
+    offers more than one (the Messages surface takes Anthropic's
+    ``output_config.effort`` and the OpenRouter ``reasoning.effort`` extension);
+    an effort the route cannot serve is rejected by that name so the caller's
+    own recovery finds the field it sent. ``None`` means the surface default
+    (see :attr:`caller_effort_parameter`)."""
     # Level-less enable-thinking; the route seam resolves the concrete effort.
     thinking_default_enable: bool = False
     reasoning_summary: Literal["auto", "concise", "detailed"] | None = None
@@ -772,6 +781,28 @@ class GatewayRequest(ContractModel):
         if len(set(value)) != len(value):
             raise ValueError("stop sequences must not repeat")
         return value
+
+    @property
+    def caller_effort_parameter(
+        self,
+    ) -> Literal["reasoning_effort", "reasoning.effort", "output_config.effort"]:
+        """The public field an unservable effort is rejected under.
+
+        The recorded caller field when the decoder knows it; otherwise the
+        surface's one effort field. The name matters: Claude Code carries its
+        effort as Messages ``output_config.effort`` and auto-recovers (drops
+        the field and retries) only when the 400 names that channel, so naming
+        a translated internal field wedges every turn instead.
+        """
+        if self.reasoning_effort_parameter is not None:
+            return self.reasoning_effort_parameter
+        match self.surface:
+            case GatewayApiSurface.RESPONSES:
+                return "reasoning.effort"
+            case GatewayApiSurface.MESSAGES:
+                return "output_config.effort"
+            case _:
+                return "reasoning_effort"
 
     @model_validator(mode="after")
     def _require_coherent_tools(self) -> GatewayRequest:

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.48"
+version = "0.3.49"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.48"
+version = "0.3.49"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.48"
+version = "0.3.49"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/encode.rs
+++ b/exp/runtime/gateway/native/src/encode.rs
@@ -37,8 +37,10 @@ pub struct ReasoningCarrierToolCall {
     pub raw_arguments: String,
 }
 
+/// Shared by the Chat and Messages encoders: both surfaces retain the same
+/// hidden-reasoning candidate and seal it under the same authority.
 #[derive(Default)]
-struct ReasoningCarrierState {
+pub(crate) struct ReasoningCarrierState {
     route_sha256: Option<String>,
     content: String,
     assistant_content: String,
@@ -48,7 +50,7 @@ struct ReasoningCarrierState {
 }
 
 impl ReasoningCarrierState {
-    fn observe(&mut self, event: &Event) -> Result<(), PublicError> {
+    pub(crate) fn observe(&mut self, event: &Event) -> Result<(), PublicError> {
         match event {
             Event::TextDelta(delta) => self.assistant_content.push_str(delta),
             Event::ReasoningContentDelta {
@@ -118,7 +120,7 @@ impl ReasoningCarrierState {
         Ok(())
     }
 
-    fn candidate(&self) -> Result<Option<ReasoningCarrierCandidate>, PublicError> {
+    pub(crate) fn candidate(&self) -> Result<Option<ReasoningCarrierCandidate>, PublicError> {
         if self.content.is_empty() || self.tool_ids.is_empty() {
             return Ok(None);
         }

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -8,11 +8,20 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{json, Map, Value};
 
 use crate::dialects::MAXIMUM_RETAINED_OUTPUT_BYTES;
-use crate::encode::{compact_json, stable_public_id};
+use crate::encode::{
+    compact_json, stable_public_id, ReasoningCarrierCandidate, ReasoningCarrierState,
+};
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
 
 const REFUSAL_MESSAGE: &str = "provider refused the request";
+
+/// The provider block index under which an exposure-gated rung's plaintext
+/// reasoning (`ReasoningContentDelta`, an OpenAI-wire event with no block
+/// index of its own) is scheduled as one Messages thinking block. Anthropic
+/// dialects index their thinking blocks from zero and never share a stream
+/// with an OpenAI-wire rung, so the reserved value cannot collide.
+const EXPOSED_REASONING_BLOCK_INDEX: u32 = u32::MAX;
 
 /// The sanitized failure for provider refusals on this surface, mirroring
 /// `refusal_failure` in the python encoder.
@@ -206,6 +215,9 @@ pub struct MessagesSseEncoder {
     refusal_seen: bool,
     usage: Option<Usage>,
     ignored_parameters: Vec<String>,
+    reasoning: ReasoningCarrierState,
+    reasoning_content_carrier: Option<String>,
+    reasoning_output_exposed: bool,
 }
 
 impl MessagesSseEncoder {
@@ -241,7 +253,38 @@ impl MessagesSseEncoder {
             saw_tool_use: false,
             refusal_seen: false,
             usage: None,
+            reasoning: ReasoningCarrierState::default(),
+            reasoning_content_carrier: None,
+            reasoning_output_exposed: false,
         }
+    }
+
+    /// Attach the authenticated carrier before the terminal is encoded.
+    ///
+    /// Mirrors `ChatSseEncoder::set_reasoning_content_carrier`: a tool turn's
+    /// hidden reasoning leaves only as the sealed carrier, here as one trailing
+    /// `redacted_thinking` block (Anthropic's opaque replay-verbatim shape).
+    pub fn set_reasoning_content_carrier(&mut self, carrier: String) {
+        self.reasoning_content_carrier = Some(carrier);
+    }
+
+    /// Show the model's plaintext reasoning to the caller as a thinking block.
+    ///
+    /// Off by default so hidden-reasoning providers never leak; on only for
+    /// rungs the catalog marks `reasoning_output_exposed` (Tencent/DeepSeek),
+    /// whose plaintext the Chat wire already returns as `reasoning_content`.
+    /// The block carries an EMPTY signature: Anthropic signs every thinking
+    /// block it issues, so an unsigned block is recognizably the gateway's own
+    /// plaintext when the caller replays it.
+    pub fn set_reasoning_output_exposed(&mut self, exposed: bool) {
+        self.reasoning_output_exposed = exposed;
+    }
+
+    /// Return the validated carrier candidate accumulated by a live stream.
+    pub fn reasoning_carrier_candidate(
+        &self,
+    ) -> Result<Option<ReasoningCarrierCandidate>, PublicError> {
+        self.reasoning.candidate()
     }
 
     /// Emit the `message_start` and `ping` lifecycle events once.
@@ -292,6 +335,7 @@ impl MessagesSseEncoder {
                 "Messages stream received an event after its terminal.",
             ));
         }
+        self.reasoning.observe(event)?;
         match event {
             Event::TextDelta(text) => self.text_delta(text),
             Event::ProviderTextDelta { delta, .. } => self.text_delta(delta),
@@ -301,6 +345,17 @@ impl MessagesSseEncoder {
                 self.refusal_seen = true;
                 Ok(Vec::new())
             }
+            Event::ReasoningContentDelta { delta, .. } => {
+                // An exposure-gated rung's plaintext reasoning streams as one
+                // unsigned thinking block, the Messages twin of the Chat
+                // wire's `reasoning_content` deltas; elsewhere it stays
+                // dropped. The sealed tool-turn carrier rides independently.
+                if self.reasoning_output_exposed && !delta.is_empty() {
+                    self.thinking_delta(EXPOSED_REASONING_BLOCK_INDEX, delta)
+                } else {
+                    Ok(Vec::new())
+                }
+            }
             Event::ProviderRefusalDelta { .. } => {
                 self.refusal_seen = true;
                 Ok(Vec::new())
@@ -309,8 +364,7 @@ impl MessagesSseEncoder {
             Event::ProviderOutputItemStarted { .. }
             | Event::ProviderOutputItemCompleted { .. }
             | Event::ReasoningSummaryDelta { .. }
-            | Event::EncryptedReasoning { .. }
-            | Event::ReasoningContentDelta { .. } => Ok(Vec::new()),
+            | Event::EncryptedReasoning { .. } => Ok(Vec::new()),
             Event::ThinkingDelta { index, delta } => self.thinking_delta(*index, delta),
             Event::ThinkingSignature { index, signature } => {
                 self.thinking_signature(*index, signature)
@@ -415,8 +469,22 @@ impl MessagesSseEncoder {
                 if self.refusal_seen {
                     return Ok(vec![error_frame(&refusal_failure())]);
                 }
+                let mut frames = Vec::new();
+                if matches!(event, Event::Completed | Event::StoppedAtSequence(_))
+                    && self.reasoning.candidate()?.is_some()
+                {
+                    // The carrier is known only once every tool call has
+                    // completed, after the sequential thinking block closed,
+                    // so it travels as one trailing opaque block.
+                    let carrier = self.reasoning_content_carrier.clone().ok_or_else(|| {
+                        invalid_provider_stream(
+                            "Messages reasoning content was not sealed by the gateway authority.",
+                        )
+                    })?;
+                    frames.extend(self.redacted_thinking(&carrier)?);
+                }
                 self.draining = true;
-                let mut frames = self.advance();
+                frames.extend(self.advance());
                 frames.push(event_frame(
                     "message_delta",
                     &json!({
@@ -859,7 +927,7 @@ impl MessagesSseEncoder {
 
 mod aggregate;
 
-pub use aggregate::{completed_messages_body, completed_messages_body_with_ignored};
+pub use aggregate::{completed_messages_body, completed_messages_body_with_reasoning};
 
 /// Attach the `x-experiential-ignored-parameters` disclosure to one message
 /// object when any control was dropped; an empty list adds nothing.

--- a/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/aggregate.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use serde_json::{json, Value};
 
-use crate::encode::stable_public_id;
+use crate::encode::{reasoning_carrier_candidate, stable_public_id};
 use crate::errors::{Failure, PublicError};
 use crate::events::{Event, Usage};
 
@@ -29,16 +29,22 @@ pub fn completed_messages_body(
     model: &str,
     events: &[Event],
 ) -> Result<AggregatedMessage, PublicError> {
-    completed_messages_body_with_ignored(request_id, model, events, &[])
+    completed_messages_body_with_reasoning(request_id, model, events, &[], None, false)
 }
 
-/// Build one non-streaming Anthropic message with ignored-control disclosure,
-/// mirroring `completed_chat_body_with_ignored`.
-pub fn completed_messages_body_with_ignored(
+/// Build one non-streaming Anthropic message carrying the turn's reasoning,
+/// mirroring `completed_chat_body_with_carrier`: an exposure-gated rung's
+/// plaintext reasoning leads the content as one UNSIGNED thinking block, and a
+/// tool turn's hidden reasoning closes it as one `redacted_thinking` block
+/// holding the sealed carrier (never plaintext: a CoT-injection vector on the
+/// way back in). The block sequence equals the streaming encoder's.
+pub fn completed_messages_body_with_reasoning(
     request_id: &str,
     model: &str,
     events: &[Event],
     ignored_parameters: &[String],
+    reasoning_content_carrier: Option<&str>,
+    reasoning_output_exposed: bool,
 ) -> Result<AggregatedMessage, PublicError> {
     let terminal = events.iter().rev().find(|event| event.is_terminal());
     let terminal = match terminal {
@@ -101,6 +107,21 @@ pub fn completed_messages_body_with_ignored(
     // compatible streams) emit every tool completion only at their terminal
     // sentinel, after later text.
     let mut slots: Vec<Option<Value>> = Vec::new();
+    let reasoning = reasoning_carrier_candidate(events)?;
+    if reasoning_output_exposed {
+        let reasoning_text: String = events
+            .iter()
+            .filter_map(|event| match event {
+                Event::ReasoningContentDelta { delta, .. } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect();
+        if !reasoning_text.is_empty() {
+            slots.push(Some(
+                json!({"type": "thinking", "thinking": reasoning_text, "signature": ""}),
+            ));
+        }
+    }
     let mut tool_positions: HashMap<u32, usize> = HashMap::new();
     let mut server_positions: HashMap<u32, usize> = HashMap::new();
     let mut thinking_positions: HashMap<u32, usize> = HashMap::new();
@@ -228,6 +249,20 @@ pub fn completed_messages_body_with_ignored(
             }
             _ => {}
         }
+    }
+    if matches!(terminal, Event::Completed | Event::StoppedAtSequence(_))
+        && saw_tool_use
+        && reasoning.is_some()
+    {
+        let carrier = reasoning_content_carrier.ok_or_else(|| {
+            PublicError::new(
+                502,
+                "invalid_provider_stream",
+                "Messages reasoning content was not sealed by the gateway authority.",
+                "api_error",
+            )
+        })?;
+        slots.push(Some(json!({"type": "redacted_thinking", "data": carrier})));
     }
     let content: Vec<Value> = slots.into_iter().flatten().collect();
     let mut body = json!({

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -945,3 +945,34 @@ fn tool_turn_reasoning_without_a_sealed_carrier_fails_closed() {
         completed_messages_body_with_reasoning("request-abc", "coding", &events, &[], None, true);
     assert!(aggregated.is_err());
 }
+
+#[test]
+fn a_stop_sequence_ending_a_reasoning_tool_turn_still_needs_and_emits_the_carrier() {
+    // Both completing terminals demand the sealed carrier, so the route must
+    // seal on `StoppedAtSequence` too (Greptile on #897): with the carrier the
+    // trailing redacted block and the terminal frames flow; without it the
+    // encoder fails closed instead of ending the stream short.
+    let mut events = tool_turn_reasoning_events();
+    events.pop();
+    events.push(Event::StoppedAtSequence("STOP".to_string()));
+    let carrier = "x-experiential-hunyuan-reasoning-v1:ZGVw:c2VhbGVk";
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_reasoning_content_carrier(carrier.to_string());
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("streams"));
+    }
+    let names = frame_names(&frames);
+    assert_eq!(names[names.len() - 2..], ["message_delta", "message_stop"]);
+    assert!(frames
+        .iter()
+        .any(|frame| frame.contains("\"redacted_thinking\"")));
+
+    let mut unsealed = MessagesSseEncoder::new("request-abc", "coding");
+    unsealed.start().expect("starts");
+    let error = events
+        .iter()
+        .find_map(|event| unsealed.feed(event).err())
+        .expect("terminal without a carrier fails");
+    assert!(error.message.contains("not sealed"));
+}

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -683,9 +683,15 @@ fn ignored_generation_controls_are_disclosed_by_both_messages_encoders() {
     ));
 
     let events = vec![Event::TextDelta("hi".to_string()), Event::Completed];
-    let aggregated =
-        completed_messages_body_with_ignored("request-abc", "coding", &events, &ignored)
-            .expect("aggregates");
+    let aggregated = completed_messages_body_with_reasoning(
+        "request-abc",
+        "coding",
+        &events,
+        &ignored,
+        None,
+        false,
+    )
+    .expect("aggregates");
     assert_eq!(
         aggregated.body["x-experiential-ignored-parameters"],
         json!(["reasoning_effort", "anthropic-beta.claude-code-20250219"])
@@ -703,4 +709,239 @@ fn ignored_generation_controls_are_disclosed_by_both_messages_encoders() {
         .body
         .get("x-experiential-ignored-parameters")
         .is_none());
+}
+
+fn exposed_reasoning_events() -> Vec<Event> {
+    vec![
+        Event::ReasoningContentDelta {
+            route_sha256: "route-a".to_string(),
+            delta: "step ".to_string(),
+        },
+        Event::ReasoningContentDelta {
+            route_sha256: "route-a".to_string(),
+            delta: "one".to_string(),
+        },
+        Event::TextDelta("answer".to_string()),
+        Event::Completed,
+    ]
+}
+
+fn tool_turn_reasoning_events() -> Vec<Event> {
+    vec![
+        Event::ReasoningContentDelta {
+            route_sha256: "route-a".to_string(),
+            delta: "think privately".to_string(),
+        },
+        Event::ToolCallStarted {
+            namespace: None,
+            caller: None,
+            index: 0,
+            call_id: "call-1".to_string(),
+            name: "lookup".to_string(),
+        },
+        Event::ToolArgumentsDelta {
+            index: 0,
+            delta: "{}".to_string(),
+        },
+        Event::ToolCallCompleted {
+            index: 0,
+            call: CompletedToolCall {
+                namespace: None,
+                caller: None,
+                call_id: "call-1".to_string(),
+                name: "lookup".to_string(),
+                provider_item_id: None,
+                provider_status: None,
+                raw_arguments: "{}".to_string(),
+                custom: false,
+            },
+        },
+        Event::Completed,
+    ]
+}
+
+fn frame_names(frames: &[String]) -> Vec<&str> {
+    frames
+        .iter()
+        .map(|frame| {
+            frame
+                .lines()
+                .next()
+                .and_then(|line| line.strip_prefix("event: "))
+                .expect("named frame")
+        })
+        .collect()
+}
+
+#[test]
+fn exposed_reasoning_streams_as_an_unsigned_thinking_block() {
+    // A Tencent/DeepSeek rung marked reasoning_output_exposed returns its
+    // plaintext reasoning on the Chat wire as `reasoning_content`; on the
+    // Messages wire the same text is a thinking block whose signature stays
+    // empty (Anthropic always signs, so an unsigned block is recognizably the
+    // gateway's plaintext when the caller replays it).
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_reasoning_output_exposed(true);
+    let mut frames = encoder.start().expect("starts");
+    for event in &exposed_reasoning_events() {
+        frames.extend(encoder.feed(event).expect("streams reasoning"));
+    }
+    assert_eq!(
+        frame_names(&frames),
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+    );
+    assert!(frames[2].contains("{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}"));
+    assert!(frames[3].contains("{\"type\":\"thinking_delta\",\"thinking\":\"step \"}"));
+    assert!(frames[4].contains("{\"type\":\"thinking_delta\",\"thinking\":\"one\"}"));
+    assert!(!frames.iter().any(|frame| frame.contains("signature_delta")));
+    assert!(frames[7].contains("{\"type\":\"text_delta\",\"text\":\"answer\"}"));
+
+    let aggregated = completed_messages_body_with_reasoning(
+        "request-abc",
+        "coding",
+        &exposed_reasoning_events(),
+        &[],
+        None,
+        true,
+    )
+    .expect("aggregates");
+    assert_eq!(
+        aggregated.body["content"],
+        json!([
+            {"type": "thinking", "thinking": "step one", "signature": ""},
+            {"type": "text", "text": "answer"},
+        ])
+    );
+}
+
+#[test]
+fn unexposed_reasoning_stays_dropped_on_the_messages_surface() {
+    // Hidden-reasoning rungs never leak: without exposure the Messages
+    // encoders keep OpenAI-wire reasoning invisible, exactly as before.
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    let mut frames = encoder.start().expect("starts");
+    for event in &exposed_reasoning_events() {
+        frames.extend(encoder.feed(event).expect("streams"));
+    }
+    assert!(!frames.iter().any(|frame| frame.contains("thinking")));
+    let aggregated = completed_messages_body("request-abc", "coding", &exposed_reasoning_events())
+        .expect("aggregates");
+    assert_eq!(
+        aggregated.body["content"],
+        json!([{"type": "text", "text": "answer"}])
+    );
+}
+
+#[test]
+fn tool_turn_reasoning_round_trips_as_a_trailing_redacted_thinking_carrier() {
+    // A tool turn's reasoning must come back as the sealed opaque carrier
+    // (never raw plaintext: a CoT-injection vector on the way back in). The
+    // carrier is only known once every tool call completed, after the
+    // sequential thinking block has closed, so it rides one trailing
+    // `redacted_thinking` block: Anthropic's own "opaque, replay verbatim"
+    // shape, which every Messages client (Claude Code) echoes untouched.
+    let carrier = "x-experiential-hunyuan-reasoning-v1:ZGVw:c2VhbGVk";
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_reasoning_output_exposed(true);
+    encoder.set_reasoning_content_carrier(carrier.to_string());
+    let mut frames = encoder.start().expect("starts");
+    for event in &tool_turn_reasoning_events() {
+        frames.extend(encoder.feed(event).expect("streams"));
+    }
+    assert_eq!(
+        frame_names(&frames),
+        vec![
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "content_block_start",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+    );
+    assert!(frames[3].contains("{\"type\":\"thinking_delta\",\"thinking\":\"think privately\"}"));
+    assert!(frames[5].contains("\"type\":\"tool_use\""));
+    assert!(frames[8].contains(&format!(
+        "{{\"type\":\"redacted_thinking\",\"data\":\"{carrier}\"}}"
+    )));
+    assert!(frames[10].contains("\"stop_reason\":\"tool_use\""));
+
+    let aggregated = completed_messages_body_with_reasoning(
+        "request-abc",
+        "coding",
+        &tool_turn_reasoning_events(),
+        &[],
+        Some(carrier),
+        true,
+    )
+    .expect("aggregates");
+    assert_eq!(
+        aggregated.body["content"],
+        json!([
+            {"type": "thinking", "thinking": "think privately", "signature": ""},
+            {"type": "tool_use", "id": "call-1", "name": "lookup", "input": {}},
+            {"type": "redacted_thinking", "data": carrier},
+        ])
+    );
+    assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
+
+    // Exposure only governs the plaintext display block; the carrier rides
+    // regardless (Fireworks-style hidden reasoning on a tool turn).
+    let hidden = completed_messages_body_with_reasoning(
+        "request-abc",
+        "coding",
+        &tool_turn_reasoning_events(),
+        &[],
+        Some(carrier),
+        false,
+    )
+    .expect("aggregates");
+    assert_eq!(
+        hidden.body["content"],
+        json!([
+            {"type": "tool_use", "id": "call-1", "name": "lookup", "input": {}},
+            {"type": "redacted_thinking", "data": carrier},
+        ])
+    );
+}
+
+#[test]
+fn tool_turn_reasoning_without_a_sealed_carrier_fails_closed() {
+    // Mirrors the Chat encoders: reasoning the gateway authority did not seal
+    // never leaves as plaintext on a tool turn.
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.start().expect("starts");
+    let events = tool_turn_reasoning_events();
+    let mut error = None;
+    for event in &events {
+        if let Err(failure) = encoder.feed(event) {
+            error = Some(failure);
+            break;
+        }
+    }
+    let error = error.expect("terminal without a carrier fails");
+    assert_eq!(error.status_code, 502);
+    assert!(error.message.contains("not sealed"));
+
+    let aggregated =
+        completed_messages_body_with_reasoning("request-abc", "coding", &events, &[], None, true);
+    assert!(aggregated.is_err());
 }

--- a/exp/runtime/gateway/native/src/route_chat.rs
+++ b/exp/runtime/gateway/native/src/route_chat.rs
@@ -886,7 +886,10 @@ async fn stream_response(
                 other => other.clone(),
             };
             if event.is_terminal() {
-                if matches!(event, Event::Completed) {
+                if matches!(event, Event::Completed | Event::StoppedAtSequence(_)) {
+                    // The encoder requires the carrier on BOTH completing
+                    // terminals; a stop sequence closing a reasoning tool turn
+                    // used to end the stream short of its terminal frames.
                     let candidate = match encoder.reasoning_carrier_candidate() {
                         Ok(candidate) => candidate,
                         Err(_) => {

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -22,7 +22,7 @@ use crate::admission::{
 };
 use crate::encode::compact_json;
 use crate::encode_messages::{
-    anthropic_error_body, completed_messages_body_with_ignored, MessagesSseEncoder,
+    anthropic_error_body, completed_messages_body_with_reasoning, MessagesSseEncoder,
 };
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
@@ -32,6 +32,7 @@ use crate::respond::{
     bearer_key, client_ip, complete_visible_refusal, escalation_error, json_response,
     latin1_header_list, read_body, send_bounded, settle_stream_end, sse_body_response,
 };
+use crate::route_chat::{seal_reasoning_candidate, seal_reasoning_events};
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
 use crate::waterfall::{acquire_attempt, CommittedAttempt, SettledAttempt, WaterfallContext, Won};
@@ -231,7 +232,7 @@ async fn settled_messages_response(admission: &Admission, settled: SettledAttemp
             if admission.stream {
                 // The withheld refusal output and its failing terminal flush
                 // outward as the stream's only frames.
-                let body = match encode_messages_sse(admission, &events) {
+                let body = match encode_messages_sse(admission, &events, None, false) {
                     Ok(body) => body,
                     Err(error) => return messages_error_response(&error),
                 };
@@ -244,18 +245,23 @@ async fn settled_messages_response(admission: &Admission, settled: SettledAttemp
     }
     let mut headers = commit_independent(admission, None);
     headers.extend(commit_dependent(admission, settled.depth));
+    // A settled attempt carries no semantic output, so no reasoning was
+    // issued and nothing needs sealing; exposure only governs display.
+    let exposed = admission.reasoning_exposed_at(settled.depth);
     if admission.stream {
-        let body = match encode_messages_sse(admission, &events) {
+        let body = match encode_messages_sse(admission, &events, None, exposed) {
             Ok(body) => body,
             Err(error) => return messages_error_response(&error),
         };
         return sse_body_response(&headers, body);
     }
-    let aggregated = match completed_messages_body_with_ignored(
+    let aggregated = match completed_messages_body_with_reasoning(
         &admission.request_id,
         &admission.alias,
         &events,
         &admission.ignored_parameters,
+        None,
+        exposed,
     ) {
         Ok(aggregated) => aggregated,
         Err(error) => return messages_error_response(&error),
@@ -279,11 +285,30 @@ async fn respond_from_messages_events(
     stream_body: bool,
 ) -> Response {
     let refusal_completed = complete_visible_refusal(&mut events);
-    let aggregated = match completed_messages_body_with_ignored(
+    // A tool turn's hidden reasoning leaves only as the sealed carrier, so it
+    // is sealed under the gateway authority before the body is assembled,
+    // exactly like the Chat surface (`respond_from_chat_events`).
+    let carrier = if refusal_completed.is_some() {
+        None
+    } else {
+        match seal_reasoning_events(&guard.bridge, &admission.request_id, depth, &events).await {
+            Ok(carrier) => carrier,
+            Err(failure) => {
+                guard
+                    .settle("failed", usage.as_ref(), &tool_names, Some(&failure), true)
+                    .await;
+                return messages_error_response(&failure.public_error());
+            }
+        }
+    };
+    let exposed = admission.reasoning_exposed_at(depth);
+    let aggregated = match completed_messages_body_with_reasoning(
         &admission.request_id,
         &admission.alias,
         &events,
         &admission.ignored_parameters,
+        carrier.as_deref(),
+        exposed,
     ) {
         Ok(aggregated) => aggregated,
         Err(error) => {
@@ -354,7 +379,7 @@ async fn respond_from_messages_events(
     let mut headers = commit_independent(&admission, None);
     headers.extend(commit_dependent(&admission, depth));
     if stream_body {
-        let body = match encode_messages_sse(&admission, &events) {
+        let body = match encode_messages_sse(&admission, &events, carrier.as_deref(), exposed) {
             Ok(body) => body,
             Err(error) => return messages_error_response(&error),
         };
@@ -363,12 +388,21 @@ async fn respond_from_messages_events(
     json_response(StatusCode::OK, &aggregated.body, &headers)
 }
 
-fn encode_messages_sse(admission: &Admission, events: &[Event]) -> Result<Vec<u8>, PublicError> {
+fn encode_messages_sse(
+    admission: &Admission,
+    events: &[Event],
+    reasoning_content_carrier: Option<&str>,
+    reasoning_output_exposed: bool,
+) -> Result<Vec<u8>, PublicError> {
     let mut encoder = MessagesSseEncoder::new_with_ignored(
         &admission.request_id,
         &admission.alias,
         admission.ignored_parameters.clone(),
     );
+    encoder.set_reasoning_output_exposed(reasoning_output_exposed);
+    if let Some(carrier) = reasoning_content_carrier {
+        encoder.set_reasoning_content_carrier(carrier.to_string());
+    }
     let mut body = Vec::new();
     for frame in encoder.start()? {
         body.extend_from_slice(frame.as_bytes());
@@ -506,6 +540,7 @@ async fn stream_messages(
         let mut committed = committed;
         let mut encoder =
             MessagesSseEncoder::new_with_ignored(&request_id, &alias, ignored_parameters);
+        encoder.set_reasoning_output_exposed(admission.reasoning_exposed_at(committed.depth));
         let mut usage: Option<Usage> = committed.usage.take();
         let mut tool_names: Vec<String> = std::mem::take(&mut committed.tool_names);
         let mut visible_refusal = committed.visible_refusal;
@@ -580,6 +615,31 @@ async fn stream_messages(
                 other => other.clone(),
             };
             if event.is_terminal() {
+                if matches!(event, Event::Completed) {
+                    // Mirrors the Chat stream: a completed tool turn with
+                    // hidden reasoning is sealed before its terminal frames.
+                    let candidate = match encoder.reasoning_carrier_candidate() {
+                        Ok(candidate) => candidate,
+                        Err(_) => {
+                            fail_stream!(Failure::new(
+                                FailureClass::MalformedResponse,
+                                "provider returned malformed reasoning continuation data",
+                            ))
+                        }
+                    };
+                    match seal_reasoning_candidate(
+                        &guard.bridge,
+                        &request_id,
+                        committed.depth,
+                        candidate,
+                    )
+                    .await
+                    {
+                        Ok(Some(carrier)) => encoder.set_reasoning_content_carrier(carrier),
+                        Ok(None) => {}
+                        Err(failure) => fail_stream!(failure),
+                    }
+                }
                 terminal = Some(event.clone());
                 if !settle_stream_end(&mut guard, Some(&event), usage.as_ref(), &tool_names, false)
                     .await

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -615,9 +615,11 @@ async fn stream_messages(
                 other => other.clone(),
             };
             if event.is_terminal() {
-                if matches!(event, Event::Completed) {
-                    // Mirrors the Chat stream: a completed tool turn with
-                    // hidden reasoning is sealed before its terminal frames.
+                if matches!(event, Event::Completed | Event::StoppedAtSequence(_)) {
+                    // Mirrors the Chat stream: a tool turn with hidden
+                    // reasoning is sealed before its terminal frames on both
+                    // terminals the encoder requires a carrier for (a stop
+                    // sequence ends the turn as legitimately as a plain stop).
                     let candidate = match encoder.reasoning_carrier_candidate() {
                         Ok(candidate) => candidate,
                         Err(_) => {

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5493,3 +5493,171 @@ def test_an_unflagged_self_hosted_rung_stays_stripped_with_no_carrier_route(
     assert initial["reasoning_output_exposed"] is False
     assert initial["hunyuan_reasoning_route_sha256"] is None
     assert initial["fireworks_reasoning_route_sha256"] is None
+
+
+def _messages_body(messages: list[JsonObject]) -> str:
+    """Return one raw Anthropic Messages request body over ``messages``."""
+    return json.dumps({"model": "coding", "max_tokens": 64, "messages": messages})
+
+
+def test_hunyuan_plain_turn_unsigned_thinking_replays_verbatim_on_messages(
+    tmp_path: Path,
+) -> None:
+    """Claude Code echoes the gateway's unsigned thinking block; the rung gets its text back.
+
+    The Messages surface returns an exposing rung's plaintext reasoning as a
+    thinking block with an EMPTY signature. Claude Code replays every content
+    block verbatim, so the next turn carries that block back, and admission
+    forwards the text as ``reasoning_content`` exactly like the Chat wire's
+    plaintext (see ``test_hunyuan_plain_turn_plaintext_reasoning_replays_verbatim``).
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    thinking = "The user wants a directory listing; ls is the command."
+    body = _messages_body(
+        [
+            {"role": "user", "content": "List the files."},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": thinking, "signature": ""},
+                    {"type": "text", "text": '{"command": "ls"}'},
+                ],
+            },
+            {"role": "user", "content": "a.txt b.txt"},
+        ]
+    )
+    admitted = _admit(control, raw_key, body, surface="messages")
+    messages = _payload_messages(admitted)
+    assert messages[1]["reasoning_content"] == thinking
+    assert admitted["route_reason"] != "reasoning_continuation"
+    assert admitted.get("ignored_parameters", []) == []
+
+
+def test_hunyuan_tool_turn_redacted_carrier_round_trips_on_messages(tmp_path: Path) -> None:
+    """A Messages tool turn replays its sealed carrier from the redacted_thinking block.
+
+    The data plane closes a tool turn with one ``redacted_thinking`` block whose
+    data is the sealed Hunyuan carrier (beside the unsigned display block that
+    streamed live). Claude Code echoes both; admission unseals the carrier to the
+    exact plaintext, forwards it upstream, pins the issuing rung, and drops the
+    display duplicate rather than sending the text twice.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    route_sha256 = initial["hunyuan_reasoning_route_sha256"]
+    hidden = "let me reason about the tool call privately"
+    sealed = json.loads(
+        control.seal_reasoning_content(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "route_depth": initial["route_depth"],
+                    "route_sha256": route_sha256,
+                    "content": hidden,
+                    "assistant_content": None,
+                    "tool_calls": [
+                        {"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}
+                    ],
+                }
+            )
+        )
+    )["carrier"]
+    control.settle(
+        json.dumps(
+            {
+                "request_id": initial["request_id"],
+                "attempt_id": initial["attempt_id"],
+                "outcome": "completed",
+                "usage": {"input_tokens": 3, "output_tokens": 2},
+                "tool_names": ["lookup"],
+                "failure": None,
+            }
+        )
+    )
+    body = _messages_body(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": hidden, "signature": ""},
+                    {"type": "tool_use", "id": "call-one", "name": "lookup", "input": {}},
+                    {"type": "redacted_thinking", "data": sealed},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "call-one", "content": "done"}],
+            },
+        ]
+    )
+    continued = _admit(control, raw_key, body, surface="messages")
+    messages = _payload_messages(continued)
+    assert continued["route_reason"] == "reasoning_continuation"
+    assert messages[1]["reasoning_content"] == hidden
+    tool_calls = messages[1]["tool_calls"]
+    assert isinstance(tool_calls, list)
+    first_call = tool_calls[0]
+    assert isinstance(first_call, dict)
+    assert first_call["id"] == "call-one"
+
+    # A tampered tool turn fails closed at the carrier authority, as on Chat.
+    tampered = json.loads(body)
+    tampered["messages"][1]["content"][1]["input"] = {"tampered": True}
+    with pytest.raises(NativeBridgeError):
+        _admit(control, raw_key, json.dumps(tampered), surface="messages")
+
+
+def test_anthropic_signed_thinking_drops_with_disclosure_on_a_foreign_route(
+    tmp_path: Path,
+) -> None:
+    """A Claude-signed thinking history reaching a non-Anthropic rung serves, disclosed.
+
+    Claude Code carries Claude's signed blocks into every later turn of a
+    session; pointing that session at a Tencent/OpenAI model used to answer a
+    named 400 on every request (2,180 refusals on one alias in 14 days). The
+    blocks are stripped for the foreign wire with the same disclosure shape
+    plaintext reasoning uses, and the turn serves.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    body = _messages_body(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "claude reasoned", "signature": "sig=="},
+                    {"type": "redacted_thinking", "data": "opaque=="},
+                    {"type": "text", "text": "prior answer"},
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+    )
+    admitted = _admit(control, raw_key, body, surface="messages")
+    ignored = cast("list[str]", admitted["ignored_parameters"])
+    assert "messages.thinking->dropped(unsupported_by_provider)" in ignored
+    messages = _payload_messages(admitted)
+    assert messages[1]["content"] == "prior answer"
+    assert "reasoning_content" not in messages[1]

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5353,3 +5353,143 @@ def test_foundry_deepseek_zero_argument_call_with_a_stray_empty_string_delta_com
         ("view_agent_graph", "{}")
     ]
     assert events[-1]["kind"] == "completed"
+
+
+def test_reasoning_content_native_rung_round_trips_preserved_thinking_off_the_tencent_hosts(
+    tmp_path: Path,
+) -> None:
+    """A self-hosted hy4-preview rung keeps Tencent's preserved-thinking contract.
+
+    Carrier eligibility is the rung's ``reasoning_content_native`` declaration,
+    not the origin hostname: on an arbitrary https origin the flagged rung
+    exposes plaintext, seals a tool turn's reasoning as the Hunyuan carrier, a
+    second replica unseals and forwards it, and a plain turn's plaintext
+    replays verbatim. The same origin without the flag stays stripped.
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://hy4-preview--serve.modal.run/v1",
+        capabilities=ModelCapabilities(
+            supports_tools=True, reasoning_output_exposed=True, reasoning_content_native=True
+        ),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "shared-secret"})
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    assert initial["reasoning_output_exposed"] is True
+    assert initial["fireworks_reasoning_route_sha256"] is None
+    route_sha256 = initial["hunyuan_reasoning_route_sha256"]
+    assert isinstance(route_sha256, str)
+
+    hidden = "reason privately about the lookup"
+    sealed = json.loads(
+        control.seal_reasoning_content(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "route_depth": initial["route_depth"],
+                    "route_sha256": route_sha256,
+                    "content": hidden,
+                    "assistant_content": None,
+                    "tool_calls": [
+                        {"call_id": "call-one", "name": "lookup", "raw_arguments": "{}"}
+                    ],
+                }
+            )
+        )
+    )["carrier"]
+    assert sealed.startswith("x-experiential-hunyuan-reasoning-v1:")
+    assert hidden not in sealed
+    assert (
+        control.settle(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "attempt_id": initial["attempt_id"],
+                    "outcome": "completed",
+                    "usage": {"input_tokens": 3, "output_tokens": 2},
+                    "tool_names": ["lookup"],
+                    "failure": None,
+                }
+            )
+        )
+        == "{}"
+    )
+    replica = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "shared-secret"})
+    )
+    continued = _admit(
+        replica,
+        raw_key,
+        json.dumps(
+            {
+                "model": "coding",
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "reasoning_content": sealed,
+                        "tool_calls": [
+                            {
+                                "id": "call-one",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call-one", "content": "done"},
+                ],
+            }
+        ),
+    )
+    route = cast("list[JsonObject]", continued["route"])
+    payload = cast("JsonObject", route[0]["upstream_payload"])
+    messages = cast("list[JsonObject]", payload["messages"])
+    assert continued["route_reason"] == "reasoning_continuation"
+    assert messages[1]["reasoning_content"] == hidden
+    assert "reasoning_history" not in payload
+
+    plain = _admit(
+        replica,
+        raw_key,
+        json.dumps(
+            {
+                "model": "coding",
+                "messages": [
+                    {"role": "user", "content": "List the files."},
+                    {
+                        "role": "assistant",
+                        "content": '{"command": "ls"}',
+                        "reasoning_content": "ls lists the directory.",
+                    },
+                    {"role": "user", "content": "a.txt"},
+                ],
+            }
+        ),
+    )
+    plain_payload = cast(
+        "JsonObject", cast("list[JsonObject]", plain["route"])[0]["upstream_payload"]
+    )
+    plain_messages = cast("list[JsonObject]", plain_payload["messages"])
+    assert plain_messages[1]["reasoning_content"] == "ls lists the directory."
+    assert plain.get("ignored_parameters", []) == []
+
+
+def test_an_unflagged_self_hosted_rung_stays_stripped_with_no_carrier_route(
+    tmp_path: Path,
+) -> None:
+    """Without ``reasoning_content_native`` an arbitrary origin has no preserved thinking."""
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://hy4-preview--serve.modal.run/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "shared-secret"})
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    assert initial["reasoning_output_exposed"] is False
+    assert initial["hunyuan_reasoning_route_sha256"] is None
+    assert initial["fireworks_reasoning_route_sha256"] is None

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -1283,13 +1283,15 @@ def test_messages_stream_zero_output_keeps_real_input_tokens(
     }
 
 
-def test_thinking_carriers_reject_non_anthropic_routes_before_dispatch(
+def test_replayed_thinking_history_serves_with_disclosure_on_a_foreign_route(
     engine: _ServingEngine,
 ) -> None:
-    """Replayed thinking HISTORY needs an Anthropic-only route and rejects
-    with no upstream dispatch; a live thinking CONFIG instead serves through
-    the admission coercion (dropped with disclosure on this non-reasoning
-    OpenAI-compatible route) because Claude Code pins one on every model."""
+    """Replayed Anthropic thinking HISTORY serves on a non-Anthropic route with
+    the drop disclosed and the blocks omitted upstream (Claude Code carries
+    Claude's signed blocks into every later turn of a session, so the old
+    pre-dispatch 400 killed every session that switched models); a live
+    thinking CONFIG likewise serves through the admission coercion (dropped
+    with disclosure on this non-reasoning OpenAI-compatible route)."""
     with _SseUpstream.payloads_lock:
         dispatched_before = len(_SseUpstream.payloads)
 
@@ -1313,13 +1315,14 @@ def test_thinking_carriers_reject_non_anthropic_routes_before_dispatch(
         f"{engine.base}/v1/messages",
         headers={"x-api-key": engine.raw_key},
         json={
-            **_messages_body("must-not-dispatch"),
+            **_messages_body("thinking-history-serves"),
             "messages": [
                 {"role": "user", "content": "go"},
                 {
                     "role": "assistant",
                     "content": [
                         {"type": "thinking", "thinking": "private", "signature": "sig=="},
+                        {"type": "redacted_thinking", "data": "opaque=="},
                         {"type": "text", "text": "done"},
                     ],
                 },
@@ -1328,11 +1331,18 @@ def test_thinking_carriers_reject_non_anthropic_routes_before_dispatch(
         },
         timeout=10.0,
     )
-    assert history.status_code == 400
-    assert "thinking" in history.json()["error"]["message"]
-
+    assert history.status_code == 200
+    assert (
+        "messages.thinking->dropped(unsupported_by_provider)"
+        in history.json()["x-experiential-ignored-parameters"]
+    )
     with _SseUpstream.payloads_lock:
-        assert len(_SseUpstream.payloads) == dispatched_before
+        dispatched_history = _SseUpstream.payloads[dispatched_before:]
+    assert len(dispatched_history) == 1
+    sent = json.dumps(dispatched_history[0])
+    assert "private" not in sent
+    assert "opaque==" not in sent
+    assert "done" in sent
 
 
 def test_encrypted_reasoning_include_rejects_non_responses_routes(

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -235,20 +235,15 @@ def _coerce_thinking_to_effort(
 
     Returns:
         The disclosed translation or drop, or ``None`` when the request
-        carries no thinking config, the route has an Anthropic rung,
-        replayed thinking blocks make the route unservable regardless, or no
-        translatable tier serves the request end to end.
+        carries no thinking config, the route has an Anthropic rung, or no
+        translatable tier serves the request end to end. Replayed Anthropic
+        thinking blocks no longer block the translation: route shaping strips
+        them from a foreign wire with disclosure.
     """
     config = request.provider_thinking_config
     if config is None or not profiles:
         return None
     if any(profile.dialect == "anthropic_messages" for profile in profiles):
-        return None
-    if any(
-        block.kind in {"thinking", "redacted_thinking"}
-        for message in request.messages
-        for block in message.provider_reasoning
-    ):
         return None
 
     def admitted(coercion: RequestCoercion) -> RequestCoercion | None:

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -904,8 +904,9 @@ def test_the_thinking_coercion_leaves_anthropic_bearing_routes_alone() -> None:
     """A route with any Anthropic rung keeps its verbatim-service preference:
     narrowing already picks the rung that honors the config, so the coercion
     declines rather than trading real thinking for a translation. Replayed
-    thinking blocks also decline it (no translation can carry signed provider
-    state, and the gateway never fabricates unsigned blocks)."""
+    thinking blocks no longer decline it on a foreign-only route: route
+    shaping drops them there with disclosure, so the live config still
+    translates to the route's effort ladder."""
     mixed = (
         GatewayWireProfile(
             dialect="anthropic_messages",
@@ -934,7 +935,15 @@ def test_the_thinking_coercion_leaves_anthropic_bearing_routes_alone() -> None:
             ),
         ),
     )
-    assert coerce_generation_parameters((_openai_reasoning_profile(),), with_blocks) is None
+    coercion = coerce_generation_parameters((_openai_reasoning_profile(),), with_blocks)
+    assert coercion is not None
+    assert coercion.disclosures == ("thinking->reasoning_effort:low",)
+    assert coercion.request.reasoning_effort == "low"
+    # The signed blocks stay on the request; the foreign wire omits them.
+    assert (
+        coercion.request.messages[1].provider_reasoning
+        == with_blocks.messages[1].provider_reasoning
+    )
 
 
 def test_forced_tool_choice_relaxes_to_auto_only_as_a_disclosed_coercion() -> None:

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from exp.runtime.models.providers.base import GatewayWireProfile
 
 TOOL_RESULT_IMAGE_DROP_DISCLOSURE = "messages.content.tool_result.image->placeholder"
+THINKING_HISTORY_DROP_DISCLOSURE = "messages.thinking->dropped(unsupported_by_provider)"
+"""Disclosed when Anthropic-signed thinking history is omitted for a foreign wire."""
 """Disclosure recorded when tool-result images degrade to placeholder text.
 
 A tool screenshot is baked into the caller's conversation history: rejecting

--- a/exp/runtime/models/providers/hunyuan.py
+++ b/exp/runtime/models/providers/hunyuan.py
@@ -6,7 +6,11 @@ endpoint that returns the model's chain-of-thought in a native ``reasoning_conte
 response field and accepts it back on an assistant turn. This module identifies
 those endpoints so the gateway marks the rung as an exposable-plaintext
 reasoning route whose replay is protected by a gateway-issued opaque carrier,
-mirroring :mod:`exp.runtime.models.providers.fireworks`.
+mirroring :mod:`exp.runtime.models.providers.fireworks`. Host recognition is
+one of two ways a rung earns that route: any other OpenAI-compatible origin
+that speaks the same contract (a self-hosted vLLM origin with a reasoning
+parser) declares it per rung through the ``reasoning_content_native``
+capability, which the compatible client reads alongside this check.
 
 Two OpenAI-compatible origins serve these models:
 

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from typing import ClassVar, Literal, cast
 
 from pydantic import JsonValue
@@ -596,6 +597,21 @@ class OpenRouterClient(OpenAICompatibleClient):
         "X-Title": OPENROUTER_TITLE,
     }
     reasoning_wire_format: ClassVar[ReasoningWireFormat] = "reasoning"
+
+    def gateway_wire_profile(self) -> GatewayWireProfile:
+        """Return the compatible profile with OpenRouter's sticky-routing hint on.
+
+        OpenRouter load-balances one model across upstream providers and pins a
+        conversation to the provider that served it only once a cache hit has
+        been observed, keyed by ``session_id`` else the OpenAI-style
+        ``prompt_cache_key`` (its documented fallback sticky key). Without the
+        hint two identical prefixes can land on different providers or nodes,
+        so the miss a caller sees is real and its metering is correct.
+        Forwarding the tenant-namespaced key makes placement deterministic per
+        conversation, and OpenRouter forwards provider-specific fields
+        upstream, so a per-node pin such as Tencent's rides along.
+        """
+        return replace(super().gateway_wire_profile(), forwards_prompt_cache_key=True)
 
 
 def _openai_message(

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -462,8 +462,17 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         chat_max_tokens_field: ChatMaxTokensField | None = None,
         sampling_requires_reasoning_none: bool = False,
         reasoning_output_exposed: bool = False,
+        reasoning_content_native: bool = False,
     ) -> None:
-        """Create one compatible client with explicit model wire capabilities."""
+        """Create one compatible client with explicit model wire capabilities.
+
+        ``reasoning_content_native`` declares that this origin returns the
+        model's chain-of-thought in the standard ``reasoning_content`` field and
+        accepts it back on assistant turns, so the rung is a preserved-thinking
+        carrier route whatever its hostname (a self-hosted vLLM origin with a
+        reasoning parser). Tencent's own origins carry that contract by
+        recognition and need no declaration.
+        """
         super().__init__(
             model=model,
             api_key=api_key,
@@ -486,12 +495,18 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         self._fireworks_reasoning_route_sha256 = (
             reasoning_content_route_sha256(model) if is_fireworks_base_url(self._base_url) else None
         )
-        # Tencent Hunyuan returns the model's plaintext reasoning natively and
-        # accepts it back; the gateway exposes it for display and round-trips it
-        # through a domain-separated opaque carrier, so this rung is both a
-        # carrier route and an exposed-plaintext route.
+        # A native ``reasoning_content`` origin returns the model's plaintext
+        # reasoning and accepts it back; the gateway exposes it for display and
+        # round-trips it through a domain-separated opaque carrier, so this rung
+        # is both a carrier route and an exposed-plaintext route. Tencent's own
+        # origins are recognized by host; any other origin declares the contract
+        # per rung. Fireworks keeps its own carrier and wire flag, so the
+        # declaration never doubles a Fireworks rung's route.
+        self._reasoning_content_native = (
+            is_hunyuan_base_url(self._base_url) or reasoning_content_native
+        ) and self._fireworks_reasoning_route_sha256 is None
         self._hunyuan_reasoning_route_sha256 = (
-            reasoning_content_route_sha256(model) if is_hunyuan_base_url(self._base_url) else None
+            reasoning_content_route_sha256(model) if self._reasoning_content_native else None
         )
         # DeepSeek's own API enforces reasoning_content on every assistant
         # message of the current turn in thinking mode (400 otherwise); both the
@@ -535,9 +550,11 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             deepseek_reasoning_history=self._deepseek_reasoning_history,
             # Tencent's prefix cache is per node behind its load balancer;
             # prompt_cache_key pins a session to one node (verified live
-            # 2026-09-05). Other compatible servers may reject unknown fields,
+            # 2026-09-05), and a declared native-reasoning origin (vLLM) allows
+            # and ignores unknown request fields, so the hint rides every
+            # carrier rung. Other compatible servers may reject unknown fields,
             # so the hint stays off them, BYOK or not.
-            forwards_prompt_cache_key=is_hunyuan_base_url(self._base_url),
+            forwards_prompt_cache_key=self._reasoning_content_native,
         )
 
     def _completion_path(self) -> str:

--- a/exp/runtime/models/providers/openai_compatible.py
+++ b/exp/runtime/models/providers/openai_compatible.py
@@ -471,7 +471,9 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
         accepts it back on assistant turns, so the rung is a preserved-thinking
         carrier route whatever its hostname (a self-hosted vLLM origin with a
         reasoning parser). Tencent's own origins carry that contract by
-        recognition and need no declaration.
+        recognition and need no declaration. The declaration decides the
+        carrier route and exposure only; the ``prompt_cache_key`` node pin stays
+        keyed on Tencent's hosts.
         """
         super().__init__(
             model=model,
@@ -550,11 +552,12 @@ class OpenAICompatibleClient(OpenAIEmbeddingMixin):
             deepseek_reasoning_history=self._deepseek_reasoning_history,
             # Tencent's prefix cache is per node behind its load balancer;
             # prompt_cache_key pins a session to one node (verified live
-            # 2026-09-05), and a declared native-reasoning origin (vLLM) allows
-            # and ignores unknown request fields, so the hint rides every
-            # carrier rung. Other compatible servers may reject unknown fields,
-            # so the hint stays off them, BYOK or not.
-            forwards_prompt_cache_key=self._reasoning_content_native,
+            # 2026-09-05). The hint stays host-keyed: a rung declaring
+            # ``reasoning_content_native`` says only that its origin speaks the
+            # reasoning_content contract, and a strict compatible server that
+            # does may still reject an unknown top-level field, so the
+            # declaration never widens what is sent, BYOK or not.
+            forwards_prompt_cache_key=is_hunyuan_base_url(self._base_url),
         )
 
     def _completion_path(self) -> str:

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -623,9 +623,9 @@ def test_reasoning_content_native_rung_resolves_a_carrier_route_on_any_origin() 
     A self-hosted vLLM origin serving hy4-preview with ``--reasoning-parser``
     returns the standard ``reasoning_content`` field and accepts it back, so a
     rung declaring ``reasoning_content_native`` resolves the Hunyuan carrier
-    route, exposes plaintext when the exposure capability is declared, and
-    pins its prefix cache with ``prompt_cache_key`` (vLLM allows and ignores
-    unknown request fields).
+    route and exposes plaintext when the exposure capability is declared. The
+    ``prompt_cache_key`` node pin stays Tencent-host-keyed: the declaration
+    says nothing about whether the origin tolerates unknown request fields.
     """
     profile = OpenAICompatibleClient(
         model=_snapshot(),
@@ -637,7 +637,7 @@ def test_reasoning_content_native_rung_resolves_a_carrier_route_on_any_origin() 
     assert profile.hunyuan_reasoning_route_sha256 is not None
     assert profile.fireworks_reasoning_route_sha256 is None
     assert profile.reasoning_output_exposed is True
-    assert profile.forwards_prompt_cache_key is True
+    assert profile.forwards_prompt_cache_key is False
 
 
 def test_reasoning_content_native_rung_without_exposure_keeps_its_carrier_but_stays_stripped() -> (

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -29,8 +29,10 @@ from exp.runtime.models.providers.errors import (
     ProviderResponseError,
 )
 from exp.runtime.models.providers.openai_compatible import (
+    OPENROUTER_BASE_URL,
     OpenAICompatibleClient,
     OpenAICompatibleResponseError,
+    OpenRouterClient,
     openai_compatible_request,
     openai_compatible_response,
     openai_embedding_request,
@@ -686,3 +688,27 @@ def test_the_flag_matches_the_tencent_hosts_route_identity_for_one_model() -> No
         api_key="fake-key",
     ).gateway_wire_profile()
     assert flagged.hunyuan_reasoning_route_sha256 == tencent.hunyuan_reasoning_route_sha256
+
+
+def test_openrouter_routes_by_prompt_cache_key_as_its_sticky_session_key() -> None:
+    """OpenRouter documents ``prompt_cache_key`` as its sticky-routing fallback key.
+
+    OpenRouter load-balances one model across upstream providers and pins a
+    conversation to the provider that served it only after a cache hit is
+    observed, keyed by ``session_id`` else the OpenAI-style ``prompt_cache_key``
+    (openrouter.ai/docs/features/prompt-caching, read 2026-09-11). Without the
+    hint, two identical prefixes can land on different providers or nodes, so
+    the cache miss a caller sees is real and the metering of it is correct.
+    Forwarding the tenant-namespaced key makes placement deterministic per
+    conversation, and OpenRouter forwards provider-specific fields upstream,
+    so Tencent's per-node pin rides along on the hy4 lane.
+    """
+    profile = OpenRouterClient(
+        model=_snapshot(provider="openrouter", model_id="tencent/hy4-preview"),
+        base_url=OPENROUTER_BASE_URL,
+        api_key="fake-key",
+    ).gateway_wire_profile()
+    assert profile.forwards_prompt_cache_key is True
+    # The OpenRouter origin is neither a Hunyuan nor a Fireworks carrier route.
+    assert profile.hunyuan_reasoning_route_sha256 is None
+    assert profile.fireworks_reasoning_route_sha256 is None

--- a/exp/runtime/models/providers/openai_compatible_test.py
+++ b/exp/runtime/models/providers/openai_compatible_test.py
@@ -612,3 +612,77 @@ def test_deepseek_client_builds_buffered_requests_with_the_backfill_from_its_ori
     )
     generic_messages = cast("list[JsonObject]", generic._build_request(_request())["messages"])
     assert "reasoning_content" not in generic_messages[2]
+
+
+_NATIVE_REASONING_ORIGIN = "https://hy4-preview--serve.modal.run/v1"
+
+
+def test_reasoning_content_native_rung_resolves_a_carrier_route_on_any_origin() -> None:
+    """The catalog flag, not the hostname, makes a rung a preserved-thinking route.
+
+    A self-hosted vLLM origin serving hy4-preview with ``--reasoning-parser``
+    returns the standard ``reasoning_content`` field and accepts it back, so a
+    rung declaring ``reasoning_content_native`` resolves the Hunyuan carrier
+    route, exposes plaintext when the exposure capability is declared, and
+    pins its prefix cache with ``prompt_cache_key`` (vLLM allows and ignores
+    unknown request fields).
+    """
+    profile = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url=_NATIVE_REASONING_ORIGIN,
+        api_key="fake-key",
+        reasoning_output_exposed=True,
+        reasoning_content_native=True,
+    ).gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is not None
+    assert profile.fireworks_reasoning_route_sha256 is None
+    assert profile.reasoning_output_exposed is True
+    assert profile.forwards_prompt_cache_key is True
+
+
+def test_reasoning_content_native_rung_without_exposure_keeps_its_carrier_but_stays_stripped() -> (
+    None
+):
+    """Exposure still fails closed per rung on a flagged origin."""
+    profile = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url=_NATIVE_REASONING_ORIGIN,
+        api_key="fake-key",
+        reasoning_content_native=True,
+    ).gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is not None
+    assert profile.reasoning_output_exposed is False
+
+
+def test_an_unflagged_arbitrary_origin_stays_stripped_and_unpinned() -> None:
+    """Without the flag an unknown origin gets no carrier, no exposure, no cache hint."""
+    profile = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url=_NATIVE_REASONING_ORIGIN,
+        api_key="fake-key",
+        reasoning_output_exposed=True,
+    ).gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is None
+    assert profile.reasoning_output_exposed is False
+    assert profile.forwards_prompt_cache_key is False
+
+
+def test_the_flag_matches_the_tencent_hosts_route_identity_for_one_model() -> None:
+    """A flagged origin and the Tencent host derive the same model-keyed route identity.
+
+    The carrier's route binding is the model's identity, so the same model
+    self-hosted resolves the same route digest the Tencent lane does; the
+    carrier domain stays the Hunyuan scheme either way.
+    """
+    flagged = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url=_NATIVE_REASONING_ORIGIN,
+        api_key="fake-key",
+        reasoning_content_native=True,
+    ).gateway_wire_profile()
+    tencent = OpenAICompatibleClient(
+        model=_snapshot(),
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        api_key="fake-key",
+    ).gateway_wire_profile()
+    assert flagged.hunyuan_reasoning_route_sha256 == tencent.hunyuan_reasoning_route_sha256

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -219,16 +219,9 @@ def route_generation_parameter_requests(
         provider_updates["maximum_output_tokens"] = min(
             (_ANTHROPIC_REQUIRED_MAX_TOKENS_DEFAULT, *route_limits)
         )
-    # The rejection names the field the CALLER sent: Claude Code carries its
-    # effort as Messages output_config.effort and auto-recovers (drops the
-    # field and retries) only when the 400 names that channel, so naming the
-    # translated internal field wedges every turn instead (issue #795).
-    if request.surface == GatewayApiSurface.RESPONSES:
-        effort_path = "reasoning.effort"
-    elif request.surface == GatewayApiSurface.MESSAGES:
-        effort_path = "output_config.effort"
-    else:
-        effort_path = "reasoning_effort"
+    # The rejection names the field the CALLER sent (the request knows which
+    # of its surface's effort fields carried the value; see the property).
+    effort_path = request.caller_effort_parameter
 
     def profile_reasoning_effort(profile: GatewayWireProfile) -> str | None:
         """Return the caller effort or this wire's required provider default."""

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -15,6 +15,9 @@ from exp.runtime.models.providers.dialect_dispatch import (
     SERVICE_TIER_DIALECTS as SERVICE_TIER_DIALECTS,
 )
 from exp.runtime.models.providers.dialect_dispatch import (
+    THINKING_HISTORY_DROP_DISCLOSURE,
+)
+from exp.runtime.models.providers.dialect_dispatch import (
     TOOL_RESULT_IMAGE_DROP_DISCLOSURE as TOOL_RESULT_IMAGE_DROP_DISCLOSURE,
 )
 from exp.runtime.models.providers.dialect_dispatch import (
@@ -691,15 +694,12 @@ def route_generation_parameter_requests(
     )
     non_anthropic_route = not all(profile.dialect == "anthropic_messages" for profile in profiles)
     if history_thinking_present and non_anthropic_route:
-        raise ProviderParameterError(
-            message=(
-                "The request replays Anthropic extended-thinking blocks that only a "
-                "native Anthropic route can carry. Remove extended-thinking content "
-                "or choose a native Anthropic-only route."
-            ),
-            param="thinking",
-            code="unsupported_parameter",
-        )
+        # Anthropic-signed thinking replays only on its own wire; the blocks are
+        # baked into a framework-managed transcript (Claude Code carries them
+        # into every later turn), so like plaintext reasoning_content the route
+        # serves and discloses the drop: foreign wires omit them at encoding.
+        if THINKING_HISTORY_DROP_DISCLOSURE not in ignored:
+            ignored.append(THINKING_HISTORY_DROP_DISCLOSURE)
     if request.provider_thinking_config is not None and non_anthropic_route:
         # A thinking CONFIG (unlike replayed thinking blocks) has a serviceable
         # cross-wire reading. The named rejection here is what lets the admit

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4602,6 +4602,38 @@ def test_a_messages_surface_effort_rejection_matches_the_client_recovery_latch()
     assert "not supported" in str(raised.value)
 
 
+def test_a_messages_effort_from_the_openrouter_channel_is_rejected_by_its_own_name() -> None:
+    """A depth sent as OpenRouter's ``reasoning.effort`` is refused under that path.
+
+    The Messages decoder records which caller field carried the effort; the
+    rejection names it so an agent built against OpenRouter's Messages endpoint
+    finds the field it sent, while the Anthropic ``output_config.effort`` default
+    (and Claude Code's recovery latch) is untouched.
+    """
+    profiles = (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://c.test",
+            model_id="hermes-4-405b",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning_effort",
+            supported_reasoning_efforts=("medium",),
+        ),
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        reasoning_effort="high",
+        reasoning_effort_parameter="reasoning.effort",
+    )
+
+    with pytest.raises(UnsupportedReasoningEffortError) as raised:
+        route_generation_parameter_requests(profiles, request)
+
+    assert raised.value.param == "reasoning.effort"
+    assert "effort parameter" in str(raised.value)
+
+
 def test_route_refuses_a_whole_empty_user_turn_before_an_anthropic_dispatch() -> None:
     """The Anthropic wire rejects empty text content blocks post-dispatch
     ("text content blocks must be non-empty"; 2026-09-05, six orgs on

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1,5 +1,6 @@
 """Tests for launch-provider streaming request payload translation."""
 
+import json
 from typing import Literal, cast
 
 import pytest
@@ -22,6 +23,7 @@ from exp.runtime.gateway.contracts import (
     GatewayProviderNativeTool,
     GatewayRequest,
     GatewayToolDefinition,
+    RedactedThinkingBlock,
     StructuredTextFormat,
     ThinkingBlock,
 )
@@ -30,6 +32,7 @@ from exp.runtime.models.providers.anthropic_tool_compat import (
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.bedrock_requests import converse_body
+from exp.runtime.models.providers.dialect_dispatch import THINKING_HISTORY_DROP_DISCLOSURE
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -2121,12 +2124,11 @@ def test_anthropic_payload_replays_thinking_blocks_first_and_verbatim() -> None:
 
 
 def test_route_shaping_rejects_thinking_by_name_so_admission_can_coerce() -> None:
-    """History thinking blocks and a live config both reject at SHAPING on a
-    non-Anthropic route: blocks are signed provider state no translation can
-    carry, and the config's named rejection is what lets the admit loop offer
-    the disclosed thinking->reasoning_effort coercion without stealing
-    narrowing preference from an Anthropic rung (coverage for the coercion
-    itself lives in capability_policy_test)."""
+    """A live thinking config rejects at SHAPING on a non-Anthropic route: the
+    config's named rejection is what lets the admit loop offer the disclosed
+    thinking->reasoning_effort coercion without stealing narrowing preference
+    from an Anthropic rung (coverage for the coercion itself lives in
+    capability_policy_test)."""
     anthropic = GatewayWireProfile(
         dialect="anthropic_messages",
         url="https://anthropic.test",
@@ -2134,20 +2136,24 @@ def test_route_shaping_rejects_thinking_by_name_so_admission_can_coerce() -> Non
     )
     fallback = GatewayWireProfile(dialect="openai_compatible", url="https://fallback.test")
 
-    for request in (
-        _thinking_history_request(),
-        _chat_request().model_copy(
-            update={
-                "surface": GatewayApiSurface.MESSAGES,
-                "provider_thinking_config": {"type": "enabled", "budget_tokens": 1024},
-            }
-        ),
-    ):
-        route_generation_parameter_requests((anthropic,), request)
-        with pytest.raises(ProviderParameterError) as raised:
-            route_generation_parameter_requests((anthropic, fallback), request)
-        assert raised.value.param == "thinking"
-        assert raised.value.code == "unsupported_parameter"
+    request = _chat_request().model_copy(
+        update={
+            "surface": GatewayApiSurface.MESSAGES,
+            "provider_thinking_config": {"type": "enabled", "budget_tokens": 1024},
+        }
+    )
+    route_generation_parameter_requests((anthropic,), request)
+    with pytest.raises(ProviderParameterError) as raised:
+        route_generation_parameter_requests((anthropic, fallback), request)
+    assert raised.value.param == "thinking"
+    assert raised.value.code == "unsupported_parameter"
+    # History thinking blocks no longer reject at shaping: they are signed
+    # provider state a foreign wire drops with disclosure (see
+    # test_replayed_anthropic_thinking_drops_with_disclosure_on_a_non_anthropic_route).
+    _public, routed = route_generation_parameter_requests(
+        (anthropic, fallback), _thinking_history_request()
+    )
+    assert THINKING_HISTORY_DROP_DISCLOSURE in routed.ignored_parameters
 
 
 def _encrypted_reasoning_request() -> GatewayRequest:
@@ -4051,8 +4057,53 @@ def _messages_request(
     )
 
 
-def test_replayed_thinking_blocks_still_reject_on_a_non_anthropic_route() -> None:
-    """Signed history blocks replay only on the wire that issued them."""
+def test_replayed_anthropic_thinking_drops_with_disclosure_on_a_non_anthropic_route() -> None:
+    """Signed history blocks replay only on the wire that issued them; elsewhere they drop.
+
+    Claude Code carries Claude's signed thinking blocks into every later turn,
+    so a session that switches to a non-Anthropic model used to die on a named
+    400 ("remove extended-thinking content" is not actionable for a
+    framework-managed history: 2,180 refusals on one alias in 14 days). The
+    route now serves the turn with the same disclosure shape plaintext
+    reasoning_content already uses, and the foreign wire omits the blocks at
+    encoding; a mixed waterfall's Anthropic rung still replays them verbatim.
+    """
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="hi"),
+            GatewayMessage(
+                role="assistant",
+                content="prior",
+                provider_reasoning=(
+                    ThinkingBlock(text="deep", signature="sig-1"),
+                    RedactedThinkingBlock(data="opaque=="),
+                ),
+            ),
+            GatewayMessage(role="user", content="again"),
+        ),
+        stream=True,
+    )
+    from exp.runtime.models.providers.wire_messages import anthropic_blocks
+
+    profile = _openai_reasoning_profile()
+    _public, routed = route_generation_parameter_requests((profile,), request)
+    assert THINKING_HISTORY_DROP_DISCLOSURE in routed.ignored_parameters
+    # The foreign wire's history renders without any reasoning item or field.
+    payload = dialect_stream_payload(profile, routed)
+    assert "deep" not in json.dumps(payload)
+    assert "opaque==" not in json.dumps(payload)
+    # A mixed waterfall discloses too, and its Anthropic rung keeps the blocks.
+    _public, mixed = route_generation_parameter_requests(
+        (_anthropic_profile("claude-sonnet-4-6"), profile), request
+    )
+    assert THINKING_HISTORY_DROP_DISCLOSURE in mixed.ignored_parameters
+    _role, blocks = anthropic_blocks(mixed.messages[1])
+    assert blocks[0] == {"type": "thinking", "thinking": "deep", "signature": "sig-1"}
+
+
+def test_replayed_anthropic_thinking_stays_verbatim_on_an_anthropic_route() -> None:
+    """The disclosed drop is for foreign wires only; Anthropic keeps its own blocks."""
     request = GatewayRequest(
         surface=GatewayApiSurface.MESSAGES,
         messages=(
@@ -4062,11 +4113,15 @@ def test_replayed_thinking_blocks_still_reject_on_a_non_anthropic_route() -> Non
                 content="prior",
                 provider_reasoning=(ThinkingBlock(text="deep", signature="sig-1"),),
             ),
+            GatewayMessage(role="user", content="again"),
         ),
         stream=True,
     )
-    with pytest.raises(ProviderParameterError, match="extended-thinking"):
-        route_generation_parameter_requests((_openai_reasoning_profile(),), request)
+    _public, routed = route_generation_parameter_requests(
+        (_anthropic_profile("claude-sonnet-4-6"),), request
+    )
+    assert THINKING_HISTORY_DROP_DISCLOSURE not in routed.ignored_parameters
+    assert routed.messages[1].provider_reasoning == request.messages[1].provider_reasoning
 
 
 def _tool_error_request(*, content: str = "exit 1") -> GatewayRequest:

--- a/exp/runtime/models/providers/wire_messages.py
+++ b/exp/runtime/models/providers/wire_messages.py
@@ -97,10 +97,14 @@ def responses_items(message: GatewayMessage) -> list[JsonObject]:
             # Plaintext reasoning replays only on an exposure-gated Chat rung;
             # route narrowing disclosed the drop for this wire.
             continue
+        if block.kind in {"thinking", "redacted_thinking"}:
+            # Anthropic-signed thinking replays only on its own wire; route
+            # shaping disclosed the drop for this one.
+            continue
         if block.kind != "encrypted_reasoning":
-            # Anthropic thinking cannot replay on the OpenAI wire; route
+            # A gateway reasoning carrier belongs to the Chat wire; route
             # admission rejects the combination before dispatch.
-            raise ProviderResponseError("thinking blocks cannot replay on the Responses wire")
+            raise ProviderResponseError("reasoning carriers cannot replay on the Responses wire")
         # Reasoning items precede the assistant action they belong to, and
         # the encrypted payload is the round-trip authority; the display-only
         # summary is deliberately empty on replay. The item id and status are
@@ -569,10 +573,17 @@ def openai_chat_message(
             }
             for call in message.tool_calls
         ]
-    if message.provider_reasoning:
-        if len(message.provider_reasoning) != 1:
+    # Anthropic-signed thinking replays only on its own wire; route shaping
+    # disclosed the drop for this one, so the Chat wire omits those blocks.
+    chat_reasoning = tuple(
+        block
+        for block in message.provider_reasoning
+        if block.kind not in {"thinking", "redacted_thinking"}
+    )
+    if chat_reasoning:
+        if len(chat_reasoning) != 1:
             raise ProviderResponseError("Chat reasoning history requires exactly one carrier")
-        block = message.provider_reasoning[0]
+        block = chat_reasoning[0]
         if block.kind == "exposed_reasoning_content":
             if reasoning_output_exposed or deepseek_reasoning_history:
                 payload["reasoning_content"] = block.content

--- a/exp/runtime/models/registry.py
+++ b/exp/runtime/models/registry.py
@@ -535,6 +535,9 @@ class RuntimeModelCatalog:
             http_kwargs["reasoning_output_exposed"] = _supports_flag(
                 capabilities, "reasoning_output_exposed"
             )
+            http_kwargs["reasoning_content_native"] = _supports_flag(
+                capabilities, "reasoning_content_native"
+            )
         http_client = factory(**http_kwargs)
         embedding_client = (
             http_client

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -547,4 +547,4 @@ def test_resolution_threads_reasoning_content_native_to_compatible_rungs() -> No
     profile = resolved.client.gateway_wire_profile()
     assert profile.hunyuan_reasoning_route_sha256 is not None
     assert profile.reasoning_output_exposed is True
-    assert profile.forwards_prompt_cache_key is True
+    assert profile.forwards_prompt_cache_key is False

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -24,6 +24,7 @@ from exp.runtime.models.credentials import ModelCredentialError
 from exp.runtime.models.preflight import CapabilityRequirement, ModelCapabilityError
 from exp.runtime.models.providers.anthropic import AnthropicClient
 from exp.runtime.models.providers.azure import AzureClient
+from exp.runtime.models.providers.openai_compatible import OpenAICompatibleClient
 from exp.runtime.models.providers.tinker_sampling import (
     TinkerOptionalDependencyError,
     TinkerSample,
@@ -524,3 +525,26 @@ def test_tinker_resolution_reports_a_missing_optional_dependency(
 
     with pytest.raises(ModelConnectionError, match="uv sync --extra sft"):
         catalog.resolve("fixture-model")
+
+
+def test_resolution_threads_reasoning_content_native_to_compatible_rungs() -> None:
+    """A flagged openai-compatible rung on any origin resolves a preserved-thinking route."""
+    catalog = RuntimeModelCatalog(
+        _catalog(
+            provider="openai-compatible",
+            base_url="https://hy4-preview--serve.modal.run/v1",
+            capabilities=ModelCapabilities(
+                supports_reasoning=True,
+                reasoning_output_exposed=True,
+                reasoning_content_native=True,
+            ),
+        ),
+        environment={"FIXTURE_API_KEY": "fixture-key"},
+        transport_factory=ScriptedJsonTransport,
+    )
+    resolved = catalog.resolve("fixture-model")
+    assert isinstance(resolved.client, OpenAICompatibleClient)
+    profile = resolved.client.gateway_wire_profile()
+    assert profile.hunyuan_reasoning_route_sha256 is not None
+    assert profile.reasoning_output_exposed is True
+    assert profile.forwards_prompt_cache_key is True

--- a/exp/runtime/models/registry_test.py
+++ b/exp/runtime/models/registry_test.py
@@ -548,3 +548,15 @@ def test_resolution_threads_reasoning_content_native_to_compatible_rungs() -> No
     assert profile.hunyuan_reasoning_route_sha256 is not None
     assert profile.reasoning_output_exposed is True
     assert profile.forwards_prompt_cache_key is False
+
+
+def test_openrouter_resolution_forwards_the_prompt_cache_key_hint() -> None:
+    """The catalog's openrouter provider resolves to a rung that routes by the hint."""
+    catalog = RuntimeModelCatalog(
+        _catalog(provider="openrouter"),
+        environment={"FIXTURE_API_KEY": "fixture-key"},
+        transport_factory=ScriptedJsonTransport,
+    )
+    resolved = catalog.resolve("fixture-model")
+    assert isinstance(resolved.client, OpenAICompatibleClient)
+    assert resolved.client.gateway_wire_profile().forwards_prompt_cache_key is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.48,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.49,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.48"
+version = "0.3.49"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Program checklist (engine side, one umbrella PR)

- [x] Host-independent Hunyuan preserved-thinking carrier: `reasoning_content_native` rung capability (this PR's first two commits)
- [x] `reasoning` (OpenRouter shape, `{effort}`) accepted on `/v1/messages` and translated to the route's reasoning effort (sibling: engine-messages-reasoning-param; commits `abda40e6`, `b36bdd04`, plus the Greptile fix commit on this branch)
- [x] Preserved thinking on `/v1/messages`: exposed `reasoning_content` rendered as an unsigned `thinking` block, tool-turn carriers as a trailing `redacted_thinking` block, both accepted back; Anthropic-signed thinking on a foreign route is a disclosed drop, not a 400 (commit cbe6d0d5, section below)
- [x] Cache affinity on the OpenRouter rung: the tenant-namespaced `prompt_cache_key` is forwarded to OpenRouter as its documented sticky-routing key (Harbor #1/#2 root cause on the openrouter hy4 rung; section below)

Each chunk lands as its own commits on this branch; the sections below describe the first chunk, the siblings append theirs.

## Why

Hunyuan preserved thinking (the sealed `reasoning_content` carrier on tool turns, plaintext exposure on plain turns, and the `prompt_cache_key` node pin) was keyed on the ORIGIN HOSTNAME: `is_hunyuan_base_url` matches only `api.hunyuan.cloud.tencent.com` and `tokenhub-intl.tencentcloudmaas.com`. The same model served from any other OpenAI-compatible origin lost the contract: `reasoning_content` stripped on every tool turn, `reasoning_output_exposed` forced off, no cache hint. That is the regression Akhara hit on the openrouter rung on 2026-09-04, and it blocks serving `tencent/Hy4-preview-FP8` from a self-hosted vLLM origin (Modal) as an Experiential Cloud lane.

## What

- `ModelCapabilities.reasoning_content_native: bool = False` (`exp/common/models/model.py`): "this origin returns the model's chain-of-thought in the standard `reasoning_content` field and accepts it back on assistant turns". Excluded from the frozen identity digest like `reasoning_output_exposed`, so declaring it never re-digests a catalog.
- The registry threads it to openrouter / openai-compatible clients beside `reasoning_output_exposed`.
- `OpenAICompatibleClient` resolves the Hunyuan carrier route when `is_hunyuan_base_url(base_url) or reasoning_content_native`, never on a Fireworks origin (Fireworks keeps its own carrier and wire flag, so the declaration cannot double a route). Exposure still requires the route AND `reasoning_output_exposed`; an undeclared origin stays stripped with no carrier route, exactly as before. `forwards_prompt_cache_key` stays keyed on Tencent's hosts (review finding): the declaration says only that the origin speaks the `reasoning_content` contract, not that it tolerates unknown top-level fields, so it never widens what is sent. (vLLM itself is `extra="allow"` and would ignore the hint, and a single-replica vLLM does not need the node pin.)
- No Rust change: the data plane consumes the resolved profile fields (`hunyuan_reasoning_route_sha256`, `reasoning_output_exposed`) and never inspects hostnames, so `exp-gateway-native` needs no release for this.
- The `enable_thinking` input translation (`chat_template_kwargs`) is protocol-level, not host-keyed; nothing to change there.
- Docs: `docs/reference/gateway-architecture.md` names the two ways a rung earns the route; `hunyuan.py` module docstring updated.

## Tests first

Written before the fix and run red on the previous code (`TypeError: unexpected keyword argument 'reasoning_content_native'`, pydantic `extra_forbidden`, `AttributeError: 'ModelCapabilities' object has no attribute 'reasoning_content_native'`):

- `openai_compatible_test.py`: a flagged rung on `https://hy4-preview--serve.modal.run/v1` resolves the Hunyuan carrier route, exposes when declared, and does NOT forward `prompt_cache_key`; flagged without exposure keeps the route but stays stripped; the same origin unflagged has no route, no exposure, no hint; the flagged origin derives the same route identity as the TokenHub host for one model.
- `registry_test.py`: the capability threads from the catalog to the resolved client's wire profile.
- `model_test.py`: default off and outside the identity digest.
- `native_bridge_test.py`: end to end on a non-Tencent origin, the flagged rung exposes plaintext, seals a tool turn's reasoning as `x-experiential-hunyuan-reasoning-v1:`, a second replica unseals and forwards it (`route_reason == "reasoning_continuation"`, no Fireworks `reasoning_history` flag), and a plain turn's plaintext replays verbatim with no disclosure; the unflagged origin stays stripped with no carrier route.

The two Tencent hosts keep every existing test green. Full suite: 4,081 passed, 6 skipped; `ruff check`, `ruff format`, `ty check` clean.

## `reasoning` on Messages (chunk 2)

### Why

`POST /v1/messages` answered 400 `unsupported_parameter` ("The parameter 'reasoning' is not supported by this gateway profile") to OpenRouter-style `reasoning: {effort: "low"}`, while OpenRouter's Anthropic-compatible Messages endpoint accepts it for the same models and our own `thinking` channel works. Agents built against that endpoint (the Harbor / Akhara switch of `hy4-preview` onto the platform) die on the first turn.

### What

- **Manifest**: `reasoning` is an installed, conditionally supported extension of the Messages surface (not an official SDK field; the SDK drift gate is unaffected). Every other unknown key still 400s.
- **Wire model** (`exp/runtime/anthropic_protocol/reasoning_channels.py`, new): `ReasoningConfig` validated closed: `effort` on the engine-owned ladder (OpenRouter's values are a subset, so an unknown tier is a named 400 under `reasoning.effort`), or a `max_tokens` budget (exclusive with `effort`, as OpenRouter defines; must stay below the request `max_tokens`, else 400 `reasoning.max_tokens`), plus `enabled` / `exclude`.
- **Resolution** (`resolve_reasoning_channels`): the three caller channels (`thinking`, `output_config.effort`, `reasoning`) collapse onto the one canonical `reasoning_effort` every downstream seam already reads (route narrowing, coercion, payload builders: Anthropic rungs get `output_config.effort` or a budget through `messages_payloads`, effort ladders get the tier snapped with disclosure as today). Precedence when `reasoning` is present: the explicit effort wins; a `thinking` config beside it drops with `thinking->dropped(superseded_by_reasoning)`; a disagreeing `output_config.effort` drops with `output_config.effort->dropped(superseded_by_reasoning)` (an agreeing one stays verbatim); `exclude: true` is disclosed (`reasoning.exclude`) rather than honored; `enabled: false` (which wins over any depth beside it) and `effort: none` both become `thinking: {type: disabled}` with the effort channel left empty, the one off form every route already honors (Anthropic's own ladder has no `none`, so carrying it as an effort was rejected there; Greptile P1s, fixed); a bare or `enabled: true` object is OpenRouter's default depth (medium); a budget becomes a budgeted `enabled` thinking config for Anthropic rungs and the nearest tier elsewhere (<=4096 low, <=16384 medium, else high), floored at Anthropic's 1024 minimum (a smaller budget is a named 400 under `reasoning.max_tokens`, never a provider rejection).
- **Rejection naming**: `GatewayRequest.reasoning_effort_parameter` records which caller field carried the effort; `caller_effort_parameter` returns it or the surface default. An unservable effort sent as `reasoning.effort` is rejected under that name; the Anthropic `output_config.effort` default (Claude Code's recovery latch, #795) is untouched and still pinned.
- `requests.py` and `streaming_requests.py` were at the 999-line ceiling; the channel logic lives in the new module and the surface-default selection moved onto the request as a property.
- Docs: `docs/reference/gateway-architecture.md` Messages paragraph. No Rust change (Messages decoding is Python via `native_decode`).

### Tests first

Written before the change and run red on unchanged main:

```
FAILED manifest_test.py::test_openrouter_reasoning_extension_is_conditionally_supported          KeyError: 'reasoning'
FAILED requests_test.py::test_openrouter_reasoning_effort_rides_the_canonical_effort_channel      400 "The parameter 'reasoning' is not supported by this gateway profile"
FAILED requests_test.py::test_openrouter_reasoning_enabled_and_budget_forms_translate             (same)
FAILED requests_test.py::test_openrouter_reasoning_rejects_conflicting_and_unknown_shapes         (same)
FAILED requests_test.py::test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosure (same)
```

After, rebased on this branch: `uv run pytest -q exp` 4090 passed / 6 skipped; `ruff check`, `ruff format --check`, `ty check` clean; plus `reasoning_channels_test.py` (incl. every off form and the budget floor) and `streaming_requests_test.py::test_a_messages_effort_from_the_openrouter_channel_is_rejected_by_its_own_name`.

## Release and platform follow-ups (not in this PR)

1. Cut an Experiential release with this change: BOTH `experiential` and `exp-gateway-native` (the Messages preserved-thinking chunk changes the Rust data plane; the crate is bumped to 0.3.49 in this PR and the root pin follows).
2. Platform: bump `experiential==<new>` AND `exp-gateway-native==0.3.49` in `pyproject.toml` (exact PyPI pins).
3. Platform: thread `reasoning_content_native` through the capability sanitizer and projection so it reaches the rung (`explabs/gateway/generation_capabilities.py::OPERATOR_CAPABILITY_KEYS`, the `_model_capabilities` projection in `explabs/gateway/catalog.py`); decide operator key vs contract-managed (recommend operator key, like `reasoning_output_exposed`, so stamps never clobber it).
4. Platform: `AuthoredContract(providers=("experiential_cloud",), wire_ids=("hy4-preview",), ...)` mirroring the tencent one (`supports_reasoning=True`, ladder none/low/medium/high, default high, not required) plus the new capability, shipped as a NEW completion migration with the pgTAP drift pin re-rendered.
5. Platform: verify the `reasoning_effort` wire shape the vLLM hy4 image honors (top-level `reasoning_effort` vs `chat_template_kwargs`) and make the EC rung translation match.
6. Platform: `OrgAwareRouteResolver` protocol conformance test at pin time (no new resolver method here, so expected green).
7. Live gate before declaring fixed: the 7-check preserved-thinking acceptance against a live gateway whose EC rung points at a vLLM origin started with `--reasoning-parser`.



## Preserved thinking on Messages (commit cbe6d0d5)

### Why
The Messages encoders mapped every OpenAI-wire reasoning event (`ReasoningContentDelta`, summaries, encrypted reasoning) to nothing, so a Tencent/DeepSeek rung's exposed reasoning never reached a Claude Code caller on `/v1/messages` and nothing came back on the next turn: Tencent preserved thinking only survived on the Chat surface. Separately, the decoder 400'd ANY replayed Anthropic thinking block on a non-Anthropic route ("The request replays Anthropic extended-thinking blocks..."), and Claude Code carries Claude's signed blocks into every later turn of a session, so a session that switched from a Claude model to any other died on every request (production: 2,180 refusals on gpt-6-astra and 737 on gpt-5.6-luna in 14 days).

### Design (mirrors the Chat surface one-for-one)
- **Plain turns, exposing rung** (`reasoning_output_exposed`): the plaintext streams and aggregates as one `thinking` block with an EMPTY signature, the Messages twin of Chat's `reasoning_content` deltas. Anthropic signs every block it issues, so an unsigned block is recognizably the gateway's when the caller replays it (the same "TokenHub accepts echoed plaintext and validates nothing" finding that made 0.7.34 replay plaintext on Chat). Hidden-reasoning rungs stay invisible exactly as before.
- **Tool turns**: the hidden reasoning leaves ONLY as the sealed carrier (never plaintext: a CoT-injection vector on the way back in), in one trailing `redacted_thinking` block whose `data` is the carrier. The carrier is known once every tool call completed, after the sequential thinking block has closed, and `redacted_thinking` is Anthropic's own "opaque, replay verbatim" shape that every Messages client echoes untouched. The Messages route seals through the same `seal_reasoning_content` bridge call as Chat on all three response paths (aggregate, guarded, live stream); a completed tool turn with reasoning and no carrier fails closed (502) like Chat.
- **Decode**: an unsigned `thinking` block becomes `exposed_reasoning_content` (forwarded to exposing rungs, dropped with the existing disclosure elsewhere); a carrier-prefixed `redacted_thinking` payload becomes `sealed_reasoning_content` (authenticated at admission, pinned to its issuing rung, tampering fails closed); the unsigned display duplicate beside a carrier is dropped so the carrier replays once. Genuine Anthropic blocks (signed, or non-prefixed redacted data) keep their verbatim-order contract for the Anthropic wire.
- **Foreign-route Anthropic thinking**: no longer a 400. Route shaping discloses `messages.thinking->dropped(unsupported_by_provider)` and the blocks stay on the request: a mixed waterfall's Anthropic rung still replays them verbatim, and the Chat and Responses builders omit them at encoding (previously they raised). The thinking->effort coercion no longer declines on replayed blocks, so Claude Code's live thinking config still translates to the route's effort ladder.
- Carrier AEAD, claims and domain separation are untouched (still unbound from catalog digests per the 0.7.31 lesson); `ReasoningCarrierState` is shared with the Chat encoder rather than duplicated.

### Files
Rust: `encode_messages.rs` (exposure + carrier seams, `EXPOSED_REASONING_BLOCK_INDEX`), `encode_messages/aggregate.rs` (`completed_messages_body_with_reasoning`; the `_with_ignored` wrapper had no caller left and is gone), `route_messages.rs` (seal + exposure on every path), `encode.rs` (`ReasoningCarrierState` pub(crate)). Python: `anthropic_protocol/gateway_reasoning.py` (new, the classifier; `requests.py` was over the 1,000-line budget), `anthropic_protocol/requests.py`, `models/providers/streaming_requests.py` + `dialect_dispatch.py` (`THINKING_HISTORY_DROP_DISCLOSURE`), `wire_messages.py` (Chat/Responses builders skip thinking kinds), `capability_policy.py`. Docs: `docs/reference/gateway-architecture.md` Messages paragraph.

### Tests first
Run red on the previous code: Rust `encode_messages` tests failed to compile (no `set_reasoning_output_exposed` / `set_reasoning_content_carrier` / `completed_messages_body_with_reasoning`); Python `KeyError`/kind assertions on the unsigned-thinking and carrier decode tests; `NameError: THINKING_HISTORY_DROP_DISCLOSURE` on the disclosed-drop tests. Then green:
- Rust (`encode_messages/tests.rs`): exposed reasoning streams as an unsigned thinking block (no `signature_delta`) and aggregates first in content; unexposed stays dropped (goldens untouched); a tool turn closes with the trailing `redacted_thinking` carrier on both paths, with and without exposure; no carrier -> 502 on both paths. `cargo test --no-default-features` 282 passed; fmt and clippy `-D warnings` clean.
- Python: `gateway_reasoning_test.py` (classifier), `requests_test.py` (unsigned -> exposed; carrier -> sealed with the display duplicate dropped; malformed carrier names its block; signed blocks unchanged), `streaming_requests_test.py` (disclosed drop on a foreign-only route with the OpenAI/Responses payload free of the text; mixed route discloses and its Anthropic rung keeps the blocks; Anthropic-only route unchanged), `capability_policy_test.py` (translation no longer declined), `native_bridge_test.py` end to end on the Messages surface against a Tencent rung: unsigned thinking replays as `reasoning_content`; a sealed carrier in `redacted_thinking` unseals to the exact text with `route_reason == "reasoning_continuation"` and a tampered turn fails closed; a Claude-signed history serves with the disclosure and no reasoning upstream. `native_messages_test.py`'s pre-dispatch-400 pin became the serve-with-disclosure pin.
- Full suite on the rebased branch: 4,087 passed, 6 skipped (the only other failure, `release_test::test_tty_child_exit_survives_terminal_close_races`, is a TTY race that passes alone); `ruff check`, `ruff format --check`, `ty check` clean.

### Release note
This chunk changes the Rust data plane, so the release must cut BOTH `experiential` and `exp-gateway-native`; the platform then bumps both exact pins. Platform follow-up: the production smoke's Messages check should assert a `thinking` block on an exposed rung once the pins land.

## Chunk 4: cache affinity as a wire-profile fact, verified per origin

Harbor saw a ~25k-token prefix hit the cache on Chat (`cached_tokens: 24896`) and miss on Messages on both turns, both requests served by the openrouter rung; the platform proved the two surfaces build byte-identical upstream prefixes, so the misses were provider-side placement and the metering (full uncached list price) was a correct report of a real miss. `forwards_prompt_cache_key` was keyed on the Tencent hosts only, so the openrouter rung never dispatched an affinity hint.

What each origin does with the hint (read 2026-09-11):

- **OpenRouter** (openrouter.ai/docs/features/prompt-caching, provider-routing): one model load-balances across upstream providers; a conversation is pinned to the provider that served it only after a cache hit is observed, keyed by `session_id` (body field or `x-session-id` header) else the OpenAI-style `prompt_cache_key` as the documented fallback sticky key, else a hash of the first system + first non-system message; sessions expire after 10 minutes idle; unsupported parameters are forwarded upstream. So `prompt_cache_key` IS the field that makes OpenRouter deterministic per conversation, and it carries Tencent's own per-node pin upstream on the hy4 lane. `provider.order` + `allow_fallbacks: false` pins a PROVIDER, not a node, and turns a provider outage into a hard failure; not used.
- **vLLM** (`vllm/entrypoints/serve/engine/protocol.py`: `OpenAIBaseModel` is `extra="allow"` and logs ignored fields; `docs/design/prefix_caching.md`): prefix caching is per engine process and content-addressed; `cache_salt` is isolation, not affinity; `prompt_cache_key` is ignored. Nothing to forward; multi-replica affinity is the load balancer's job.
- **Tencent TokenHub**: honors `prompt_cache_key` as a node pin (measured 2026-09-05); stays host-keyed.
- **Strict OpenAI-compatible servers**: may 400 on an unknown top-level field (the earlier Greptile finding), so nothing widens what is sent to them.

Change: `OpenRouterClient.gateway_wire_profile()` sets `forwards_prompt_cache_key=True` structurally (the class is the provider and OpenRouter documents the field). No new catalog key: the origins that honor the hint are OpenRouter (now on) and Tencent (host-keyed), vLLM ignores it, strict shims must not get it, so a per-deployment knob would have no consumer; add one when an origin documents honoring it. Tests first (red: the OpenRouter profile and the registry-resolved openrouter rung reported the hint off), then green; the payload builder already sends only the admission-derived namespaced key (`streaming_requests_test`, "derived key rides prompt_cache_key on flagged rungs").

**Platform declaration for the openrouter house rung on hy4: none.** The hint is on for every `provider = 'openrouter'` rung once this engine version is pinned. Confirmation is a live two-turn same-prefix probe through `/v1/messages` on the openrouter rung showing `cache_read_input_tokens` on turn two and a `cached_input_tokens` ledger row, after the pin bump rolls. Whether OpenRouter's pin reaches Tencent's node every time is OpenRouter's behavior: if misses persist with the hint, the remedy is routing Tencent-first (the house-pool chunk), not another request field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


