### PR TITLE
gateway: carry the billed cache-write leg from every wire into settlement (native 0.3.52, 0.7.68)

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -333,13 +333,16 @@ Normalized usage follows OpenAI subset semantics on every wire: `reasoning_token
 of `output_tokens`, and `cached_input_tokens` (cache reads) and `cache_creation_input_tokens`
 (billed cache writes) are disjoint subsets of `input_tokens`, which is every prompt token billed at
 some rate (Anthropic and Bedrock report their cache legs beside a fresh-input count and are folded;
-OpenAI and Gemini totals already include them). Settlement prices each subset at its own rate and
-the remainder at the base rate. The write leg is carried only where the wire reports a positive
-count: Anthropic `cache_creation_input_tokens`, Bedrock `cacheWriteInputTokens`, and OpenAI's
+OpenAI and Gemini totals already include them). The hosted control plane's settlement prices each subset
+at its own rate and the remainder at the base rate; the engine's own ledger valuation
+(`estimated_cost_nano_usd`) carries no cache-write rate and keeps valuing the write leg as ordinary
+input. The write leg is carried exactly as the wire reports it, zero included:
+Anthropic `cache_creation_input_tokens`, Bedrock `cacheWriteInputTokens`, and OpenAI's
 `cache_write_tokens` detail (`prompt_tokens_details` on Chat Completions, `input_tokens_details` on
 Responses; billed at 1.25x the input rate on GPT-5.6 and later, reported as zero on earlier models,
-absent on compatible relays). Gemini publishes none. `None` is priced as zero writes and never
-approximated from the fresh input. Wires that report reasoning outside
+absent on compatible relays). It is `None` only where the wire gives no usable count (Gemini, and
+OpenAI-shaped usage without the detail), never for a reported zero, so a consumer may approximate
+only an unknown leg. Wires that report reasoning outside
 their output total are folded by the native usage mappers before the counts leave the data plane:
 Gemini `thoughtsTokenCount` is additive by Google's definition and always folds into
 `output_tokens`; on the OpenAI-shaped wires (Chat Completions and Responses) the provider's own

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -330,8 +330,16 @@ month. Management and remaining-allocation reports are CLI surfaces only. There 
 dashboard.
 
 Normalized usage follows OpenAI subset semantics on every wire: `reasoning_tokens` counts a subset
-of `output_tokens` and `cached_input_tokens` a subset of `input_tokens`, and settlement prices the
-subset at its own rate and the remainder at the base rate. Wires that report reasoning outside
+of `output_tokens`, and `cached_input_tokens` (cache reads) and `cache_creation_input_tokens`
+(billed cache writes) are disjoint subsets of `input_tokens`, which is every prompt token billed at
+some rate (Anthropic and Bedrock report their cache legs beside a fresh-input count and are folded;
+OpenAI and Gemini totals already include them). Settlement prices each subset at its own rate and
+the remainder at the base rate. The write leg is carried only where the wire reports a positive
+count: Anthropic `cache_creation_input_tokens`, Bedrock `cacheWriteInputTokens`, and OpenAI's
+`cache_write_tokens` detail (`prompt_tokens_details` on Chat Completions, `input_tokens_details` on
+Responses; billed at 1.25x the input rate on GPT-5.6 and later, reported as zero on earlier models,
+absent on compatible relays). Gemini publishes none. `None` is priced as zero writes and never
+approximated from the fresh input. Wires that report reasoning outside
 their output total are folded by the native usage mappers before the counts leave the data plane:
 Gemini `thoughtsTokenCount` is additive by Google's definition and always folds into
 `output_tokens`; on the OpenAI-shaped wires (Chat Completions and Responses) the provider's own

--- a/exp/runtime/gateway/batch/line_wire.py
+++ b/exp/runtime/gateway/batch/line_wire.py
@@ -68,7 +68,8 @@ def line_usage(body: JsonObject | None) -> GatewayUsage:
     """Extract one served line's usage across the three provider wire shapes.
 
     Chat Completions bodies report ``prompt_tokens``/``completion_tokens`` with
-    ``prompt_tokens_details.cached_tokens`` and
+    ``prompt_tokens_details.cached_tokens`` (and, on GPT-5.6 and later, the
+    billed ``prompt_tokens_details.cache_write_tokens`` leg) and
     ``completion_tokens_details.reasoning_tokens``; Responses bodies report
     ``input_tokens``/``output_tokens`` with the ``input_tokens_details`` and
     ``output_tokens_details`` equivalents; Anthropic messages report
@@ -107,6 +108,11 @@ def line_usage(body: JsonObject | None) -> GatewayUsage:
     cached = _detail_count(
         usage, ("prompt_tokens_details", "input_tokens_details"), "cached_tokens"
     )
+    # OpenAI names its billed write leg inside the same details object as the
+    # read leg (GPT-5.6+; the synchronous normalizer reads the same key).
+    cache_write = _detail_count(
+        usage, ("prompt_tokens_details", "input_tokens_details"), "cache_write_tokens"
+    )
     reasoning = _detail_count(
         usage, ("completion_tokens_details", "output_tokens_details"), "reasoning_tokens"
     )
@@ -144,7 +150,7 @@ def line_usage(body: JsonObject | None) -> GatewayUsage:
         output_tokens=output_tokens,
         cached_input_tokens=cached,
         # Present only when nonzero, matching the synchronous normalizer.
-        cache_creation_input_tokens=cache_creation if cache_creation else None,
+        cache_creation_input_tokens=(cache_creation or cache_write) or None,
         reasoning_tokens=reasoning,
     )
 

--- a/exp/runtime/gateway/batch/line_wire.py
+++ b/exp/runtime/gateway/batch/line_wire.py
@@ -128,12 +128,16 @@ def line_usage(body: JsonObject | None) -> GatewayUsage:
             and "output_tokens_details" not in usage
         )
     )
-    if cached is None and anthropic_shaped:
-        # The Anthropic wire always has a cache-read leg (zero when nothing
-        # was read), and the synchronous normalizer reports it as such, so
-        # the rendered chat usage carries cached_tokens: 0 rather than
-        # omitting the detail.
-        cached = cache_read or 0
+    if anthropic_shaped:
+        # The Anthropic wire always has cache-read and cache-write legs (zero
+        # when nothing was read or written), and the synchronous normalizer
+        # reports both as such, so the rendered chat usage carries
+        # cached_tokens: 0 rather than omitting the detail and the write leg
+        # is a reported zero rather than an unknown.
+        if cached is None:
+            cached = cache_read or 0
+        if cache_creation is None:
+            cache_creation = 0
     output_tokens = reported_output
     if reasoning:
         total = _count(usage.get("total_tokens"), "usage.total_tokens")
@@ -149,8 +153,9 @@ def line_usage(body: JsonObject | None) -> GatewayUsage:
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cached_input_tokens=cached,
-        # Present only when nonzero, matching the synchronous normalizer.
-        cache_creation_input_tokens=(cache_creation or cache_write) or None,
+        # Exactly as reported (zero included), matching the synchronous
+        # normalizer; unknown only where the wire carries no write count.
+        cache_creation_input_tokens=cache_creation if cache_creation is not None else cache_write,
         reasoning_tokens=reasoning,
     )
 

--- a/exp/runtime/gateway/batch/line_wire_test.py
+++ b/exp/runtime/gateway/batch/line_wire_test.py
@@ -323,7 +323,7 @@ def test_anthropic_usage_without_cache_legs_reports_a_zero_cached_leg() -> None:
     rendered chat usage says cached_tokens: 0, as the synchronous normalizer does."""
     plain = line_usage({"usage": {"input_tokens": 9, "output_tokens": 2}})
     assert (plain.input_tokens, plain.output_tokens) == (9, 2)
-    assert plain.cached_input_tokens == 0 and plain.cache_creation_input_tokens is None
+    assert plain.cached_input_tokens == 0 and plain.cache_creation_input_tokens == 0
     message = {
         **_ANTHROPIC_MESSAGE,
         "content": [{"type": "text", "text": "ok"}],
@@ -498,8 +498,8 @@ def test_malformed_blocks_are_a_typed_rendering_failure() -> None:
 
 def test_openai_shaped_usage_carries_the_billed_cache_write_leg() -> None:
     """OpenAI's `cache_write_tokens` detail (GPT-5.6+, billed at 1.25x input) rides as the
-    creation leg on both wire shapes, like the synchronous normalizer; a zero or absent detail
-    stays unknown rather than being approximated from the fresh input."""
+    creation leg on both wire shapes exactly as reported, like the synchronous normalizer; only
+    an absent detail leaves the leg unknown."""
     chat = line_usage(
         {
             "usage": {
@@ -528,7 +528,11 @@ def test_openai_shaped_usage_carries_the_billed_cache_write_leg() -> None:
         }
     )
     assert responses.cached_input_tokens == 9077
-    assert responses.cache_creation_input_tokens is None
+    assert responses.cache_creation_input_tokens == 0
+    without_detail = line_usage(
+        {"usage": {"prompt_tokens": 9, "completion_tokens": 2, "total_tokens": 11}}
+    )
+    assert without_detail.cache_creation_input_tokens is None
     with pytest.raises(ProviderResponseError, match="cache_write_tokens"):
         line_usage(
             {

--- a/exp/runtime/gateway/batch/line_wire_test.py
+++ b/exp/runtime/gateway/batch/line_wire_test.py
@@ -494,3 +494,48 @@ def test_malformed_blocks_are_a_typed_rendering_failure() -> None:
             anthropic_result_body(
                 _line("/v1/chat/completions", _CHAT_BODY), unnamed, request_id="r", created_at=0.0
             )
+
+
+def test_openai_shaped_usage_carries_the_billed_cache_write_leg() -> None:
+    """OpenAI's `cache_write_tokens` detail (GPT-5.6+, billed at 1.25x input) rides as the
+    creation leg on both wire shapes, like the synchronous normalizer; a zero or absent detail
+    stays unknown rather than being approximated from the fresh input."""
+    chat = line_usage(
+        {
+            "usage": {
+                "prompt_tokens": 9080,
+                "completion_tokens": 5,
+                "total_tokens": 9085,
+                "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 9077},
+                "completion_tokens_details": {"reasoning_tokens": 5},
+            }
+        }
+    )
+    assert (chat.input_tokens, chat.cached_input_tokens, chat.cache_creation_input_tokens) == (
+        9080,
+        0,
+        9077,
+    )
+    responses = line_usage(
+        {
+            "usage": {
+                "input_tokens": 9080,
+                "input_tokens_details": {"cache_write_tokens": 0, "cached_tokens": 9077},
+                "output_tokens": 29,
+                "output_tokens_details": {"reasoning_tokens": 20},
+                "total_tokens": 9109,
+            }
+        }
+    )
+    assert responses.cached_input_tokens == 9077
+    assert responses.cache_creation_input_tokens is None
+    with pytest.raises(ProviderResponseError, match="cache_write_tokens"):
+        line_usage(
+            {
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "prompt_tokens_details": {"cache_write_tokens": -1},
+                }
+            }
+        )

--- a/exp/runtime/gateway/batch/providers_test.py
+++ b/exp/runtime/gateway/batch/providers_test.py
@@ -540,7 +540,9 @@ def test_anthropic_results_fold_cache_legs_into_input_and_name_the_subsets() -> 
     read = results["line-1"]
     assert (read.input_tokens, read.output_tokens) == (4510, 16)
     assert read.cached_input_tokens == 4501
-    assert read.cache_creation_input_tokens is None
+    # The Anthropic wire reports its write leg on every turn, so a read turn
+    # carries a reported zero rather than an unknown leg.
+    assert read.cache_creation_input_tokens == 0
 
 
 def test_anthropic_canceled_and_expired_lines_carry_a_reason() -> None:

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/dialects/anthropic.rs
+++ b/exp/runtime/gateway/native/src/dialects/anthropic.rs
@@ -75,7 +75,7 @@ impl Normalizer {
                     input_tokens: Some(input_tokens),
                     output_tokens: Some(self.output_tokens),
                     cached_input_tokens: Some(self.cache_read),
-                    cache_creation_input_tokens: (self.cache_write > 0).then_some(self.cache_write),
+                    cache_creation_input_tokens: Some(self.cache_write),
                     reasoning_tokens: None,
                 }));
             }
@@ -313,9 +313,10 @@ impl Normalizer {
                     input_tokens: Some(input_tokens),
                     output_tokens: Some(self.output_tokens),
                     cached_input_tokens: Some(self.cache_read),
-                    // Present only when nonzero so cache-less streams keep
-                    // their exact pre-field usage shape.
-                    cache_creation_input_tokens: (self.cache_write > 0).then_some(self.cache_write),
+                    // The wire always reports the write leg (zero when
+                    // nothing was written), and settlement distinguishes a
+                    // reported zero from an unknown leg, so it rides as is.
+                    cache_creation_input_tokens: Some(self.cache_write),
                     // Anthropic reports thinking inside output_tokens and
                     // publishes no separate count, so the reasoning subset
                     // stays unknown instead of being invented.

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -347,6 +347,7 @@ mod bedrock_tests {
                     "input_tokens": 12,
                     "output_tokens": 4,
                     "cached_input_tokens": 2,
+                    "cache_creation_input_tokens": 1,
                     "reasoning_tokens": null,
                 }),
                 json!({"kind": "completed"}),

--- a/exp/runtime/gateway/native/src/dialects/bedrock.rs
+++ b/exp/runtime/gateway/native/src/dialects/bedrock.rs
@@ -402,6 +402,7 @@ mod bedrock_tests {
                     "input_tokens": 9,
                     "output_tokens": 4,
                     "cached_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
                     "reasoning_tokens": null,
                 }),
                 json!({"kind": "completed"}),

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -35,15 +35,32 @@ use serde_json::Value;
 use crate::errors::Failure;
 
 /// Normalized token usage mirroring `GatewayUsage` semantics.
+///
+/// `input_tokens` is EVERY prompt token the provider bills at some rate:
+/// wires that report their cache legs beside a fresh-input count (Anthropic
+/// Messages `input_tokens` + `cache_read_input_tokens` +
+/// `cache_creation_input_tokens`, Bedrock Converse `inputTokens` +
+/// `cacheReadInputTokens` + `cacheWriteInputTokens`) are folded here, and
+/// wires whose total already includes them (OpenAI `prompt_tokens` /
+/// `input_tokens`, Gemini `promptTokenCount`) pass through. Both
+/// `cached_input_tokens` (read leg) and `cache_creation_input_tokens` (write
+/// leg) are therefore disjoint SUBSETS of `input_tokens` on every wire, and a
+/// consumer prices `input - cached - creation` as fresh input, the read leg at
+/// the cached rate and the write leg at the cache-write rate.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Usage {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
     /// Cache-write tokens inside the input total, present only when the
-    /// provider reported a nonzero count (Anthropic-only today). The ledger
-    /// keeps billing the folded input total; this leg exists so callers see
-    /// their prompt being cached (Claude Code displays it).
+    /// provider reported a POSITIVE count: Anthropic `cache_creation_input_tokens`
+    /// (the sum of its 5-minute and 1-hour `cache_creation` legs), Bedrock
+    /// `cacheWriteInputTokens`, OpenAI `prompt_tokens_details.cache_write_tokens`
+    /// (Chat) / `input_tokens_details.cache_write_tokens` (Responses). `None`
+    /// covers both "the wire has no such count" (Gemini, relays that strip the
+    /// detail) and "reported zero", so settlement prices `None` as zero writes
+    /// and never approximates one. Rides the settle callback (`cache_creation_input_tokens`)
+    /// and the client usage blocks (Claude Code displays it).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_creation_input_tokens: Option<u64>,
     pub reasoning_tokens: Option<u64>,

--- a/exp/runtime/gateway/native/src/events.rs
+++ b/exp/runtime/gateway/native/src/events.rs
@@ -52,15 +52,17 @@ pub struct Usage {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
-    /// Cache-write tokens inside the input total, present only when the
-    /// provider reported a POSITIVE count: Anthropic `cache_creation_input_tokens`
-    /// (the sum of its 5-minute and 1-hour `cache_creation` legs), Bedrock
+    /// Cache-write tokens inside the input total, exactly as the wire reported
+    /// them, zero included: Anthropic `cache_creation_input_tokens` (the sum of
+    /// its 5-minute and 1-hour `cache_creation` legs), Bedrock
     /// `cacheWriteInputTokens`, OpenAI `prompt_tokens_details.cache_write_tokens`
     /// (Chat) / `input_tokens_details.cache_write_tokens` (Responses). `None`
-    /// covers both "the wire has no such count" (Gemini, relays that strip the
-    /// detail) and "reported zero", so settlement prices `None` as zero writes
-    /// and never approximates one. Rides the settle callback (`cache_creation_input_tokens`)
-    /// and the client usage blocks (Claude Code displays it).
+    /// means the wire gave NO usable write count (Gemini, OpenAI models and
+    /// compatible relays that omit the detail) — never "reported zero" — so a
+    /// consumer may approximate only a `None` leg and must price a reported
+    /// `0` as zero writes. Rides the settle callback
+    /// (`cache_creation_input_tokens`) and the client usage blocks (Claude
+    /// Code displays it).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_creation_input_tokens: Option<u64>,
     pub reasoning_tokens: Option<u64>,

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -550,7 +550,7 @@ fn custom_tool_input_passes_through_the_hold_back_untouched() {
 // never invented where the wire has none.
 
 #[test]
-fn openai_responses_usage_carries_the_billed_cache_write_leg_when_positive() {
+fn openai_responses_usage_carries_the_billed_cache_write_leg_as_reported() {
     // Verbatim gpt-5.6-luna usage (api.openai.com, 2026-09-11,
     // prompt_cache_retention=24h): the first turn writes 9077 of the 9080
     // prompt tokens, the second reads them back. OpenAI bills GPT-5.6+ writes
@@ -577,10 +577,19 @@ fn openai_responses_usage_carries_the_billed_cache_write_leg_when_positive() {
     .expect("valid usage")
     .expect("usage present");
     assert_eq!(read_turn.cached_input_tokens, Some(9077));
-    // A reported zero is "no positive write count", the same `None` a wire
-    // without the detail yields (gpt-5.4-nano reports `cache_write_tokens: 0`
-    // on the turn that filled its cache because it does not bill writes).
-    assert_eq!(read_turn.cache_creation_input_tokens, None);
+    // A reported zero rides as zero (gpt-5.4-nano reports `cache_write_tokens:
+    // 0` even on the turn that filled its cache, because it bills no writes);
+    // only an absent detail is unknown.
+    assert_eq!(read_turn.cache_creation_input_tokens, Some(0));
+    let without_detail = openai_usage(Some(&json!({
+        "input_tokens": 36,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 7,
+        "total_tokens": 43,
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(without_detail.cache_creation_input_tokens, None);
     let malformed = openai_usage(Some(&json!({
         "input_tokens": 1,
         "input_tokens_details": {"cache_write_tokens": -1},
@@ -593,7 +602,7 @@ fn openai_responses_usage_carries_the_billed_cache_write_leg_when_positive() {
 }
 
 #[test]
-fn openai_compatible_usage_carries_the_billed_cache_write_leg_when_positive() {
+fn openai_compatible_usage_carries_the_billed_cache_write_leg_as_reported() {
     // Verbatim gpt-5.6-luna Chat Completions usage (api.openai.com,
     // 2026-09-11, streamed with stream_options.include_usage and identical
     // non-streaming): `prompt_tokens_details.cache_write_tokens` is the write
@@ -624,10 +633,11 @@ fn openai_compatible_usage_carries_the_billed_cache_write_leg_when_positive() {
     }))
     .expect("valid usage");
     assert_eq!(read_turn.cached_input_tokens, Some(9077));
-    assert_eq!(read_turn.cache_creation_input_tokens, None);
-    // Pre-GPT-5.6 OpenAI and compatible relays carry no write detail at all
-    // (verbatim gpt-5.4-nano, and the OpenRouter/Foundry shapes above): the
-    // leg stays unknown instead of being approximated from the fresh input.
+    assert_eq!(read_turn.cache_creation_input_tokens, Some(0));
+    // Pre-GPT-5.6 OpenAI Chat and compatible relays carry no write detail at
+    // all (verbatim gpt-5.4-nano, and the OpenRouter/Foundry shapes above):
+    // the leg stays unknown (the consumer's approximation case), never an
+    // invented zero.
     let without_detail = openai_compatible_usage(&json!({
         "prompt_tokens": 9072,
         "completion_tokens": 5,
@@ -653,9 +663,11 @@ fn bedrock_and_gemini_usage_report_the_write_leg_only_where_the_wire_has_one() {
     assert_eq!(bedrock.input_tokens, Some(12));
     assert_eq!(bedrock.cached_input_tokens, Some(2));
     assert_eq!(bedrock.cache_creation_input_tokens, Some(1));
+    // Converse omits zero-valued legs, so an absent write leg is a reported
+    // zero, not an unknown.
     let no_write =
         bedrock_usage(Some(&json!({"inputTokens": 9, "outputTokens": 4}))).expect("valid usage");
-    assert_eq!(no_write.cache_creation_input_tokens, None);
+    assert_eq!(no_write.cache_creation_input_tokens, Some(0));
     // Gemini publishes no write count, so none is invented.
     let gemini = gemini_usage(&json!({
         "promptTokenCount": 30,

--- a/exp/runtime/gateway/native/src/events/tests.rs
+++ b/exp/runtime/gateway/native/src/events/tests.rs
@@ -544,3 +544,126 @@ fn custom_tool_input_passes_through_the_hold_back_untouched() {
         "{}\"\" ls -la"
     );
 }
+
+// Cache-write pins: the billed write leg rides as `cache_creation_input_tokens`
+// on every wire that reports one, as a subset of `input_tokens`, and is
+// never invented where the wire has none.
+
+#[test]
+fn openai_responses_usage_carries_the_billed_cache_write_leg_when_positive() {
+    // Verbatim gpt-5.6-luna usage (api.openai.com, 2026-09-11,
+    // prompt_cache_retention=24h): the first turn writes 9077 of the 9080
+    // prompt tokens, the second reads them back. OpenAI bills GPT-5.6+ writes
+    // at 1.25x the input rate, so dropping the leg under-meters every write.
+    let write_turn = openai_usage(Some(&json!({
+        "input_tokens": 9080,
+        "input_tokens_details": {"cache_write_tokens": 9077, "cached_tokens": 0},
+        "output_tokens": 32,
+        "output_tokens_details": {"reasoning_tokens": 23},
+        "total_tokens": 9112,
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(write_turn.input_tokens, Some(9080));
+    assert_eq!(write_turn.cached_input_tokens, Some(0));
+    assert_eq!(write_turn.cache_creation_input_tokens, Some(9077));
+    let read_turn = openai_usage(Some(&json!({
+        "input_tokens": 9080,
+        "input_tokens_details": {"cache_write_tokens": 0, "cached_tokens": 9077},
+        "output_tokens": 29,
+        "output_tokens_details": {"reasoning_tokens": 20},
+        "total_tokens": 9109,
+    })))
+    .expect("valid usage")
+    .expect("usage present");
+    assert_eq!(read_turn.cached_input_tokens, Some(9077));
+    // A reported zero is "no positive write count", the same `None` a wire
+    // without the detail yields (gpt-5.4-nano reports `cache_write_tokens: 0`
+    // on the turn that filled its cache because it does not bill writes).
+    assert_eq!(read_turn.cache_creation_input_tokens, None);
+    let malformed = openai_usage(Some(&json!({
+        "input_tokens": 1,
+        "input_tokens_details": {"cache_write_tokens": -1},
+        "output_tokens": 1,
+    })));
+    assert_eq!(
+        malformed.unwrap_err(),
+        "OpenAI cache_write_tokens must be a non-negative integer"
+    );
+}
+
+#[test]
+fn openai_compatible_usage_carries_the_billed_cache_write_leg_when_positive() {
+    // Verbatim gpt-5.6-luna Chat Completions usage (api.openai.com,
+    // 2026-09-11, streamed with stream_options.include_usage and identical
+    // non-streaming): `prompt_tokens_details.cache_write_tokens` is the write
+    // leg, a subset of prompt_tokens beside cached_tokens.
+    let write_turn = openai_compatible_usage(&json!({
+        "prompt_tokens": 9080,
+        "completion_tokens": 5,
+        "total_tokens": 9085,
+        "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 9077, "audio_tokens": 0},
+        "completion_tokens_details": {
+            "reasoning_tokens": 5,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
+    }))
+    .expect("valid usage");
+    assert_eq!(write_turn.input_tokens, Some(9080));
+    assert_eq!(write_turn.cached_input_tokens, Some(0));
+    assert_eq!(write_turn.cache_creation_input_tokens, Some(9077));
+    assert_eq!(write_turn.reasoning_tokens, Some(5));
+    let read_turn = openai_compatible_usage(&json!({
+        "prompt_tokens": 9080,
+        "completion_tokens": 5,
+        "total_tokens": 9085,
+        "prompt_tokens_details": {"cached_tokens": 9077, "cache_write_tokens": 0, "audio_tokens": 0},
+        "completion_tokens_details": {"reasoning_tokens": 5},
+    }))
+    .expect("valid usage");
+    assert_eq!(read_turn.cached_input_tokens, Some(9077));
+    assert_eq!(read_turn.cache_creation_input_tokens, None);
+    // Pre-GPT-5.6 OpenAI and compatible relays carry no write detail at all
+    // (verbatim gpt-5.4-nano, and the OpenRouter/Foundry shapes above): the
+    // leg stays unknown instead of being approximated from the fresh input.
+    let without_detail = openai_compatible_usage(&json!({
+        "prompt_tokens": 9072,
+        "completion_tokens": 5,
+        "total_tokens": 9077,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "completion_tokens_details": {"reasoning_tokens": 0},
+    }))
+    .expect("valid usage");
+    assert_eq!(without_detail.cache_creation_input_tokens, None);
+}
+
+#[test]
+fn bedrock_and_gemini_usage_report_the_write_leg_only_where_the_wire_has_one() {
+    // Converse names its write leg; it folds into input AND rides as the
+    // creation subset so settlement can price it at the cache-write rate.
+    let bedrock = bedrock_usage(Some(&json!({
+        "inputTokens": 9,
+        "outputTokens": 4,
+        "cacheReadInputTokens": 2,
+        "cacheWriteInputTokens": 1,
+    })))
+    .expect("valid usage");
+    assert_eq!(bedrock.input_tokens, Some(12));
+    assert_eq!(bedrock.cached_input_tokens, Some(2));
+    assert_eq!(bedrock.cache_creation_input_tokens, Some(1));
+    let no_write =
+        bedrock_usage(Some(&json!({"inputTokens": 9, "outputTokens": 4}))).expect("valid usage");
+    assert_eq!(no_write.cache_creation_input_tokens, None);
+    // Gemini publishes no write count, so none is invented.
+    let gemini = gemini_usage(&json!({
+        "promptTokenCount": 30,
+        "cachedContentTokenCount": 20,
+        "candidatesTokenCount": 4,
+        "totalTokenCount": 34,
+    }))
+    .expect("valid usage");
+    assert_eq!(gemini.cached_input_tokens, Some(20));
+    assert_eq!(gemini.cache_creation_input_tokens, None);
+}

--- a/exp/runtime/gateway/native/src/events/usage.rs
+++ b/exp/runtime/gateway/native/src/events/usage.rs
@@ -67,6 +67,14 @@ fn optional_usage_detail(
     }
 }
 
+/// Keep a cache-write leg only when it is positive: `Usage.cache_creation_input_tokens`
+/// is `None` for "no positive write count reported", whether the wire omits
+/// the field (relays that strip details, Gemini) or reports zero (a cache
+/// hit, or an OpenAI model that does not bill writes and reports `0`).
+fn positive_cache_write(count: Option<u64>) -> Option<u64> {
+    count.filter(|count| *count > 0)
+}
+
 /// Sum persistable legs into one ledger count. Individually persistable legs
 /// whose total is not are a provider contract violation, never a clamped or
 /// wrapped total.
@@ -114,6 +122,10 @@ fn fold_openai_shaped_reasoning(
 /// omitted object is unknown usage, while a malformed one fails the stream.
 /// `output_tokens_details.reasoning_tokens` folds into `output_tokens` when
 /// the provider's `total_tokens` shows it was reported additively.
+/// `input_tokens_details.cache_write_tokens` (the prompt-cache write leg
+/// OpenAI bills at a premium on GPT-5.6 and later; reported as `0` on models
+/// that do not bill writes) rides as `cache_creation_input_tokens` when
+/// positive. Both details are subsets of `input_tokens`.
 pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
     let value = match value {
         None | Some(Value::Null) => return Ok(None),
@@ -147,7 +159,12 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
             "cached_tokens",
             "OpenAI cached_tokens",
         )?,
-        cache_creation_input_tokens: None,
+        cache_creation_input_tokens: positive_cache_write(optional_usage_detail(
+            object,
+            "input_tokens_details",
+            "cache_write_tokens",
+            "OpenAI cache_write_tokens",
+        )?),
         reasoning_tokens,
     }))
 }
@@ -156,6 +173,10 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
 /// instead of silently dropping token accounting.
 /// `completion_tokens_details.reasoning_tokens` folds into `output_tokens`
 /// when the provider's `total_tokens` shows it was reported additively.
+/// `prompt_tokens_details.cache_write_tokens` (OpenAI's billed cache-write
+/// leg, a subset of `prompt_tokens` like `cached_tokens`) rides as
+/// `cache_creation_input_tokens` when positive; compatible relays that omit
+/// the detail leave it unknown.
 pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
@@ -185,14 +206,21 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
             "cached_tokens",
             "cached_tokens",
         )?,
-        cache_creation_input_tokens: None,
+        cache_creation_input_tokens: positive_cache_write(optional_usage_detail(
+            object,
+            "prompt_tokens_details",
+            "cache_write_tokens",
+            "cache_write_tokens",
+        )?),
         reasoning_tokens,
     })
 }
 
 /// Parse Gemini `usageMetadata`: cached tokens are an input subset, absent
 /// counts are zero (`require_integer` parity), and `thoughtsTokenCount` stays
-/// unknown when omitted.
+/// unknown when omitted. Gemini publishes no cache-write count (implicit
+/// caching writes are free and explicit caches bill by storage time), so the
+/// write leg stays unknown rather than invented.
 ///
 /// Google defines thinking tokens as ADDITIVE to `candidatesTokenCount`
 /// (`totalTokenCount` = prompt + candidates + thoughts, and response pricing
@@ -238,11 +266,12 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
 }
 
 /// Parse Bedrock `metadata.usage`: cache read and write legs fold into total
-/// input, cached input reports the read leg, and absent counts are zero
-/// (`require_integer` parity). Legs and the folded total beyond the
-/// persistable ledger range are provider contract violations and fail the
-/// stream rather than reaching settlement as a value the ledger could never
-/// write. Converse bills a reasoning model's thinking inside `outputTokens`
+/// input, cached input reports the read leg, a positive write leg rides as
+/// `cache_creation_input_tokens` (Converse bills it at the provider's
+/// cache-write rate), and absent counts are zero (`require_integer` parity).
+/// Legs and the folded total beyond the persistable ledger range are provider
+/// contract violations and fail the stream rather than reaching settlement as
+/// a value the ledger could never write. Converse bills a reasoning model's thinking inside `outputTokens`
 /// and publishes no separate count, so `reasoning_tokens` stays unknown.
 pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
     let usage = value
@@ -268,7 +297,7 @@ pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
             "Bedrock outputTokens",
         )?),
         cached_input_tokens: Some(cache_read),
-        cache_creation_input_tokens: None,
+        cache_creation_input_tokens: positive_cache_write(Some(cache_write)),
         reasoning_tokens: None,
     })
 }

--- a/exp/runtime/gateway/native/src/events/usage.rs
+++ b/exp/runtime/gateway/native/src/events/usage.rs
@@ -67,14 +67,6 @@ fn optional_usage_detail(
     }
 }
 
-/// Keep a cache-write leg only when it is positive: `Usage.cache_creation_input_tokens`
-/// is `None` for "no positive write count reported", whether the wire omits
-/// the field (relays that strip details, Gemini) or reports zero (a cache
-/// hit, or an OpenAI model that does not bill writes and reports `0`).
-fn positive_cache_write(count: Option<u64>) -> Option<u64> {
-    count.filter(|count| *count > 0)
-}
-
 /// Sum persistable legs into one ledger count. Individually persistable legs
 /// whose total is not are a provider contract violation, never a clamped or
 /// wrapped total.
@@ -124,8 +116,9 @@ fn fold_openai_shaped_reasoning(
 /// the provider's `total_tokens` shows it was reported additively.
 /// `input_tokens_details.cache_write_tokens` (the prompt-cache write leg
 /// OpenAI bills at a premium on GPT-5.6 and later; reported as `0` on models
-/// that do not bill writes) rides as `cache_creation_input_tokens` when
-/// positive. Both details are subsets of `input_tokens`.
+/// that do not bill writes) rides as `cache_creation_input_tokens` exactly as
+/// reported, zero included; an absent detail leaves the leg unknown. Both
+/// details are subsets of `input_tokens`.
 pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
     let value = match value {
         None | Some(Value::Null) => return Ok(None),
@@ -159,12 +152,12 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
             "cached_tokens",
             "OpenAI cached_tokens",
         )?,
-        cache_creation_input_tokens: positive_cache_write(optional_usage_detail(
+        cache_creation_input_tokens: optional_usage_detail(
             object,
             "input_tokens_details",
             "cache_write_tokens",
             "OpenAI cache_write_tokens",
-        )?),
+        )?,
         reasoning_tokens,
     }))
 }
@@ -175,8 +168,8 @@ pub fn openai_usage(value: Option<&Value>) -> Result<Option<Usage>, String> {
 /// when the provider's `total_tokens` shows it was reported additively.
 /// `prompt_tokens_details.cache_write_tokens` (OpenAI's billed cache-write
 /// leg, a subset of `prompt_tokens` like `cached_tokens`) rides as
-/// `cache_creation_input_tokens` when positive; compatible relays that omit
-/// the detail leave it unknown.
+/// `cache_creation_input_tokens` exactly as reported, zero included;
+/// compatible relays that omit the detail leave it unknown.
 pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
     let object = value
         .as_object()
@@ -206,12 +199,12 @@ pub fn openai_compatible_usage(value: &Value) -> Result<Usage, String> {
             "cached_tokens",
             "cached_tokens",
         )?,
-        cache_creation_input_tokens: positive_cache_write(optional_usage_detail(
+        cache_creation_input_tokens: optional_usage_detail(
             object,
             "prompt_tokens_details",
             "cache_write_tokens",
             "cache_write_tokens",
-        )?),
+        )?,
         reasoning_tokens,
     })
 }
@@ -266,9 +259,10 @@ pub fn gemini_usage(value: &Value) -> Result<Usage, String> {
 }
 
 /// Parse Bedrock `metadata.usage`: cache read and write legs fold into total
-/// input, cached input reports the read leg, a positive write leg rides as
+/// input, cached input reports the read leg, the write leg rides as
 /// `cache_creation_input_tokens` (Converse bills it at the provider's
-/// cache-write rate), and absent counts are zero (`require_integer` parity).
+/// cache-write rate; the wire omits zero-valued legs, so absent is a
+/// reported zero), and absent counts are zero (`require_integer` parity).
 /// Legs and the folded total beyond the persistable ledger range are provider
 /// contract violations and fail the stream rather than reaching settlement as
 /// a value the ledger could never write. Converse bills a reasoning model's thinking inside `outputTokens`
@@ -297,7 +291,7 @@ pub fn bedrock_usage(value: Option<&Value>) -> Result<Usage, String> {
             "Bedrock outputTokens",
         )?),
         cached_input_tokens: Some(cache_read),
-        cache_creation_input_tokens: positive_cache_write(Some(cache_write)),
+        cache_creation_input_tokens: Some(cache_write),
         reasoning_tokens: None,
     })
 }

--- a/exp/runtime/gateway/native/src/settlement.rs
+++ b/exp/runtime/gateway/native/src/settlement.rs
@@ -76,6 +76,10 @@ fn settle_argument(
             "input_tokens": usage.input_tokens,
             "output_tokens": usage.output_tokens,
             "cached_input_tokens": usage.cached_input_tokens,
+            // The billed cache-write subset of input_tokens (see
+            // `events::Usage`); null when the wire reported no positive
+            // count, which the control plane prices as zero writes.
+            "cache_creation_input_tokens": usage.cache_creation_input_tokens,
             "reasoning_tokens": usage.reasoning_tokens,
         })),
         "tool_names": tool_names,
@@ -464,6 +468,54 @@ mod tests {
             system_time_to_rfc3339(leap),
             "2020-02-29T00:00:00.000+00:00"
         );
+    }
+
+    #[test]
+    fn settle_argument_carries_the_cache_write_leg_beside_the_other_counts() {
+        // The control plane prices the write subset at the cache-write rate,
+        // so the settle payload names it; an unknown leg rides as null (the
+        // control plane's backward-compatible parse reads null as zero writes).
+        let with_write = Usage {
+            input_tokens: Some(9080),
+            output_tokens: Some(32),
+            cached_input_tokens: Some(0),
+            cache_creation_input_tokens: Some(9077),
+            reasoning_tokens: Some(23),
+        };
+        let argument = settle_argument(
+            "req",
+            "att",
+            "completed",
+            Some(&with_write),
+            &[],
+            None,
+            true,
+            true,
+            None,
+            None,
+        );
+        let parsed: Value = serde_json::from_str(&argument).expect("valid json");
+        assert_eq!(parsed["usage"]["input_tokens"], json!(9080));
+        assert_eq!(parsed["usage"]["cached_input_tokens"], json!(0));
+        assert_eq!(parsed["usage"]["cache_creation_input_tokens"], json!(9077));
+        let without_write = Usage {
+            cache_creation_input_tokens: None,
+            ..with_write
+        };
+        let argument = settle_argument(
+            "req",
+            "att",
+            "completed",
+            Some(&without_write),
+            &[],
+            None,
+            true,
+            true,
+            None,
+            None,
+        );
+        let parsed: Value = serde_json::from_str(&argument).expect("valid json");
+        assert_eq!(parsed["usage"]["cache_creation_input_tokens"], Value::Null);
     }
 
     #[test]

--- a/exp/runtime/gateway/native/src/settlement.rs
+++ b/exp/runtime/gateway/native/src/settlement.rs
@@ -77,8 +77,9 @@ fn settle_argument(
             "output_tokens": usage.output_tokens,
             "cached_input_tokens": usage.cached_input_tokens,
             // The billed cache-write subset of input_tokens (see
-            // `events::Usage`); null when the wire reported no positive
-            // count, which the control plane prices as zero writes.
+            // `events::Usage`): a reported zero rides as 0; null means the
+            // wire gave no usable count (the control plane may approximate
+            // only that case).
             "cache_creation_input_tokens": usage.cache_creation_input_tokens,
             "reasoning_tokens": usage.reasoning_tokens,
         })),
@@ -473,8 +474,8 @@ mod tests {
     #[test]
     fn settle_argument_carries_the_cache_write_leg_beside_the_other_counts() {
         // The control plane prices the write subset at the cache-write rate,
-        // so the settle payload names it; an unknown leg rides as null (the
-        // control plane's backward-compatible parse reads null as zero writes).
+        // so the settle payload names it; an unknown leg rides as null, which
+        // the control plane may approximate, while a reported zero rides as 0.
         let with_write = Usage {
             input_tokens: Some(9080),
             output_tokens: Some(32),

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -257,6 +257,10 @@ def _usage_from_payload(
         input_tokens=_optional_count(payload.get("input_tokens")),
         output_tokens=_optional_count(payload.get("output_tokens")),
         cached_input_tokens=_optional_count(payload.get("cached_input_tokens")),
+        # The billed cache-write subset of input_tokens; absent or null (a
+        # wire without the count, or a pre-0.3.52 data plane) stays unknown
+        # and is priced as zero writes, never approximated.
+        cache_creation_input_tokens=_optional_count(payload.get("cache_creation_input_tokens")),
         reasoning_tokens=_optional_count(payload.get("reasoning_tokens")),
         tool_names=names,
     )

--- a/exp/runtime/gateway/native_settlement.py
+++ b/exp/runtime/gateway/native_settlement.py
@@ -257,9 +257,9 @@ def _usage_from_payload(
         input_tokens=_optional_count(payload.get("input_tokens")),
         output_tokens=_optional_count(payload.get("output_tokens")),
         cached_input_tokens=_optional_count(payload.get("cached_input_tokens")),
-        # The billed cache-write subset of input_tokens; absent or null (a
-        # wire without the count, or a pre-0.3.52 data plane) stays unknown
-        # and is priced as zero writes, never approximated.
+        # The billed cache-write subset of input_tokens: a reported zero is 0;
+        # absent or null (a wire without the count, or a pre-0.3.52 data
+        # plane) stays unknown, the one case a consumer may approximate.
         cache_creation_input_tokens=_optional_count(payload.get("cache_creation_input_tokens")),
         reasoning_tokens=_optional_count(payload.get("reasoning_tokens")),
         tool_names=names,

--- a/exp/runtime/gateway/native_settlement_test.py
+++ b/exp/runtime/gateway/native_settlement_test.py
@@ -48,6 +48,37 @@ def test_usage_from_payload_handles_tokens_and_tool_names() -> None:
     assert complete.input_tokens == 10
     assert complete.output_tokens == 3
     assert complete.cached_input_tokens == 2
+    # A payload from a data plane that predates the write leg carries no
+    # key; the leg stays unknown instead of being approximated.
+    assert complete.cache_creation_input_tokens is None
+
+
+def test_usage_from_payload_carries_the_cache_write_leg() -> None:
+    """The settle payload's cache-write subset reaches GatewayUsage (gpt-5.6-luna shape)."""
+    luna_write_turn = _usage_from_payload(
+        {
+            "input_tokens": 9080,
+            "output_tokens": 32,
+            "cached_input_tokens": 0,
+            "cache_creation_input_tokens": 9077,
+            "reasoning_tokens": 23,
+        },
+        [],
+    )
+    assert luna_write_turn is not None
+    assert luna_write_turn.cache_creation_input_tokens == 9077
+    read_turn = _usage_from_payload(
+        {
+            "input_tokens": 9080,
+            "output_tokens": 29,
+            "cached_input_tokens": 9077,
+            "cache_creation_input_tokens": None,
+            "reasoning_tokens": 20,
+        },
+        [],
+    )
+    assert read_turn is not None
+    assert read_turn.cache_creation_input_tokens is None
 
 
 def test_terminal_from_settlement_normalizes_usage_and_tools() -> None:

--- a/exp/runtime/gateway/stream_contracts.py
+++ b/exp/runtime/gateway/stream_contracts.py
@@ -36,14 +36,14 @@ class GatewayUsage(ContractModel):
     output_tokens: int | None = Field(default=None, ge=0)
     cached_input_tokens: int | None = Field(default=None, ge=0)
     cache_creation_input_tokens: int | None = Field(default=None, ge=0)
-    """Billed cache-write tokens inside the input total, present only when the
-    provider reported a POSITIVE count: Anthropic ``cache_creation_input_tokens``
+    """Billed cache-write tokens inside the input total, exactly as the wire
+    reported them, zero included: Anthropic ``cache_creation_input_tokens``
     (5-minute + 1-hour legs), Bedrock ``cacheWriteInputTokens``, OpenAI
     ``prompt_tokens_details.cache_write_tokens`` (Chat) /
     ``input_tokens_details.cache_write_tokens`` (Responses; billed at 1.25x
-    input on GPT-5.6 and later). ``None`` means no positive count was reported
-    (a wire without one, or zero) and is priced as zero writes, never
-    approximated from the fresh input."""
+    input on GPT-5.6 and later). ``None`` means the wire gave NO usable write
+    count (Gemini, OpenAI models and compatible relays that omit the detail),
+    never a reported zero; a consumer may approximate only a ``None`` leg."""
     reasoning_tokens: int | None = Field(default=None, ge=0)
     tool_names: tuple[str, ...] = ()
     """Invoked tool names in first-use order, names only and never arguments."""

--- a/exp/runtime/gateway/stream_contracts.py
+++ b/exp/runtime/gateway/stream_contracts.py
@@ -17,9 +17,16 @@ from exp.common.models.model import MAXIMUM_TOOL_CALL_ID_CHARACTERS, ToolCall
 class GatewayUsage(ContractModel):
     """Normalized token counts and invoked tool names from one provider attempt.
 
-    Cached-input and reasoning counts are subsets of the total input and output counts when
-    present. They identify differently priced portions of those totals and must not be added a
-    second time by callers.
+    ``input_tokens`` is EVERY prompt token the provider bills at some rate: the native mappers fold
+    the wires that report cache legs beside a fresh-input count (Anthropic ``input_tokens`` +
+    ``cache_read_input_tokens`` + ``cache_creation_input_tokens``, Bedrock ``inputTokens`` +
+    ``cacheReadInputTokens`` + ``cacheWriteInputTokens``) and pass through the wires whose total
+    already includes them (OpenAI ``prompt_tokens`` / ``input_tokens``, Gemini
+    ``promptTokenCount``). ``cached_input_tokens`` (read leg) and ``cache_creation_input_tokens``
+    (write leg) are therefore disjoint subsets of ``input_tokens`` on every wire, and
+    ``reasoning_tokens`` a subset of ``output_tokens``. They identify differently priced portions
+    of those totals (fresh input = ``input - cached - creation``) and must not be added a second
+    time by callers.
 
     A terminal event may carry only ``tool_names`` when the provider omits token usage. In that
     case both token totals remain unknown instead of being represented as zero.
@@ -29,9 +36,14 @@ class GatewayUsage(ContractModel):
     output_tokens: int | None = Field(default=None, ge=0)
     cached_input_tokens: int | None = Field(default=None, ge=0)
     cache_creation_input_tokens: int | None = Field(default=None, ge=0)
-    """Cache-write tokens inside the input total (Anthropic-only today),
-    present only when the provider reported a nonzero count; billing keeps
-    using the folded input total."""
+    """Billed cache-write tokens inside the input total, present only when the
+    provider reported a POSITIVE count: Anthropic ``cache_creation_input_tokens``
+    (5-minute + 1-hour legs), Bedrock ``cacheWriteInputTokens``, OpenAI
+    ``prompt_tokens_details.cache_write_tokens`` (Chat) /
+    ``input_tokens_details.cache_write_tokens`` (Responses; billed at 1.25x
+    input on GPT-5.6 and later). ``None`` means no positive count was reported
+    (a wire without one, or zero) and is priced as zero writes, never
+    approximated from the fresh input."""
     reasoning_tokens: int | None = Field(default=None, ge=0)
     tool_names: tuple[str, ...] = ()
     """Invoked tool names in first-use order, names only and never arguments."""

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -498,6 +498,7 @@ def test_native_bedrock_normalizer_matches_the_golden_fixture() -> None:
             "input_tokens": 3,
             "output_tokens": 0,
             "cached_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
             "reasoning_tokens": None,
         },
         {
@@ -616,6 +617,7 @@ ANTHROPIC_THINKING_EVENTS: tuple[JsonObject, ...] = (
         "cached_input_tokens": 2,
         # Anthropic reports thinking inside output_tokens with no separate
         # count, so the reasoning subset stays unknown.
+        "cache_creation_input_tokens": 0,
         "reasoning_tokens": None,
     },
     {"kind": "completed"},
@@ -627,13 +629,15 @@ def _anthropic_start_usage(input_tokens: int, output_tokens: int, cached: int) -
 
     The start-frame meters reach the Messages encoder's own ``message_start``
     (Claude Code reads input there) and stand in for settlement until the
-    terminal report supersedes them at ``message_stop``.
+    terminal report supersedes them at ``message_stop``. The wire always
+    reports its cache-write leg, so a cache-less turn carries a reported zero.
     """
     return {
         "kind": "usage",
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "cached_input_tokens": cached,
+        "cache_creation_input_tokens": 0,
         "reasoning_tokens": None,
     }
 
@@ -691,6 +695,7 @@ ANTHROPIC_LIVE_TOOL_EVENTS: tuple[JsonObject, ...] = (
         "input_tokens": 663,
         "output_tokens": 33,
         "cached_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
         "reasoning_tokens": None,
     },
     {"kind": "completed"},
@@ -755,6 +760,7 @@ def test_native_anthropic_normalizer_completes_a_zero_argument_tool_call() -> No
             "input_tokens": 550,
             "output_tokens": 37,
             "cached_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
             "reasoning_tokens": None,
         },
         {"kind": "completed"},
@@ -860,6 +866,7 @@ ANTHROPIC_LIVE_WEB_SEARCH_EVENTS: tuple[JsonObject, ...] = (
         "input_tokens": 12284,
         "output_tokens": 103,
         "cached_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
         "reasoning_tokens": None,
     },
     {"kind": "completed"},

--- a/exp/runtime/gateway/tests/native_dialect_parity_test.py
+++ b/exp/runtime/gateway/tests/native_dialect_parity_test.py
@@ -466,6 +466,9 @@ BEDROCK_GOLDEN_EVENTS: tuple[JsonObject, ...] = (
         "input_tokens": 12,
         "output_tokens": 4,
         "cached_input_tokens": 2,
+        # Converse's write leg rides as the creation subset (settlement
+        # prices it at the cache-write rate) besides folding into input.
+        "cache_creation_input_tokens": 1,
         "reasoning_tokens": None,
     },
     {"kind": "completed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.67"
+version = "0.7.68"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.51,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.52,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,12 +637,12 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.67"
+version = "0.7.68"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why

OpenAI bills prompt-cache **writes** at 1.25x the uncached input rate on GPT-5.6 and later, and reports the leg on both wires. The engine dropped it everywhere the platform could see: the OpenAI mappers set `cache_creation_input_tokens: None`, Bedrock folded `cacheWriteInputTokens` into input and dropped the leg, and the settle callback (`settle_argument`) never carried the field. The control plane therefore priced every write as plain input. Production Luna on 2026-09-10 settled $1,147 against ~$1,657 billed by OpenAI; repricing the same attempts with cache writes and long-context reproduces the bill to 0.1%.

## What each provider exposes (live, 2026-09-11, house keys)

| Wire | Field | Sample (write turn → read turn) |
|---|---|---|
| OpenAI Chat Completions, `gpt-5.6-luna` (24h retention, its only mode), streamed and non-streamed identical | `prompt_tokens_details.cache_write_tokens` | `prompt_tokens: 9080, cached_tokens: 0, cache_write_tokens: 9077` → `cached_tokens: 9077, cache_write_tokens: 0` |
| OpenAI Responses, `gpt-5.6-luna` | `input_tokens_details.cache_write_tokens` | `input_tokens: 9080, {cache_write_tokens: 9077, cached_tokens: 0}` → `{cache_write_tokens: 0, cached_tokens: 9077}` |
| OpenAI `gpt-5.4-nano` (no write charge) | Responses reports `cache_write_tokens: 0` on the turn that filled the cache; Chat omits the key | `prompt_tokens: 9072, cached_tokens: 0` → `cached_tokens: 8960` |
| Anthropic Messages, `claude-haiku-4-5` | `cache_creation_input_tokens` + `cache_creation.{ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}`; `input_tokens` EXCLUDES both cache legs | `input_tokens: 11, cache_creation_input_tokens: 10267, cache_read_input_tokens: 0` → `cache_creation_input_tokens: 0, cache_read_input_tokens: 10267` (same on `message_start` and `message_delta`) |
| Bedrock Converse | `cacheWriteInputTokens` (already parsed, was dropped) | fixture |
| Gemini | none (implicit cache writes are free; explicit caches bill by storage) | – |

OpenAI docs (developers.openai.com/api/docs/guides/prompt-caching): "The ordinary input tokens equals total input tokens minus cached tokens minus cache-write tokens"; "Cache writes cost 1.25× the standard, uncached input-token rate" on GPT-5.6+, "No additional cache-write charge" before.

## Change

- `openai_usage` (Responses) and `openai_compatible_usage` (Chat) read the `cache_write_tokens` detail exactly as reported (zero included); `bedrock_usage` reports its write leg (Converse omits zero-valued legs, so absent is a reported zero); Anthropic now reports its leg on every turn instead of only when positive.
- **Zero vs unknown (platform contract):** `cache_creation_input_tokens` is `Some(n)` whenever the wire gave a usable count, `0` included; `None` ONLY when the wire has no such count (Gemini; OpenAI Chat on pre-GPT-5.6 models and compatible relays that omit the detail). The control plane may approximate only a `None` leg and must price a reported `0` as zero writes. Goldens for cache-less Anthropic/Bedrock streams now carry `"cache_creation_input_tokens": 0`.
- `settle_argument` carries `usage.cache_creation_input_tokens` (null when unknown); `native_settlement._usage_from_payload` reads it into `GatewayUsage.cache_creation_input_tokens`, the EXISTING field the platform's settlement already consumes for batches (no new field, no alias). A pre-0.3.52 payload (no key) parses exactly as before.
- Batch `line_usage` reads the same detail on OpenAI-shaped batch bodies (the `gpt-5.6-luna-batch` lane) and reports the Anthropic leg on every line.
- Convention pinned in `events::Usage`, `GatewayUsage`, and docs/reference/gateway-architecture.md: `input_tokens` is every prompt token billed at some rate on every wire (Anthropic/Bedrock cache legs folded in, OpenAI/Gemini totals passed through); `cached_input_tokens` and `cache_creation_input_tokens` are disjoint subsets of it; fresh input = `input − cached − creation`.
- Not carried: Anthropic's 5-minute vs 1-hour split (no consumer today; the total is what `cache_creation_input_tokens` already sums). Not changed: the engine's own SQLite ledger schema and `ledger_valuation` (no cache-write rate in `GatewayTokenPrices`; the docs now say so); the platform's Postgres ledger is the consumer this fixes.

## Settlement payload shape (settle callback `usage` object)

```json
{"input_tokens": 9080, "output_tokens": 32, "cached_input_tokens": 0, "cache_creation_input_tokens": 9077, "reasoning_tokens": 23}
```

`cache_creation_input_tokens` is `0` for a reported zero and `null` when the wire gave no usable count. Python: `GatewayUsage.cache_creation_input_tokens: int | None`.

## Validation

- `cargo fmt --check`, `cargo clippy --no-default-features --all-targets -- -D warnings`: clean.
- `cargo test --no-default-features`: 291 passed (new pins: verbatim Luna Chat + Responses payloads, OpenAI usage without the detail, Bedrock write leg + absent-is-zero, Gemini none, settle payload with/without the leg; Bedrock goldens updated).
- `ruff format`, `ruff check`, `ty check`: clean.
- `pytest exp/runtime/gateway`: passes except the known environmental `native_truncation_test` cell on this mac (fails on clean origin/main too; CI is the arbiter). First gate run tripped `native_waterfall_test::test_ledger_conserves_every_admitted_request` (1 == 12), which passes locally and is unrelated to usage parsing.
- Native crate 0.3.51 → 0.3.52 (Cargo.toml, crate pyproject, Cargo.lock), parent floor `>=0.3.52`, parent `0.7.68`, `uv lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
