### PR TITLE
messages: accept OpenRouter's reasoning object as a second effort channel

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -179,7 +179,12 @@ possible billable dispatch is visible to the gateway ledger.
 First-party CLI compatibility is capture-driven: the fields real Claude Code and Codex send by
 default are accepted and preserved. On the Messages surface, `output_config` forwards verbatim on
 Anthropic rungs (a canonical `effort` also rides `reasoning_effort`, caller keys always win over
-engine-derived ones), mid-conversation `system` turns keep their position on wires that express
+engine-derived ones); OpenRouter's `reasoning` object (`effort`, or a `max_tokens` budget, plus
+`enabled` / `exclude`) is accepted as a second effort channel, mapped onto the same canonical
+effort (a budget becomes a budgeted `thinking` config on Anthropic rungs and the nearest tier
+elsewhere), and when it is present it wins: a `thinking` config beside it and a disagreeing
+`output_config.effort` drop with disclosure, `exclude` is disclosed rather than honored, and an
+effort the route cannot serve is rejected as `reasoning.effort`; mid-conversation `system` turns keep their position on wires that express
 them (instruction-hoisting rungs narrow out), and `thinking.display` rides the verbatim thinking
 config. The conditional Claude Code fields `diagnostics` and `speed` forward verbatim on
 Anthropic rungs with their required `anthropic-beta` tokens and drop with disclosure elsewhere.

--- a/exp/runtime/anthropic_protocol/manifest.py
+++ b/exp/runtime/anthropic_protocol/manifest.py
@@ -40,6 +40,12 @@ MESSAGES_MANIFEST = CompatibilityManifest(
         _field("tools", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
         _field("tool_choice", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "function_tools"),
         _field("thinking", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "extended_thinking"),
+        # OpenRouter's Anthropic-compatible Messages endpoint accepts its
+        # ``reasoning`` object (effort / max_tokens / enabled / exclude) on
+        # this surface, and agents built against it send the field verbatim.
+        # Not an official SDK field: an installed extension, decoded closed and
+        # mapped onto the canonical effort channel (see requests.py).
+        _field("reasoning", CompatibilityDisposition.CONDITIONALLY_SUPPORTED, "reasoning"),
         _field(
             "context_management",
             CompatibilityDisposition.CONDITIONALLY_SUPPORTED,

--- a/exp/runtime/anthropic_protocol/manifest_test.py
+++ b/exp/runtime/anthropic_protocol/manifest_test.py
@@ -142,3 +142,9 @@ def test_every_official_sdk_tool_type_is_consciously_classified() -> None:
         sdk_types - MESSAGES_SERVER_TOOL_TYPES_ACCEPTED - MESSAGES_SERVER_TOOL_TYPES_REJECTED
     )
     assert not undecided, _decided(undecided, "Anthropic-defined tool")
+
+
+def test_openrouter_reasoning_extension_is_conditionally_supported() -> None:
+    """The OpenRouter ``reasoning`` object is an installed extension, not an SDK field."""
+    decisions = {field.field_path: field.disposition for field in MESSAGES_MANIFEST.fields}
+    assert decisions["reasoning"] == CompatibilityDisposition.CONDITIONALLY_SUPPORTED

--- a/exp/runtime/anthropic_protocol/reasoning_channels.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels.py
@@ -116,8 +116,9 @@ def resolve_reasoning_channels(
 
     * ``effort`` is the canonical tier; ``max_tokens`` is a thinking budget
       (forwarded as a budgeted ``enabled`` config on Anthropic rungs, mapped to
-      the nearest tier elsewhere); ``enabled: false`` is ``none``; a bare or
-      ``enabled: true`` object is OpenRouter's default depth.
+      the nearest tier elsewhere); ``enabled: false`` is ``none`` and wins over
+      any depth sent beside it; a bare or ``enabled: true`` object is
+      OpenRouter's default depth.
     * A ``thinking`` config beside it is dropped with disclosure, and an
       ``output_config.effort`` that disagrees is dropped with disclosure (an
       agreeing one stays, so the caller's forwarded object is untouched).
@@ -143,7 +144,12 @@ def resolve_reasoning_channels(
             disclosures=(),
         )
     disclosures: list[str] = []
-    if reasoning.max_tokens is not None:
+    if reasoning.enabled is False:
+        # An explicit off switch wins over any depth beside it (effort or a
+        # budget): the caller asked for no reasoning, so none is configured.
+        effort: ReasoningEffort = "none"
+        resolved_thinking: JsonObject | None = None
+    elif reasoning.max_tokens is not None:
         if reasoning.max_tokens >= max_tokens:
             raise invalid_field(
                 "reasoning.max_tokens",
@@ -152,14 +158,11 @@ def resolve_reasoning_channels(
             )
         budget: JsonObject = {"type": "enabled", "budget_tokens": reasoning.max_tokens}
         effort = thinking_config_reasoning_effort(budget)
-        resolved_thinking: JsonObject | None = budget
+        resolved_thinking = budget
     else:
-        if reasoning.enabled is False:
-            effort = "none"
-        elif reasoning.effort is not None:
-            effort = reasoning.effort
-        else:
-            effort = _REASONING_ENABLED_DEFAULT_EFFORT
+        effort = (
+            reasoning.effort if reasoning.effort is not None else _REASONING_ENABLED_DEFAULT_EFFORT
+        )
         resolved_thinking = None
     if thinking is not None:
         disclosures.append(REASONING_SUPERSEDES_THINKING_DISCLOSURE)

--- a/exp/runtime/anthropic_protocol/reasoning_channels.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels.py
@@ -1,0 +1,178 @@
+"""Reasoning channels of the Anthropic Messages surface, collapsed onto one effort.
+
+Three caller channels can name a reasoning depth on ``POST /v1/messages``:
+Anthropic's ``thinking`` config, Anthropic's ``output_config.effort``, and
+OpenRouter's ``reasoning`` extension (its Anthropic-compatible Messages endpoint
+accepts the object next to ``thinking``, and agents built against it send the
+field verbatim). This module owns the closed wire model of that extension and
+the resolution rule that turns the three channels into the single canonical
+effort (plus the thinking config Anthropic rungs forward) every downstream seam
+reads: route narrowing, the coercion policy, and the payload builders.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models.model import ReasoningEffort
+from exp.runtime.anthropic_protocol.media_blocks import AnthropicWireModel
+from exp.runtime.models.providers.reasoning_compat import (
+    REASONING_EFFORTS,
+    thinking_config_reasoning_effort,
+)
+from exp.runtime.openai_protocol.errors import invalid_field
+
+REASONING_SUPERSEDES_THINKING_DISCLOSURE = "thinking->dropped(superseded_by_reasoning)"
+"""Disclosure recorded when the OpenRouter ``reasoning`` object and a
+``thinking`` config both name a depth: the explicit effort wins and the thinking
+config is dropped (Anthropic rungs still reason at that effort through the
+shared channel)."""
+
+REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE = (
+    "output_config.effort->dropped(superseded_by_reasoning)"
+)
+"""Disclosure recorded when ``output_config.effort`` disagrees with the
+OpenRouter ``reasoning`` effort: the explicit effort wins and the forwarded
+``output_config`` loses its ``effort`` key so the two cannot diverge."""
+
+REASONING_EXCLUDE_DISCLOSURE = "reasoning.exclude"
+"""Disclosure recorded when the caller asked to omit reasoning from the reply
+(``reasoning.exclude: true``), a rendering choice this gateway does not
+honor: Anthropic rungs stream their thinking blocks as always and other rungs
+carry no reasoning on this surface."""
+
+# OpenRouter documents ``enabled: true`` as its default depth (medium).
+_REASONING_ENABLED_DEFAULT_EFFORT: ReasoningEffort = "medium"
+
+
+class ReasoningConfig(AnthropicWireModel):
+    """OpenRouter's ``reasoning`` object, validated closed.
+
+    OpenRouter's own rule applies: ``effort`` and ``max_tokens`` are exclusive.
+    ``effort`` is the engine-owned ladder (OpenRouter's values are a subset),
+    so an unknown tier is a named 400 rather than a provider guess.
+    """
+
+    effort: ReasoningEffort | None = None
+    max_tokens: int | None = Field(default=None, gt=0)
+    exclude: bool | None = None
+    enabled: bool | None = None
+
+    @model_validator(mode="after")
+    def _effort_or_budget(self) -> ReasoningConfig:
+        """Enforce OpenRouter's exclusivity: one depth signal, not two."""
+        if self.effort is not None and self.max_tokens is not None:
+            raise ValueError("reasoning.effort and reasoning.max_tokens are exclusive; send one")
+        return self
+
+
+class ReasoningChannels(BaseModel):
+    """The canonical reasoning signals one Messages body resolves to."""
+
+    model_config = ConfigDict(frozen=True)
+
+    effort: ReasoningEffort | None
+    effort_parameter: Literal["reasoning.effort", "output_config.effort"] | None
+    """The caller field that named the effort, when the decoder must record it
+    (``None`` leaves the surface default, ``output_config.effort``)."""
+    thinking_config: JsonObject | None
+    output_config: JsonObject | None
+    disclosures: tuple[str, ...]
+
+
+def output_config_effort(config: JsonObject | None) -> ReasoningEffort | None:
+    """Map a canonical caller ``output_config.effort`` into the shared field.
+
+    A canonical ladder value rides ``reasoning_effort`` so route narrowing,
+    the coercion policy, and non-Anthropic rungs all see it; the raw object
+    still forwards verbatim on Anthropic rungs with the caller's keys
+    winning, so an unrecognized future effort value stays provider-decided
+    instead of gateway-rejected.
+    """
+    if config is None:
+        return None
+    effort = config.get("effort")
+    if isinstance(effort, str) and effort in REASONING_EFFORTS:
+        # The membership check above is the narrowing proof for this cast.
+        return cast("ReasoningEffort", effort)
+    return None
+
+
+def resolve_reasoning_channels(
+    reasoning: ReasoningConfig | None,
+    *,
+    max_tokens: int,
+    thinking: JsonObject | None,
+    output_config: JsonObject | None,
+) -> ReasoningChannels:
+    """Collapse the caller's reasoning channels onto the canonical effort.
+
+    Without the OpenRouter object, the surface behaves as Anthropic defines it:
+    ``thinking`` forwards byte-for-byte and a canonical ``output_config.effort``
+    rides ``reasoning_effort``. With it, the explicit OpenRouter signal wins:
+
+    * ``effort`` is the canonical tier; ``max_tokens`` is a thinking budget
+      (forwarded as a budgeted ``enabled`` config on Anthropic rungs, mapped to
+      the nearest tier elsewhere); ``enabled: false`` is ``none``; a bare or
+      ``enabled: true`` object is OpenRouter's default depth.
+    * A ``thinking`` config beside it is dropped with disclosure, and an
+      ``output_config.effort`` that disagrees is dropped with disclosure (an
+      agreeing one stays, so the caller's forwarded object is untouched).
+    * ``exclude: true`` is disclosed, never honored.
+
+    Args:
+        reasoning: The validated OpenRouter object, or ``None`` when absent.
+        max_tokens: The caller's reply ceiling, which a budget must stay below.
+        thinking: The caller's raw ``thinking`` object, byte-for-byte.
+        output_config: The caller's raw ``output_config`` object, byte-for-byte.
+
+    Raises:
+        OpenAIProtocolError: ``reasoning.max_tokens`` does not leave room for
+            the reply under ``max_tokens`` (both OpenRouter and Anthropic
+            require a strictly smaller budget).
+    """
+    if reasoning is None:
+        return ReasoningChannels(
+            effort=output_config_effort(output_config),
+            effort_parameter=None,
+            thinking_config=thinking,
+            output_config=output_config,
+            disclosures=(),
+        )
+    disclosures: list[str] = []
+    if reasoning.max_tokens is not None:
+        if reasoning.max_tokens >= max_tokens:
+            raise invalid_field(
+                "reasoning.max_tokens",
+                "reasoning.max_tokens must be below max_tokens so the reply has room "
+                "after thinking.",
+            )
+        budget: JsonObject = {"type": "enabled", "budget_tokens": reasoning.max_tokens}
+        effort = thinking_config_reasoning_effort(budget)
+        resolved_thinking: JsonObject | None = budget
+    else:
+        if reasoning.enabled is False:
+            effort = "none"
+        elif reasoning.effort is not None:
+            effort = reasoning.effort
+        else:
+            effort = _REASONING_ENABLED_DEFAULT_EFFORT
+        resolved_thinking = None
+    if thinking is not None:
+        disclosures.append(REASONING_SUPERSEDES_THINKING_DISCLOSURE)
+    if output_config is not None and output_config.get("effort", effort) != effort:
+        output_config = {key: value for key, value in output_config.items() if key != "effort"}
+        output_config = output_config or None
+        disclosures.append(REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE)
+    if reasoning.exclude:
+        disclosures.append(REASONING_EXCLUDE_DISCLOSURE)
+    return ReasoningChannels(
+        effort=effort,
+        effort_parameter="reasoning.effort",
+        thinking_config=resolved_thinking,
+        output_config=output_config,
+        disclosures=tuple(disclosures),
+    )

--- a/exp/runtime/anthropic_protocol/reasoning_channels_test.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels_test.py
@@ -38,6 +38,24 @@ def test_budget_form_becomes_a_budgeted_thinking_config_by_tier() -> None:
     )
     assert channels.thinking_config == {"type": "enabled", "budget_tokens": 4096}
     assert channels.effort == "low"
+    # An explicit off switch beside a budget (or an effort) configures nothing.
+    off = resolve_reasoning_channels(
+        ReasoningConfig(enabled=False, max_tokens=4096),
+        max_tokens=8192,
+        thinking=None,
+        output_config=None,
+    )
+    assert off.effort == "none"
+    assert off.thinking_config is None
+    assert (
+        resolve_reasoning_channels(
+            ReasoningConfig(enabled=False, effort="high"),
+            max_tokens=8192,
+            thinking=None,
+            output_config=None,
+        ).effort
+        == "none"
+    )
     with pytest.raises(OpenAIProtocolError) as oversized:
         resolve_reasoning_channels(
             ReasoningConfig(max_tokens=8192), max_tokens=8192, thinking=None, output_config=None

--- a/exp/runtime/anthropic_protocol/reasoning_channels_test.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels_test.py
@@ -1,0 +1,72 @@
+"""Tests for the Messages reasoning-channel resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from exp.runtime.anthropic_protocol.reasoning_channels import (
+    REASONING_EXCLUDE_DISCLOSURE,
+    REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE,
+    REASONING_SUPERSEDES_THINKING_DISCLOSURE,
+    ReasoningConfig,
+    output_config_effort,
+    resolve_reasoning_channels,
+)
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+
+def test_absent_reasoning_keeps_the_anthropic_channels_verbatim() -> None:
+    """Without the OpenRouter object the surface is exactly Anthropic's."""
+    channels = resolve_reasoning_channels(
+        None,
+        max_tokens=128,
+        thinking={"type": "enabled", "budget_tokens": 1024},
+        output_config={"effort": "low"},
+    )
+    assert channels.effort == "low"
+    assert channels.effort_parameter is None
+    assert channels.thinking_config == {"type": "enabled", "budget_tokens": 1024}
+    assert channels.output_config == {"effort": "low"}
+    assert channels.disclosures == ()
+    assert output_config_effort({"effort": "hyperdrive"}) is None
+
+
+def test_budget_form_becomes_a_budgeted_thinking_config_by_tier() -> None:
+    """A token budget forwards as ``enabled`` thinking and maps to the nearest tier."""
+    channels = resolve_reasoning_channels(
+        ReasoningConfig(max_tokens=4096), max_tokens=8192, thinking=None, output_config=None
+    )
+    assert channels.thinking_config == {"type": "enabled", "budget_tokens": 4096}
+    assert channels.effort == "low"
+    with pytest.raises(OpenAIProtocolError) as oversized:
+        resolve_reasoning_channels(
+            ReasoningConfig(max_tokens=8192), max_tokens=8192, thinking=None, output_config=None
+        )
+    assert oversized.value.detail.param == "reasoning.max_tokens"
+
+
+def test_explicit_effort_supersedes_the_anthropic_channels_with_disclosure() -> None:
+    """Both channels present: the OpenRouter effort wins and every drop is disclosed."""
+    channels = resolve_reasoning_channels(
+        ReasoningConfig(effort="high", exclude=True),
+        max_tokens=128,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "low", "format": {"type": "text"}},
+    )
+    assert channels.effort == "high"
+    assert channels.effort_parameter == "reasoning.effort"
+    assert channels.thinking_config is None
+    assert channels.output_config == {"format": {"type": "text"}}
+    assert channels.disclosures == (
+        REASONING_SUPERSEDES_THINKING_DISCLOSURE,
+        REASONING_SUPERSEDES_OUTPUT_CONFIG_DISCLOSURE,
+        REASONING_EXCLUDE_DISCLOSURE,
+    )
+    # An output_config reduced to its effort alone drops entirely.
+    alone = resolve_reasoning_channels(
+        ReasoningConfig(effort="high"),
+        max_tokens=128,
+        thinking=None,
+        output_config={"effort": "low"},
+    )
+    assert alone.output_config is None

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -36,7 +36,7 @@ from exp.common.models.content import (
     MessageContentPart,
     TextContentPart,
 )
-from exp.common.models.model import ReasoningEffort, ToolCall
+from exp.common.models.model import ToolCall
 from exp.runtime.anthropic_protocol.manifest import (
     MESSAGES_BETA_TOKENS_FORWARDED,
     MESSAGES_MANIFEST,
@@ -50,6 +50,10 @@ from exp.runtime.anthropic_protocol.media_blocks import (
     document_part_from_block,
     image_part_from_block,
 )
+from exp.runtime.anthropic_protocol.reasoning_channels import (
+    ReasoningConfig,
+    resolve_reasoning_channels,
+)
 from exp.runtime.gateway.compatibility import CompatibilityDisposition
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
@@ -61,7 +65,6 @@ from exp.runtime.gateway.contracts import (
     RedactedThinkingBlock,
     ThinkingBlock,
 )
-from exp.runtime.models.providers.reasoning_compat import REASONING_EFFORTS
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import disposition_map
 from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
@@ -284,6 +287,7 @@ class _MessagesRequest(AnthropicWireModel):
     tool_choice: _ToolChoice | None = None
     metadata: _Metadata | None = None
     thinking: _ThinkingConfig | None = None
+    reasoning: ReasoningConfig | None = None
     context_management: JsonObject | None = None
     output_config: JsonObject | None = None
     diagnostics: JsonObject | None = None
@@ -359,6 +363,16 @@ def decode_messages(
     parallel_tool_calls: bool | None = None
     if request.tool_choice is not None and request.tool_choice.disable_parallel_tool_use:
         parallel_tool_calls = False
+    channels = resolve_reasoning_channels(
+        request.reasoning,
+        max_tokens=request.max_tokens,
+        thinking=cast(JsonObject, payload["thinking"]) if request.thinking is not None else None,
+        output_config=(
+            cast(JsonObject, payload["output_config"])
+            if request.output_config is not None
+            else None
+        ),
+    )
     try:
         canonical = GatewayRequest(
             surface=GatewayApiSurface.MESSAGES,
@@ -382,11 +396,7 @@ def decode_messages(
             stream=request.stream,
             include_usage=request.stream,
             metadata=_gateway_metadata(request.metadata),
-            # The raw payload value, not the re-serialized wire model, so the
-            # provider receives the caller's thinking config byte-for-byte.
-            provider_thinking_config=(
-                cast(JsonObject, payload["thinking"]) if request.thinking is not None else None
-            ),
+            provider_thinking_config=channels.thinking_config,
             context_management=_context_management(payload),
             diagnostics=_diagnostics(payload),
             speed=request.speed,
@@ -399,13 +409,10 @@ def decode_messages(
             ),
             inference_geo=request.inference_geo,
             provider_beta_tokens=forwarded_betas,
-            ignored_parameters=dropped_beta_disclosures,
-            reasoning_effort=_output_config_effort(request.output_config),
-            provider_output_config=(
-                cast(JsonObject, payload["output_config"])
-                if request.output_config is not None
-                else None
-            ),
+            ignored_parameters=(*dropped_beta_disclosures, *channels.disclosures),
+            reasoning_effort=channels.effort,
+            reasoning_effort_parameter=channels.effort_parameter,
+            provider_output_config=channels.output_config,
         )
     except ValidationError as exc:
         raise _validation_error(exc.errors(include_url=False)[0]) from exc
@@ -432,24 +439,6 @@ def _require_served_server_tool_types(tools: tuple[_Tool | _ServerTool, ...]) ->
                 f"Supported server tool types: {supported}. Remove the tool or use a "
                 "supported type.",
             )
-
-
-def _output_config_effort(config: JsonObject | None) -> ReasoningEffort | None:
-    """Map a canonical caller ``output_config.effort`` into the shared field.
-
-    A canonical ladder value rides ``reasoning_effort`` so route narrowing,
-    the coercion policy, and non-Anthropic rungs all see it; the raw object
-    still forwards verbatim on Anthropic rungs with the caller's keys
-    winning, so an unrecognized future effort value stays provider-decided
-    instead of gateway-rejected.
-    """
-    if config is None:
-        return None
-    effort = config.get("effort")
-    if isinstance(effort, str) and effort in REASONING_EFFORTS:
-        # The membership check above is the narrowing proof for this cast.
-        return cast("ReasoningEffort", effort)
-    return None
 
 
 def _context_management(payload: JsonObject) -> JsonObject | None:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1795,3 +1795,89 @@ def test_forced_tool_choice_decodes_to_the_canonical_forced_forms() -> None:
     assert decode_messages(
         _body(tool_choice={"type": "auto"}, tools=tools)
     ).request.tool_choice == ("auto")
+
+
+def test_openrouter_reasoning_effort_rides_the_canonical_effort_channel() -> None:
+    """OpenRouter's ``reasoning: {effort}`` is a second effort channel beside thinking.
+
+    Agents built against OpenRouter's Anthropic-compatible Messages endpoint
+    send it verbatim; the gateway maps it onto ``reasoning_effort`` so every
+    rung (native Anthropic through ``output_config`` or a budget, effort
+    ladders elsewhere) sees the same canonical tier.
+    """
+    decoded = decode_messages(_body(reasoning={"effort": "low"}))
+    assert decoded.request.reasoning_effort == "low"
+    assert decoded.request.provider_thinking_config is None
+    assert decoded.request.provider_output_config is None
+    assert decoded.request.reasoning_effort_parameter == "reasoning.effort"
+    assert decoded.request.ignored_parameters == ()
+    # The Anthropic channel alone keeps the surface default for rejections.
+    native = decode_messages(_body(output_config={"effort": "low"}))
+    assert native.request.reasoning_effort_parameter is None
+    assert decode_messages(_body(reasoning={"effort": "none"})).request.reasoning_effort == "none"
+    assert decode_messages(_body(reasoning={"effort": "max"})).request.reasoning_effort == "max"
+
+
+def test_openrouter_reasoning_enabled_and_budget_forms_translate() -> None:
+    """``enabled: true`` is OpenRouter's default depth; a token budget maps by tier."""
+    enabled = decode_messages(_body(reasoning={"enabled": True}))
+    assert enabled.request.reasoning_effort == "medium"
+    disabled = decode_messages(_body(reasoning={"enabled": False}))
+    assert disabled.request.reasoning_effort == "none"
+    # A budget becomes the budgeted thinking config Anthropic rungs forward and
+    # non-Anthropic rungs translate by tier (<=4096 low, <=16384 medium, else high).
+    budget = decode_messages(_body(max_tokens=64000, reasoning={"max_tokens": 32000}))
+    assert budget.request.provider_thinking_config == {"type": "enabled", "budget_tokens": 32000}
+    assert budget.request.reasoning_effort == "high"
+    # exclude only hides reasoning from the reply, which this gateway does not
+    # render for non-Anthropic rungs anyway; it is dropped with disclosure.
+    excluded = decode_messages(_body(reasoning={"effort": "high", "exclude": True}))
+    assert excluded.request.reasoning_effort == "high"
+    assert "reasoning.exclude" in excluded.request.ignored_parameters
+
+
+def test_openrouter_reasoning_rejects_conflicting_and_unknown_shapes() -> None:
+    """Closed validation: effort and max_tokens are exclusive; unknown keys 400."""
+    with pytest.raises(OpenAIProtocolError) as both:
+        decode_messages(_body(reasoning={"effort": "high", "max_tokens": 2000}))
+    assert both.value.detail.param == "reasoning"
+    with pytest.raises(OpenAIProtocolError) as unknown:
+        decode_messages(_body(reasoning={"effort": "high", "depth": 3}))
+    assert unknown.value.status_code == 400
+    with pytest.raises(OpenAIProtocolError) as bad_effort:
+        decode_messages(_body(reasoning={"effort": "hyperdrive"}))
+    assert bad_effort.value.detail.param == "reasoning.effort"
+    with pytest.raises(OpenAIProtocolError) as oversized:
+        decode_messages(_body(max_tokens=2000, reasoning={"max_tokens": 2000}))
+    assert oversized.value.detail.param == "reasoning.max_tokens"
+
+
+def test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosure() -> None:
+    """Two reasoning channels on one request: the explicit effort wins, disclosed.
+
+    ``thinking`` is dropped (Anthropic rungs still reason at the effort through
+    the shared channel) and an ``output_config.effort`` that disagrees is
+    dropped from the forwarded object so it and the routing decision cannot
+    diverge; the payload seam re-seeds the effort from the shared channel.
+    """
+    decoded = decode_messages(
+        _body(
+            reasoning={"effort": "high"},
+            thinking={"type": "enabled", "budget_tokens": 2048},
+            output_config={"effort": "low", "format": {"type": "text"}},
+        )
+    )
+    assert decoded.request.reasoning_effort == "high"
+    assert decoded.request.provider_thinking_config is None
+    assert decoded.request.provider_output_config == {"format": {"type": "text"}}
+    assert decoded.request.reasoning_effort_parameter == "reasoning.effort"
+    assert "thinking->dropped(superseded_by_reasoning)" in decoded.request.ignored_parameters
+    assert (
+        "output_config.effort->dropped(superseded_by_reasoning)"
+        in decoded.request.ignored_parameters
+    )
+    # An agreeing output_config.effort needs no disclosure.
+    agreeing = decode_messages(
+        _body(reasoning={"effort": "high"}, output_config={"effort": "high"})
+    )
+    assert agreeing.request.ignored_parameters == ()

--- a/exp/runtime/gateway/contracts.py
+++ b/exp/runtime/gateway/contracts.py
@@ -513,6 +513,15 @@ class GatewayRequest(ContractModel):
     logprobs: bool | None = None
     top_logprobs: int | None = Field(default=None, ge=0, le=20)
     reasoning_effort: ReasoningEffort | None = None
+    reasoning_effort_parameter: (
+        Literal["reasoning_effort", "reasoning.effort", "output_config.effort"] | None
+    ) = Field(default=None, exclude=True)
+    """Exact caller field normalized into ``reasoning_effort``, when a surface
+    offers more than one (the Messages surface takes Anthropic's
+    ``output_config.effort`` and the OpenRouter ``reasoning.effort`` extension);
+    an effort the route cannot serve is rejected by that name so the caller's
+    own recovery finds the field it sent. ``None`` means the surface default
+    (see :attr:`caller_effort_parameter`)."""
     # Level-less enable-thinking; the route seam resolves the concrete effort.
     thinking_default_enable: bool = False
     reasoning_summary: Literal["auto", "concise", "detailed"] | None = None
@@ -772,6 +781,28 @@ class GatewayRequest(ContractModel):
         if len(set(value)) != len(value):
             raise ValueError("stop sequences must not repeat")
         return value
+
+    @property
+    def caller_effort_parameter(
+        self,
+    ) -> Literal["reasoning_effort", "reasoning.effort", "output_config.effort"]:
+        """The public field an unservable effort is rejected under.
+
+        The recorded caller field when the decoder knows it; otherwise the
+        surface's one effort field. The name matters: Claude Code carries its
+        effort as Messages ``output_config.effort`` and auto-recovers (drops
+        the field and retries) only when the 400 names that channel, so naming
+        a translated internal field wedges every turn instead.
+        """
+        if self.reasoning_effort_parameter is not None:
+            return self.reasoning_effort_parameter
+        match self.surface:
+            case GatewayApiSurface.RESPONSES:
+                return "reasoning.effort"
+            case GatewayApiSurface.MESSAGES:
+                return "output_config.effort"
+            case _:
+                return "reasoning_effort"
 
     @model_validator(mode="after")
     def _require_coherent_tools(self) -> GatewayRequest:

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -219,16 +219,9 @@ def route_generation_parameter_requests(
         provider_updates["maximum_output_tokens"] = min(
             (_ANTHROPIC_REQUIRED_MAX_TOKENS_DEFAULT, *route_limits)
         )
-    # The rejection names the field the CALLER sent: Claude Code carries its
-    # effort as Messages output_config.effort and auto-recovers (drops the
-    # field and retries) only when the 400 names that channel, so naming the
-    # translated internal field wedges every turn instead (issue #795).
-    if request.surface == GatewayApiSurface.RESPONSES:
-        effort_path = "reasoning.effort"
-    elif request.surface == GatewayApiSurface.MESSAGES:
-        effort_path = "output_config.effort"
-    else:
-        effort_path = "reasoning_effort"
+    # The rejection names the field the CALLER sent (the request knows which
+    # of its surface's effort fields carried the value; see the property).
+    effort_path = request.caller_effort_parameter
 
     def profile_reasoning_effort(profile: GatewayWireProfile) -> str | None:
         """Return the caller effort or this wire's required provider default."""

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -4602,6 +4602,38 @@ def test_a_messages_surface_effort_rejection_matches_the_client_recovery_latch()
     assert "not supported" in str(raised.value)
 
 
+def test_a_messages_effort_from_the_openrouter_channel_is_rejected_by_its_own_name() -> None:
+    """A depth sent as OpenRouter's ``reasoning.effort`` is refused under that path.
+
+    The Messages decoder records which caller field carried the effort; the
+    rejection names it so an agent built against OpenRouter's Messages endpoint
+    finds the field it sent, while the Anthropic ``output_config.effort`` default
+    (and Claude Code's recovery latch) is untouched.
+    """
+    profiles = (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://c.test",
+            model_id="hermes-4-405b",
+            supports_reasoning=True,
+            reasoning_wire_format="reasoning_effort",
+            supported_reasoning_efforts=("medium",),
+        ),
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="hi"),),
+        reasoning_effort="high",
+        reasoning_effort_parameter="reasoning.effort",
+    )
+
+    with pytest.raises(UnsupportedReasoningEffortError) as raised:
+        route_generation_parameter_requests(profiles, request)
+
+    assert raised.value.param == "reasoning.effort"
+    assert "effort parameter" in str(raised.value)
+
+
 def test_route_refuses_a_whole_empty_user_turn_before_an_anthropic_dispatch() -> None:
     """The Anthropic wire rejects empty text content blocks post-dispatch
     ("text content blocks must be non-empty"; 2026-09-05, six orgs on


### PR DESCRIPTION
## Why

`POST /v1/messages` answered 400 `unsupported_parameter` ("The parameter 'reasoning' is not supported by this gateway profile") to OpenRouter-style `reasoning: {effort: "low"}`, while OpenRouter's Anthropic-compatible Messages endpoint accepts it for the same models and our own `thinking` channel works. Agents built against that endpoint (the Harbor / Akhara AI switch of `hy4-preview` onto the platform) die on the first turn.

## What

- **Manifest**: `reasoning` is an installed, conditionally supported extension of the Messages surface (not an official SDK field; the SDK drift gate is unaffected). Every other unknown key still 400s.
- **Wire model** (`exp/runtime/anthropic_protocol/reasoning_channels.py`, new): `ReasoningConfig` validated closed: `effort` on the engine-owned ladder (OpenRouter's values are a subset, so an unknown tier is a named 400 under `reasoning.effort`), or a `max_tokens` budget (exclusive with `effort`, as OpenRouter defines; must stay below the request `max_tokens`), plus `enabled` / `exclude`.
- **Resolution** (`resolve_reasoning_channels`): the three caller channels (`thinking`, `output_config.effort`, `reasoning`) collapse onto the one canonical `reasoning_effort` every downstream seam already reads (route narrowing, coercion, payload builders: Anthropic rungs get `output_config.effort` or a budget through `messages_payloads`, effort ladders get the tier snapped with disclosure as today). Precedence when `reasoning` is present: the explicit effort wins; a `thinking` config beside it drops with `thinking->dropped(superseded_by_reasoning)`, a disagreeing `output_config.effort` drops with `output_config.effort->dropped(superseded_by_reasoning)` (an agreeing one is left verbatim), `exclude: true` is disclosed (`reasoning.exclude`) rather than honored, `enabled: false` is `none`, a bare or `enabled: true` object is OpenRouter's default depth (medium), and a budget becomes a budgeted `enabled` thinking config for Anthropic rungs and the nearest tier elsewhere (<=4096 low, <=16384 medium, else high).
- **Rejection naming**: `GatewayRequest.reasoning_effort_parameter` records which caller field carried the effort; `caller_effort_parameter` returns it or the surface default. An unservable effort sent as `reasoning.effort` is rejected under that name; the Anthropic `output_config.effort` default (Claude Code's recovery latch, #795) is untouched and still pinned by its test.
- `requests.py` and `streaming_requests.py` were at the 999-line ceiling; the channel logic lives in the new module and the surface-default selection moved onto the request as a property.
- Docs: `docs/reference/gateway-architecture.md` Messages paragraph.

## Test-first

Written before the change and run red on unchanged main:

```
FAILED manifest_test.py::test_openrouter_reasoning_extension_is_conditionally_supported          KeyError: 'reasoning'
FAILED requests_test.py::test_openrouter_reasoning_effort_rides_the_canonical_effort_channel      400 "The parameter 'reasoning' is not supported by this gateway profile"
FAILED requests_test.py::test_openrouter_reasoning_enabled_and_budget_forms_translate             (same)
FAILED requests_test.py::test_openrouter_reasoning_rejects_conflicting_and_unknown_shapes         (same)
FAILED requests_test.py::test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosure (same)
```

After: `uv run ruff check .`, `ruff format --check .`, `ty check` clean; `uv run pytest -q exp` 4082 passed / 6 skipped (incl. the new `reasoning_channels_test.py` and `test_a_messages_effort_from_the_openrouter_channel_is_rejected_by_its_own_name`).

## Release

No release cut here. The platform consumes exact PyPI pins (`experiential==0.7.62` today), so landing this for customers means cutting the next `experiential` release and bumping the pin there. The Rust data plane is untouched (Messages decoding runs in Python via `native_decode`), so `exp-gateway-native` needs no release for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
