### PR TITLE
release: bump experiential to 0.7.67 (nano-USD unit, Messages start-frame + count_tokens)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.66"
+version = "0.7.67"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.66"
+version = "0.7.67"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump carrying #914 (message_start pre-dispatch estimate, count_tokens served; crate 0.3.51) and #915 (money unit micro→nano everywhere, SNAPSHOT_SCHEMA_VERSION 3→4 with a typed ×1000 upgrade of schema-3 documents on read, overflow guard). Publishes experiential 0.7.67 and the exp-gateway-native 0.3.51 wheel matrix.

Platform follow-up: pin experiential==0.7.67 + exp-gateway-native==0.3.51 inside the nano-USD platform PR (one release, worker-first roll with the schema-4 publish fence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)