### PR TITLE
release: bump experiential to 0.7.65 (per-request cache-stakes throttle failover, throttle_cache_threshold)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.64"
+version = "0.7.65"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.64"
+version = "0.7.65"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the release carrying #900 (the only change on `main` since `v0.7.64`): per-request cache-stakes throttle failover. `GatewayPoolRecord.throttle_cache_threshold` (additive, default `None`, carried onto `ExactModelPool` and `ExecutionSnapshot`) makes a throttle on one rung surface to the caller exactly when the requesting organization's observed cached-token fraction on that rung is at or above the threshold, and fail over cold otherwise, under every `failover_mode`; `None` keeps each mode's legacy rule byte-for-byte. The fraction is the worker's existing per-(rung, organization) EWMA in `RungLoadRegistry`, now read through `cached_fraction()` with the retention horizon enforced at read time. Dispositions are disclosed as `throttle_failover_cold` (cold attempt's `dispatch_reason`, throttled rung as `preferred_deployment`) and counted on the control plane as `throttle_surfaced_cache_preserving` / `throttle_failover_cold`. No snapshot digest moves and `SNAPSHOT_SCHEMA_VERSION` stays at 3. The pool records now live in `exp.common.models.gateway_pools` (package exports unchanged).

The native crate is unchanged at `exp-gateway-native` 0.3.49 (no `.rs` change since `v0.7.64`), so this release publishes `experiential` 0.7.65 only; the publish job drops the rebuilt native wheels whose filenames are already on PyPI. This PR changes only `pyproject.toml` `version` and the matching `uv.lock` line.

Platform follow-up: pin `experiential==0.7.65` (native stays `exp-gateway-native==0.3.49`); then author `throttle_cache_threshold` only once the pin is fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
