### PR TITLE
release: bump experiential to 0.7.66 (Claude Code Messages asks)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.65"
+version = "0.7.66"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.65"
+version = "0.7.66"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump for the release carrying #905: bare `thinking: {type: enabled}` accepted, Anthropic server tools become a disclosed drop on non-Anthropic routes, cache markers disclosed as not_forwarded(provider_decides_caching), superseded-thinking disclosure names, Anthropic upstream start-frame usage on message_start. Crate already at 0.3.50 (bumped in #905), so this release publishes both `experiential` 0.7.66 and the `exp-gateway-native` 0.3.50 wheel matrix.

Platform follow-up: pin `experiential==0.7.66` and `exp-gateway-native==0.3.50`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)