### PR TITLE
gateway: Messages start frame carries the pre-dispatch input estimate; serve /v1/messages/count_tokens

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -16,8 +16,13 @@ It serves:
   request-level failures, and a `generate: false` prewarm answered without provider work; the
   bearer key is authenticated before the upgrade is accepted, and a GET without a well-formed
   upgrade answers 426, the status the Codex client maps to its HTTP fallback)
-- `POST /v1/messages` (the Anthropic Messages API; `POST /v1/messages/count_tokens` answers an
-  explicit Anthropic-shaped refusal because the gateway has no tokenizer authority)
+- `POST /v1/messages` (the Anthropic Messages API) and `POST /v1/messages/count_tokens`, which
+  answers Anthropic's `{"input_tokens": N}` from the gateway's own reservation tokenizer (the
+  credit reservation's estimator without its headroom): authenticated and granted exactly like
+  `/v1/messages`, no ledger row, no charge. The gateway has no tokenizer authority for any rung
+  (the Anthropic provider client does not forward `count_tokens`), so every answer is an
+  estimate and the body says so through the shared `x-experiential-ignored-parameters`
+  disclosure (`input_tokens->estimated(gateway_tokenizer)`).
 - `POST /v1/embeddings` (the OpenAI Embeddings API: message-less and never streamed; served
   only by aliases whose catalog capabilities declare `supports_embeddings` on an OpenAI-wire
   connection, billed on the provider's reported `prompt_tokens` with no output leg, and
@@ -677,13 +682,20 @@ The thinking vocabulary names the outcome, never a bare field: `thinking->reason
 `thinking->dropped(unsupported_by_route)` (no rung can reason at any depth). A caller reading a
 bare `thinking` as "my depth was stripped" is the misreading this vocabulary exists to prevent.
 
-On the Messages stream, `message_start.message.usage` carries what the upstream already reported
-before content — an Anthropic upstream's own start-frame input and cache meters, mirrored — and
-`message_delta.usage` carries the final meters (input, output, `cache_read_input_tokens`,
-`cache_creation_input_tokens`, plus the platform's cost extensions). An OpenAI-wire upstream
-reports nothing before its final chunk, so its `message_start` keeps the zero placeholder and the
-final meters ride `message_delta`; the official Anthropic SDK accumulators (Python and TypeScript)
-copy every usage field present on `message_delta`, so their final message shows the true counts.
+On the Messages stream, `message_start.message.usage` is a PRE-DISPATCH figure and
+`message_delta.usage` is the authoritative one. The start frame carries what the upstream already
+reported before content — an Anthropic upstream's own start-frame input and cache meters,
+mirrored — and otherwise the control plane's pre-dispatch count of the prompt (the reservation
+estimator without its headroom, carried on the admission as `input_token_estimate`) in
+Anthropic's documented start shape, `{"input_tokens": N, "output_tokens": 1}`. An OpenAI-wire
+upstream reports nothing before its final chunk, so without the estimate its `message_start`
+showed the zero placeholder that clients reading input from the start frame alone (Claude Code)
+display as 0 input tokens. `message_delta.usage` carries the provider's final meters (input,
+output, `cache_read_input_tokens`, `cache_creation_input_tokens`, plus the platform's cost
+extensions); the official Anthropic SDK accumulators (Python and TypeScript) copy every usage
+field present on `message_delta`, so their final message shows the true counts. The estimate is
+display-only: the encoder keeps it apart from the usage it settles from, so it never reaches
+`message_delta` or the ledger, which bill the provider's report.
 The per-deployment `capability_parity` export joins catalog declarations with the engine's
 provider-family ground truth so a catalog can pre-warn on gaps and route around them before a
 caller hits that 400.

--- a/exp/runtime/anthropic_protocol/reasoning_channels.py
+++ b/exp/runtime/anthropic_protocol/reasoning_channels.py
@@ -109,7 +109,7 @@ def output_config_effort(config: JsonObject | None) -> ReasoningEffort | None:
 def resolve_reasoning_channels(
     reasoning: ReasoningConfig | None,
     *,
-    max_tokens: int,
+    max_tokens: int | None,
     thinking: JsonObject | None,
     output_config: JsonObject | None,
 ) -> ReasoningChannels:
@@ -138,7 +138,9 @@ def resolve_reasoning_channels(
 
     Args:
         reasoning: The validated OpenRouter object, or ``None`` when absent.
-        max_tokens: The caller's reply ceiling, which a budget must stay below.
+        max_tokens: The caller's reply ceiling, which a budget must stay below;
+            ``None`` for a ``count_tokens`` body, which has no reply to leave
+            room for.
         thinking: The caller's raw ``thinking`` object, byte-for-byte.
         output_config: The caller's raw ``output_config`` object, byte-for-byte.
 
@@ -163,7 +165,7 @@ def resolve_reasoning_channels(
         effort = None
         resolved_thinking: JsonObject | None = _THINKING_DISABLED
     elif reasoning.max_tokens is not None:
-        if reasoning.max_tokens >= max_tokens:
+        if max_tokens is not None and reasoning.max_tokens >= max_tokens:
             raise invalid_field(
                 "reasoning.max_tokens",
                 "reasoning.max_tokens must be below max_tokens so the reply has room "

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -29,7 +29,6 @@ import json
 from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
-from pydantic_core import ErrorDetails
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.content import (
@@ -58,6 +57,7 @@ from exp.runtime.anthropic_protocol.reasoning_channels import (
     ReasoningConfig,
     resolve_reasoning_channels,
 )
+from exp.runtime.anthropic_protocol.wire_validation import validate_wire, validation_error
 from exp.runtime.gateway.compatibility import CompatibilityDisposition
 from exp.runtime.gateway.contracts import (
     GatewayApiSurface,
@@ -69,21 +69,9 @@ from exp.runtime.gateway.contracts import (
     RedactedThinkingBlock,
     ThinkingBlock,
 )
-from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field, unsupported_field
+from exp.runtime.openai_protocol.errors import invalid_field, unsupported_field
 from exp.runtime.openai_protocol.manifest import disposition_map
 from exp.runtime.openai_protocol.requests import DecodedGatewayRequest
-
-_REJECTED_BLOCK_HINTS = {
-    kind: (
-        f"{kind} blocks are not supported: the Anthropic Messages wire defines no "
-        f"{kind} content, so send {kind} on the Chat Completions surface"
-    )
-    for kind in ("video", "audio")
-}
-_REJECTED_TOOL_RESULT_BLOCK_HINTS = {
-    "document": "document blocks are not supported inside tool_result content",
-    **_REJECTED_BLOCK_HINTS,
-}
 
 
 class _TextBlock(AnthropicWireModel):
@@ -388,7 +376,7 @@ def _decode(
 ) -> DecodedGatewayRequest:
     """Validate ``payload`` against ``wire`` and build the canonical request."""
     _validate_manifest(payload)
-    request = _validate_wire(payload, wire)
+    request = validate_wire(payload, wire)
     _require_served_server_tool_types(request.tools)
     forwarded_betas, dropped_beta_disclosures = _beta_tokens(anthropic_beta)
     messages: list[GatewayMessage] = []
@@ -474,7 +462,7 @@ def _decode(
             provider_output_config=channels.output_config,
         )
     except ValidationError as exc:
-        raise _validation_error(exc.errors(include_url=False)[0]) from exc
+        raise validation_error(exc.errors(include_url=False)[0]) from exc
     return DecodedGatewayRequest(alias=request.model, request=canonical)
 
 
@@ -581,101 +569,6 @@ def _validate_manifest(payload: JsonObject) -> None:
         disposition = decisions.get(field)
         if disposition is None or disposition == CompatibilityDisposition.UNSUPPORTED:
             raise unsupported_field(field)
-
-
-def _validate_wire(payload: JsonObject, wire: type[_MessagesRequest]) -> _MessagesRequest:
-    """Validate the strict wire model with a field-specific public error."""
-    try:
-        return wire.model_validate(payload)
-    except ValidationError as exc:
-        hint = _rejected_block_hint(payload)
-        if hint is not None:
-            param, message = hint
-            raise invalid_field(param, message) from exc
-        # A union miss reports one error PER ARM, and the first arm is the
-        # scalar one: naming it ("content.str: Input should be a valid
-        # string") misdirects a caller whose list merely held an unsupported
-        # block. The deepest location is the arm that actually matched the
-        # payload's shape, so its error names the offending element.
-        errors = exc.errors(include_url=False)
-        first = max(errors, key=lambda error: len(error["loc"]))
-        raise _validation_error(first) from exc
-
-
-def _validation_error(first: ErrorDetails) -> OpenAIProtocolError:
-    """Convert one Pydantic error location into a stable dotted field error.
-
-    The public message keeps the expected-vs-got shape: it names the field
-    and states what the decoder expected there (Pydantic's own expectation
-    text, which never echoes the caller's value), so a rejected request says
-    what to fix instead of only where it failed.
-    """
-    location = first["loc"]
-    cleaned: list[str] = []
-    for part in location:
-        text = str(part)
-        # Union arm labels in pydantic locations are noise for callers: wire
-        # model class names (private or public), scalar type names, and
-        # constrained-type spellings. Real wire fields are snake_case.
-        if isinstance(part, str) and (
-            part.startswith("_")
-            or "[" in text
-            or text[:1].isupper()
-            or text in ("str", "int", "float", "bool", "none", "list", "dict")
-        ):
-            continue
-        cleaned.append(text)
-    param = ".".join(cleaned) or "body"
-    if first["type"] == "extra_forbidden":
-        return invalid_field(
-            param,
-            f"Unknown parameter '{param}'. Remove the field and resend the request.",
-        )
-    if param == "body" and first["type"] == "value_error":
-        # A whole-request rule (such as the attachment count ceiling) has no
-        # field of its own, so its own wording is the only useful message.
-        return invalid_field(param, first["msg"].removeprefix("Value error, ") + ".")
-    return invalid_field(param, f"Invalid value for '{param}': {first['msg']}.")
-
-
-def _rejected_block_hint(payload: JsonObject) -> tuple[str, str] | None:
-    """Return the field path and message for a known-but-unsupported block.
-
-    The path names the exact offending block (and, for a ``tool_result``, the
-    offending sub-block), so the caller is never sent to the union's string
-    arm for a list-shaped problem.
-    """
-    messages = payload.get("messages")
-    if not isinstance(messages, list):
-        return None
-    for message_index, message in enumerate(messages):
-        if not isinstance(message, dict) or not isinstance(message.get("content"), list):
-            continue
-        for block_index, block in enumerate(cast(list[object], message["content"])):
-            if not isinstance(block, dict):
-                continue
-            block_object = cast(JsonObject, block)
-            param = f"messages.{message_index}.content.{block_index}"
-            hint = _REJECTED_BLOCK_HINTS.get(str(block_object.get("type")))
-            if hint is not None:
-                return param, hint
-            if block_object.get("type") == "tool_result" and isinstance(
-                block_object.get("content"), list
-            ):
-                for inner_index, inner in enumerate(cast(list[object], block_object["content"])):
-                    if not isinstance(inner, dict):
-                        continue
-                    inner_type = str(cast(JsonObject, inner).get("type"))
-                    inner_param = f"{param}.content.{inner_index}"
-                    hint = _REJECTED_TOOL_RESULT_BLOCK_HINTS.get(inner_type)
-                    if hint is not None:
-                        return inner_param, hint
-                    if inner_type not in ("text", "image"):
-                        return inner_param, (
-                            f"unsupported block type '{inner_type}' inside tool_result "
-                            "content; only text and image sub-blocks are supported."
-                        )
-    return None
 
 
 def _system_text(system: str | tuple[_TextBlock, ...] | None) -> str | None:

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -317,6 +317,18 @@ class _MessagesRequest(AnthropicWireModel):
     region set is an evolving provider surface."""
 
 
+class _CountTokensRequest(_MessagesRequest):
+    """The ``count_tokens`` body: a Messages body with no generation budget.
+
+    Anthropic's count endpoint takes the prompt-side fields (``model``,
+    ``messages``, ``system``, ``tools``, ``tool_choice``, ``thinking``) and
+    no ``max_tokens``; a body that carries one is still counted, since the
+    budget changes nothing about the prompt.
+    """
+
+    max_tokens: int | None = Field(default=None, gt=0)
+
+
 def decode_messages(
     payload: JsonObject,
     *,
@@ -340,8 +352,43 @@ def decode_messages(
         OpenAIProtocolError: The body is invalid, unknown, or unsupported.
             The HTTP layer renders it in the Anthropic error envelope.
     """
+    return _decode(payload, _MessagesRequest, anthropic_beta=anthropic_beta)
+
+
+def decode_messages_count_tokens(
+    payload: JsonObject,
+    *,
+    anthropic_beta: str | None = None,
+) -> DecodedGatewayRequest:
+    """Decode one Anthropic ``count_tokens`` body for prompt counting.
+
+    Identical to :func:`decode_messages` except that ``max_tokens`` is
+    optional: Anthropic's count request carries only prompt-side fields, so
+    the canonical request has no output budget (``maximum_output_tokens`` is
+    ``None``) and is never dispatched, only counted.
+
+    Args:
+        payload: Parsed JSON request body.
+        anthropic_beta: Optional raw caller ``anthropic-beta`` header value.
+
+    Returns:
+        Public alias and the canonical request to count.
+
+    Raises:
+        OpenAIProtocolError: The body is invalid, unknown, or unsupported.
+    """
+    return _decode(payload, _CountTokensRequest, anthropic_beta=anthropic_beta)
+
+
+def _decode(
+    payload: JsonObject,
+    wire: type[_MessagesRequest],
+    *,
+    anthropic_beta: str | None,
+) -> DecodedGatewayRequest:
+    """Validate ``payload`` against ``wire`` and build the canonical request."""
     _validate_manifest(payload)
-    request = _validate_wire(payload)
+    request = _validate_wire(payload, wire)
     _require_served_server_tool_types(request.tools)
     forwarded_betas, dropped_beta_disclosures = _beta_tokens(anthropic_beta)
     messages: list[GatewayMessage] = []
@@ -398,7 +445,9 @@ def decode_messages(
             tool_choice=_gateway_tool_choice(request.tool_choice),
             parallel_tool_calls=parallel_tool_calls,
             maximum_output_tokens=request.max_tokens,
-            maximum_output_tokens_parameter="max_tokens",
+            maximum_output_tokens_parameter="max_tokens"
+            if request.max_tokens is not None
+            else None,
             stop=_stop_sequences(request.stop_sequences),
             temperature=request.temperature,
             top_p=request.top_p,
@@ -534,10 +583,10 @@ def _validate_manifest(payload: JsonObject) -> None:
             raise unsupported_field(field)
 
 
-def _validate_wire(payload: JsonObject) -> _MessagesRequest:
+def _validate_wire(payload: JsonObject, wire: type[_MessagesRequest]) -> _MessagesRequest:
     """Validate the strict wire model with a field-specific public error."""
     try:
-        return _MessagesRequest.model_validate(payload)
+        return wire.model_validate(payload)
     except ValidationError as exc:
         hint = _rejected_block_hint(payload)
         if hint is not None:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -9,7 +9,7 @@ from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.content import MAXIMUM_DOCUMENTS_PER_REQUEST
-from exp.runtime.anthropic_protocol.requests import decode_messages
+from exp.runtime.anthropic_protocol.requests import decode_messages, decode_messages_count_tokens
 from exp.runtime.gateway.contracts import (
     ExposedReasoningContentBlock,
     GatewayApiSurface,
@@ -343,6 +343,34 @@ def test_missing_max_tokens_is_rejected_with_its_field() -> None:
     with pytest.raises(OpenAIProtocolError) as excinfo:
         decode_messages(payload)
     assert excinfo.value.detail.param == "max_tokens"
+
+
+def test_count_tokens_body_needs_no_max_tokens() -> None:
+    """Anthropic's count request carries only prompt-side fields.
+
+    The count decoder is the Messages decoder with the generation budget
+    optional: a body of ``model`` + ``messages`` (plus system and tools)
+    decodes to a canonical request with no output ceiling, a body that does
+    carry ``max_tokens`` keeps it, and everything else is validated exactly
+    as the generation endpoint validates it.
+    """
+    payload = _body(
+        system="be terse",
+        tools=[{"name": "search", "description": "look up", "input_schema": {"type": "object"}}],
+    )
+    del payload["max_tokens"]
+    decoded = decode_messages_count_tokens(payload)
+    assert decoded.alias == "coding"
+    assert decoded.request.maximum_output_tokens is None
+    assert decoded.request.maximum_output_tokens_parameter is None
+    assert len(decoded.request.tools) == 1
+
+    budgeted = decode_messages_count_tokens(_body())
+    assert budgeted.request.maximum_output_tokens == 128
+
+    with pytest.raises(OpenAIProtocolError) as excinfo:
+        decode_messages_count_tokens({"model": "coding"})
+    assert excinfo.value.detail.param == "messages"
 
 
 def test_image_blocks_are_retained_in_caller_order() -> None:

--- a/exp/runtime/anthropic_protocol/wire_validation.py
+++ b/exp/runtime/anthropic_protocol/wire_validation.py
@@ -1,0 +1,139 @@
+"""Wire validation and public error rendering for the Anthropic Messages decoder.
+
+The strict wire models live beside the decoder in ``requests.py``; this module
+turns their Pydantic rejections into the stable, field-specific public errors
+the HTTP layer renders in the Anthropic envelope, and recognizes the
+known-but-unsupported content blocks (video, audio, documents inside a
+``tool_result``) whose union miss would otherwise misdirect the caller.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from pydantic import BaseModel, ValidationError
+from pydantic_core import ErrorDetails
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError, invalid_field
+
+_REJECTED_BLOCK_HINTS = {
+    kind: (
+        f"{kind} blocks are not supported: the Anthropic Messages wire defines no "
+        f"{kind} content, so send {kind} on the Chat Completions surface"
+    )
+    for kind in ("video", "audio")
+}
+_REJECTED_TOOL_RESULT_BLOCK_HINTS = {
+    "document": "document blocks are not supported inside tool_result content",
+    **_REJECTED_BLOCK_HINTS,
+}
+
+
+def validate_wire[WireModelT: BaseModel](payload: JsonObject, wire: type[WireModelT]) -> WireModelT:
+    """Validate ``payload`` against the strict wire model ``wire``.
+
+    Args:
+        payload: Parsed JSON request body.
+        wire: The closed Messages wire model to validate against (the
+            generation request, or the ``count_tokens`` variant).
+
+    Returns:
+        The validated wire model.
+
+    Raises:
+        OpenAIProtocolError: The body fails validation; the error names the
+            exact offending field (a known-but-unsupported block first, else
+            the deepest Pydantic location) and states what was expected.
+    """
+    try:
+        return wire.model_validate(payload)
+    except ValidationError as exc:
+        hint = rejected_block_hint(payload)
+        if hint is not None:
+            param, message = hint
+            raise invalid_field(param, message) from exc
+        # A union miss reports one error PER ARM, and the first arm is the
+        # scalar one: naming it ("content.str: Input should be a valid
+        # string") misdirects a caller whose list merely held an unsupported
+        # block. The deepest location is the arm that actually matched the
+        # payload's shape, so its error names the offending element.
+        errors = exc.errors(include_url=False)
+        first = max(errors, key=lambda error: len(error["loc"]))
+        raise validation_error(first) from exc
+
+
+def validation_error(first: ErrorDetails) -> OpenAIProtocolError:
+    """Convert one Pydantic error location into a stable dotted field error.
+
+    The public message keeps the expected-vs-got shape: it names the field
+    and states what the decoder expected there (Pydantic's own expectation
+    text, which never echoes the caller's value), so a rejected request says
+    what to fix instead of only where it failed.
+    """
+    location = first["loc"]
+    cleaned: list[str] = []
+    for part in location:
+        text = str(part)
+        # Union arm labels in pydantic locations are noise for callers: wire
+        # model class names (private or public), scalar type names, and
+        # constrained-type spellings. Real wire fields are snake_case.
+        if isinstance(part, str) and (
+            part.startswith("_")
+            or "[" in text
+            or text[:1].isupper()
+            or text in ("str", "int", "float", "bool", "none", "list", "dict")
+        ):
+            continue
+        cleaned.append(text)
+    param = ".".join(cleaned) or "body"
+    if first["type"] == "extra_forbidden":
+        return invalid_field(
+            param,
+            f"Unknown parameter '{param}'. Remove the field and resend the request.",
+        )
+    if param == "body" and first["type"] == "value_error":
+        # A whole-request rule (such as the attachment count ceiling) has no
+        # field of its own, so its own wording is the only useful message.
+        return invalid_field(param, first["msg"].removeprefix("Value error, ") + ".")
+    return invalid_field(param, f"Invalid value for '{param}': {first['msg']}.")
+
+
+def rejected_block_hint(payload: JsonObject) -> tuple[str, str] | None:
+    """Return the field path and message for a known-but-unsupported block.
+
+    The path names the exact offending block (and, for a ``tool_result``, the
+    offending sub-block), so the caller is never sent to the union's string
+    arm for a list-shaped problem.
+    """
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return None
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, dict) or not isinstance(message.get("content"), list):
+            continue
+        for block_index, block in enumerate(cast(list[object], message["content"])):
+            if not isinstance(block, dict):
+                continue
+            block_object = cast(JsonObject, block)
+            param = f"messages.{message_index}.content.{block_index}"
+            hint = _REJECTED_BLOCK_HINTS.get(str(block_object.get("type")))
+            if hint is not None:
+                return param, hint
+            if block_object.get("type") == "tool_result" and isinstance(
+                block_object.get("content"), list
+            ):
+                for inner_index, inner in enumerate(cast(list[object], block_object["content"])):
+                    if not isinstance(inner, dict):
+                        continue
+                    inner_type = str(cast(JsonObject, inner).get("type"))
+                    inner_param = f"{param}.content.{inner_index}"
+                    hint = _REJECTED_TOOL_RESULT_BLOCK_HINTS.get(inner_type)
+                    if hint is not None:
+                        return inner_param, hint
+                    if inner_type not in ("text", "image"):
+                        return inner_param, (
+                            f"unsupported block type '{inner_type}' inside tool_result "
+                            "content; only text and image sub-blocks are supported."
+                        )
+    return None

--- a/exp/runtime/anthropic_protocol/wire_validation_test.py
+++ b/exp/runtime/anthropic_protocol/wire_validation_test.py
@@ -1,0 +1,55 @@
+"""Field-specific public errors from the Messages wire validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field
+
+from exp.common.core.artifacts import JsonObject
+from exp.runtime.anthropic_protocol.wire_validation import rejected_block_hint, validate_wire
+from exp.runtime.openai_protocol.errors import OpenAIProtocolError
+
+
+class _Wire(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    model: str = Field(min_length=1)
+    max_tokens: int | None = None
+
+
+def test_validate_wire_returns_the_validated_model_or_names_the_field() -> None:
+    """The generic validator returns the model it was handed and names the offending field."""
+    assert validate_wire({"model": "coding"}, _Wire).model == "coding"
+    with pytest.raises(OpenAIProtocolError) as unknown:
+        validate_wire({"model": "coding", "stream": True}, _Wire)
+    assert unknown.value.detail.param == "stream"
+    with pytest.raises(OpenAIProtocolError) as missing:
+        validate_wire({}, _Wire)
+    assert missing.value.detail.param == "model"
+
+
+def test_rejected_block_hint_names_the_offending_block() -> None:
+    """A known-but-unsupported block is named by its exact path, tool_result sub-blocks included."""
+    assert rejected_block_hint({"messages": "not a list"}) is None
+    video: JsonObject = {
+        "messages": [{"role": "user", "content": [{"type": "video", "source": {}}]}]
+    }
+    hint = rejected_block_hint(video)
+    assert hint is not None
+    assert hint[0] == "messages.0.content.0"
+    nested: JsonObject = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t1",
+                        "content": [{"type": "text", "text": "ok"}, {"type": "document"}],
+                    }
+                ],
+            }
+        ]
+    }
+    nested_hint = rejected_block_hint(nested)
+    assert nested_hint is not None
+    assert nested_hint[0] == "messages.0.content.0.content.1"

--- a/exp/runtime/gateway/attempt_tokens.py
+++ b/exp/runtime/gateway/attempt_tokens.py
@@ -130,6 +130,24 @@ def worst_case_input_tokens(request: ServingRequest) -> int:
     planning constants, and decoded-length proxies for opaque carriers, all
     scaled by :data:`INPUT_TOKEN_HEADROOM_PERCENT`.
     """
+    return _prompt_counter(request).total()
+
+
+def counted_input_tokens(request: ServingRequest) -> int:
+    """The counted prompt for one request, before any headroom.
+
+    The same walk as :func:`worst_case_input_tokens` without the reservation
+    scaling: the figure a caller is shown as its input count (the Messages
+    ``message_start`` placeholder for an OpenAI-wire upstream, the
+    ``count_tokens`` answer). It is the gateway's own tokenizer estimate,
+    never a provider report, and it never reaches the ledger: the reservation
+    keeps its headroom and settlement keeps the provider's meters.
+    """
+    return _prompt_counter(request).counted()
+
+
+def _prompt_counter(request: ServingRequest) -> _PromptCounter:
+    """Walk one request's prompt into a counter, once."""
     counter = _PromptCounter()
     match request:
         case EmbeddingsRequest():
@@ -141,7 +159,7 @@ def worst_case_input_tokens(request: ServingRequest) -> int:
             _count_completion_prompt(request, counter)
         case _:  # pragma: no cover - exhaustive over the ServingRequest union.
             assert_never(request)
-    return counter.total()
+    return counter
 
 
 def _count_completion_prompt(request: GatewayRequest, counter: _PromptCounter) -> None:
@@ -277,13 +295,16 @@ class _PromptCounter:
             return [self._scrub(item) for item in value]
         return value
 
-    def total(self) -> int:
-        """Tokenize the gathered prompt once and apply the headroom."""
+    def counted(self) -> int:
+        """Tokenize the gathered prompt once, without headroom."""
         counted = 0
         if self._chunks:
             counted = len(reservation_encoder().encode_ordinary("\n".join(self._chunks)))
-        counted += self._fixed + self._opaque_bytes // OPAQUE_BYTES_PER_TOKEN
-        return (counted * (100 + INPUT_TOKEN_HEADROOM_PERCENT) + 99) // 100
+        return counted + self._fixed + self._opaque_bytes // OPAQUE_BYTES_PER_TOKEN
+
+    def total(self) -> int:
+        """The counted prompt scaled by the reservation headroom."""
+        return (self.counted() * (100 + INPUT_TOKEN_HEADROOM_PERCENT) + 99) // 100
 
 
 def worst_case_output_tokens(

--- a/exp/runtime/gateway/attempt_tokens_test.py
+++ b/exp/runtime/gateway/attempt_tokens_test.py
@@ -31,6 +31,7 @@ from exp.runtime.gateway.attempt_tokens import (
     TOOLS_PRESENT_TOKENS,
     VIDEO_BYTES_PER_TOKEN,
     VIDEO_TOKENS,
+    counted_input_tokens,
     worst_case_input_tokens,
 )
 from exp.runtime.gateway.contracts import (
@@ -650,3 +651,20 @@ def test_encoder_is_loaded_once_and_the_estimate_stays_cheap() -> None:
         worst_case_input_tokens(request)
     per_call = (time.perf_counter() - started) / 5
     assert per_call < 0.25
+
+
+def test_counted_input_tokens_is_the_estimate_before_headroom() -> None:
+    """The start-frame / count_tokens figure is the counted prompt, not the reservation.
+
+    The reservation adds ``INPUT_TOKEN_HEADROOM_PERCENT`` on top so caps are
+    not leaked past; a figure shown to the caller as their input count must be
+    the counted prompt itself, so the two differ by exactly the headroom.
+    """
+    request = _chat((GatewayMessage(role="user", content="Hello, world!"),))
+    counted = counted_input_tokens(request)
+    assert counted == 4 + MESSAGE_FRAMING_TOKENS
+    assert (
+        worst_case_input_tokens(request)
+        == (counted * (100 + INPUT_TOKEN_HEADROOM_PERCENT) + 99) // 100
+    )
+    assert counted < worst_case_input_tokens(request)

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.50"
+version = "0.3.51"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.50"
+version = "0.3.51"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.50"
+version = "0.3.51"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/admission.rs
+++ b/exp/runtime/gateway/native/src/admission.rs
@@ -51,6 +51,12 @@ pub(crate) struct Admission {
     /// the flag (default false) and never invoke that callback.
     #[serde(default)]
     pub output_guardrail: bool,
+    /// The control plane's pre-dispatch count of the prompt (the reservation
+    /// estimator without its headroom). Messages admissions carry it so the
+    /// caller's `message_start` shows a real input figure when the upstream
+    /// reports nothing before its final chunk; display-only, never settled.
+    #[serde(default)]
+    pub input_token_estimate: Option<u64>,
 }
 
 impl Admission {

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -214,6 +214,10 @@ pub struct MessagesSseEncoder {
     saw_tool_use: bool,
     refusal_seen: bool,
     usage: Option<Usage>,
+    /// Pre-dispatch prompt estimate shown on `message_start` when no upstream
+    /// start usage is known. Kept apart from `usage` so it can never reach
+    /// `message_delta`, whose meters are the provider's own report.
+    pre_dispatch_input_estimate: Option<u64>,
     ignored_parameters: Vec<String>,
     reasoning: ReasoningCarrierState,
     reasoning_content_carrier: Option<String>,
@@ -253,6 +257,7 @@ impl MessagesSseEncoder {
             saw_tool_use: false,
             refusal_seen: false,
             usage: None,
+            pre_dispatch_input_estimate: None,
             reasoning: ReasoningCarrierState::default(),
             reasoning_content_carrier: None,
             reasoning_output_exposed: false,
@@ -269,6 +274,19 @@ impl MessagesSseEncoder {
                 self.usage = Some(usage);
             }
         }
+    }
+
+    /// Seed `message_start` with the control plane's pre-dispatch prompt
+    /// count for an upstream that reports nothing before its final chunk.
+    ///
+    /// Anthropic's documented start frame carries the prompt's input count
+    /// with `output_tokens: 1`, and clients that read input from
+    /// `message_start` alone (Claude Code) otherwise display the zero
+    /// placeholder. The estimate is display-only: an upstream's own start
+    /// usage (`set_initial_usage`) outranks it whichever is set first, and
+    /// `message_delta` keeps the provider's report.
+    pub fn set_pre_dispatch_input_estimate(&mut self, estimate: Option<u64>) {
+        self.pre_dispatch_input_estimate = estimate;
     }
 
     /// Attach the authenticated carrier before the terminal is encoded.
@@ -315,7 +333,7 @@ impl MessagesSseEncoder {
             "content": [],
             "stop_reason": Value::Null,
             "stop_sequence": Value::Null,
-            "usage": messages_usage(self.usage.as_ref()),
+            "usage": self.start_usage(),
         });
         // Same body-level disclosure as the Chat and Responses encoders: the
         // Anthropic envelope has no field for it, and the official SDK
@@ -329,6 +347,17 @@ impl MessagesSseEncoder {
             ),
             event_frame("ping", &json!({"type": "ping"})),
         ])
+    }
+
+    /// The `message_start` meters: the upstream's own start usage when known,
+    /// else the pre-dispatch estimate in Anthropic's start-frame shape, else
+    /// the zero placeholder.
+    fn start_usage(&self) -> Value {
+        match (self.usage.as_ref(), self.pre_dispatch_input_estimate) {
+            (Some(usage), _) => messages_usage(Some(usage)),
+            (None, Some(estimate)) => json!({"input_tokens": estimate, "output_tokens": 1}),
+            (None, None) => messages_usage(None),
+        }
     }
 
     pub fn saw_terminal(&self) -> bool {

--- a/exp/runtime/gateway/native/src/encode_messages/tests_claude_code.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests_claude_code.rs
@@ -130,3 +130,57 @@ fn a_reply_with_reasoning_text_and_a_tool_call_renders_every_part_on_the_aggrega
         .expect("tool block");
     assert_eq!(tool["name"], json!("lookup"));
 }
+
+#[test]
+fn start_frame_carries_the_pre_dispatch_estimate_when_the_upstream_reports_nothing() {
+    // An OpenAI-wire upstream reports usage only in its final chunk, so the
+    // start frame would otherwise carry the zero placeholder that Claude Code
+    // reads as "0 input tokens". The admission's pre-dispatch prompt estimate
+    // fills it with Anthropic's `output_tokens: 1` placeholder; the estimate
+    // is display-only (message_delta and the ledger keep the provider's
+    // report).
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_initial_usage(None);
+    encoder.set_pre_dispatch_input_estimate(Some(1234));
+    let frames = encoder.start().expect("starts");
+    let start: Value = serde_json::from_str(
+        frames[0]
+            .lines()
+            .nth(1)
+            .and_then(|line| line.strip_prefix("data: "))
+            .expect("data line"),
+    )
+    .expect("json");
+    assert_eq!(
+        start["message"]["usage"],
+        json!({"input_tokens": 1234, "output_tokens": 1})
+    );
+}
+
+#[test]
+fn upstream_start_usage_outranks_the_pre_dispatch_estimate() {
+    // An Anthropic upstream's own start meters are the truth; the estimate
+    // never overrides a reported count, whichever order the route sets them.
+    let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
+    encoder.set_pre_dispatch_input_estimate(Some(1234));
+    encoder.set_initial_usage(Some(Usage {
+        input_tokens: Some(30),
+        output_tokens: Some(1),
+        cached_input_tokens: Some(10),
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    }));
+    let frames = encoder.start().expect("starts");
+    let start: Value = serde_json::from_str(
+        frames[0]
+            .lines()
+            .nth(1)
+            .and_then(|line| line.strip_prefix("data: "))
+            .expect("data line"),
+    )
+    .expect("json");
+    assert_eq!(
+        start["message"]["usage"],
+        json!({"input_tokens": 20, "output_tokens": 1, "cache_read_input_tokens": 10})
+    );
+}

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -76,17 +76,52 @@ fn messages_api_key(headers: &HeaderMap) -> Result<String, PublicError> {
     })
 }
 
-/// Refuse token counting in the caller's own envelope. Anthropic clients
-/// probe this endpoint; the gateway has no tokenizer authority to answer
-/// truthfully, so it refuses explicitly in Anthropic shape and clients fall
-/// back to their local estimate.
-pub(crate) async fn messages_count_tokens() -> Response {
-    messages_error_response(&PublicError::new(
-        404,
-        "route_not_served",
-        "count_tokens is not served by this gateway.",
-        "invalid_request_error",
-    ))
+/// `POST /v1/messages/count_tokens`: the gateway's own count of the prompt in
+/// Anthropic's `{"input_tokens": N}` shape.
+///
+/// Authenticated and granted exactly like `/v1/messages` (the control plane's
+/// `count_tokens` callback decodes the body with the shared Messages decoder
+/// and checks the alias grant), but nothing is accepted, reserved, or
+/// charged. The gateway has no tokenizer authority for any rung, so the body
+/// discloses the figure as an estimate through the shared
+/// `x-experiential-ignored-parameters` field.
+pub(crate) async fn messages_count_tokens(
+    State(state): State<AppState>,
+    request: axum::extract::Request,
+) -> Response {
+    state.handled_requests.fetch_add(1, Ordering::Relaxed);
+    let (parts, raw_body) = request.into_parts();
+    let headers = parts.headers;
+    let body = match read_body(raw_body).await {
+        Ok(body) => body,
+        Err(error) => return messages_error_response(&error),
+    };
+    let raw_key = match messages_api_key(&headers) {
+        Ok(key) => key,
+        Err(error) => return messages_error_response(&error),
+    };
+    let authenticate = compact_json(&json!({"raw_key": raw_key}));
+    if let Err(error) = state.bridge.call("authenticate", authenticate).await {
+        return messages_error_response(&error);
+    }
+    let body_text = match String::from_utf8(body.to_vec()) {
+        Ok(text) => text,
+        Err(_) => return messages_error_response(&PublicError::invalid_json()),
+    };
+    let anthropic_beta = latin1_header_list(&headers, "anthropic-beta");
+    let argument = compact_json(&json!({
+        "raw_key": raw_key,
+        "body": body_text,
+        "surface": "messages",
+        "anthropic_beta": anthropic_beta,
+    }));
+    match state.bridge.call("count_tokens", argument).await {
+        Ok(text) => match serde_json::from_str::<Value>(&text) {
+            Ok(payload) => json_response(StatusCode::OK, &payload, &[]),
+            Err(_) => messages_error_response(&PublicError::internal()),
+        },
+        Err(error) => messages_error_response(&error),
+    }
 }
 
 pub(crate) async fn messages(
@@ -400,6 +435,7 @@ fn encode_messages_sse(
         admission.ignored_parameters.clone(),
     );
     encoder.set_reasoning_output_exposed(reasoning_output_exposed);
+    encoder.set_pre_dispatch_input_estimate(admission.input_token_estimate);
     if let Some(carrier) = reasoning_content_carrier {
         encoder.set_reasoning_content_carrier(carrier.to_string());
     }
@@ -563,6 +599,7 @@ async fn stream_messages(
         // start frame, tracked pre-commit; put them on the caller's
         // `message_start` instead of the zero placeholder.
         encoder.set_initial_usage(usage.clone());
+        encoder.set_pre_dispatch_input_estimate(admission.input_token_estimate);
         let start_frames = match encoder.start() {
             Ok(frames) => frames,
             Err(_) => {

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -112,7 +112,6 @@ pub(crate) async fn messages_count_tokens(
     let argument = compact_json(&json!({
         "raw_key": raw_key,
         "body": body_text,
-        "surface": "messages",
         "anthropic_beta": anthropic_beta,
     }));
     match state.bridge.call("count_tokens", argument).await {

--- a/exp/runtime/gateway/native_bridge.py
+++ b/exp/runtime/gateway/native_bridge.py
@@ -30,6 +30,7 @@ import time
 from collections.abc import Callable
 
 from exp.common.core.artifacts import JsonObject, sha256_bytes
+from exp.runtime.gateway.attempt_tokens import counted_input_tokens
 from exp.runtime.gateway.contracts import (
     AuthorizationSnapshot,
     DirectTarget,
@@ -79,6 +80,7 @@ from exp.runtime.gateway.native_continuation import (
 from exp.runtime.gateway.native_continuation import (
     select_bound_continuation_route as _select_bound_continuation_route,
 )
+from exp.runtime.gateway.native_count_tokens import NativeCountTokensMixin
 from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_body
 from exp.runtime.gateway.native_dispatch import dispatch_signature_headers
 from exp.runtime.gateway.native_embeddings import NativeEmbeddingsMixin
@@ -169,7 +171,11 @@ _REQUEST_TIMEOUT_SECONDS = 120.0
 
 
 class NativeControlPlane(
-    NativeBatchRelayMixin, NativeEmbeddingsMixin, NativeImagesMixin, NativeObservabilityMixin
+    NativeBatchRelayMixin,
+    NativeCountTokensMixin,
+    NativeEmbeddingsMixin,
+    NativeImagesMixin,
+    NativeObservabilityMixin,
 ):
     """Authority and accounting callbacks for the native data plane.
 
@@ -673,6 +679,11 @@ class NativeControlPlane(
             "refusal_failover": authorization.refusal_failover,
             "output_guardrail": bool(policy is not None and policy.output_checks),
         }
+        if request.surface == GatewayApiSurface.MESSAGES:
+            # Display-only: what `message_start` shows as input when the
+            # upstream reports nothing before its final chunk. The ledger
+            # never reads it; settlement keeps the provider's meters.
+            response["input_token_estimate"] = counted_input_tokens(public_request)
         if request.surface == GatewayApiSurface.RESPONSES:
             response["surface"] = "responses"
             response["envelope"] = responses_envelope(public_request)

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5664,3 +5664,51 @@ def test_anthropic_signed_thinking_drops_with_disclosure_on_a_foreign_route(
     messages = _payload_messages(admitted)
     assert messages[1]["content"] == "prior answer"
     assert "reasoning_content" not in messages[1]
+
+
+def test_count_tokens_estimates_without_accepting_a_request(tmp_path: Path) -> None:
+    """``count_tokens`` answers Anthropic's shape from the counted prompt and writes no row.
+
+    The count is the gateway's own tokenizer estimate (there is no Anthropic
+    tokenizer authority for a foreign rung), disclosed through the shared
+    ignored-parameters body field, and it never accepts a request or reserves
+    an attempt: the usage report stays empty.
+    """
+    control, raw_key = _control_plane(tmp_path)
+    body = _messages_body([{"role": "user", "content": "Hello, world!"}])
+    counted = json.loads(
+        control.count_tokens(json.dumps({"raw_key": raw_key, "body": body, "surface": "messages"}))
+    )
+    assert isinstance(counted["input_tokens"], int)
+    assert counted["input_tokens"] > 0
+    assert counted["x-experiential-ignored-parameters"] == [
+        "input_tokens->estimated(gateway_tokenizer)"
+    ]
+    report = json.loads(control.usage_json("{}"))
+    assert report["totals"]["requests"] == 0
+
+    with pytest.raises(NativeBridgeError) as ungranted:
+        control.count_tokens(
+            json.dumps(
+                {
+                    "raw_key": raw_key,
+                    "body": json.dumps(
+                        {
+                            "model": "not-granted",
+                            "max_tokens": 8,
+                            "messages": [{"role": "user", "content": "x"}],
+                        }
+                    ),
+                    "surface": "messages",
+                }
+            )
+        )
+    assert json.loads(ungranted.value.public_error_json)["status_code"] == 404
+
+    with pytest.raises(NativeBridgeError) as malformed:
+        control.count_tokens(
+            json.dumps(
+                {"raw_key": raw_key, "body": json.dumps({"model": "coding"}), "surface": "messages"}
+            )
+        )
+    assert json.loads(malformed.value.public_error_json)["status_code"] == 400

--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5675,10 +5675,12 @@ def test_count_tokens_estimates_without_accepting_a_request(tmp_path: Path) -> N
     an attempt: the usage report stays empty.
     """
     control, raw_key = _control_plane(tmp_path)
-    body = _messages_body([{"role": "user", "content": "Hello, world!"}])
-    counted = json.loads(
-        control.count_tokens(json.dumps({"raw_key": raw_key, "body": body, "surface": "messages"}))
+    # Anthropic's count body carries no max_tokens (Claude Code sends
+    # model + messages + system + tools).
+    body = json.dumps(
+        {"model": "coding", "messages": [{"role": "user", "content": "Hello, world!"}]}
     )
+    counted = json.loads(control.count_tokens(json.dumps({"raw_key": raw_key, "body": body})))
     assert isinstance(counted["input_tokens"], int)
     assert counted["input_tokens"] > 0
     assert counted["x-experiential-ignored-parameters"] == [
@@ -5693,13 +5695,8 @@ def test_count_tokens_estimates_without_accepting_a_request(tmp_path: Path) -> N
                 {
                     "raw_key": raw_key,
                     "body": json.dumps(
-                        {
-                            "model": "not-granted",
-                            "max_tokens": 8,
-                            "messages": [{"role": "user", "content": "x"}],
-                        }
+                        {"model": "not-granted", "messages": [{"role": "user", "content": "x"}]}
                     ),
-                    "surface": "messages",
                 }
             )
         )
@@ -5707,8 +5704,6 @@ def test_count_tokens_estimates_without_accepting_a_request(tmp_path: Path) -> N
 
     with pytest.raises(NativeBridgeError) as malformed:
         control.count_tokens(
-            json.dumps(
-                {"raw_key": raw_key, "body": json.dumps({"model": "coding"}), "surface": "messages"}
-            )
+            json.dumps({"raw_key": raw_key, "body": json.dumps({"model": "coding"})})
         )
     assert json.loads(malformed.value.public_error_json)["status_code"] == 400

--- a/exp/runtime/gateway/native_count_tokens.py
+++ b/exp/runtime/gateway/native_count_tokens.py
@@ -1,0 +1,80 @@
+"""The ``count_tokens`` callback for the native bridge.
+
+:class:`NativeCountTokensMixin` answers ``POST /v1/messages/count_tokens``
+for :class:`~exp.runtime.gateway.native_bridge.NativeControlPlane`: the
+decoded Messages request is counted with the gateway's own reservation
+tokenizer (the estimator the credit reservation uses, without its headroom)
+and answered in Anthropic's ``{"input_tokens": N}`` shape. No request is
+accepted, no attempt is reserved, nothing is charged: the count is a read
+against the same grants ``/v1/messages`` admits under.
+
+The gateway has no tokenizer authority for any rung (the Anthropic provider
+client does not forward ``count_tokens``), so every answer is an estimate and
+says so through the shared ``x-experiential-ignored-parameters`` disclosure
+the Messages surface already carries on its message bodies.
+"""
+
+from __future__ import annotations
+
+import json
+
+from exp.runtime.gateway.attempt_tokens import counted_input_tokens
+from exp.runtime.gateway.discovery import require_granted_authority
+from exp.runtime.gateway.native_accounting import NativeBridgeError
+from exp.runtime.gateway.native_accounting import (
+    authority_error as _authority_error,
+)
+from exp.runtime.gateway.native_components import NativeGatewayComponents
+from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_body
+from exp.runtime.gateway.native_settlement import optional_text
+
+COUNT_TOKENS_ESTIMATE_DISCLOSURE = "input_tokens->estimated(gateway_tokenizer)"
+"""Body disclosure telling the caller the count is the gateway's estimate."""
+
+
+class NativeCountTokensMixin:
+    """Token counting for the Messages surface, without a ledger row."""
+
+    _components: NativeGatewayComponents
+
+    def count_tokens(self, argument: str) -> str:
+        """Count one Messages request's input tokens for an authenticated key.
+
+        Args:
+            argument: JSON object with ``raw_key``, ``body`` (raw request body
+                text), optional ``surface`` (defaulting to ``"messages"``),
+                and the optional ``anthropic_beta`` header list, decoded with
+                the same shared decoder ``/v1/messages`` admits through.
+
+        Returns:
+            JSON object with ``input_tokens`` (the counted prompt before any
+            reservation headroom) and the ``x-experiential-ignored-parameters``
+            disclosure naming the count as the gateway's estimate.
+
+        Raises:
+            NativeBridgeError: The body failed protocol validation (400), or
+                the alias is unknown or not granted to this key (the shared
+                no-oracle 404).
+        """
+        data = json.loads(argument)
+        try:
+            decoded = decode_native_body(
+                data["body"],
+                surface=str(data.get("surface", "messages")),
+                anthropic_beta=optional_text(data.get("anthropic_beta")),
+            )
+        except NativeDecodeError as exc:
+            raise NativeBridgeError(exc.error) from exc
+        try:
+            authorities = self._components.store.granted_alias_authorities(raw_key=data["raw_key"])
+            require_granted_authority(authorities, decoded.alias)
+        except Exception as exc:  # noqa: BLE001 - boundary sanitizes every failure.
+            raise _authority_error(exc) from exc
+        disclosures = dict.fromkeys(
+            (*decoded.request.ignored_parameters, COUNT_TOKENS_ESTIMATE_DISCLOSURE)
+        )
+        body = {
+            "input_tokens": counted_input_tokens(decoded.request),
+            "x-experiential-ignored-parameters": list(disclosures),
+        }
+        return json.dumps(body, separators=(",", ":"))

--- a/exp/runtime/gateway/native_count_tokens.py
+++ b/exp/runtime/gateway/native_count_tokens.py
@@ -25,7 +25,7 @@ from exp.runtime.gateway.native_accounting import (
     authority_error as _authority_error,
 )
 from exp.runtime.gateway.native_components import NativeGatewayComponents
-from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_body
+from exp.runtime.gateway.native_decode import NativeDecodeError, decode_native_count_tokens_body
 from exp.runtime.gateway.native_settlement import optional_text
 
 COUNT_TOKENS_ESTIMATE_DISCLOSURE = "input_tokens->estimated(gateway_tokenizer)"
@@ -42,9 +42,10 @@ class NativeCountTokensMixin:
 
         Args:
             argument: JSON object with ``raw_key``, ``body`` (raw request body
-                text), optional ``surface`` (defaulting to ``"messages"``),
-                and the optional ``anthropic_beta`` header list, decoded with
-                the same shared decoder ``/v1/messages`` admits through.
+                text), and the optional ``anthropic_beta`` header list. The
+                body is Anthropic's count request (prompt-side fields, no
+                ``max_tokens``), decoded by the count entrypoint of the shared
+                Messages decoder ``/v1/messages`` admits through.
 
         Returns:
             JSON object with ``input_tokens`` (the counted prompt before any
@@ -58,9 +59,8 @@ class NativeCountTokensMixin:
         """
         data = json.loads(argument)
         try:
-            decoded = decode_native_body(
+            decoded = decode_native_count_tokens_body(
                 data["body"],
-                surface=str(data.get("surface", "messages")),
                 anthropic_beta=optional_text(data.get("anthropic_beta")),
             )
         except NativeDecodeError as exc:

--- a/exp/runtime/gateway/native_decode.py
+++ b/exp/runtime/gateway/native_decode.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 from exp.common.core.artifacts import JsonObject
-from exp.runtime.anthropic_protocol.requests import decode_messages
+from exp.runtime.anthropic_protocol.requests import decode_messages, decode_messages_count_tokens
 from exp.runtime.openai_protocol.errors import OpenAIProtocolError
 from exp.runtime.openai_protocol.images_requests import DecodedImagesRequest, decode_images
 from exp.runtime.openai_protocol.requests import (
@@ -69,6 +69,34 @@ def decode_native_body(
             idempotency_key=idempotency_key,
             client_request_id=client_request_id,
         )
+    except OpenAIProtocolError as exc:
+        raise NativeDecodeError(exc) from exc
+
+
+def decode_native_count_tokens_body(
+    body: str,
+    *,
+    anthropic_beta: str | None = None,
+) -> DecodedGatewayRequest:
+    """Decode one raw ``/v1/messages/count_tokens`` body for prompt counting.
+
+    Anthropic's count body carries no ``max_tokens``, so it decodes through
+    the count-specific Messages entrypoint rather than the generation one.
+
+    Args:
+        body: Raw request body text.
+        anthropic_beta: Optional raw caller ``anthropic-beta`` header value.
+
+    Returns:
+        The public alias and the canonical request to count.
+
+    Raises:
+        NativeDecodeError: The body is not JSON, not an object, or fails
+            shared protocol validation.
+    """
+    payload = _load_object_body(body)
+    try:
+        return decode_messages_count_tokens(payload, anthropic_beta=anthropic_beta)
     except OpenAIProtocolError as exc:
         raise NativeDecodeError(exc) from exc
 

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -1047,10 +1047,12 @@ def test_count_tokens_answers_anthropic_shape_from_the_gateway_estimate(
         return int(report["totals"]["requests"])
 
     before = counted_requests()
+    # Anthropic's count body carries no max_tokens.
+    count_body = {k: v for k, v in _messages_body("fast-token").items() if k != "max_tokens"}
     counted = httpx.post(
         f"{engine.base}/v1/messages/count_tokens",
         headers={"x-api-key": engine.raw_key},
-        json=_messages_body("fast-token"),
+        json=count_body,
         timeout=10.0,
     )
     assert counted.status_code == 200, counted.text
@@ -1065,7 +1067,7 @@ def test_count_tokens_answers_anthropic_shape_from_the_gateway_estimate(
     ungranted = httpx.post(
         f"{engine.base}/v1/messages/count_tokens",
         headers={"x-api-key": engine.raw_key},
-        json={**_messages_body("fast-token"), "model": "not-granted"},
+        json={**count_body, "model": "not-granted"},
         timeout=10.0,
     )
     assert ungranted.status_code == 404

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -959,6 +959,16 @@ def test_streaming_message_emits_the_full_anthropic_lifecycle(
         "output_tokens": 4,
         "cache_read_input_tokens": 2,
     }
+    # An OpenAI-wire upstream reports nothing before its final chunk, so the
+    # start frame carries the gateway's pre-dispatch prompt estimate (what a
+    # client that reads input from message_start, e.g. Claude Code, shows)
+    # with Anthropic's ``output_tokens: 1`` placeholder; the authoritative
+    # meters stay on message_delta above and are what the ledger bills.
+    message_start = next(payload for payload in payloads if payload["type"] == "message_start")
+    start_usage = message_start["message"]["usage"]
+    assert start_usage["output_tokens"] == 1
+    assert isinstance(start_usage["input_tokens"], int) and start_usage["input_tokens"] > 0
+    assert "cache_read_input_tokens" not in start_usage
 
 
 def test_tool_calls_translate_to_tool_use_blocks(engine: _ServingEngine) -> None:
@@ -1009,14 +1019,66 @@ def test_protocol_and_key_failures_are_anthropic_shaped(engine: _ServingEngine) 
     assert unknown_field.json()["error"]["type"] == "invalid_request_error"
     assert "unknown_field" in unknown_field.json()["error"]["message"]
 
-    count_tokens = httpx.post(
+    malformed_count = httpx.post(
         f"{engine.base}/v1/messages/count_tokens",
         headers={"x-api-key": engine.raw_key},
         json={},
         timeout=10.0,
     )
-    assert count_tokens.status_code == 404
-    assert count_tokens.json()["error"]["type"] == "not_found_error"
+    assert malformed_count.status_code == 400
+    assert malformed_count.json()["error"]["type"] == "invalid_request_error"
+
+
+def test_count_tokens_answers_anthropic_shape_from_the_gateway_estimate(
+    engine: _ServingEngine,
+) -> None:
+    """``POST /v1/messages/count_tokens`` counts the prompt without a ledger row.
+
+    Anthropic's shape (``{"input_tokens": N}``) with the gateway's own
+    tokenizer estimate for a foreign rung, disclosed through the shared body
+    field; an ungranted alias answers the same no-oracle 404 as the model
+    listing; an unknown key answers 401 in the Anthropic envelope.
+    """
+
+    def counted_requests() -> int:
+        report = httpx.get(
+            f"{engine.base}/usage.json", headers={"x-api-key": engine.raw_key}, timeout=10.0
+        ).json()
+        return int(report["totals"]["requests"])
+
+    before = counted_requests()
+    counted = httpx.post(
+        f"{engine.base}/v1/messages/count_tokens",
+        headers={"x-api-key": engine.raw_key},
+        json=_messages_body("fast-token"),
+        timeout=10.0,
+    )
+    assert counted.status_code == 200, counted.text
+    body = counted.json()
+    assert isinstance(body["input_tokens"], int) and body["input_tokens"] > 0
+    assert body["x-experiential-ignored-parameters"] == [
+        "input_tokens->estimated(gateway_tokenizer)"
+    ]
+    # A count is a read: no request is accepted, reserved, or charged.
+    assert counted_requests() == before
+
+    ungranted = httpx.post(
+        f"{engine.base}/v1/messages/count_tokens",
+        headers={"x-api-key": engine.raw_key},
+        json={**_messages_body("fast-token"), "model": "not-granted"},
+        timeout=10.0,
+    )
+    assert ungranted.status_code == 404
+    assert ungranted.json()["error"]["type"] == "not_found_error"
+
+    bad_key = httpx.post(
+        f"{engine.base}/v1/messages/count_tokens",
+        headers={"x-api-key": "exp_vk_invalid"},
+        json=_messages_body("fast-token"),
+        timeout=10.0,
+    )
+    assert bad_key.status_code == 401
+    assert bad_key.json()["error"]["type"] == "authentication_error"
 
 
 def test_native_serves_an_effort_on_a_reasoning_less_route_by_dropping_it(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.50,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.51,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.50"
+version = "0.3.51"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Why

Harbor's Claude Code (2026-09-11) on a foreign Messages route showed **0 input / 0 output tokens** for every turn and its `count_tokens` probe got a 404. Two engine facts behind that:

- Claude Code reads its input figure from `message_start.message.usage` only. An OpenAI-wire upstream reports usage in its final chunk alone, so the gateway's start frame carried the `{input_tokens: 0, output_tokens: 0}` placeholder while the true meters rode `message_delta` (which the SDK accumulators read, but Claude Code's display does not).
- `POST /v1/messages/count_tokens` answered 404 `route_not_served` ("count_tokens is not served by this gateway").

## What

**1. `message_start` carries a real pre-dispatch input estimate for OpenAI-wire upstreams**

- `attempt_tokens.counted_input_tokens(request)`: the `worst_case_input_tokens` walk **without** the reservation headroom (`_PromptCounter` split into `counted()` + `total()`; the reservation arithmetic is unchanged).
- The Messages admission carries `input_token_estimate` (only the Messages surface has a start-frame consumer; chat/Responses admits are untouched). Rust `Admission` gains the `#[serde(default)] Option<u64>` field.
- `MessagesSseEncoder::set_pre_dispatch_input_estimate`: seeds `message_start` with Anthropic's documented start shape `{"input_tokens": N, "output_tokens": 1}` when no upstream start usage is known. An Anthropic upstream's own start meters (#905) still win whichever is set first. The estimate lives in its **own field**, never in the `usage` the terminal frame settles from, so it cannot reach `message_delta` or the ledger.
- Seeded on both the live stream path and the buffered (guarded / settled) SSE path.

**2. `POST /v1/messages/count_tokens` is served**

- New `count_tokens` bridge callback in `exp/runtime/gateway/native_count_tokens.py` (`NativeCountTokensMixin`; `native_bridge.py` is at its 999-line budget), mirroring the read-side `models` / `model_detail` pattern: shared Messages decoder (malformed → 400), `granted_alias_authorities` + `require_granted_authority` (ungranted/unknown alias → the shared no-oracle 404), then `counted_input_tokens`. **No request row, no reservation, no charge.**
- Rust handler authenticates like `/v1/messages` (`x-api-key` or Bearer; unknown key → 401 in the Anthropic envelope) and answers `{"input_tokens": N, "x-experiential-ignored-parameters": ["input_tokens->estimated(gateway_tokenizer)"]}`. The Anthropic provider client has no `count_tokens` forwarding (grep is empty), so the estimate answers for **every** rung and says so through the existing body-disclosure mechanism; no new field invented.

**3. Contract documented** in `docs/reference/gateway-architecture.md`: start = pre-dispatch estimate, `message_delta` = authoritative, estimate never reaches the ledger; count_tokens = estimate, granted like `/v1/messages`.

**4. Crate bump** `exp-gateway-native` 0.3.50 → 0.3.51 (Cargo.toml, Cargo.lock, native/pyproject.toml, root pin `>=0.3.51,<0.4`, uv.lock).

## Tests first: red → green

Red (before the implementation, on the released 0.3.50 extension):

```
encode_messages::tests_claude_code — cargo test
error[E0599]: no method named `set_pre_dispatch_input_estimate` found for struct `MessagesSseEncoder`

attempt_tokens_test.py
ImportError: cannot import name 'counted_input_tokens' from 'exp.runtime.gateway.attempt_tokens'

native_bridge_test.py::test_count_tokens_estimates_without_accepting_a_request
AttributeError: 'NativeControlPlane' object has no attribute 'count_tokens'

tests/native_messages_test.py (full stack, native engine subprocess)
FAILED test_streaming_message_emits_the_full_anthropic_lifecycle     assert 0 == 1   (message_start output_tokens)
FAILED test_count_tokens_answers_anthropic_shape_from_the_gateway_estimate
  AssertionError: {"type":"error","error":{"type":"not_found_error","message":"count_tokens is not served by this gateway."}}
  assert 404 == 200
```

Green (after):

| Check | Result |
|---|---|
| `cargo test --no-default-features` | 287 passed |
| `cargo clippy --no-default-features --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `uv run pytest -n 4 --dist worksteal -q -k "not live" exp` | 4105 passed, 1 skipped (the 3 release-evidence tests pass on the committed tree; they refuse a dirty checkout by design) |
| `uv run pytest -q exp/runtime/gateway/tests/native_messages_test.py` | 34 passed |
| `uv run pytest exp/runtime/gateway/native_bridge_test.py -k rust -rs` | 21 passed, 0 skipped |
| `ruff check .` / `ruff format --check .` / `ty check` | clean |

New/changed tests:
- Rust `tests_claude_code.rs`: `start_frame_carries_the_pre_dispatch_estimate_when_the_upstream_reports_nothing`, `upstream_start_usage_outranks_the_pre_dispatch_estimate`.
- `attempt_tokens_test.py`: `counted_input_tokens` == framing + counted, `worst_case_input_tokens` == counted × (100+headroom)/100 ceil.
- `native_bridge_test.py`: `count_tokens` answers the shape + disclosure, writes no usage row, ungranted alias 404, malformed body 400.
- `tests/native_messages_test.py`: streaming lifecycle asserts `message_start.usage.output_tokens == 1`, `input_tokens > 0`, no cache leg, while `message_delta.usage` stays `{7, 4, cache_read 2}`; the count_tokens 404 pin flipped to a 200/404/401 test plus a malformed-body 400 (`json={}`), with usage totals unchanged across the count.

## Not in this PR

- Release (both `experiential` and `exp-gateway-native`): a release PR follows once this lands, as with #905 → #906.
- Platform follow-ups after the pin bump: `explabs/gateway/engine_messages_contract_test.py` pins the count_tokens 404 and must flip; the production smoke; the coding-agents docs page says count_tokens is 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
