### PR TITLE
gateway: Claude Code on foreign Messages routes (Harbor round 2): bare enabled thinking, named disclosures, server-tool drop, start-frame meters

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -385,7 +385,10 @@ configuration is forwarded verbatim on models that honor it, overriding the cata
 adaptive default; on the adaptive-only generation, which rejects `enabled`/`disabled`
 configs outright, an `enabled` config translates to adaptive with the dropped
 `thinking.budget_tokens` disclosed as ignored, and `disabled` is rejected by name
-because those models cannot turn thinking off), requires
+because those models cannot turn thinking off; a bare `{type: enabled}` with no budget, which
+Claude Code sends, is legal at the gateway boundary: an Anthropic rung receives the gateway's
+derived budget (`thinking.budget_tokens->derived`, or `thinking->dropped(no_legal_budget)` when
+none fits under `max_tokens`) and an effort route reads it as the default depth), requires
 `max_tokens`, validates `cache_control` (carrying it everywhere the Anthropic wire caches
 natively: `tool_use` blocks, tool definitions, the top-level automatic marker, and block-level
 markers on system and message text runs and on `tool_result` breakpoints all forward verbatim.
@@ -395,8 +398,11 @@ This is what makes Claude Code sessions cacheable at all: it marks its system bl
 conversation breakpoints on every request, and flattening them once billed whole sessions
 uncached at ~10x. Responses report both cache legs back out of the folded ledger total, so
 callers see `cache_creation_input_tokens` on the writing turn and `cache_read_input_tokens` on
-later turns. Routes with no Anthropic rung disclose the dropped markers through
-`ignored_parameters`), carries the provider-native tool annotations (`strict`,
+later turns. Routes with no Anthropic rung have no field for the markers and disclose them as
+`<path>.cache_control->not_forwarded(provider_caches_implicitly)`: the wording never says
+"ignored", because the OpenAI-family provider still caches the prefix on its own and the ledger
+bills those reads at the cached rate — Harbor saw 14,976 cached tokens billed beside an
+"ignored" marker on 2026-09-11), carries the provider-native tool annotations (`strict`,
 `eager_input_streaming`, `defer_loading`, `allowed_callers`, `input_examples`; each accepted
 bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthropic rungs with
 disclosure-drops elsewhere, keeps every official SDK tool and top-level field a recorded
@@ -412,8 +418,15 @@ citation-bearing text blocks, and the `pause_turn` stop reason) reaches the call
 both response paths, and a next-turn echo of those blocks (each carried verbatim as a
 whole-message block) re-serves byte-for-byte; every other Anthropic-defined tool type is
 rejected by name because the data plane does not yet carry its result blocks. Like the thinking
-carriers, server tools replay only on the Anthropic wire, so a route with any other rung rejects
-them by name instead of dropping a requested capability. The terminal `message_delta` usage
+carriers, server tools replay only on the Anthropic wire. A MIXED route (an Anthropic rung beside
+another) rejects them by name; a route with NO Anthropic rung serves the turn without them,
+dropping the declared tool (`tools.web_search->dropped(unsupported_by_provider)`), its echoed
+`server_tool_use` / `*_tool_result` history blocks
+(`messages.server_tool_blocks->dropped(unsupported_by_provider)`), the citations of a cited
+answer whose text stays (`messages.content.citations->dropped(unsupported_by_provider)`), and a
+selector that named the tool (`tool_choice->dropped(unsupported_by_provider)`), because Claude
+Code recovers on its own once WebSearch is simply absent while a 400 kills the turn (two
+production turns on 2026-09-11). The terminal `message_delta` usage
 report supersedes the `message_start` input legs when present, because server-tool turns re-read
 fetched results as input and the start-frame count severely undercounts the billed total.
 
@@ -656,6 +669,20 @@ through `ignored_parameters`, logged, and counted in the `admission_parameter_co
 metric; every serving surface carries that list to the caller as a body-level
 `x-experiential-ignored-parameters` key (Chat chunk and completion, Responses envelope, and the
 Anthropic message on both `message_start` and the aggregated body), so a drop is never silent; nothing coercible keeps the first rung's own field-scoped rejection.
+The thinking vocabulary names the outcome, never a bare field: `thinking->reasoning_effort:<tier>`
+(the config was TRANSLATED onto the route's effort ladder and applies at that tier),
+`thinking->dropped(superseded_by_effort)` (the caller's own `output_config.effort` or
+`reasoning.effort` already states the depth, which is what serves), and
+`thinking->dropped(unsupported_by_route)` (no rung can reason at any depth). A caller reading a
+bare `thinking` as "my depth was stripped" is the misreading this vocabulary exists to prevent.
+
+On the Messages stream, `message_start.message.usage` carries what the upstream already reported
+before content — an Anthropic upstream's own start-frame input and cache meters, mirrored — and
+`message_delta.usage` carries the final meters (input, output, `cache_read_input_tokens`,
+`cache_creation_input_tokens`, plus the platform's cost extensions). An OpenAI-wire upstream
+reports nothing before its final chunk, so its `message_start` keeps the zero placeholder and the
+final meters ride `message_delta`; the official Anthropic SDK accumulators (Python and TypeScript)
+copy every usage field present on `message_delta`, so their final message shows the true counts.
 The per-deployment `capability_parity` export joins catalog declarations with the engine's
 provider-family ground truth so a catalog can pre-warn on gaps and route around them before a
 caller hits that 400.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -399,10 +399,11 @@ conversation breakpoints on every request, and flattening them once billed whole
 uncached at ~10x. Responses report both cache legs back out of the folded ledger total, so
 callers see `cache_creation_input_tokens` on the writing turn and `cache_read_input_tokens` on
 later turns. Routes with no Anthropic rung have no field for the markers and disclose them as
-`<path>.cache_control->not_forwarded(provider_caches_implicitly)`: the wording never says
-"ignored", because the OpenAI-family provider still caches the prefix on its own and the ledger
-bills those reads at the cached rate — Harbor saw 14,976 cached tokens billed beside an
-"ignored" marker on 2026-09-11), carries the provider-native tool annotations (`strict`,
+`<path>.cache_control->not_forwarded(provider_decides_caching)`: the wording never says
+"ignored", because caching is then the provider's own decision — OpenAI-family providers cache
+the prefix implicitly and the ledger bills those reads at the cached rate (Harbor saw 14,976
+cached tokens billed beside an "ignored" marker on 2026-09-11), while a generic endpoint may not
+cache at all), carries the provider-native tool annotations (`strict`,
 `eager_input_streaming`, `defer_loading`, `allowed_callers`, `input_examples`; each accepted
 bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthropic rungs with
 disclosure-drops elsewhere, keeps every official SDK tool and top-level field a recorded

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -267,9 +267,15 @@ class _ThinkingConfig(AnthropicWireModel):
 
     @model_validator(mode="after")
     def _require_budget_only_when_enabled(self) -> _ThinkingConfig:
-        """Bind the token budget to the one mode Anthropic defines it for."""
-        if self.type == "enabled" and self.budget_tokens is None:
-            raise ValueError("thinking.budget_tokens is required when thinking is enabled")
+        """Bind the token budget to the one mode Anthropic defines it for.
+
+        A budget is legal only on ``enabled``, but it is not REQUIRED there at
+        this boundary: Claude Code sends a bare ``{"type": "enabled"}`` and the
+        provider wire needs a budget, so route shaping derives one for an
+        Anthropic rung (disclosed) and an effort route reads the bare config as
+        its default depth. Rejecting it here made every such session die at
+        the gateway (Harbor, 2026-09-11).
+        """
         if self.type != "enabled" and self.budget_tokens is not None:
             raise ValueError("thinking.budget_tokens is valid only when thinking is enabled")
         return self

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -169,9 +169,10 @@ def test_thinking_config_is_carried_verbatim() -> None:
     assert decoded.request.provider_thinking_config == config
     assert decode_messages(_body()).request.provider_thinking_config is None
 
-    with pytest.raises(OpenAIProtocolError) as excinfo:
-        decode_messages(_body(thinking={"type": "enabled"}))
-    assert excinfo.value.detail.param == "thinking"
+    # Claude Code sends a bare enabled config (no budget); the decoder keeps it
+    # verbatim and route shaping derives or translates the depth per rung.
+    bare: JsonObject = {"type": "enabled"}
+    assert decode_messages(_body(thinking=bare)).request.provider_thinking_config == bare
     with pytest.raises(OpenAIProtocolError):
         decode_messages(_body(thinking={"type": "adaptive", "budget_tokens": 64}))
 
@@ -2043,3 +2044,37 @@ def test_anthropic_signed_thinking_still_decodes_verbatim_beside_gateway_blocks(
         "redacted_thinking",
     ]
     assert assistant.provider_anthropic_blocks is not None
+
+
+def test_claude_code_beta_header_set_decodes_with_per_token_disclosures() -> None:
+    """Claude Code's live beta header set never rejects the request.
+
+    The allowlisted tokens forward; every other token (the product umbrella,
+    the effort beta, fine-grained tool streaming) drops with its own
+    disclosure and the rest of the request decodes untouched.
+    """
+    header = (
+        "claude-code-20250219,interleaved-thinking-2025-05-14,"
+        "fine-grained-tool-streaming-2025-05-14,effort-2025-11-24,"
+        "context-management-2025-06-27"
+    )
+    decoded = decode_messages(
+        _body(
+            thinking={"type": "enabled"},
+            output_config={"effort": "high"},
+            tools=[{"name": "Bash", "input_schema": {"type": "object", "properties": {}}}],
+        ),
+        anthropic_beta=header,
+    )
+    assert decoded.request.provider_beta_tokens == (
+        "interleaved-thinking-2025-05-14",
+        "context-management-2025-06-27",
+    )
+    assert decoded.request.ignored_parameters == (
+        "anthropic-beta.claude-code-20250219",
+        "anthropic-beta.fine-grained-tool-streaming-2025-05-14",
+        "anthropic-beta.effort-2025-11-24",
+    )
+    assert decoded.request.reasoning_effort == "high"
+    assert decoded.request.provider_thinking_config == {"type": "enabled"}
+    assert [tool.name for tool in decoded.request.tools] == ["Bash"]

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.49"
+version = "0.3.50"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.49"
+version = "0.3.50"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.49"
+version = "0.3.50"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -57,6 +57,27 @@ impl Normalizer {
                     "Anthropic cache_creation_input_tokens",
                 )
                 .map_err(|message| malformed(&message))?;
+                self.output_tokens =
+                    count_or_zero(usage, "output_tokens", "Anthropic output_tokens")
+                        .map_err(|message| malformed(&message))?;
+                // Surface the start-frame meters at once: the Messages encoder
+                // mirrors them on its own `message_start` (Claude Code reads
+                // the input legs there), and the settlement tracker holds them
+                // as the best known count until the terminal report, which
+                // supersedes them at `message_stop` (server-tool turns re-read
+                // fetched results as input, so the start count undercounts).
+                let input_tokens = bounded_ledger_sum(
+                    &[self.input_tokens, self.cache_read, self.cache_write],
+                    "Anthropic input",
+                )
+                .map_err(|message| malformed(&message))?;
+                events.push(Event::Usage(Usage {
+                    input_tokens: Some(input_tokens),
+                    output_tokens: Some(self.output_tokens),
+                    cached_input_tokens: Some(self.cache_read),
+                    cache_creation_input_tokens: (self.cache_write > 0).then_some(self.cache_write),
+                    reasoning_tokens: None,
+                }));
             }
             "content_block_start" => {
                 let index = require_u64(&payload, "index", "Anthropic content index")
@@ -409,7 +430,16 @@ mod tests {
             "type": "message_start",
             "message": {"usage": {"input_tokens": 2230, "output_tokens": 25}},
         }));
-        assert!(normalizer.feed(&start_message).expect("start").is_empty());
+        // The start-frame meters surface early so the Messages encoder can put
+        // them on its own `message_start` (Claude Code reads input there); the
+        // terminal report still supersedes them at `message_stop`.
+        assert!(matches!(
+            normalizer.feed(&start_message).expect("start").as_slice(),
+            [Event::Usage(usage)]
+                if usage.input_tokens == Some(2230)
+                    && usage.output_tokens == Some(25)
+                    && usage.cached_input_tokens == Some(0)
+        ));
 
         let start = frame(serde_json::json!({
             "type": "content_block_start",

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -259,6 +259,18 @@ impl MessagesSseEncoder {
         }
     }
 
+    /// Seed the meters `message_start` reports from what the upstream already
+    /// said (an Anthropic upstream's own start frame). `None` keeps the zero
+    /// placeholder an OpenAI-wire upstream forces, whose final meters ride
+    /// `message_delta` (the official SDK accumulators copy them from there).
+    pub fn set_initial_usage(&mut self, usage: Option<Usage>) {
+        if let Some(usage) = usage {
+            if usage.has_token_counts() {
+                self.usage = Some(usage);
+            }
+        }
+    }
+
     /// Attach the authenticated carrier before the terminal is encoded.
     ///
     /// Mirrors `ChatSseEncoder::set_reasoning_content_carrier`: a tool turn's
@@ -303,7 +315,7 @@ impl MessagesSseEncoder {
             "content": [],
             "stop_reason": Value::Null,
             "stop_sequence": Value::Null,
-            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "usage": messages_usage(self.usage.as_ref()),
         });
         // Same body-level disclosure as the Chat and Responses encoders: the
         // Anthropic envelope has no field for it, and the official SDK
@@ -946,3 +958,5 @@ pub(super) fn disclose_ignored_parameters(message: &mut Value, ignored_parameter
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_claude_code;

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -726,7 +726,7 @@ fn exposed_reasoning_events() -> Vec<Event> {
     ]
 }
 
-fn tool_turn_reasoning_events() -> Vec<Event> {
+pub(super) fn tool_turn_reasoning_events() -> Vec<Event> {
     vec![
         Event::ReasoningContentDelta {
             route_sha256: "route-a".to_string(),
@@ -760,7 +760,7 @@ fn tool_turn_reasoning_events() -> Vec<Event> {
     ]
 }
 
-fn frame_names(frames: &[String]) -> Vec<&str> {
+pub(super) fn frame_names(frames: &[String]) -> Vec<&str> {
     frames
         .iter()
         .map(|frame| {
@@ -944,35 +944,4 @@ fn tool_turn_reasoning_without_a_sealed_carrier_fails_closed() {
     let aggregated =
         completed_messages_body_with_reasoning("request-abc", "coding", &events, &[], None, true);
     assert!(aggregated.is_err());
-}
-
-#[test]
-fn a_stop_sequence_ending_a_reasoning_tool_turn_still_needs_and_emits_the_carrier() {
-    // Both completing terminals demand the sealed carrier, so the route must
-    // seal on `StoppedAtSequence` too (Greptile on #897): with the carrier the
-    // trailing redacted block and the terminal frames flow; without it the
-    // encoder fails closed instead of ending the stream short.
-    let mut events = tool_turn_reasoning_events();
-    events.pop();
-    events.push(Event::StoppedAtSequence("STOP".to_string()));
-    let carrier = "x-experiential-hunyuan-reasoning-v1:ZGVw:c2VhbGVk";
-    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
-    encoder.set_reasoning_content_carrier(carrier.to_string());
-    let mut frames = encoder.start().expect("starts");
-    for event in &events {
-        frames.extend(encoder.feed(event).expect("streams"));
-    }
-    let names = frame_names(&frames);
-    assert_eq!(names[names.len() - 2..], ["message_delta", "message_stop"]);
-    assert!(frames
-        .iter()
-        .any(|frame| frame.contains("\"redacted_thinking\"")));
-
-    let mut unsealed = MessagesSseEncoder::new("request-abc", "coding");
-    unsealed.start().expect("starts");
-    let error = events
-        .iter()
-        .find_map(|event| unsealed.feed(event).err())
-        .expect("terminal without a carrier fails");
-    assert!(error.message.contains("not sealed"));
 }

--- a/exp/runtime/gateway/native/src/encode_messages/tests_claude_code.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests_claude_code.rs
@@ -1,0 +1,132 @@
+//! Inline tests for `encode_messages` that pin the Claude Code / Harbor
+//! contracts (2026-09-11): carrier sealing on stop-sequence terminals, the
+//! upstream start-frame meters on `message_start`, and mixed
+//! reasoning+content+tool replies on the aggregate body. A second submodule
+//! file so each stays within the repository line budget.
+
+use super::tests::{frame_names, tool_turn_reasoning_events};
+use super::*;
+
+#[test]
+fn a_stop_sequence_ending_a_reasoning_tool_turn_still_needs_and_emits_the_carrier() {
+    // Both completing terminals demand the sealed carrier, so the route must
+    // seal on `StoppedAtSequence` too (Greptile on #897): with the carrier the
+    // trailing redacted block and the terminal frames flow; without it the
+    // encoder fails closed instead of ending the stream short.
+    let mut events = tool_turn_reasoning_events();
+    events.pop();
+    events.push(Event::StoppedAtSequence("STOP".to_string()));
+    let carrier = "x-experiential-hunyuan-reasoning-v1:ZGVw:c2VhbGVk";
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_reasoning_content_carrier(carrier.to_string());
+    let mut frames = encoder.start().expect("starts");
+    for event in &events {
+        frames.extend(encoder.feed(event).expect("streams"));
+    }
+    let names = frame_names(&frames);
+    assert_eq!(names[names.len() - 2..], ["message_delta", "message_stop"]);
+    assert!(frames
+        .iter()
+        .any(|frame| frame.contains("\"redacted_thinking\"")));
+
+    let mut unsealed = MessagesSseEncoder::new("request-abc", "coding");
+    unsealed.start().expect("starts");
+    let error = events
+        .iter()
+        .find_map(|event| unsealed.feed(event).err())
+        .expect("terminal without a carrier fails");
+    assert!(error.message.contains("not sealed"));
+}
+
+#[test]
+fn start_frame_carries_the_upstream_start_usage_when_known() {
+    // An Anthropic upstream reports its input and cache meters on its own
+    // message_start; the gateway's message_start mirrors them (input excludes
+    // cached reads, as on the terminal frame) instead of the zero placeholder.
+    // An OpenAI-wire upstream reports nothing before its final chunk, so the
+    // placeholder stays and the final meters ride message_delta.
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_initial_usage(Some(Usage {
+        input_tokens: Some(2230),
+        output_tokens: Some(25),
+        cached_input_tokens: Some(2000),
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    }));
+    let frames = encoder.start().expect("starts");
+    let start: Value = serde_json::from_str(
+        frames[0]
+            .lines()
+            .nth(1)
+            .and_then(|line| line.strip_prefix("data: "))
+            .expect("data line"),
+    )
+    .expect("json");
+    assert_eq!(
+        start["message"]["usage"],
+        json!({"input_tokens": 230, "output_tokens": 25, "cache_read_input_tokens": 2000})
+    );
+
+    let mut bare = MessagesSseEncoder::new("request-abc", "coding");
+    bare.set_initial_usage(None);
+    let frames = bare.start().expect("starts");
+    let start: Value = serde_json::from_str(
+        frames[0]
+            .lines()
+            .nth(1)
+            .and_then(|line| line.strip_prefix("data: "))
+            .expect("data line"),
+    )
+    .expect("json");
+    assert_eq!(
+        start["message"]["usage"],
+        json!({"input_tokens": 0, "output_tokens": 0})
+    );
+}
+
+#[test]
+fn a_reply_with_reasoning_text_and_a_tool_call_renders_every_part_on_the_aggregate_body() {
+    // Production 2026-09-11 (request-4e333079…, hy4-preview, non-streaming,
+    // tools present, budget 32000): the body carried ONE thinking block and
+    // stop_reason end_turn. If the model had also produced text or a tool
+    // call, the aggregate path must render them beside the thinking block;
+    // a thinking-only body therefore reflects the model's own output.
+    let mut events = vec![
+        Event::ReasoningContentDelta {
+            route_sha256: "route-a".to_string(),
+            delta: "plan first".to_string(),
+        },
+        Event::TextDelta("Running the lookup.".to_string()),
+    ];
+    events.extend(tool_turn_reasoning_events().into_iter().skip(1));
+    let aggregated = completed_messages_body_with_reasoning(
+        "request-abc",
+        "coding",
+        &events,
+        &[],
+        Some("x-experiential-hunyuan-reasoning-v1:sealed"),
+        true,
+    )
+    .expect("aggregates");
+    let content = aggregated.body["content"]
+        .as_array()
+        .expect("content array");
+    let types: Vec<&str> = content
+        .iter()
+        .map(|block| block["type"].as_str().expect("typed block"))
+        .collect();
+    assert!(types.contains(&"thinking"), "{types:?}");
+    assert!(types.contains(&"text"), "{types:?}");
+    assert!(types.contains(&"tool_use"), "{types:?}");
+    assert_eq!(aggregated.body["stop_reason"], json!("tool_use"));
+    let text = content
+        .iter()
+        .find(|block| block["type"] == json!("text"))
+        .expect("text block");
+    assert_eq!(text["text"], json!("Running the lookup."));
+    let tool = content
+        .iter()
+        .find(|block| block["type"] == json!("tool_use"))
+        .expect("tool block");
+    assert_eq!(tool["name"], json!("lookup"));
+}

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -559,6 +559,10 @@ async fn stream_messages(
 
         // Mirror any prefix-peeked first token before a start-frame send can cancel and drop it.
         guard.record_first_token(committed.relay.first_token_at());
+        // An Anthropic upstream reports its input and cache meters on its own
+        // start frame, tracked pre-commit; put them on the caller's
+        // `message_start` instead of the zero placeholder.
+        encoder.set_initial_usage(usage.clone());
         let start_frames = match encoder.start() {
             Ok(frames) => frames,
             Err(_) => {

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -4986,7 +4986,10 @@ def test_adaptive_thinking_drops_with_the_effort_on_a_reasoning_less_route(
         }
     )
     admission = _flatten_started(control, _admit(control, raw_key, body, surface="messages"))
-    assert admission["ignored_parameters"] == ["reasoning_effort", "thinking"]
+    assert admission["ignored_parameters"] == [
+        "reasoning_effort",
+        "thinking->dropped(unsupported_by_route)",
+    ]
     upstream = admission["upstream_payload"]
     assert isinstance(upstream, dict)
     assert "thinking" not in upstream

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -619,11 +619,27 @@ ANTHROPIC_THINKING_EVENTS: tuple[JsonObject, ...] = (
 )
 
 
+def _anthropic_start_usage(input_tokens: int, output_tokens: int, cached: int) -> dict[str, object]:
+    """The usage event an Anthropic ``message_start`` now surfaces before content.
+
+    The start-frame meters reach the Messages encoder's own ``message_start``
+    (Claude Code reads input there) and stand in for settlement until the
+    terminal report supersedes them at ``message_stop``.
+    """
+    return {
+        "kind": "usage",
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cached_input_tokens": cached,
+        "reasoning_tokens": None,
+    }
+
+
 def test_native_anthropic_normalizer_emits_thinking_events() -> None:
     """Extended-thinking frames normalize to dedicated events, never silence."""
     result = _native_normalized("anthropic_messages", ANTHROPIC_THINKING_CHUNKS)
     assert result["failure"] is None
-    assert result["events"] == list(ANTHROPIC_THINKING_EVENTS)
+    assert result["events"] == [_anthropic_start_usage(8, 0, 2), *ANTHROPIC_THINKING_EVENTS]
 
 
 # Captured from a live api.anthropic.com tool_use stream (2026-08-28,
@@ -682,7 +698,7 @@ def test_native_anthropic_normalizer_decodes_the_live_tool_use_wire() -> None:
     """The real captured tool_use wire decodes to the canonical event stream."""
     result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_TOOL_FRAMES)
     assert result["failure"] is None
-    assert result["events"] == list(ANTHROPIC_LIVE_TOOL_EVENTS)
+    assert result["events"] == [_anthropic_start_usage(663, 12, 0), *ANTHROPIC_LIVE_TOOL_EVENTS]
 
 
 # Captured live (2026-08-28, claude-haiku-4-5, ids neutralized): a
@@ -718,6 +734,7 @@ def test_native_anthropic_normalizer_completes_a_zero_argument_tool_call() -> No
     result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_ZERO_ARG_FRAMES)
     assert result["failure"] is None
     assert result["events"] == [
+        _anthropic_start_usage(550, 21, 0),
         {"kind": "tool_call_started", "index": 0, "call_id": "toolu_fixture", "name": "get_time"},
         {"kind": "tool_arguments_delta", "index": 0, "text": ""},
         # The completion-time seed streams before the completed call so every
@@ -855,7 +872,10 @@ def test_native_anthropic_normalizer_decodes_the_live_web_search_wire() -> None:
     """
     result = _native_normalized("anthropic_messages", ANTHROPIC_LIVE_WEB_SEARCH_FRAMES)
     assert result["failure"] is None
-    assert result["events"] == list(ANTHROPIC_LIVE_WEB_SEARCH_EVENTS)
+    assert result["events"] == [
+        _anthropic_start_usage(2230, 25, 0),
+        *ANTHROPIC_LIVE_WEB_SEARCH_EVENTS,
+    ]
 
 
 def test_native_responses_preserves_multi_message_status_phase_and_idless_call() -> None:

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -69,8 +69,16 @@ rung whose strict validator requires it."""
 EFFORT_DROP_DISCLOSURE = "reasoning_effort"
 """Disclosure recorded when a zero-reasoning route drops the caller effort."""
 
-THINKING_DROP_DISCLOSURE = "thinking"
-"""Disclosure recorded when a zero-reasoning route drops adaptive thinking."""
+THINKING_DROP_DISCLOSURE = "thinking->dropped(unsupported_by_route)"
+"""Disclosure recorded when a route that cannot honor any depth drops the
+thinking config (no reasoning rung, or no legal budget under the ceiling)."""
+
+THINKING_SUPERSEDED_BY_EFFORT_DISCLOSURE = "thinking->dropped(superseded_by_effort)"
+"""Disclosure recorded when the caller's own effort (``output_config.effort``
+or ``reasoning.effort``) states the depth and the thinking config beside it is
+therefore redundant. Named so a caller never reads it as a stripped depth:
+Harbor read a bare ``thinking`` as "effort high does not apply" (2026-09-11)."""
+
 
 THINKING_DISABLED_DISCLOSURE = "thinking.type->adaptive"
 """Disclosure recorded when an adaptive-only route overrides a disabled thinking config."""
@@ -262,7 +270,7 @@ def _coerce_thinking_to_effort(
         return admitted(
             RequestCoercion(
                 request=request.model_copy(update={"provider_thinking_config": None}),
-                disclosures=(THINKING_DROP_DISCLOSURE,),
+                disclosures=(THINKING_SUPERSEDED_BY_EFFORT_DISCLOSURE,),
             )
         )
     requested_tier = thinking_config_reasoning_effort(config)

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -182,7 +182,7 @@ def test_effort_drop_takes_adaptive_thinking_with_it_but_keeps_a_budget() -> Non
     assert coercion.request.reasoning_effort is None
     assert coercion.request.provider_output_config is None
     assert coercion.request.provider_thinking_config is None
-    assert coercion.disclosures == ("reasoning_effort", "thinking")
+    assert coercion.disclosures == ("reasoning_effort", "thinking->dropped(unsupported_by_route)")
 
     budgeted = adaptive.model_copy(
         update={"provider_thinking_config": {"type": "enabled", "budget_tokens": 2048}}
@@ -483,7 +483,7 @@ def test_disabled_thinking_drops_only_on_adaptive_only_anthropic_routes() -> Non
     # exactly what the route already does).
     shim_only = coerce_generation_parameters((shim,), request)
     assert shim_only is not None
-    assert "thinking" in shim_only.disclosures
+    assert "thinking->dropped(unsupported_by_route)" in shim_only.disclosures
     assert shim_only.request.provider_thinking_config is None
     # Only a disabled config is coercible; other types keep their own path.
     assert (
@@ -596,7 +596,7 @@ def test_adaptive_thinking_drops_when_no_legal_budget_fits_max_tokens() -> None:
     assert coercion.request.provider_thinking_config is None
     # The replayed thinking block survives; the coercion only drops the config.
     assert any(message.provider_reasoning for message in coercion.request.messages)
-    assert coercion.disclosures == ("thinking",)
+    assert coercion.disclosures == ("thinking->dropped(unsupported_by_route)",)
 
 
 def test_adaptive_thinking_drops_on_a_zero_reasoning_route_without_an_effort() -> None:
@@ -628,7 +628,7 @@ def test_adaptive_thinking_drops_on_a_zero_reasoning_route_without_an_effort() -
     assert coercion.request.reasoning_effort is None
     assert coercion.request.provider_thinking_config is None
     assert coercion.request.context_management == {"edits": [{"type": "clear_tool_uses_20250919"}]}
-    assert coercion.disclosures == ("thinking",)
+    assert coercion.disclosures == ("thinking->dropped(unsupported_by_route)",)
 
     only_clear_thinking = adaptive_only.model_copy(
         update={"context_management": {"edits": [{"type": "clear_thinking_20251015"}]}}
@@ -803,7 +803,10 @@ def test_an_explicit_effort_beside_a_thinking_config_wins_verbatim() -> None:
     )
 
     assert coercion is not None
-    assert coercion.disclosures == ("thinking",)
+    # Named supersession, not a bare "thinking": a caller reading the
+    # disclosure list must not conclude their depth was stripped (Harbor read
+    # "thinking" as "effort high does not apply", 2026-09-11).
+    assert coercion.disclosures == ("thinking->dropped(superseded_by_effort)",)
     assert coercion.request.provider_thinking_config is None
     assert coercion.request.reasoning_effort == "low"
 
@@ -817,7 +820,7 @@ def test_a_thinking_config_drops_with_disclosure_on_a_non_reasoning_route() -> N
     )
 
     assert coercion is not None
-    assert "thinking" in coercion.disclosures
+    assert "thinking->dropped(unsupported_by_route)" in coercion.disclosures
     assert coercion.request.provider_thinking_config is None
     assert coercion.request.reasoning_effort is None
 
@@ -832,7 +835,7 @@ def test_an_active_thinking_config_never_snaps_to_none() -> None:
     )
 
     assert coercion is not None
-    assert "thinking" in coercion.disclosures
+    assert "thinking->dropped(unsupported_by_route)" in coercion.disclosures
     assert coercion.request.reasoning_effort is None
 
 
@@ -888,7 +891,7 @@ def test_a_disabled_thinking_config_never_snaps_to_an_active_effort() -> None:
         _messages_request(provider_thinking_config={"type": "disabled"}),
     )
     assert coercion is not None
-    assert "thinking" in coercion.disclosures
+    assert "thinking->dropped(unsupported_by_route)" in coercion.disclosures
     assert coercion.request.reasoning_effort is None
 
     exact = coerce_generation_parameters(
@@ -1009,3 +1012,65 @@ def test_strict_tool_schemas_close_their_objects_for_a_closing_dialect() -> None
     closed_request = coercion.request
     assert coerce_strict_tool_schemas((anthropic,), closed_request) is None
     assert coerce_strict_tool_schemas((anthropic,), _request()) is None
+
+
+def _hy4_route() -> tuple[GatewayWireProfile, GatewayWireProfile]:
+    """The production hy4-preview route: Tencent then OpenRouter, both OpenAI wire."""
+    tencent = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        model_id="hy4-preview",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+        supported_reasoning_efforts=("none", "low", "medium", "high"),
+        reasoning_effort="high",
+    )
+    openrouter = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://openrouter.ai/api/v1",
+        model_id="tencent/hy4-preview",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning",
+        supported_reasoning_efforts=("none", "low", "high"),
+    )
+    return tencent, openrouter
+
+
+def test_thinking_translates_to_an_effort_on_the_hy4_tencent_openrouter_route() -> None:
+    """Claude Code's think-mode config lands on the hy4 ladders as a translation, never a strip.
+
+    Harbor runs Claude Code think-mode-high against hy4-preview served by a
+    Tencent rung (none/low/medium/high) then an OpenRouter rung (none/low/high).
+    A 32k budget must translate to ``high`` with the ``thinking->reasoning_effort``
+    disclosure; a bare enabled config (Claude Code omits the budget) is the
+    default depth; medium narrows onto the one rung that speaks it.
+    """
+    route = _hy4_route()
+    for thinking, expected in (
+        ({"type": "enabled", "budget_tokens": 32000}, "high"),
+        ({"type": "enabled"}, "medium"),
+        ({"type": "enabled", "budget_tokens": 8192}, "medium"),
+        ({"type": "adaptive"}, "medium"),
+    ):
+        coercion = coerce_generation_parameters(
+            route, _messages_request(provider_thinking_config=thinking)
+        )
+        assert coercion is not None, thinking
+        assert coercion.disclosures == (f"thinking->reasoning_effort:{expected}",), thinking
+        assert coercion.request.reasoning_effort == expected
+        assert coercion.request.provider_thinking_config is None
+
+
+def test_output_config_effort_high_beside_thinking_keeps_high_on_the_hy4_route() -> None:
+    """``output_config.effort: high`` (Claude Code's setting) wins; the config drop names why."""
+    coercion = coerce_generation_parameters(
+        _hy4_route(),
+        _messages_request(
+            provider_thinking_config={"type": "enabled", "budget_tokens": 32000},
+            reasoning_effort="high",
+            provider_output_config={"effort": "high"},
+        ),
+    )
+    assert coercion is not None
+    assert coercion.request.reasoning_effort == "high"
+    assert coercion.disclosures == ("thinking->dropped(superseded_by_effort)",)

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
 
 TOOL_RESULT_IMAGE_DROP_DISCLOSURE = "messages.content.tool_result.image->placeholder"
 THINKING_HISTORY_DROP_DISCLOSURE = "messages.thinking->dropped(unsupported_by_provider)"
+
+CACHE_CONTROL_NOT_FORWARDED_SUFFIX = "->not_forwarded(provider_caches_implicitly)"
+"""Suffix for cache-marker disclosures on routes with no Anthropic rung: the
+marker has no wire field there, but the provider still caches the prefix on
+its own (and the ledger bills cache reads at the cached rate), so the wording
+never claims caching is off."""
 """Disclosed when Anthropic-signed thinking history is omitted for a foreign wire."""
 """Disclosure recorded when tool-result images degrade to placeholder text.
 

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -34,11 +34,13 @@ if TYPE_CHECKING:
 TOOL_RESULT_IMAGE_DROP_DISCLOSURE = "messages.content.tool_result.image->placeholder"
 THINKING_HISTORY_DROP_DISCLOSURE = "messages.thinking->dropped(unsupported_by_provider)"
 
-CACHE_CONTROL_NOT_FORWARDED_SUFFIX = "->not_forwarded(provider_caches_implicitly)"
+CACHE_CONTROL_NOT_FORWARDED_SUFFIX = "->not_forwarded(provider_decides_caching)"
 """Suffix for cache-marker disclosures on routes with no Anthropic rung: the
-marker has no wire field there, but the provider still caches the prefix on
-its own (and the ledger bills cache reads at the cached rate), so the wording
-never claims caching is off."""
+marker has no wire field there, so it is not forwarded, and whether the prefix
+is cached is the provider's own decision (OpenAI-family providers cache
+implicitly and the ledger bills those reads at the cached rate; a generic
+endpoint may not cache at all). The wording states exactly that and never
+claims caching is off or on."""
 """Disclosed when Anthropic-signed thinking history is omitted for a foreign wire."""
 """Disclosure recorded when tool-result images degrade to placeholder text.
 

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping
-from typing import cast
+import logging
+from collections.abc import Collection, Mapping, Sequence
+from typing import TYPE_CHECKING, cast
 
 from exp.common.models.known_models import canonical_model_id, known_model_metadata
 from exp.common.models.model import ReasoningEffort
@@ -11,6 +12,12 @@ from exp.runtime.models.providers.errors import (
     ProviderParameterError,
     UnsupportedReasoningEffortError,
 )
+
+if TYPE_CHECKING:
+    from exp.runtime.gateway.contracts import GatewayRequest
+    from exp.runtime.models.providers.base import GatewayWireProfile
+
+_logger = logging.getLogger(__name__)
 
 REASONING_EFFORTS = (
     "none",
@@ -441,3 +448,123 @@ def _require_exact_effort(
 def _normalized_model(model_id: str) -> str:
     """Normalize common provider separators without weakening identity checks."""
     return model_id.lower().replace(".", "-").replace("_", "-")
+
+
+def fill_bare_enabled_budget(
+    config: Mapping[str, object], maximum_output_tokens: int | None
+) -> dict[str, object] | None:
+    """Give a budget-less ``enabled`` thinking config the derived legal budget.
+
+    Claude Code sends ``{"type": "enabled"}``; the Anthropic wire requires
+    ``1024 <= budget_tokens < max_tokens``. The fill is the same derivation the
+    adaptive->enabled translation uses, so both paths agree on the depth an
+    unspecified budget means.
+
+    Args:
+        config: The caller's verbatim thinking object (type ``enabled``, no
+            budget).
+        maximum_output_tokens: The caller's reply ceiling.
+
+    Returns:
+        The config with ``budget_tokens`` filled, or ``None`` when no legal
+        budget fits under the ceiling (the caller cannot request thinking on
+        this turn at all).
+    """
+    budget = anthropic_thinking_budget_tokens(maximum_output_tokens)
+    if budget is None:
+        return None
+    return {**config, "budget_tokens": budget}
+
+
+THINKING_BUDGET_DERIVED_DISCLOSURE = "thinking.budget_tokens->derived"
+"""Disclosure recorded when a bare ``enabled`` config (no budget, Claude Code's
+shape) is forwarded to an Anthropic rung with the gateway's derived budget."""
+
+THINKING_NO_LEGAL_BUDGET_DISCLOSURE = "thinking->dropped(no_legal_budget)"
+"""Disclosure recorded when a bare ``enabled`` config cannot be forwarded
+because no budget in [1024, max_tokens) exists under the caller's ceiling."""
+
+
+def shape_anthropic_thinking_config(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+    provider_updates: dict[str, object],
+    ignored: list[str],
+) -> None:
+    """Family-gate a caller thinking config for a route with Anthropic rungs.
+
+    The adaptive-thinking generation rejects caller ``enabled``/``disabled``
+    configs outright and the budgeted generation rejects ``adaptive`` by name,
+    so verbatim forwarding is decided per model family (a route is one
+    exact-model pool, so the answer is uniform across rungs). The named
+    rejections here are what let the admit loop offer the disclosed coercions
+    instead of the provider's own opaque 400 (which never fails over). A bare
+    ``enabled`` config (Claude Code's shape) gets the derived legal budget,
+    disclosed, or drops with disclosure when no legal budget fits the ceiling.
+
+    Args:
+        profiles: The route's wire profiles.
+        request: The caller's canonical request; ``provider_thinking_config``
+            must be present.
+        provider_updates: The dispatched-request overrides, written in place.
+        ignored: The route's disclosure list, appended in place.
+
+    Raises:
+        ProviderParameterError: The config names a mode this family rejects.
+    """
+    from exp.runtime.models.providers.errors import ProviderParameterError
+
+    config = request.provider_thinking_config
+    if config is None:
+        return
+
+    def disclose(path: str) -> None:
+        if path not in ignored:
+            ignored.append(path)
+
+    config_type = str(config.get("type"))
+    adaptive_only = all(anthropic_adaptive_only_thinking(profile.model_id) for profile in profiles)
+    budgeted_enabled_only = all(
+        profile.dialect == "anthropic_messages"
+        and anthropic_budgeted_enabled_only(profile.model_id)
+        for profile in profiles
+    )
+    if budgeted_enabled_only and config_type == "adaptive":
+        raise ProviderParameterError(
+            message=(
+                "The parameter 'thinking.type' cannot be 'adaptive' on this model: "
+                "it reasons via an explicit token budget. Send thinking "
+                "{type: 'enabled', budget_tokens: N} or remove the field."
+            ),
+            param="thinking.type",
+            code="unsupported_parameter",
+        )
+    if adaptive_only and config_type == "enabled":
+        # Translate to the model's one supported mode, emitted explicitly so
+        # the promise holds even on routes with no pinned effort. The token
+        # budget has no adaptive equivalent, so it is disclosed as ignored
+        # rather than silently mapped onto an effort level.
+        provider_updates["provider_thinking_config"] = {"type": "adaptive"}
+        disclose("thinking.budget_tokens")
+        _logger.warning(
+            "translated a caller 'enabled' thinking config to adaptive for an "
+            "adaptive-only Anthropic route; thinking.budget_tokens was disclosed as ignored"
+        )
+    elif config_type == "enabled" and "budget_tokens" not in config:
+        filled = fill_bare_enabled_budget(config, request.maximum_output_tokens)
+        if filled is None:
+            provider_updates["provider_thinking_config"] = None
+            disclose(THINKING_NO_LEGAL_BUDGET_DISCLOSURE)
+        else:
+            provider_updates["provider_thinking_config"] = filled
+            disclose(THINKING_BUDGET_DERIVED_DISCLOSURE)
+    elif adaptive_only and config_type == "disabled":
+        raise ProviderParameterError(
+            message=(
+                "The parameter 'thinking.type' cannot be 'disabled' on this model: "
+                "it always reasons adaptively. Remove the thinking field or choose "
+                "a model that supports disabling thinking."
+            ),
+            param="thinking.type",
+            code="unsupported_parameter",
+        )

--- a/exp/runtime/models/providers/server_tools.py
+++ b/exp/runtime/models/providers/server_tools.py
@@ -13,10 +13,11 @@ client-facing tool name a Claude Code user recognises.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from exp.runtime.gateway.contracts import GatewayRequest
+    from exp.runtime.gateway.contracts import GatewayMessage, GatewayRequest
 
 # Client-facing labels for the server tools Claude Code exposes, keyed by the
 # Anthropic tool name. Unknown names render bare.
@@ -114,3 +115,102 @@ def anthropic_server_tools_message(names: Sequence[str]) -> str:
         f"to a Claude model alias for requests that use {pronoun}, or disable "
         f"{pronoun} and resend."
     )
+
+
+@dataclass(frozen=True)
+class StrippedServerTools:
+    """The dispatched history with Anthropic server-tool carriers removed."""
+
+    messages: tuple[GatewayMessage, ...]
+    dropped_blocks: bool
+    """Whether any ``server_tool_use`` / ``*_tool_result`` block was removed."""
+    dropped_citations: bool
+    """Whether a cited answer kept its text and lost its citations."""
+
+
+def strip_anthropic_server_tools(messages: Sequence[GatewayMessage]) -> StrippedServerTools:
+    """Remove the Anthropic server-tool carriers a foreign wire cannot replay.
+
+    Used only for a route with NO Anthropic rung (a mixed route still rejects,
+    because its Anthropic rung could run the tool). Echoed ``server_tool_use``
+    and ``*_tool_result`` blocks leave the dispatched history entirely; a
+    cited answer block is server-tool OUTPUT the model already produced, so
+    its text stays as an ordinary assistant turn and only the citations (an
+    Anthropic-only carrier) are dropped. The caller's public request is never
+    touched: the disclosures on it name each removal.
+
+    Args:
+        messages: The dispatched history, possibly already rewritten by an
+            earlier route-shaping step.
+
+    Returns:
+        The rewritten history plus which kinds of carrier were removed.
+    """
+    from exp.runtime.gateway.contracts import GatewayMessage
+
+    kept: list[GatewayMessage] = []
+    dropped_blocks = False
+    dropped_citations = False
+    for message in messages:
+        block = message.provider_anthropic_block
+        if block is None:
+            kept.append(message)
+            continue
+        text = block.get("text") if block.get("type") == "text" else None
+        if isinstance(text, str) and text:
+            kept.append(GatewayMessage(role="assistant", content=text))
+            dropped_citations = True
+            continue
+        dropped_blocks = True
+    return StrippedServerTools(
+        messages=tuple(kept), dropped_blocks=dropped_blocks, dropped_citations=dropped_citations
+    )
+
+
+def disclose_dropped_server_tools(
+    request: GatewayRequest,
+    messages: Sequence[GatewayMessage],
+    ignored: list[str],
+) -> tuple[tuple[GatewayMessage, ...], bool]:
+    """Strip every server-tool carrier for a route with no Anthropic rung, disclosed.
+
+    Rejecting the whole call killed Claude Code turns on hy4-preview
+    (akhara-ai, 2026-09-11) although the agent recovers on its own once the
+    tool is simply absent (it falls back to WebFetch/Bash). The dispatched
+    request drops the declared tool, its echoed history blocks, and a selector
+    that named it, each with its own disclosure; the public request keeps the
+    caller's history verbatim.
+
+    Args:
+        request: The caller's canonical request.
+        messages: The dispatched history so far (an earlier shaping step may
+            already have rewritten it).
+        ignored: The route's disclosure list, appended in place.
+
+    Returns:
+        The rewritten dispatched history and whether ``tool_choice`` must be
+        cleared on the dispatched request.
+    """
+    from exp.runtime.gateway.contracts import GatewayNamedToolChoice
+
+    def disclose(path: str) -> None:
+        if path not in ignored:
+            ignored.append(path)
+
+    stripped = strip_anthropic_server_tools(messages)
+    for entry in request.provider_server_tools:
+        declared = entry.get("name") or entry.get("type")
+        if isinstance(declared, str) and declared:
+            disclose(f"tools.{declared}->dropped(unsupported_by_provider)")
+    if stripped.dropped_blocks:
+        disclose("messages.server_tool_blocks->dropped(unsupported_by_provider)")
+    if stripped.dropped_citations:
+        disclose("messages.content.citations->dropped(unsupported_by_provider)")
+    server_tool_names = anthropic_server_tool_names(request)
+    clear_tool_choice = (
+        isinstance(request.tool_choice, GatewayNamedToolChoice)
+        and request.tool_choice.name in server_tool_names
+    ) or (request.tool_choice == "required" and not request.tools)
+    if clear_tool_choice:
+        disclose("tool_choice->dropped(unsupported_by_provider)")
+    return stripped.messages, clear_tool_choice

--- a/exp/runtime/models/providers/streaming_requests.py
+++ b/exp/runtime/models/providers/streaming_requests.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
+    GatewayMessage,
     GatewayNamedToolChoice,
     GatewayRequest,
 )
 from exp.runtime.models.providers.dialect_dispatch import (
-    SERVICE_TIER_DIALECTS as SERVICE_TIER_DIALECTS,
+    CACHE_CONTROL_NOT_FORWARDED_SUFFIX,
+    THINKING_HISTORY_DROP_DISCLOSURE,
 )
 from exp.runtime.models.providers.dialect_dispatch import (
-    THINKING_HISTORY_DROP_DISCLOSURE,
+    SERVICE_TIER_DIALECTS as SERVICE_TIER_DIALECTS,
 )
 from exp.runtime.models.providers.dialect_dispatch import (
     TOOL_RESULT_IMAGE_DROP_DISCLOSURE as TOOL_RESULT_IMAGE_DROP_DISCLOSURE,
@@ -73,13 +75,13 @@ from exp.runtime.models.providers.openai_payloads import (
 )
 from exp.runtime.models.providers.reasoning_compat import (
     REASONING_EFFORTS,
-    anthropic_adaptive_only_thinking,
-    anthropic_budgeted_enabled_only,
+    shape_anthropic_thinking_config,
 )
 from exp.runtime.models.providers.server_tools import (
     anthropic_server_tool_names,
     anthropic_server_tools_message,
     anthropic_server_tools_present,
+    disclose_dropped_server_tools,
 )
 
 if TYPE_CHECKING:
@@ -501,7 +503,7 @@ def route_generation_parameter_requests(
     if request.provider_cache_control is not None and not any(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
-        ignore("provider_cache_control", "cache_control")
+        ignore("provider_cache_control", f"cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}")
     if request.inference_geo is not None and not all(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
@@ -563,8 +565,9 @@ def route_generation_parameter_requests(
         for message in request.messages
         for call in message.tool_calls
     ) and not all(profile.dialect == "anthropic_messages" for profile in profiles):
-        if "messages.tool_calls.cache_control" not in ignored:
-            ignored.append("messages.tool_calls.cache_control")
+        tool_call_marker = f"messages.tool_calls.cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}"
+        if tool_call_marker not in ignored:
+            ignored.append(tool_call_marker)
 
     # Block-level cache markers (system and message text runs, tool-result
     # breakpoints) follow the #699 rule: kept while ANY rung is Anthropic
@@ -576,8 +579,9 @@ def route_generation_parameter_requests(
         message.provider_text_blocks or message.cache_control is not None
         for message in request.messages
     ) and not any(profile.dialect == "anthropic_messages" for profile in profiles):
-        if "messages.content.cache_control" not in ignored:
-            ignored.append("messages.content.cache_control")
+        content_marker = f"messages.content.cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}"
+        if content_marker not in ignored:
+            ignored.append(content_marker)
 
     # LiteLLM stamps ``provider_specific_fields`` on every assistant message it
     # returns, and naive agent loops echo the dump back verbatim. No wire takes
@@ -592,7 +596,10 @@ def route_generation_parameter_requests(
     # rejection (Claude Code sends eager_input_streaming conditionally).
     if not all(profile.dialect == "anthropic_messages" for profile in profiles):
         tool_annotation_paths = (
-            ("tools.cache_control", any(tool.cache_control is not None for tool in request.tools)),
+            (
+                f"tools.cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}",
+                any(tool.cache_control is not None for tool in request.tools),
+            ),
             (
                 "tools.eager_input_streaming",
                 any(tool.eager_input_streaming is not None for tool in request.tools),
@@ -717,69 +724,31 @@ def route_generation_parameter_requests(
             code="unsupported_parameter",
         )
     if request.provider_thinking_config is not None and not non_anthropic_route:
-        # The adaptive-thinking generation rejects caller enabled/disabled
-        # configs outright, so verbatim forwarding is family-gated (a route
-        # is one exact-model pool, so the answer is uniform across rungs).
-        config_type = str(request.provider_thinking_config.get("type"))
-        adaptive_only = all(
-            anthropic_adaptive_only_thinking(profile.model_id) for profile in profiles
-        )
-        # A budgeted-enabled-only model (haiku-4-5) rejects an adaptive config
-        # by NAME; the named rejection here is what lets the admit loop offer
-        # the disclosed adaptive->enabled(budget) coercion instead of the
-        # provider's own opaque 400 (which never fails over).
-        budgeted_enabled_only = all(
-            profile.dialect == "anthropic_messages"
-            and anthropic_budgeted_enabled_only(profile.model_id)
-            for profile in profiles
-        )
-        if budgeted_enabled_only and config_type == "adaptive":
-            raise ProviderParameterError(
-                message=(
-                    "The parameter 'thinking.type' cannot be 'adaptive' on this model: "
-                    "it reasons via an explicit token budget. Send thinking "
-                    "{type: 'enabled', budget_tokens: N} or remove the field."
-                ),
-                param="thinking.type",
-                code="unsupported_parameter",
-            )
-        if adaptive_only and config_type == "enabled":
-            # Translate to the model's one supported mode, emitted explicitly
-            # so the promise holds even on routes with no pinned effort. The
-            # token budget has no adaptive equivalent, so it is disclosed as
-            # ignored rather than silently mapped onto an effort level.
-            provider_updates["provider_thinking_config"] = {"type": "adaptive"}
-            if "thinking.budget_tokens" not in ignored:
-                ignored.append("thinking.budget_tokens")
-            _logger.warning(
-                "translated a caller 'enabled' thinking config to adaptive for an "
-                "adaptive-only Anthropic route; thinking.budget_tokens was disclosed "
-                "as ignored"
-            )
-        elif adaptive_only and config_type == "disabled":
-            raise ProviderParameterError(
-                message=(
-                    "The parameter 'thinking.type' cannot be 'disabled' on this model: "
-                    "it always reasons adaptively. Remove the thinking field or choose "
-                    "a model that supports disabling thinking."
-                ),
-                param="thinking.type",
-                code="unsupported_parameter",
-            )
+        shape_anthropic_thinking_config(profiles, request, provider_updates, ignored)
     if anthropic_server_tools_present(request) and not all(
         profile.dialect == "anthropic_messages" for profile in profiles
     ):
         server_tool_names = anthropic_server_tool_names(request)
-        # Server tools execute inside Anthropic's API; silently dropping a
-        # search capability the caller asked for would be a behavior lie, so
-        # a route that cannot serve them rejects and NAMES the tool (Claude
-        # Code's WebSearch is the common case) so the caller knows which
-        # feature needs a Claude model.
-        raise ProviderParameterError(
-            message=anthropic_server_tools_message(server_tool_names),
-            param="tools",
-            code="unsupported_parameter",
+        if any(profile.dialect == "anthropic_messages" for profile in profiles):
+            # A mixed route has a rung that could run the tool; the request
+            # still cannot be served uniformly, so it rejects and NAMES the
+            # tool (Claude Code's WebSearch is the common case).
+            raise ProviderParameterError(
+                message=anthropic_server_tools_message(server_tool_names),
+                param="tools",
+                code="unsupported_parameter",
+            )
+        # No rung on this route can run an Anthropic server tool: the
+        # dispatched request drops the carriers with disclosure and the turn
+        # serves (see ``disclose_dropped_server_tools``).
+        current_messages = provider_updates.get("messages", request.messages)
+        stripped_messages, clear_tool_choice = disclose_dropped_server_tools(
+            request, cast("Sequence[GatewayMessage]", current_messages), ignored
         )
+        provider_updates["messages"] = stripped_messages
+        provider_updates["provider_server_tools"] = ()
+        if clear_tool_choice:
+            provider_updates["tool_choice"] = None
     if any(message.provider_native_item is not None for message in request.messages) and not all(
         profile.dialect == "openai_responses" for profile in profiles
     ):

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1234,7 +1234,9 @@ def test_mixed_route_keeps_the_prompt_cache_marker_when_any_rung_is_anthropic() 
     # No rung can cache: dropped with disclosure.
     public_only, provider_only = route_generation_parameter_requests((fallback,), request)
     assert provider_only.provider_cache_control is None
-    assert "cache_control" in public_only.ignored_parameters
+    assert (
+        "cache_control->not_forwarded(provider_caches_implicitly)" in public_only.ignored_parameters
+    )
 
 
 def test_route_shaping_omits_parallel_control_when_tool_choice_disables_tools() -> None:
@@ -2596,12 +2598,15 @@ def test_tool_call_cache_hint_forwards_to_anthropic_and_discloses_elsewhere() ->
         (GatewayWireProfile(dialect="openai_compatible", url="https://openai.test"),),
         request,
     )
-    assert "messages.tool_calls.cache_control" in public.ignored_parameters
+    assert (
+        "messages.tool_calls.cache_control->not_forwarded(provider_caches_implicitly)"
+        in public.ignored_parameters
+    )
     anthropic_public, _provider = route_generation_parameter_requests(
         (GatewayWireProfile(dialect="anthropic_messages", url="https://anthropic.test"),),
         request,
     )
-    assert "messages.tool_calls.cache_control" not in anthropic_public.ignored_parameters
+    assert not any("cache_control" in path for path in anthropic_public.ignored_parameters)
 
     # The hint never perturbs digests, artifacts, or replay identity.
     bare = hinted.model_copy(update={"cache_control": None})
@@ -3043,7 +3048,7 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
     # rungs.
     assert set(mixed_public.ignored_parameters) == {
         "inference_geo",
-        "tools.cache_control",
+        "tools.cache_control->not_forwarded(provider_caches_implicitly)",
         "tools.eager_input_streaming",
         "tools.defer_loading",
         "tools.allowed_callers",
@@ -3282,10 +3287,16 @@ def test_block_cache_markers_reach_the_anthropic_wire_and_survive_mixed_routes()
     mixed_public, mixed_provider = route_generation_parameter_requests(
         (anthropic, fallback), request
     )
-    assert "messages.content.cache_control" not in mixed_public.ignored_parameters
+    assert not any("cache_control" in path for path in mixed_public.ignored_parameters)
     assert mixed_provider.messages[0].provider_text_blocks
     foreign_public, _foreign_provider = route_generation_parameter_requests((fallback,), request)
-    assert "messages.content.cache_control" in foreign_public.ignored_parameters
+    # Not "ignored": the provider still caches the prefix implicitly (Harbor saw
+    # 14,976 cached tokens billed at the cached rate beside this disclosure),
+    # so the wording says what actually happens to the marker.
+    assert (
+        "messages.content.cache_control->not_forwarded(provider_caches_implicitly)"
+        in foreign_public.ignored_parameters
+    )
 
 
 def test_litellm_provider_specific_fields_are_dropped_with_disclosure_on_every_route() -> None:
@@ -4839,3 +4850,123 @@ def test_a_tool_result_name_drops_with_disclosure_off_the_openai_wires() -> None
     )
     # Namespace/caller attribution stays a Responses-only concern.
     assert not any("attribution" in path for path in public_request.ignored_parameters)
+
+
+def _hy4_foreign_route() -> tuple[GatewayWireProfile, GatewayWireProfile]:
+    """hy4-preview's production route: two OpenAI-wire rungs, no Anthropic rung."""
+    return (
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+            model_id="hy4-preview",
+        ),
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://openrouter.ai/api/v1",
+            model_id="tencent/hy4-preview",
+        ),
+    )
+
+
+def test_server_tools_drop_with_disclosure_on_an_all_foreign_route() -> None:
+    """Claude Code's WebSearch on a non-Anthropic route serves the turn minus the tool.
+
+    Two akhara-ai requests died on the named 400 on 2026-09-11 (hy4-preview,
+    tencent+openrouter). The agent recovers with WebFetch/Bash when the tool is
+    simply absent, so a route with NO Anthropic rung now strips the server tool
+    and its echoed history blocks from the dispatched request with per-path
+    disclosures; the public request keeps the caller's history verbatim. A
+    mixed route still rejects (its Anthropic rung could serve the tool).
+    """
+    request = _web_search_messages_request(
+        echoed_block=True, tool_choice=GatewayNamedToolChoice(name="web_search")
+    )
+    public, provider = route_generation_parameter_requests(_hy4_foreign_route(), request)
+    assert provider.provider_server_tools == ()
+    assert all(message.provider_anthropic_block is None for message in provider.messages)
+    assert [message.role for message in provider.messages] == ["user", "user"]
+    assert provider.tool_choice is None
+    assert set(public.ignored_parameters) >= {
+        "tools.web_search->dropped(unsupported_by_provider)",
+        "messages.server_tool_blocks->dropped(unsupported_by_provider)",
+        "tool_choice->dropped(unsupported_by_provider)",
+    }
+    # The caller's own history is untouched on the public copy.
+    assert public.provider_server_tools == request.provider_server_tools
+    assert any(message.provider_anthropic_block is not None for message in public.messages)
+
+    # A cited answer block (server-tool output) keeps its text and loses only
+    # the citations the foreign wire cannot carry.
+    cited = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(
+            GatewayMessage(role="user", content="search"),
+            GatewayMessage(
+                role="assistant",
+                provider_anthropic_block={
+                    "type": "text",
+                    "text": "Python 3.13 is out.",
+                    "citations": [{"type": "web_search_result_location", "url": "https://x"}],
+                },
+            ),
+            GatewayMessage(role="user", content="and now?"),
+        ),
+        maximum_output_tokens=256,
+        maximum_output_tokens_parameter="max_tokens",
+        stream=True,
+        include_usage=True,
+    )
+    public, provider = route_generation_parameter_requests(_hy4_foreign_route(), cited)
+    assert provider.messages[1].content == "Python 3.13 is out."
+    assert provider.messages[1].provider_anthropic_block is None
+    assert "messages.content.citations->dropped(unsupported_by_provider)" in (
+        public.ignored_parameters
+    )
+
+
+def test_a_bare_enabled_thinking_config_gets_a_derived_budget_on_an_anthropic_route() -> None:
+    """Claude Code omits budget_tokens; the Anthropic wire requires one, so it is derived.
+
+    Anthropic rejects ``{type: enabled}`` without a budget (minimum 1024, below
+    max_tokens), so a budgeted-only Anthropic route fills the same derived
+    budget the adaptive->enabled translation uses and discloses the fill; with
+    no legal budget under the ceiling the config drops with disclosure.
+    """
+    haiku = _anthropic_profile("claude-haiku-4-5")
+    public, provider = route_generation_parameter_requests(
+        (haiku,), _messages_request(thinking={"type": "enabled"}, maximum_output_tokens=4096)
+    )
+    assert provider.provider_thinking_config == {"type": "enabled", "budget_tokens": 2048}
+    assert "thinking.budget_tokens->derived" in public.ignored_parameters
+
+    public, provider = route_generation_parameter_requests(
+        (haiku,), _messages_request(thinking={"type": "enabled"}, maximum_output_tokens=1024)
+    )
+    assert provider.provider_thinking_config is None
+    assert "thinking->dropped(no_legal_budget)" in public.ignored_parameters
+
+
+def test_claude_code_beta_tokens_disclose_without_dropping_the_request_on_a_foreign_route() -> None:
+    """Forwarded-class beta tokens are disclosed no-ops off the Anthropic wire; nothing else
+    moves."""
+    request = _messages_request(maximum_output_tokens=4096).model_copy(
+        update={
+            "provider_beta_tokens": (
+                "interleaved-thinking-2025-05-14",
+                "context-management-2025-06-27",
+            ),
+            "tools": (
+                GatewayToolDefinition(
+                    name="Bash", description="run", parameters={"type": "object", "properties": {}}
+                ),
+            ),
+        }
+    )
+    public, provider = route_generation_parameter_requests(_hy4_foreign_route(), request)
+    assert provider.provider_beta_tokens == ()
+    assert {
+        "anthropic-beta.interleaved-thinking-2025-05-14",
+        "anthropic-beta.context-management-2025-06-27",
+    } <= set(public.ignored_parameters)
+    assert [tool.name for tool in provider.tools] == ["Bash"]
+    assert provider.messages == request.messages

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -1235,7 +1235,7 @@ def test_mixed_route_keeps_the_prompt_cache_marker_when_any_rung_is_anthropic() 
     public_only, provider_only = route_generation_parameter_requests((fallback,), request)
     assert provider_only.provider_cache_control is None
     assert (
-        "cache_control->not_forwarded(provider_caches_implicitly)" in public_only.ignored_parameters
+        "cache_control->not_forwarded(provider_decides_caching)" in public_only.ignored_parameters
     )
 
 
@@ -2599,7 +2599,7 @@ def test_tool_call_cache_hint_forwards_to_anthropic_and_discloses_elsewhere() ->
         request,
     )
     assert (
-        "messages.tool_calls.cache_control->not_forwarded(provider_caches_implicitly)"
+        "messages.tool_calls.cache_control->not_forwarded(provider_decides_caching)"
         in public.ignored_parameters
     )
     anthropic_public, _provider = route_generation_parameter_requests(
@@ -3048,7 +3048,7 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
     # rungs.
     assert set(mixed_public.ignored_parameters) == {
         "inference_geo",
-        "tools.cache_control->not_forwarded(provider_caches_implicitly)",
+        "tools.cache_control->not_forwarded(provider_decides_caching)",
         "tools.eager_input_streaming",
         "tools.defer_loading",
         "tools.allowed_callers",
@@ -3294,7 +3294,7 @@ def test_block_cache_markers_reach_the_anthropic_wire_and_survive_mixed_routes()
     # 14,976 cached tokens billed at the cached rate beside this disclosure),
     # so the wording says what actually happens to the marker.
     assert (
-        "messages.content.cache_control->not_forwarded(provider_caches_implicitly)"
+        "messages.content.cache_control->not_forwarded(provider_decides_caching)"
         in foreign_public.ignored_parameters
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.49,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.50,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.49"
+version = "0.3.50"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

Spandana's 2026-09-11 feedback running Claude Code think-mode-high against `hy4-preview` on `/v1/messages` (Tencent + OpenRouter OpenAI-wire rungs, no Anthropic rung), confirmed live on production engine 0.7.64 by the coordinator (04:54Z): a bare `thinking: {type: enabled}` 400s, `web_search` 400s the whole turn, cache markers are disclosed as "ignored" while cache reads are billed, the `thinking` disclosure reads as "stripped" although the translation applied, and Claude Code logs `input_tokens: 0` because our `message_start` carries a zero placeholder.

## Checklist

- [x] **1. Bare `thinking: {type: "enabled"}` no longer 400s.** Anthropic's API requires `budget_tokens` on `enabled` (min 1024, below `max_tokens`; Claude 4.7+ reject `enabled` outright), so the gateway boundary accepts the bare form and route shaping does the right thing per rung: an Anthropic rung gets the derived legal budget (`thinking.budget_tokens->derived`; `thinking->dropped(no_legal_budget)` when none fits under the ceiling), an adaptive-only Anthropic model still translates to `adaptive`, and an effort route reads it as the default depth (`thinking->reasoning_effort:medium`). `_ThinkingConfig` validator, `shape_anthropic_thinking_config` + `fill_bare_enabled_budget` (reasoning_compat.py, extracted from `route_generation_parameter_requests` to stay under the line budget).
- [x] **2. Thinking never reads as "stripped".** Live: `thinking {enabled, 32000}` on hy4 translates to `thinking->reasoning_effort:high` (already correct). What Harbor saw was the bare `thinking` disclosure of the SUPERSEDED path: Claude Code sends `output_config: {effort: high}`, which already states the depth, so the config beside it dropped with a bare `thinking`. Vocabulary now names the outcome: `thinking->dropped(superseded_by_effort)` and `thinking->dropped(unsupported_by_route)`. New tests pin the exact hy4 route (Tencent `none/low/medium/high` default high, OpenRouter `none/low/high`): 32k → high, bare → medium, 8192 → medium (narrows onto Tencent), adaptive → medium, `output_config.effort: high` beside a config → high with the supersession disclosure.
- [x] **3. Server tools on a route with NO Anthropic rung: disclosed drop, not 400.** Prior design rejected on purpose ("silently dropping a search capability would be a behavior lie"); two akhara-ai turns died on it. The disclosure is not silent, and the agent recovers with WebFetch/Bash once the tool is simply absent, so the dispatched request drops the declared tool (`tools.web_search->dropped(unsupported_by_provider)`), echoed `server_tool_use`/`*_tool_result` blocks (`messages.server_tool_blocks->dropped(...)`), the citations of a cited answer whose text stays (`messages.content.citations->dropped(...)`), and a selector that named the tool (`tool_choice->dropped(...)`); the public request keeps the caller's history verbatim. A MIXED route (Anthropic rung beside another) still rejects by name (existing test kept).
- [x] **4. `cache_control` wording.** `<path>.cache_control->not_forwarded(provider_decides_caching)` for the top-level, content, tool-call and tool-definition markers on routes with no Anthropic rung. Nothing is forwarded (there is no field), the provider caches on its own, and the ledger bills cached reads at the cached rate (Harbor: 14,976 cached tokens beside an "ignored" marker).
- [x] **5. `anthropic-beta` headers.** Verified and pinned with Claude Code's live header set (`claude-code-20250219, interleaved-thinking-2025-05-14, fine-grained-tool-streaming-2025-05-14, effort-2025-11-24, context-management-2025-06-27`): allowlisted tokens forward on Anthropic rungs, every other token is a per-token disclosure, and on a foreign route the forwarded class is disclosed too while tools/messages/effort are untouched. No behavior change.
- [x] **6. Stream usage shape.** Contract: `message_start.message.usage` carries what the upstream already reported before content; `message_delta.usage` carries the FULL final meters (input, output, `cache_read_input_tokens`, `cache_creation_input_tokens` when >0, plus the platform's cost fields). An **Anthropic upstream** reports input/cache on its own start frame: the dialect now surfaces that as an early `Usage` event (tracked pre-commit, superseded by the terminal report at `message_stop`) and the encoder mirrors it on our `message_start` instead of `{0, 0}`. An **OpenAI-wire upstream** (hy4's rungs) reports usage only in its final chunk, so `message_start` keeps the zero placeholder — option (b): nothing earlier is knowable without buffering the whole stream. SDK check: the Anthropic Python SDK 0.75.0 (`anthropic/lib/streaming/_messages.py`, `_accumulate_event`) and the TypeScript SDK `main` (`MessageStream.ts` `#accumulateMessage`) both copy `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens` and `output_tokens` from `message_delta` when present, so their final message shows the true counts. A client that reads only `message_start` still sees zeros on OpenAI-wire rungs; that is the documented limit. Side effect to know: a mid-stream failure on an Anthropic rung now settles with the start-frame counts (exact input, ~1 output) instead of "unknown usage". Crate 0.3.49 → 0.3.50.
- [x] **7. Execution deadline vs long think-mode turns (analysis, no code).** The per-request deadline is `now + request_timeout_seconds` at admission (`native_bridge.py` L326/L855; engine default `_REQUEST_TIMEOUT_SECONDS = 120`, the platform worker passes 600 from `explabs/gateway/worker.py:198`), the relay classifies a stalled read past it as `Timeout` "gateway execution deadline exceeded" (`relay.rs:72`), and the platform edge holds 660 s (`serving_gateway.py:66`). It is per WORKER, not per deployment or key. Observed hy4: 165–447 s for 10k–24k output tokens (~55 tok/s); a 64k-output turn needs ~20 min and cannot finish. Smallest safe change: derive the deadline from the caller's `max_tokens` — `max(floor, first_byte_allowance + max_tokens × COMPLETION_SECONDS_PER_OUTPUT_TOKEN)` (the constant already exists: `base.py:56`, 0.03 s/token ≈ 33 tok/s → 64k ≈ 1,966 s) capped by a configured ceiling, with the platform raising the chain in lockstep (worker `request_timeout_seconds` → ceiling, edge `_TOTAL_TIMEOUT_SECONDS` = ceiling + 60, ingress-nginx `proxy-read-timeout` and the load-balancer idle timeout above it; streaming keeps the socket alive). Deliberately not implemented here: it spans the platform's whole timeout chain and the edge, so it is a platform-led change with an engine knob.
- [x] **8. Thinking-only `end_turn` reply.** Pinned that the aggregate body renders every part of a reply carrying reasoning + text + a tool call (`a_reply_with_reasoning_text_and_a_tool_call_renders_every_part_on_the_aggregate_body`; the existing `exposed_reasoning_streams_as_an_unsigned_thinking_block` already pinned thinking + text). So request-4e333079's one-thinking-block body with `output_tokens: 125` reflects Hy4's own output (it reasoned and stopped), not an encoder drop.

## Tests first

Red on unchanged code (12 Python failures + Rust compile failure), then green:

```
FAILED requests_test::test_thinking_config_is_carried_verbatim                                 (400 on bare enabled)
FAILED requests_test::test_claude_code_beta_header_set_decodes_with_per_token_disclosures
FAILED capability_policy_test::{…drops_when_no_legal_budget…, …zero_reasoning_route…, …explicit_effort_beside_a_thinking_config…, test_output_config_effort_high_beside_thinking_keeps_high_on_the_hy4_route}   (bare "thinking")
FAILED streaming_requests_test::{…tool_call_cache_hint…, …tool_annotations…, …block_cache_markers…}   (old cache_control wording)
FAILED streaming_requests_test::test_server_tools_drop_with_disclosure_on_an_all_foreign_route   (400)
FAILED streaming_requests_test::test_a_bare_enabled_thinking_config_gets_a_derived_budget_on_an_anthropic_route
FAILED streaming_requests_test::test_claude_code_beta_tokens_disclose_without_dropping_the_request_on_a_foreign_route
error[E0599]: no method named `set_initial_usage` … (start_frame_carries_the_upstream_start_usage_when_known; dialect test asserting the early Usage event)
```

After: `uv run pytest -q exp` 4,141 passed / 6 skipped (the two evidence tests and release tests pass on the committed tree); `cargo test` 285 passed; `cargo fmt --check`, `clippy -D warnings`, `ruff check`, `ruff format --check`, `ty check` clean. `encode_messages/tests.rs` split into `tests_claude_code.rs` to stay under the 999-line budget.

## Release step

Cut BOTH `experiential` (next patch after 0.7.65) and `exp-gateway-native` **0.3.50** from main after merge; the platform then bumps both exact pins.

## Platform follow-ups

1. Pin bump (`experiential==<new>`, `exp-gateway-native==0.3.50`) and rewrite any platform test pinning the old strings (`"thinking"` bare disclosure, `messages.content.cache_control`, the server-tool 400 on foreign routes, `budget_tokens is required`).
2. Deadline chain per chunk 7 if long-output turns are wanted: worker `request_timeout_seconds`, edge `_TOTAL_TIMEOUT_SECONDS`, ingress and load-balancer timeouts, plus the engine knob.
3. Docs (Claude Code page): say a bare `thinking: {type: enabled}` is accepted, WebSearch is dropped with disclosure on non-Claude models, and that per-turn usage is on `message_delta` (Claude Code's own cost figure stays Anthropic-list-priced regardless).
4. `/v1/messages/count_tokens` 404 is by design; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)