### PR TITLE
gateway: shell-quote compatibility key path

### DIFF
--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import sys
 from pathlib import Path
 
@@ -552,6 +553,7 @@ def _emit_gateway_ready(
             markup=False,
         )
         _console.print(
-            f"export EXP_GATEWAY_KEY=\"$(tr -d '\\n' < {compatibility.key_file})\"",
+            "export EXP_GATEWAY_KEY=\"$(tr -d '\\n' < "
+            f'{shlex.quote(str(compatibility.key_file))})"',
             markup=False,
         )

--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import re
+import shlex
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, datetime
@@ -532,3 +533,29 @@ def test_first_run_unknown_setup_outcome_delivers_the_only_raw_key(
     assert "export EXP_GATEWAY_KEY=exp_vk_unknown_secret" in transcript
     assert "Preserve this one-time gateway key: exp_vk_unknown_secret" in transcript
     assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript
+
+
+def test_project_gateway_key_command_shell_quotes_the_key_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The copyable export treats every character in the key path as data."""
+    output = io.StringIO()
+    monkeypatch.setattr(
+        run_app,
+        "_console",
+        Console(file=output, width=1_000, force_terminal=False, no_color=True, highlight=False),
+    )
+    key_file = Path("/tmp/key path'quoted;line\nbreak")
+    compatibility = ProjectGatewayCompatibility(
+        alias="project-a",
+        alias_revision_id="revision-a",
+        identity_id="identity-a",
+        key_file=key_file,
+        policy_id="policy-a",
+        changed=False,
+    )
+
+    run_app._emit_gateway_ready(port=8000, compatibility=compatibility, ghost=False)
+
+    command = f"export EXP_GATEWAY_KEY=\"$(tr -d '\\n' < {shlex.quote(str(key_file))})\""
+    assert output.getvalue().endswith(f"{command}\n")


### PR DESCRIPTION
## Why

The project gateway's copyable `EXP_GATEWAY_KEY` command inserted the compatibility key-file path
directly into shell syntax. A valid root containing whitespace or metacharacters could make the
command fail or interpret path content as shell syntax.

Closes #909

## What

- Render the compatibility key-file path with `shlex.quote` before placing it after the shell
  input-redirection operator.
- Add a direct readiness-output regression whose path contains a space, single quote, semicolon,
  and embedded newline.
- Keep the existing command shape and credential-delivery behavior unchanged.

## Validation

- `uv run --no-sync pytest -q exp/cli/gateway/serve_test.py -k 'not unbindable_port'`: passed,
  11 tests and 1 deselected
- `uv run --no-sync ruff check .`: passed
- `uv run --no-sync ruff format --check .`: passed, 837 files already formatted
- `uv run --no-sync ty check`: passed

The deselected existing test opens an IPv4 listener, which this restricted workspace prohibits
with `PermissionError: [Errno 1] Operation not permitted`. It does not exercise readiness-output
rendering.

## Non-goals

This change does not alter key storage, key permissions, gateway initialization, the native data
plane, or the shape of the printed environment variables.
