### PR TITLE
gateway: normalize bounded batch field errors

### DIFF
--- a/exp/runtime/gateway/batch/contracts.py
+++ b/exp/runtime/gateway/batch/contracts.py
@@ -19,6 +19,8 @@ from exp.common.core.artifacts import ContractModel, JsonObject
 
 MAXIMUM_BATCH_LINES = 50_000
 MAXIMUM_INPUT_FILE_BYTES = 100 * 1024 * 1024
+MAXIMUM_CUSTOM_ID_CHARACTERS = 256
+MAXIMUM_FILENAME_CHARACTERS = 512
 COMPLETION_WINDOW = "24h"
 COMPLETION_WINDOW_SECONDS = 24 * 60 * 60
 
@@ -105,7 +107,7 @@ class BatchLine(ContractModel):
     at: the caller's own value, else the deployment default.
     """
 
-    custom_id: str = Field(min_length=1, max_length=256)
+    custom_id: str = Field(min_length=1, max_length=MAXIMUM_CUSTOM_ID_CHARACTERS)
     surface: BatchSurface
     model: str = Field(min_length=1, max_length=256)
     provider_model: str = Field(min_length=1, max_length=2_048)
@@ -297,7 +299,7 @@ class BatchFile(ContractModel):
 
     file_id: str = Field(min_length=1, max_length=128)
     organization_id: str = Field(min_length=1, max_length=128)
-    filename: str = Field(min_length=1, max_length=512)
+    filename: str = Field(min_length=1, max_length=MAXIMUM_FILENAME_CHARACTERS)
     purpose: Literal["batch", "batch_output"] = "batch"
     size_bytes: int = Field(ge=0)
     created_at: AwareDatetime

--- a/exp/runtime/gateway/batch/engine.py
+++ b/exp/runtime/gateway/batch/engine.py
@@ -20,6 +20,8 @@ from exp.common.core.artifacts import JsonObject
 from exp.runtime.gateway.batch.contracts import (
     BATCH_SURFACES,
     COMPLETION_WINDOW_SECONDS,
+    MAXIMUM_CUSTOM_ID_CHARACTERS,
+    MAXIMUM_FILENAME_CHARACTERS,
     TERMINAL_STATUSES,
     BatchCounts,
     BatchDeployment,
@@ -117,6 +119,8 @@ class BatchEngine:
         """
         if purpose != "batch":
             raise BatchSubmitError("files uploaded to this gateway must use purpose 'batch'")
+        if len(filename) > MAXIMUM_FILENAME_CHARACTERS:
+            raise BatchSubmitError(f"filename exceeds {MAXIMUM_FILENAME_CHARACTERS} characters")
         parse_input_jsonl(content)
         record = BatchFile(
             file_id=_new_id("file"),
@@ -222,6 +226,19 @@ class BatchEngine:
                         line_number=line_number,
                         code="missing_custom_id",
                         message=f"line {line_number} carries no custom_id",
+                    )
+                )
+                continue
+            if len(custom_id) > MAXIMUM_CUSTOM_ID_CHARACTERS:
+                errors.append(
+                    BatchLineError(
+                        line_number=line_number,
+                        custom_id=custom_id,
+                        code="invalid_custom_id",
+                        message=(
+                            f"line {line_number} custom_id exceeds "
+                            f"{MAXIMUM_CUSTOM_ID_CHARACTERS} characters"
+                        ),
                     )
                 )
                 continue

--- a/exp/runtime/gateway/batch/plane_test.py
+++ b/exp/runtime/gateway/batch/plane_test.py
@@ -186,6 +186,73 @@ def test_malformed_payloads_and_bad_base64_are_client_errors() -> None:
     assert status == 400 and "base64" in body["error"]["message"]
 
 
+def test_oversized_file_and_line_fields_are_client_errors() -> None:
+    """Bounded caller fields render 400s instead of leaking model validation errors."""
+    plane = _plane()
+    content = _chat_line("x" * 257).encode("utf-8")
+    status, file_object = _call(
+        plane,
+        "file_create",
+        filename="input.jsonl",
+        purpose="batch",
+        content_b64=base64.b64encode(content).decode("ascii"),
+    )
+    assert status == 200
+    status, body = _call(
+        plane,
+        "batch_create",
+        input_file_id=file_object["id"],
+        endpoint="/v1/chat/completions",
+    )
+    assert status == 400
+    assert body["error"]["code"] == "invalid_request_error"
+    assert body["error"]["message"] == (
+        "every input line was rejected: line 1 custom_id exceeds 256 characters"
+    )
+
+    status, body = _call(
+        plane,
+        "file_create",
+        filename="x" * 513,
+        purpose="batch",
+        content_b64=base64.b64encode(_chat_line("a").encode("utf-8")).decode("ascii"),
+    )
+    assert status == 400
+    assert body["error"]["code"] == "invalid_request_error"
+    assert body["error"]["message"] == "filename exceeds 512 characters"
+
+
+def test_oversized_custom_id_is_a_line_error_in_a_mixed_batch() -> None:
+    """An oversized ID rejects its line without discarding valid peers."""
+    plane = _plane()
+    oversized_id = "x" * 257
+    content = "\n".join((_chat_line("valid"), _chat_line(oversized_id))).encode("utf-8")
+    status, file_object = _call(
+        plane,
+        "file_create",
+        filename="input.jsonl",
+        purpose="batch",
+        content_b64=base64.b64encode(content).decode("ascii"),
+    )
+    assert status == 200
+    status, batch_object = _call(
+        plane,
+        "batch_create",
+        input_file_id=file_object["id"],
+        endpoint="/v1/chat/completions",
+    )
+    assert status == 200
+    assert batch_object["request_counts"]["total"] == 1
+    assert batch_object["errors"]["data"] == [
+        {
+            "code": "invalid_custom_id",
+            "message": "line 2 custom_id exceeds 256 characters",
+            "line": 2,
+            "custom_id": oversized_id,
+        }
+    ]
+
+
 def test_unknown_ids_map_to_404() -> None:
     """Missing files and batches produce not_found envelopes."""
     plane = _plane()


### PR DESCRIPTION
## Why

The batch control plane translated `BatchSubmitError` into stable OpenAI-style client responses,
but oversized `filename` and `custom_id` values reached Pydantic persistence models first. Their
`ValidationError` exceptions escaped the envelope boundary instead of returning status 400.

Closes #907

## What

- Give the existing 512-character filename and 256-character custom ID limits shared names in
  `batch.contracts`.
- Reject an oversized filename at the engine boundary with `BatchSubmitError`.
- Record an oversized custom ID as an `invalid_custom_id` line rejection, preserving the batch
  engine's existing per-line validation behavior.
- Add a control-plane regression that asserts the exact status, error code, and message for both
  inputs.

## Validation

- `uv run --no-sync ruff check .`: passed
- `uv run --no-sync ruff format --check .`: passed, 837 files already formatted
- `uv run --no-sync ty check`: passed
- `uv run --no-sync pytest -q exp/runtime/gateway/batch/contracts_test.py exp/runtime/gateway/batch/engine_test.py exp/runtime/gateway/batch/plane_test.py`: passed, 56 tests

The full test run was started but could not complete in the restricted workspace because an
existing gateway test opens an IPv4 socket and the sandbox returned `PermissionError: [Errno 1]
Operation not permitted`. The failing node was
`exp/cli/gateway/serve_test.py::test_unbindable_port_fails_before_any_ready_receipt`; it does not
exercise the batch files changed here.

## Non-goals

This change does not alter the accepted limits, the native data plane, provider dispatch, or batch
persistence formats.
