### PR TITLE
release: bump experiential to 0.7.64 (Harbor/Hy4 gap program)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.63"
+version = "0.7.64"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.63"
+version = "0.7.64"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the release carrying #897: host-independent Hunyuan carrier eligibility (`reasoning_content_native`), OpenRouter-style `reasoning` on `/v1/messages`, preserved thinking on the Messages surface, cache-affinity hint as a rung capability. The native crate is already at 0.3.49 (bumped in #897), so this release publishes both `experiential` 0.7.64 and the `exp-gateway-native` 0.3.49 wheel matrix.

Platform follow-up: pin `experiential==0.7.64` and `exp-gateway-native==0.3.49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)