### PR TITLE
messages: real pre-dispatch usage estimate, Anthropic cache token fields on every usage frame, unambiguous cache_control disclosure

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -404,11 +404,14 @@ conversation breakpoints on every request, and flattening them once billed whole
 uncached at ~10x. Responses report both cache legs back out of the folded ledger total, so
 callers see `cache_creation_input_tokens` on the writing turn and `cache_read_input_tokens` on
 later turns. Routes with no Anthropic rung have no field for the markers and disclose them as
-`<path>.cache_control->not_forwarded(provider_decides_caching)`: the wording never says
-"ignored", because caching is then the provider's own decision — OpenAI-family providers cache
-the prefix implicitly and the ledger bills those reads at the cached rate (Harbor saw 14,976
-cached tokens billed beside an "ignored" marker on 2026-09-11), while a generic endpoint may not
-cache at all), carries the provider-native tool annotations (`strict`,
+`<path>.cache_control->not_forwarded(provider_caches_automatically; cache reads reported in
+usage.cache_read_input_tokens)`: the wording never says "ignored" and names where the caching
+shows up, because the disclosure rides in `x-experiential-ignored-parameters` and a bare
+"not forwarded" beside a billed cache read was read as "caching is ignored" (Harbor, 2026-09-11:
+`cache_read_input_tokens: 256` on a Tencent rung under the old wording). OpenAI-family and other
+OpenAI-compatible providers cache the prefix implicitly, without breakpoints, and the ledger
+bills those reads at the cached rate; a provider that never caches reports the leg as 0),
+carries the provider-native tool annotations (`strict`,
 `eager_input_streaming`, `defer_loading`, `allowed_callers`, `input_examples`; each accepted
 bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthropic rungs with
 disclosure-drops elsewhere, keeps every official SDK tool and top-level field a recorded
@@ -683,19 +686,31 @@ The thinking vocabulary names the outcome, never a bare field: `thinking->reason
 bare `thinking` as "my depth was stripped" is the misreading this vocabulary exists to prevent.
 
 On the Messages stream, `message_start.message.usage` is a PRE-DISPATCH figure and
-`message_delta.usage` is the authoritative one. The start frame carries what the upstream already
+`message_delta.usage` is the authoritative one. Every Messages usage object (`message_start`,
+`message_delta`, and the non-streamed body) carries Anthropic's four legs, always present and
+`0` when the provider reported none: `input_tokens` (uncached input), `cache_creation_input_tokens`,
+`cache_read_input_tokens`, and `output_tokens`. The cache legs come out of the normalized
+folded total the ledger bills: an Anthropic rung's own `cache_read_input_tokens` /
+`cache_creation_input_tokens`, an OpenAI-wire rung's `prompt_tokens_details.cached_tokens`
+(Chat) or `input_tokens_details.cached_tokens` (Responses), Gemini's `cachedContentTokenCount`,
+Bedrock's `cacheReadInputTokens`; only the Anthropic wire reports cache writes, every other
+rung carries `cache_creation_input_tokens: 0`. The start frame carries what the upstream already
 reported before content — an Anthropic upstream's own start-frame input and cache meters,
 mirrored — and otherwise the control plane's pre-dispatch count of the prompt (the reservation
-estimator without its headroom, carried on the admission as `input_token_estimate`) in
-Anthropic's documented start shape, `{"input_tokens": N, "output_tokens": 1}`. An OpenAI-wire
-upstream reports nothing before its final chunk, so without the estimate its `message_start`
-showed the zero placeholder that clients reading input from the start frame alone (Claude Code)
-display as 0 input tokens. `message_delta.usage` carries the provider's final meters (input,
-output, `cache_read_input_tokens`, `cache_creation_input_tokens`, plus the platform's cost
-extensions); the official Anthropic SDK accumulators (Python and TypeScript) copy every usage
-field present on `message_delta`, so their final message shows the true counts. The estimate is
-display-only: the encoder keeps it apart from the usage it settles from, so it never reaches
-`message_delta` or the ledger, which bill the provider's report.
+estimator without its headroom, carried on the admission as `input_token_estimate`, the same
+count `count_tokens` answers) in Anthropic's documented start shape,
+`{"input_tokens": N, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0, "output_tokens": 1}`
+(nothing is cached before dispatch). The count covers the system blocks, every turn's content
+blocks (tool_use and tool_result included), and each tool definition, so a Claude Code session
+reads in the thousands there; a two-digit figure is a two-digit prompt (Claude Code's own
+startup probes), never a stub. An OpenAI-wire upstream reports nothing before its final chunk,
+so without the estimate its `message_start` showed the zero placeholder that clients reading
+input from the start frame alone (Claude Code) display as 0 input tokens. `message_delta.usage`
+carries the provider's final meters plus the platform's cost extensions; the official Anthropic
+SDK accumulators (Python and TypeScript) copy every usage field present on `message_delta`, so
+their final message shows the true counts. The estimate is display-only: the encoder keeps it
+apart from the usage it settles from, so it never reaches `message_delta` or the ledger, which
+bill the provider's report.
 The per-deployment `capability_parity` export joins catalog declarations with the engine's
 provider-family ground truth so a catalog can pre-warn on gaps and route around them before a
 caller hits that 400.

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -404,13 +404,14 @@ conversation breakpoints on every request, and flattening them once billed whole
 uncached at ~10x. Responses report both cache legs back out of the folded ledger total, so
 callers see `cache_creation_input_tokens` on the writing turn and `cache_read_input_tokens` on
 later turns. Routes with no Anthropic rung have no field for the markers and disclose them as
-`<path>.cache_control->not_forwarded(provider_caches_automatically; cache reads reported in
-usage.cache_read_input_tokens)`: the wording never says "ignored" and names where the caching
-shows up, because the disclosure rides in `x-experiential-ignored-parameters` and a bare
-"not forwarded" beside a billed cache read was read as "caching is ignored" (Harbor, 2026-09-11:
-`cache_read_input_tokens: 256` on a Tencent rung under the old wording). OpenAI-family and other
-OpenAI-compatible providers cache the prefix implicitly, without breakpoints, and the ledger
-bills those reads at the cached rate; a provider that never caches reports the leg as 0),
+`<path>.cache_control->not_forwarded(provider_decides_caching; cache reads reported in
+usage.cache_read_input_tokens)`: the wording never says "ignored", never claims caching is on or
+off (OpenAI-family and most OpenAI-compatible providers cache the prefix implicitly, without
+breakpoints, and the ledger bills those reads at the cached rate; a generic endpoint may never
+cache), and names where whatever the provider does shows up, because the disclosure rides in
+`x-experiential-ignored-parameters` and a bare "not forwarded" beside a billed cache read was
+read as "caching is ignored" (Harbor, 2026-09-11: `cache_read_input_tokens: 256` on a Tencent
+rung under the old wording; a provider that never caches reports the leg as 0),
 carries the provider-native tool annotations (`strict`,
 `eager_input_streaming`, `defer_loading`, `allowed_callers`, `input_examples`; each accepted
 bare by the live API, verified 2026-08-30) and `inference_geo` verbatim on Anthropic rungs with

--- a/exp/runtime/gateway/attempt_tokens_test.py
+++ b/exp/runtime/gateway/attempt_tokens_test.py
@@ -20,6 +20,7 @@ from exp.common.models.content import (
     VideoContentPart,
 )
 from exp.common.models.model import ToolCall
+from exp.runtime.anthropic_protocol.requests import decode_messages
 from exp.runtime.gateway.attempt_tokens import (
     AUDIO_BYTES_PER_TOKEN,
     DOCUMENT_BYTES_PER_TOKEN,
@@ -668,3 +669,99 @@ def test_counted_input_tokens_is_the_estimate_before_headroom() -> None:
         == (counted * (100 + INPUT_TOKEN_HEADROOM_PERCENT) + 99) // 100
     )
     assert counted < worst_case_input_tokens(request)
+
+
+def _claude_code_messages_payload(*, system: bool = True, tools: bool = True) -> JsonObject:
+    """A Claude Code-shaped Messages body: system array, tool definitions, six turns."""
+    system_block = (
+        "You are Claude Code, an interactive CLI tool that helps users with software "
+        "engineering tasks. Use the instructions below and the tools available to you. "
+    ) * 40
+    messages: list[JsonObject] = []
+    for turn in range(6):
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Turn {turn}: " + "explain the module layout in detail. " * 10,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        )
+        messages.append(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Reading the file now. " * 5},
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_{turn:03d}",
+                        "name": "Read",
+                        "input": {"file_path": "/repo/src/main.py"},
+                    },
+                ],
+            }
+        )
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": f"toolu_{turn:03d}",
+                        "content": [{"type": "text", "text": "def main():\n    pass\n" * 20}],
+                    }
+                ],
+            }
+        )
+    messages.append({"role": "user", "content": "Now summarize."})
+    payload: JsonObject = {"model": "coding", "max_tokens": 32_000, "messages": messages}
+    if system:
+        payload["system"] = [
+            {"type": "text", "text": system_block, "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "Project instructions: " + system_block[:2000]},
+        ]
+    if tools:
+        payload["tools"] = [
+            {
+                "name": f"Tool{index}",
+                "description": f"Tool {index}. " + "Reads a file from the local filesystem. " * 8,
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "The absolute path"},
+                        "offset": {"type": "number", "description": "The first line to read"},
+                    },
+                    "required": ["file_path"],
+                },
+            }
+            for index in range(12)
+        ]
+    return payload
+
+
+def test_messages_estimate_counts_system_every_turn_and_the_tools() -> None:
+    """A Claude Code-shaped Messages request counts in the thousands, not tens.
+
+    The start-frame / ``count_tokens`` figure is the counted prompt of the
+    DECODED Messages request: the system array (folded into the leading
+    system turn), every user, assistant, tool_use and tool_result block, and
+    each tool definition. Dropping the system blocks or the tools lowers the
+    count by at least what they contribute, so neither can be silently
+    skipped by a later decoder change.
+    """
+    full = counted_input_tokens(decode_messages(_claude_code_messages_payload()).request)
+    assert full > 1_000, full
+    without_system = counted_input_tokens(
+        decode_messages(_claude_code_messages_payload(system=False)).request
+    )
+    without_tools = counted_input_tokens(
+        decode_messages(_claude_code_messages_payload(tools=False)).request
+    )
+    # Two system blocks totalling about 1,500 tokens (counted 1,492 on the
+    # reservation BPE); twelve tools plus the fixed tool-use preamble.
+    assert full - without_system > 1_200, (full, without_system)
+    assert full - without_tools > TOOLS_PRESENT_TOKENS + 12 * 30, (full, without_tools)

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -87,56 +87,6 @@ pub(super) fn stop_sequence_value(terminal: &Event) -> Value {
     }
 }
 
-/// Anthropic's usage object for every Messages frame that carries one:
-/// `message_start.message.usage`, `message_delta.usage`, and the
-/// non-streamed body's `usage`. All four token legs are always present,
-/// `0` when the provider reported none, because Anthropic clients (the
-/// official SDK accumulators, Claude Code's context meter) read the cache
-/// legs by key and treat an absent key as "not Anthropic's shape".
-///
-/// Mapping from the normalized `Usage` (whose `input_tokens` is the FOLDED
-/// total the ledger bills: uncached + cache reads + cache writes):
-///
-/// | Anthropic field                | source                                              |
-/// |--------------------------------|-----------------------------------------------------|
-/// | `input_tokens`                 | `input_tokens - cached_input_tokens - cache_creation_input_tokens` (uncached input, saturating) |
-/// | `cache_creation_input_tokens`  | `cache_creation_input_tokens`, else `0` (Anthropic-wire rungs only) |
-/// | `cache_read_input_tokens`      | `cached_input_tokens`, else `0` (Anthropic `cache_read_input_tokens`, OpenAI-wire `prompt_tokens_details.cached_tokens` / `input_tokens_details.cached_tokens`, Gemini `cachedContentTokenCount`, Bedrock `cacheReadInputTokens`) |
-/// | `output_tokens`                | `output_tokens` (reasoning folded in where the provider bills it additively) |
-///
-/// Unknown usage (no provider report) renders every leg as `0`.
-pub(super) fn messages_usage(usage: Option<&Usage>) -> Value {
-    let usage = match usage {
-        Some(usage) if usage.has_token_counts() => usage,
-        _ => return usage_object(0, 0, 0, 0),
-    };
-    let cached = usage.cached_input_tokens.unwrap_or(0);
-    let creation = usage.cache_creation_input_tokens.unwrap_or(0);
-    // Both cache legs come back out of the folded ledger total so callers
-    // see the provider's own shape: input_tokens excludes cached reads and
-    // cache writes, each reported on its own leg.
-    usage_object(
-        usage
-            .input_tokens
-            .unwrap_or(0)
-            .saturating_sub(cached)
-            .saturating_sub(creation),
-        creation,
-        cached,
-        usage.output_tokens.unwrap_or(0),
-    )
-}
-
-/// The four-leg Anthropic usage object in Anthropic's own field order.
-fn usage_object(input: u64, cache_creation: u64, cache_read: u64, output: u64) -> Value {
-    json!({
-        "input_tokens": input,
-        "cache_creation_input_tokens": cache_creation,
-        "cache_read_input_tokens": cache_read,
-        "output_tokens": output,
-    })
-}
-
 /// Frame one named, compact, UTF-8-preserving Anthropic SSE event.
 fn event_frame(name: &str, payload: &Value) -> String {
     format!("event: {name}\ndata: {}\n\n", compact_json(payload))
@@ -984,8 +934,11 @@ impl MessagesSseEncoder {
 }
 
 mod aggregate;
+mod usage;
 
 pub use aggregate::{completed_messages_body, completed_messages_body_with_reasoning};
+pub(crate) use usage::messages_usage;
+use usage::usage_object;
 
 /// Attach the `x-experiential-ignored-parameters` disclosure to one message
 /// object when any control was dropped; an empty list adds nothing.
@@ -1006,3 +959,5 @@ pub(super) fn disclose_ignored_parameters(message: &mut Value, ignored_parameter
 mod tests;
 #[cfg(test)]
 mod tests_claude_code;
+#[cfg(test)]
+mod tests_usage;

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use serde_json::{json, Map, Value};
+use serde_json::{json, Value};
 
 use crate::dialects::MAXIMUM_RETAINED_OUTPUT_BYTES;
 use crate::encode::{
@@ -87,39 +87,54 @@ pub(super) fn stop_sequence_value(terminal: &Event) -> Value {
     }
 }
 
-/// The Anthropic usage shape from `messages_usage`: cached reads come back
-/// out of the normalized input total, and unknown usage reports zero counts
-/// because the Anthropic shape requires both fields.
+/// Anthropic's usage object for every Messages frame that carries one:
+/// `message_start.message.usage`, `message_delta.usage`, and the
+/// non-streamed body's `usage`. All four token legs are always present,
+/// `0` when the provider reported none, because Anthropic clients (the
+/// official SDK accumulators, Claude Code's context meter) read the cache
+/// legs by key and treat an absent key as "not Anthropic's shape".
+///
+/// Mapping from the normalized `Usage` (whose `input_tokens` is the FOLDED
+/// total the ledger bills: uncached + cache reads + cache writes):
+///
+/// | Anthropic field                | source                                              |
+/// |--------------------------------|-----------------------------------------------------|
+/// | `input_tokens`                 | `input_tokens - cached_input_tokens - cache_creation_input_tokens` (uncached input, saturating) |
+/// | `cache_creation_input_tokens`  | `cache_creation_input_tokens`, else `0` (Anthropic-wire rungs only) |
+/// | `cache_read_input_tokens`      | `cached_input_tokens`, else `0` (Anthropic `cache_read_input_tokens`, OpenAI-wire `prompt_tokens_details.cached_tokens` / `input_tokens_details.cached_tokens`, Gemini `cachedContentTokenCount`, Bedrock `cacheReadInputTokens`) |
+/// | `output_tokens`                | `output_tokens` (reasoning folded in where the provider bills it additively) |
+///
+/// Unknown usage (no provider report) renders every leg as `0`.
 pub(super) fn messages_usage(usage: Option<&Usage>) -> Value {
     let usage = match usage {
         Some(usage) if usage.has_token_counts() => usage,
-        _ => return json!({"input_tokens": 0, "output_tokens": 0}),
+        _ => return usage_object(0, 0, 0, 0),
     };
     let cached = usage.cached_input_tokens.unwrap_or(0);
     let creation = usage.cache_creation_input_tokens.unwrap_or(0);
-    let mut body = Map::new();
     // Both cache legs come back out of the folded ledger total so callers
     // see the provider's own shape: input_tokens excludes cached reads and
     // cache writes, each reported on its own leg.
-    body.insert(
-        "input_tokens".to_string(),
-        json!(usage
+    usage_object(
+        usage
             .input_tokens
             .unwrap_or(0)
             .saturating_sub(cached)
-            .saturating_sub(creation)),
-    );
-    body.insert(
-        "output_tokens".to_string(),
-        json!(usage.output_tokens.unwrap_or(0)),
-    );
-    if cached > 0 {
-        body.insert("cache_read_input_tokens".to_string(), json!(cached));
-    }
-    if creation > 0 {
-        body.insert("cache_creation_input_tokens".to_string(), json!(creation));
-    }
-    Value::Object(body)
+            .saturating_sub(creation),
+        creation,
+        cached,
+        usage.output_tokens.unwrap_or(0),
+    )
+}
+
+/// The four-leg Anthropic usage object in Anthropic's own field order.
+fn usage_object(input: u64, cache_creation: u64, cache_read: u64, output: u64) -> Value {
+    json!({
+        "input_tokens": input,
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+        "output_tokens": output,
+    })
 }
 
 /// Frame one named, compact, UTF-8-preserving Anthropic SSE event.
@@ -350,12 +365,14 @@ impl MessagesSseEncoder {
     }
 
     /// The `message_start` meters: the upstream's own start usage when known,
-    /// else the pre-dispatch estimate in Anthropic's start-frame shape, else
-    /// the zero placeholder.
+    /// else the pre-dispatch estimate in Anthropic's start-frame shape (the
+    /// counted prompt as `input_tokens`, both cache legs `0` because nothing
+    /// is cached before dispatch, and Anthropic's `output_tokens: 1`
+    /// placeholder), else the zero placeholder.
     fn start_usage(&self) -> Value {
         match (self.usage.as_ref(), self.pre_dispatch_input_estimate) {
             (Some(usage), _) => messages_usage(Some(usage)),
-            (None, Some(estimate)) => json!({"input_tokens": estimate, "output_tokens": 1}),
+            (None, Some(estimate)) => usage_object(estimate, 0, 0, 1),
             (None, None) => messages_usage(None),
         }
     }

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -15,11 +15,69 @@ fn usage_reports_cached_reads_out_of_the_input_total() {
     };
     assert_eq!(
         messages_usage(Some(&usage)),
-        json!({"input_tokens": 7, "output_tokens": 4, "cache_read_input_tokens": 3})
+        json!({
+            "input_tokens": 7,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 3,
+            "output_tokens": 4,
+        })
     );
     assert_eq!(
         messages_usage(None),
-        json!({"input_tokens": 0, "output_tokens": 0})
+        json!({
+            "input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 0,
+        })
+    );
+}
+
+#[test]
+fn usage_carries_both_cache_legs_as_zero_when_the_provider_reports_none() {
+    // An OpenAI-wire provider that reports no `prompt_tokens_details` is an
+    // uncached completion in Anthropic's shape, not a completion with the
+    // cache fields missing: Claude Code and the SDK accumulators read the
+    // legs by key.
+    let usage = Usage {
+        input_tokens: Some(437),
+        output_tokens: Some(12),
+        cached_input_tokens: None,
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 437,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 12,
+        })
+    );
+}
+
+#[test]
+fn usage_reports_openai_wire_cached_tokens_as_cache_reads() {
+    // The folded total from `prompt_tokens_details.cached_tokens` (a real
+    // Claude Code turn on an OpenAI-compatible rung: 437 prompt tokens of
+    // which 256 were a cached prefix) comes back as uncached input plus the
+    // cache-read leg.
+    let usage = Usage {
+        input_tokens: Some(437),
+        output_tokens: Some(12),
+        cached_input_tokens: Some(256),
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 181,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 256,
+            "output_tokens": 12,
+        })
     );
 }
 
@@ -656,8 +714,9 @@ fn usage_reports_both_cache_legs_out_of_the_folded_input_total() {
         messages_usage(Some(&usage)),
         json!({
             "input_tokens": 205,
-            "output_tokens": 9,
             "cache_creation_input_tokens": 45_338,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 9,
         })
     );
 }

--- a/exp/runtime/gateway/native/src/encode_messages/tests.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests.rs
@@ -5,83 +5,6 @@ use super::*;
 use crate::events::CompletedToolCall;
 
 #[test]
-fn usage_reports_cached_reads_out_of_the_input_total() {
-    let usage = Usage {
-        input_tokens: Some(10),
-        output_tokens: Some(4),
-        cached_input_tokens: Some(3),
-        cache_creation_input_tokens: None,
-        reasoning_tokens: None,
-    };
-    assert_eq!(
-        messages_usage(Some(&usage)),
-        json!({
-            "input_tokens": 7,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 3,
-            "output_tokens": 4,
-        })
-    );
-    assert_eq!(
-        messages_usage(None),
-        json!({
-            "input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "output_tokens": 0,
-        })
-    );
-}
-
-#[test]
-fn usage_carries_both_cache_legs_as_zero_when_the_provider_reports_none() {
-    // An OpenAI-wire provider that reports no `prompt_tokens_details` is an
-    // uncached completion in Anthropic's shape, not a completion with the
-    // cache fields missing: Claude Code and the SDK accumulators read the
-    // legs by key.
-    let usage = Usage {
-        input_tokens: Some(437),
-        output_tokens: Some(12),
-        cached_input_tokens: None,
-        cache_creation_input_tokens: None,
-        reasoning_tokens: None,
-    };
-    assert_eq!(
-        messages_usage(Some(&usage)),
-        json!({
-            "input_tokens": 437,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "output_tokens": 12,
-        })
-    );
-}
-
-#[test]
-fn usage_reports_openai_wire_cached_tokens_as_cache_reads() {
-    // The folded total from `prompt_tokens_details.cached_tokens` (a real
-    // Claude Code turn on an OpenAI-compatible rung: 437 prompt tokens of
-    // which 256 were a cached prefix) comes back as uncached input plus the
-    // cache-read leg.
-    let usage = Usage {
-        input_tokens: Some(437),
-        output_tokens: Some(12),
-        cached_input_tokens: Some(256),
-        cache_creation_input_tokens: None,
-        reasoning_tokens: None,
-    };
-    assert_eq!(
-        messages_usage(Some(&usage)),
-        json!({
-            "input_tokens": 181,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 256,
-            "output_tokens": 12,
-        })
-    );
-}
-
-#[test]
 fn error_body_folds_param_and_maps_status_first() {
     let mut error = PublicError::new(
         400,
@@ -696,29 +619,6 @@ fn paused_turn_keeps_its_stop_reason_on_both_paths() {
     let aggregated = completed_messages_body("request-abc", "coding", &events).expect("aggregates");
     assert_eq!(aggregated.body["stop_reason"], json!("pause_turn"));
     assert!(!aggregated.incomplete);
-}
-
-#[test]
-fn usage_reports_both_cache_legs_out_of_the_folded_input_total() {
-    // A live cached turn folds input as uncached + read + write for the
-    // ledger; callers get the provider's own shape back, with each cache
-    // leg on its own field (Claude Code displays cache_creation on turn 1).
-    let usage = Usage {
-        input_tokens: Some(45_543),
-        output_tokens: Some(9),
-        cached_input_tokens: Some(0),
-        cache_creation_input_tokens: Some(45_338),
-        reasoning_tokens: None,
-    };
-    assert_eq!(
-        messages_usage(Some(&usage)),
-        json!({
-            "input_tokens": 205,
-            "cache_creation_input_tokens": 45_338,
-            "cache_read_input_tokens": 0,
-            "output_tokens": 9,
-        })
-    );
 }
 
 #[test]

--- a/exp/runtime/gateway/native/src/encode_messages/tests_claude_code.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests_claude_code.rs
@@ -64,7 +64,12 @@ fn start_frame_carries_the_upstream_start_usage_when_known() {
     .expect("json");
     assert_eq!(
         start["message"]["usage"],
-        json!({"input_tokens": 230, "output_tokens": 25, "cache_read_input_tokens": 2000})
+        json!({
+            "input_tokens": 230,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 2000,
+            "output_tokens": 25,
+        })
     );
 
     let mut bare = MessagesSseEncoder::new("request-abc", "coding");
@@ -80,7 +85,12 @@ fn start_frame_carries_the_upstream_start_usage_when_known() {
     .expect("json");
     assert_eq!(
         start["message"]["usage"],
-        json!({"input_tokens": 0, "output_tokens": 0})
+        json!({
+            "input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 0,
+        })
     );
 }
 
@@ -136,9 +146,9 @@ fn start_frame_carries_the_pre_dispatch_estimate_when_the_upstream_reports_nothi
     // An OpenAI-wire upstream reports usage only in its final chunk, so the
     // start frame would otherwise carry the zero placeholder that Claude Code
     // reads as "0 input tokens". The admission's pre-dispatch prompt estimate
-    // fills it with Anthropic's `output_tokens: 1` placeholder; the estimate
-    // is display-only (message_delta and the ledger keep the provider's
-    // report).
+    // fills it with Anthropic's `output_tokens: 1` placeholder and both cache
+    // legs at zero (nothing is cached before dispatch); the estimate is
+    // display-only (message_delta and the ledger keep the provider's report).
     let mut encoder = MessagesSseEncoder::new("request-abc", "coding");
     encoder.set_initial_usage(None);
     encoder.set_pre_dispatch_input_estimate(Some(1234));
@@ -153,7 +163,12 @@ fn start_frame_carries_the_pre_dispatch_estimate_when_the_upstream_reports_nothi
     .expect("json");
     assert_eq!(
         start["message"]["usage"],
-        json!({"input_tokens": 1234, "output_tokens": 1})
+        json!({
+            "input_tokens": 1234,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 1,
+        })
     );
 }
 
@@ -181,6 +196,11 @@ fn upstream_start_usage_outranks_the_pre_dispatch_estimate() {
     .expect("json");
     assert_eq!(
         start["message"]["usage"],
-        json!({"input_tokens": 20, "output_tokens": 1, "cache_read_input_tokens": 10})
+        json!({
+            "input_tokens": 20,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 10,
+            "output_tokens": 1,
+        })
     );
 }

--- a/exp/runtime/gateway/native/src/encode_messages/tests_usage.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/tests_usage.rs
@@ -1,0 +1,108 @@
+//! Inline tests for the Anthropic usage object every Messages frame carries,
+//! split from `tests` so each test file stays within the repository line
+//! budget.
+
+use serde_json::json;
+
+use super::usage::messages_usage;
+use crate::events::Usage;
+
+#[test]
+fn usage_reports_cached_reads_out_of_the_input_total() {
+    let usage = Usage {
+        input_tokens: Some(10),
+        output_tokens: Some(4),
+        cached_input_tokens: Some(3),
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 7,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 3,
+            "output_tokens": 4,
+        })
+    );
+    assert_eq!(
+        messages_usage(None),
+        json!({
+            "input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 0,
+        })
+    );
+}
+
+#[test]
+fn usage_carries_both_cache_legs_as_zero_when_the_provider_reports_none() {
+    // An OpenAI-wire provider that reports no `prompt_tokens_details` is an
+    // uncached completion in Anthropic's shape, not a completion with the
+    // cache fields missing: Claude Code and the SDK accumulators read the
+    // legs by key.
+    let usage = Usage {
+        input_tokens: Some(437),
+        output_tokens: Some(12),
+        cached_input_tokens: None,
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 437,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 12,
+        })
+    );
+}
+
+#[test]
+fn usage_reports_openai_wire_cached_tokens_as_cache_reads() {
+    // The folded total from `prompt_tokens_details.cached_tokens` (a real
+    // Claude Code turn on an OpenAI-compatible rung: 437 prompt tokens of
+    // which 256 were a cached prefix) comes back as uncached input plus the
+    // cache-read leg.
+    let usage = Usage {
+        input_tokens: Some(437),
+        output_tokens: Some(12),
+        cached_input_tokens: Some(256),
+        cache_creation_input_tokens: None,
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 181,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 256,
+            "output_tokens": 12,
+        })
+    );
+}
+
+#[test]
+fn usage_reports_both_cache_legs_out_of_the_folded_input_total() {
+    // A live cached turn folds input as uncached + read + write for the
+    // ledger; callers get the provider's own shape back, with each cache
+    // leg on its own field (Claude Code displays cache_creation on turn 1).
+    let usage = Usage {
+        input_tokens: Some(45_543),
+        output_tokens: Some(9),
+        cached_input_tokens: Some(0),
+        cache_creation_input_tokens: Some(45_338),
+        reasoning_tokens: None,
+    };
+    assert_eq!(
+        messages_usage(Some(&usage)),
+        json!({
+            "input_tokens": 205,
+            "cache_creation_input_tokens": 45_338,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 9,
+        })
+    );
+}

--- a/exp/runtime/gateway/native/src/encode_messages/usage.rs
+++ b/exp/runtime/gateway/native/src/encode_messages/usage.rs
@@ -1,0 +1,57 @@
+//! The Anthropic usage object rendered on every public Messages frame,
+//! split from `encode_messages` so the implementation stays within the
+//! repository line budget.
+
+use serde_json::{json, Value};
+
+use crate::events::Usage;
+
+/// Anthropic's usage object for every Messages frame that carries one:
+/// `message_start.message.usage`, `message_delta.usage`, and the
+/// non-streamed body's `usage`. All four token legs are always present,
+/// `0` when the provider reported none, because Anthropic clients (the
+/// official SDK accumulators, Claude Code's context meter) read the cache
+/// legs by key and treat an absent key as "not Anthropic's shape".
+///
+/// Mapping from the normalized `Usage` (whose `input_tokens` is the FOLDED
+/// total the ledger bills: uncached + cache reads + cache writes):
+///
+/// | Anthropic field                | source                                              |
+/// |--------------------------------|-----------------------------------------------------|
+/// | `input_tokens`                 | `input_tokens - cached_input_tokens - cache_creation_input_tokens` (uncached input, saturating) |
+/// | `cache_creation_input_tokens`  | `cache_creation_input_tokens`, else `0` (Anthropic-wire rungs only) |
+/// | `cache_read_input_tokens`      | `cached_input_tokens`, else `0` (Anthropic `cache_read_input_tokens`, OpenAI-wire `prompt_tokens_details.cached_tokens` / `input_tokens_details.cached_tokens`, Gemini `cachedContentTokenCount`, Bedrock `cacheReadInputTokens`) |
+/// | `output_tokens`                | `output_tokens` (reasoning folded in where the provider bills it additively) |
+///
+/// Unknown usage (no provider report) renders every leg as `0`.
+pub(crate) fn messages_usage(usage: Option<&Usage>) -> Value {
+    let usage = match usage {
+        Some(usage) if usage.has_token_counts() => usage,
+        _ => return usage_object(0, 0, 0, 0),
+    };
+    let cached = usage.cached_input_tokens.unwrap_or(0);
+    let creation = usage.cache_creation_input_tokens.unwrap_or(0);
+    // Both cache legs come back out of the folded ledger total so callers
+    // see the provider's own shape: input_tokens excludes cached reads and
+    // cache writes, each reported on its own leg.
+    usage_object(
+        usage
+            .input_tokens
+            .unwrap_or(0)
+            .saturating_sub(cached)
+            .saturating_sub(creation),
+        creation,
+        cached,
+        usage.output_tokens.unwrap_or(0),
+    )
+}
+
+/// The four-leg Anthropic usage object in Anthropic's own field order.
+pub(super) fn usage_object(input: u64, cache_creation: u64, cache_read: u64, output: u64) -> Value {
+    json!({
+        "input_tokens": input,
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+        "output_tokens": output,
+    })
+}

--- a/exp/runtime/gateway/testdata/parity_goldens.json
+++ b/exp/runtime/gateway/testdata/parity_goldens.json
@@ -298,10 +298,10 @@
   "data: {\"id\":\"chatcmpl_ff596a02add1b410b6dc664a47e25b3e\",\"object\":\"chat.completion.chunk\",\"created\":1700000000,\"model\":\"coding\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4,\"total_tokens\":14,\"prompt_tokens_details\":{\"cached_tokens\":1},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}\n\n",
   "data: [DONE]\n\n"
  ],
- "messages_block_order_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{}},{\"type\":\"text\",\"text\":\"after\"}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}",
- "messages_deferred_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{}},{\"type\":\"text\",\"text\":\"after\"}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}",
+ "messages_block_order_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{}},{\"type\":\"text\",\"text\":\"after\"}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}",
+ "messages_deferred_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{}},{\"type\":\"text\",\"text\":\"after\"}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}",
  "messages_deferred_frames": [
-  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}}\n\n",
   "event: ping\ndata: {\"type\":\"ping\"}\n\n",
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{}}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n",
@@ -309,19 +309,19 @@
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"after\"}}\n\n",
   "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
-  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}\n\n",
+  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}\n\n",
   "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
  ],
  "messages_failure_frames": [
-  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}}\n\n",
   "event: ping\ndata: {\"type\":\"ping\"}\n\n",
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"oops\"}}\n\n",
   "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"message\":\"provider stream failed\"}}\n\n"
  ],
- "messages_interleaved_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"tool_use\",\"id\":\"call-a\",\"name\":\"alpha\",\"input\":{\"a\":1}},{\"type\":\"tool_use\",\"id\":\"call-b\",\"name\":\"beta\",\"input\":{\"b\":2}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":6,\"output_tokens\":3}}",
+ "messages_interleaved_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"tool_use\",\"id\":\"call-a\",\"name\":\"alpha\",\"input\":{\"a\":1}},{\"type\":\"tool_use\",\"id\":\"call-b\",\"name\":\"beta\",\"input\":{\"b\":2}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":6,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":3}}",
  "messages_interleaved_frames": [
-  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}}\n\n",
   "event: ping\ndata: {\"type\":\"ping\"}\n\n",
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call-a\",\"name\":\"alpha\",\"input\":{}}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"a\\\": \"}}\n\n",
@@ -330,12 +330,12 @@
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call-b\",\"name\":\"beta\",\"input\":{}}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"b\\\": 2}\"}}\n\n",
   "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
-  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":6,\"output_tokens\":3}}\n\n",
+  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":6,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":3}}\n\n",
   "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
  ],
- "messages_tool_stream_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"text\",\"text\":\"Hello é\"},{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{\"q\":\"x\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":7,\"output_tokens\":4,\"cache_read_input_tokens\":3}}",
+ "messages_tool_stream_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"text\",\"text\":\"Hello é\"},{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"search\",\"input\":{\"q\":\"x\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":7,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":3,\"output_tokens\":4}}",
  "messages_tool_stream_frames": [
-  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}}\n\n",
   "event: ping\ndata: {\"type\":\"ping\"}\n\n",
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hel\"}}\n\n",
@@ -345,7 +345,7 @@
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"q\\\": \"}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"x\\\"}\"}}\n\n",
   "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
-  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":7,\"output_tokens\":4,\"cache_read_input_tokens\":3}}\n\n",
+  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":7,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":3,\"output_tokens\":4}}\n\n",
   "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
  ],
  "responses_completed_body": "{\"id\":\"resp_ff596a02add1b410b6dc664a47e25b3e\",\"object\":\"response\",\"created_at\":1700000000.25,\"completed_at\":1700000000.25,\"status\":\"completed\",\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"metadata\":{\"team\":\"core\"},\"model\":\"coding\",\"output\":[{\"id\":\"rs_01161eec6982f41bdc4271a8fceb6c60\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Checked the plan.\"}],\"status\":\"completed\"},{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello é\",\"annotations\":[]}]},{\"id\":\"fc_5c5e7c69cf9de82d85831c773eaec6be\",\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"search\",\"arguments\":\"{\\\"q\\\": \\\"x\\\"}\",\"status\":\"completed\"}],\"parallel_tool_calls\":true,\"temperature\":0.5,\"top_p\":null,\"reasoning\":{\"effort\":\"high\",\"summary\":\"concise\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"function\",\"name\":\"search\",\"description\":\"Find things.\",\"parameters\":{\"type\":\"object\",\"properties\":{\"q\":{\"type\":\"string\"}}},\"strict\":false}],\"max_output_tokens\":128,\"previous_response_id\":null,\"usage\":{\"input_tokens\":10,\"input_tokens_details\":{\"cached_tokens\":1,\"cache_write_tokens\":0},\"output_tokens\":4,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":14}}",
@@ -401,7 +401,7 @@
   "data: [DONE]\n\n"
  ],
  "messages_thinking_frames": [
-  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}\n\n",
+  "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":0}}}\n\n",
   "event: ping\ndata: {\"type\":\"ping\"}\n\n",
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me \"}}\n\n",
@@ -413,9 +413,9 @@
   "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
   "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n",
   "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":2}\n\n",
-  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":7,\"cache_read_input_tokens\":2}}\n\n",
+  "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":2,\"output_tokens\":7}}\n\n",
   "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
  ],
- "messages_thinking_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"Let me check.\",\"signature\":\"c2lnbmF0dXJl\"},{\"type\":\"redacted_thinking\",\"data\":\"b3BhcXVl\"},{\"type\":\"text\",\"text\":\"Hello\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":7,\"cache_read_input_tokens\":2}}",
+ "messages_thinking_body": "{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"coding\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"Let me check.\",\"signature\":\"c2lnbmF0dXJl\"},{\"type\":\"redacted_thinking\",\"data\":\"b3BhcXVl\"},{\"type\":\"text\",\"text\":\"Hello\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":2,\"output_tokens\":7}}",
  "responses_encrypted_reasoning_body": "{\"id\":\"resp_ff596a02add1b410b6dc664a47e25b3e\",\"object\":\"response\",\"created_at\":1700000000.0,\"completed_at\":1700000000.0,\"status\":\"completed\",\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"metadata\":null,\"model\":\"coding\",\"output\":[{\"id\":\"rs_01161eec6982f41bdc4271a8fceb6c60\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"planned\"}],\"status\":\"completed\",\"encrypted_content\":\"ZW5jcnlwdGVk\"},{\"id\":\"msg_ff596a02add1b410b6dc664a47e25b3e\",\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\",\"annotations\":[]}]}],\"parallel_tool_calls\":true,\"temperature\":null,\"top_p\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"tool_choice\":\"auto\",\"tools\":[],\"max_output_tokens\":null,\"previous_response_id\":null,\"usage\":{\"input_tokens\":12,\"input_tokens_details\":{\"cached_tokens\":0,\"cache_write_tokens\":0},\"output_tokens\":9,\"output_tokens_details\":{\"reasoning_tokens\":4},\"total_tokens\":21}}"
 }

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -1106,8 +1106,12 @@ def test_start_frame_estimate_counts_the_whole_claude_code_prompt(
     """
     payloads = _stream_payloads(engine, _claude_code_body("fast-token", stream=True))
     message_start = next(payload for payload in payloads if payload["type"] == "message_start")
-    start_usage = message_start["message"]["usage"]
-    assert start_usage["input_tokens"] > 1_000, start_usage
+    message = message_start["message"]
+    assert isinstance(message, dict)
+    start_usage = message["usage"]
+    assert isinstance(start_usage, dict)
+    input_tokens = start_usage["input_tokens"]
+    assert isinstance(input_tokens, int) and input_tokens > 1_000, start_usage
     assert {k: v for k, v in start_usage.items() if k != "input_tokens"} == {
         "cache_creation_input_tokens": 0,
         "cache_read_input_tokens": 0,
@@ -1124,7 +1128,7 @@ def test_start_frame_estimate_counts_the_whole_claude_code_prompt(
         timeout=10.0,
     )
     assert counted.status_code == 200, counted.text
-    assert counted.json()["input_tokens"] == start_usage["input_tokens"]
+    assert counted.json()["input_tokens"] == input_tokens
 
 
 def test_uncached_completion_reports_both_cache_legs_as_zero(engine: _ServingEngine) -> None:

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -120,21 +120,22 @@ def _content_chunk(text: str) -> bytes:
     )
 
 
-def _terminal_frames(finish_reason: str) -> bytes:
-    """Encode the finishing chunk, usage chunk, and done sentinel."""
+def _terminal_frames(finish_reason: str, *, cached: bool = True) -> bytes:
+    """Encode the finishing chunk, usage chunk, and done sentinel.
+
+    Args:
+        finish_reason: The provider finish reason on the closing choice.
+        cached: Whether the usage chunk reports a cached prefix through
+            ``prompt_tokens_details.cached_tokens`` (an uncached completion
+            omits the details object entirely, as OpenAI-compatible servers do).
+    """
+    usage: JsonObject = {"prompt_tokens": 9, "completion_tokens": 4}
+    if cached:
+        usage["prompt_tokens_details"] = {"cached_tokens": 2}
     return b"".join(
         (
             _sse_frame({"choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}]}),
-            _sse_frame(
-                {
-                    "choices": [],
-                    "usage": {
-                        "prompt_tokens": 9,
-                        "completion_tokens": 4,
-                        "prompt_tokens_details": {"cached_tokens": 2},
-                    },
-                }
-            ),
+            _sse_frame({"choices": [], "usage": usage}),
             b"data: [DONE]\n\n",
         )
     )
@@ -250,6 +251,10 @@ class _SseUpstream(BaseHTTPRequestHandler):
                 self.wfile.write(_zero_output_terminal_frames("stop"))
             elif prompt == "truncated-token":
                 self.wfile.write(_zero_output_terminal_frames("length"))
+            elif prompt == "uncached-token":
+                self.wfile.write(_content_chunk("hello "))
+                self.wfile.write(_content_chunk("world"))
+                self.wfile.write(_terminal_frames("stop", cached=False))
             else:
                 self.wfile.write(_content_chunk("hello "))
                 self.wfile.write(_content_chunk("world"))
@@ -887,7 +892,12 @@ def test_non_streaming_message_answers_the_anthropic_shape_and_accounts(
         "content": [{"type": "text", "text": "hello world"}],
         "stop_reason": "end_turn",
         "stop_sequence": None,
-        "usage": {"input_tokens": 7, "output_tokens": 4, "cache_read_input_tokens": 2},
+        "usage": {
+            "input_tokens": 7,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 2,
+            "output_tokens": 4,
+        },
     }
     assert _completed_attempts(engine.base) == completed_before + 1
 
@@ -954,21 +964,195 @@ def test_streaming_message_emits_the_full_anthropic_lifecycle(
     assert text == "hello world"
     message_delta = next(payload for payload in payloads if payload["type"] == "message_delta")
     assert message_delta["delta"]["stop_reason"] == "end_turn"
+    # OpenAI-wire ``prompt_tokens_details.cached_tokens`` comes back as the
+    # cache-read leg with ``input_tokens`` the uncached remainder; the
+    # creation leg is present at 0 (nothing on this wire reports cache writes).
     assert message_delta["usage"] == {
         "input_tokens": 7,
-        "output_tokens": 4,
+        "cache_creation_input_tokens": 0,
         "cache_read_input_tokens": 2,
+        "output_tokens": 4,
     }
     # An OpenAI-wire upstream reports nothing before its final chunk, so the
     # start frame carries the gateway's pre-dispatch prompt estimate (what a
     # client that reads input from message_start, e.g. Claude Code, shows)
-    # with Anthropic's ``output_tokens: 1`` placeholder; the authoritative
+    # in Anthropic's start shape: both cache legs 0 (nothing is cached before
+    # dispatch) and the ``output_tokens: 1`` placeholder; the authoritative
     # meters stay on message_delta above and are what the ledger bills.
     message_start = next(payload for payload in payloads if payload["type"] == "message_start")
     start_usage = message_start["message"]["usage"]
-    assert start_usage["output_tokens"] == 1
     assert isinstance(start_usage["input_tokens"], int) and start_usage["input_tokens"] > 0
-    assert "cache_read_input_tokens" not in start_usage
+    assert {k: v for k, v in start_usage.items() if k != "input_tokens"} == {
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 1,
+    }
+
+
+def _claude_code_body(prompt: str, *, stream: bool = False) -> JsonObject:
+    """Return a Claude Code-shaped Messages body: system array, tools, many turns.
+
+    Several thousand tokens of prompt, so a start-frame estimate that missed
+    the system blocks, the tool definitions, or the earlier turns would be
+    off by an order of magnitude rather than by tokenizer drift. ``prompt``
+    is the final user turn, which also selects the loopback upstream's reply.
+    """
+    system_block = (
+        "You are Claude Code, an interactive CLI tool that helps users with software "
+        "engineering tasks. Use the instructions below and the tools available to you. "
+    ) * 40
+    tools: list[JsonObject] = [
+        {
+            "name": f"Tool{index}",
+            "description": f"Tool {index}. " + "Reads a file from the local filesystem. " * 8,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "file_path": {"type": "string", "description": "The absolute path"},
+                    "offset": {"type": "number", "description": "The first line to read"},
+                    "limit": {"type": "number", "description": "How many lines to read"},
+                },
+                "required": ["file_path"],
+                "additionalProperties": False,
+            },
+        }
+        for index in range(12)
+    ]
+    messages: list[JsonObject] = []
+    for turn in range(6):
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Turn {turn}: " + "explain the module layout in detail. " * 10,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        )
+        messages.append(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Reading the file now. " * 5},
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_{turn:03d}",
+                        "name": "Tool0",
+                        "input": {"file_path": "/repo/src/main.py"},
+                    },
+                ],
+            }
+        )
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": f"toolu_{turn:03d}",
+                        "content": [{"type": "text", "text": "def main():\n    pass\n" * 20}],
+                    }
+                ],
+            }
+        )
+    messages.append({"role": "user", "content": prompt})
+    payload: JsonObject = {
+        "model": "coding",
+        "max_tokens": 64,
+        "system": [
+            {"type": "text", "text": system_block, "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "Project instructions: " + system_block[:2000]},
+        ],
+        "messages": messages,
+        "tools": tools,
+        "metadata": {"user_id": "harbor"},
+    }
+    if stream:
+        payload["stream"] = True
+    return payload
+
+
+def _stream_payloads(engine: _ServingEngine, body: JsonObject) -> list[JsonObject]:
+    """Stream one Messages request and return its decoded SSE data payloads."""
+    with httpx.stream(
+        "POST",
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json=body,
+        timeout=30.0,
+    ) as response:
+        assert response.status_code == 200, response.read()
+        raw = b"".join(response.iter_bytes()).decode()
+    return [
+        json.loads(line.removeprefix("data: "))
+        for line in raw.splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+def test_start_frame_estimate_counts_the_whole_claude_code_prompt(
+    engine: _ServingEngine,
+) -> None:
+    """The pre-dispatch estimate covers system, every turn, and the tools.
+
+    Harbor's Claude Code (2026-09-11) read a ``message_start`` of
+    ``input_tokens: 10`` as a stub. The start frame's estimate is the same
+    count ``count_tokens`` answers for the same prompt, so a Claude Code
+    session of several thousand tokens shows thousands there, in Anthropic's
+    start shape (both cache legs 0, ``output_tokens: 1``).
+    """
+    payloads = _stream_payloads(engine, _claude_code_body("fast-token", stream=True))
+    message_start = next(payload for payload in payloads if payload["type"] == "message_start")
+    start_usage = message_start["message"]["usage"]
+    assert start_usage["input_tokens"] > 1_000, start_usage
+    assert {k: v for k, v in start_usage.items() if k != "input_tokens"} == {
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 1,
+    }
+
+    count_body = {
+        k: v for k, v in _claude_code_body("fast-token").items() if k not in {"max_tokens"}
+    }
+    counted = httpx.post(
+        f"{engine.base}/v1/messages/count_tokens",
+        headers={"x-api-key": engine.raw_key},
+        json=count_body,
+        timeout=10.0,
+    )
+    assert counted.status_code == 200, counted.text
+    assert counted.json()["input_tokens"] == start_usage["input_tokens"]
+
+
+def test_uncached_completion_reports_both_cache_legs_as_zero(engine: _ServingEngine) -> None:
+    """A provider reporting no cached tokens yields zero legs, not missing keys.
+
+    Anthropic's shape carries ``cache_creation_input_tokens`` and
+    ``cache_read_input_tokens`` on every usage object; the official SDK
+    accumulators and Claude Code read them by key, so an uncached completion
+    renders them as 0 on ``message_delta`` and on the non-streamed body.
+    """
+    expected = {
+        "input_tokens": 9,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 4,
+    }
+    payloads = _stream_payloads(engine, _messages_body("uncached-token", stream=True))
+    message_delta = next(payload for payload in payloads if payload["type"] == "message_delta")
+    assert message_delta["usage"] == expected
+
+    response = httpx.post(
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json=_messages_body("uncached-token"),
+        timeout=30.0,
+    )
+    assert response.status_code == 200
+    assert response.json()["usage"] == expected
 
 
 def test_tool_calls_translate_to_tool_use_blocks(engine: _ServingEngine) -> None:
@@ -1312,8 +1496,9 @@ def test_messages_non_stream_zero_output_keeps_real_input_tokens(
     assert body["stop_reason"] == stop_reason
     assert body["usage"] == {
         "input_tokens": 7,
-        "output_tokens": 0,
+        "cache_creation_input_tokens": 0,
         "cache_read_input_tokens": 2,
+        "output_tokens": 0,
     }
 
 
@@ -1342,8 +1527,9 @@ def test_messages_stream_zero_output_keeps_real_input_tokens(
     assert message_delta["delta"]["stop_reason"] == stop_reason
     assert message_delta["usage"] == {
         "input_tokens": 7,
-        "output_tokens": 0,
+        "cache_creation_input_tokens": 0,
         "cache_read_input_tokens": 2,
+        "output_tokens": 0,
     }
 
 

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -34,13 +34,21 @@ if TYPE_CHECKING:
 TOOL_RESULT_IMAGE_DROP_DISCLOSURE = "messages.content.tool_result.image->placeholder"
 THINKING_HISTORY_DROP_DISCLOSURE = "messages.thinking->dropped(unsupported_by_provider)"
 
-CACHE_CONTROL_NOT_FORWARDED_SUFFIX = "->not_forwarded(provider_decides_caching)"
-"""Suffix for cache-marker disclosures on routes with no Anthropic rung: the
-marker has no wire field there, so it is not forwarded, and whether the prefix
-is cached is the provider's own decision (OpenAI-family providers cache
-implicitly and the ledger bills those reads at the cached rate; a generic
-endpoint may not cache at all). The wording states exactly that and never
-claims caching is off or on."""
+CACHE_CONTROL_NOT_FORWARDED_SUFFIX = (
+    "->not_forwarded(provider_caches_automatically;"
+    " cache reads reported in usage.cache_read_input_tokens)"
+)
+"""Suffix for cache-marker disclosures on routes with no Anthropic rung.
+
+The marker has no wire field there, so it is not forwarded; the provider
+caches the prompt prefix on its own terms (OpenAI-family and other
+OpenAI-compatible servers cache implicitly, without breakpoints), and every
+cache read it reports comes back on the Anthropic usage leg named here and is
+billed at the cached rate. The disclosure travels in
+``x-experiential-ignored-parameters``, so the wording has to say where the
+caller's caching actually shows up: a bare "not forwarded" next to a billed
+``cache_read_input_tokens`` read as "caching is ignored" (Harbor, 2026-09-11).
+A provider that never caches reports the leg as 0."""
 """Disclosed when Anthropic-signed thinking history is omitted for a foreign wire."""
 """Disclosure recorded when tool-result images degrade to placeholder text.
 

--- a/exp/runtime/models/providers/dialect_dispatch.py
+++ b/exp/runtime/models/providers/dialect_dispatch.py
@@ -35,20 +35,21 @@ TOOL_RESULT_IMAGE_DROP_DISCLOSURE = "messages.content.tool_result.image->placeho
 THINKING_HISTORY_DROP_DISCLOSURE = "messages.thinking->dropped(unsupported_by_provider)"
 
 CACHE_CONTROL_NOT_FORWARDED_SUFFIX = (
-    "->not_forwarded(provider_caches_automatically;"
+    "->not_forwarded(provider_decides_caching;"
     " cache reads reported in usage.cache_read_input_tokens)"
 )
 """Suffix for cache-marker disclosures on routes with no Anthropic rung.
 
-The marker has no wire field there, so it is not forwarded; the provider
-caches the prompt prefix on its own terms (OpenAI-family and other
-OpenAI-compatible servers cache implicitly, without breakpoints), and every
-cache read it reports comes back on the Anthropic usage leg named here and is
-billed at the cached rate. The disclosure travels in
-``x-experiential-ignored-parameters``, so the wording has to say where the
-caller's caching actually shows up: a bare "not forwarded" next to a billed
+The marker has no wire field there, so it is not forwarded, and whether the
+prefix is cached is the provider's own decision: OpenAI-family and most
+OpenAI-compatible servers cache implicitly, without breakpoints, while a
+generic endpoint may never cache. Whatever the provider does shows up on the
+Anthropic usage leg named here (billed at the cached rate when nonzero, `0`
+when the provider caches nothing). The disclosure travels in
+``x-experiential-ignored-parameters``, so it has to say where the caller's
+caching is reported: a bare "not forwarded" next to a billed
 ``cache_read_input_tokens`` read as "caching is ignored" (Harbor, 2026-09-11).
-A provider that never caches reports the leg as 0."""
+The wording never claims caching is off or on."""
 """Disclosed when Anthropic-signed thinking history is omitted for a foreign wire."""
 """Disclosure recorded when tool-result images degrade to placeholder text.
 

--- a/exp/runtime/models/providers/dialect_dispatch_test.py
+++ b/exp/runtime/models/providers/dialect_dispatch_test.py
@@ -1,2 +1,25 @@
-"""Inline tests for the dialect dispatch seam (currently exercised through
-``streaming_requests_test`` and every payload-builder suite)."""
+"""Inline tests for the dialect dispatch seam.
+
+The request-shaping behaviour is exercised through ``streaming_requests_test``
+and every payload-builder suite; this module pins the disclosure wording that
+callers read off the wire.
+"""
+
+from __future__ import annotations
+
+from exp.runtime.models.providers.dialect_dispatch import CACHE_CONTROL_NOT_FORWARDED_SUFFIX
+
+
+def test_cache_control_disclosure_names_where_cache_reads_show_up() -> None:
+    """The unforwarded-marker disclosure is a stable wire string that never reads as "ignored".
+
+    It travels in ``x-experiential-ignored-parameters`` beside a billed
+    ``cache_read_input_tokens`` on OpenAI-compatible routes, so it has to say
+    that the provider caches on its own and where the reads are reported.
+    """
+    assert CACHE_CONTROL_NOT_FORWARDED_SUFFIX == (
+        "->not_forwarded(provider_caches_automatically;"
+        " cache reads reported in usage.cache_read_input_tokens)"
+    )
+    assert "ignored" not in CACHE_CONTROL_NOT_FORWARDED_SUFFIX
+    assert "usage.cache_read_input_tokens" in CACHE_CONTROL_NOT_FORWARDED_SUFFIX

--- a/exp/runtime/models/providers/dialect_dispatch_test.py
+++ b/exp/runtime/models/providers/dialect_dispatch_test.py
@@ -15,10 +15,10 @@ def test_cache_control_disclosure_names_where_cache_reads_show_up() -> None:
 
     It travels in ``x-experiential-ignored-parameters`` beside a billed
     ``cache_read_input_tokens`` on OpenAI-compatible routes, so it has to say
-    that the provider caches on its own and where the reads are reported.
+    that caching is the provider's decision and where any reads are reported.
     """
     assert CACHE_CONTROL_NOT_FORWARDED_SUFFIX == (
-        "->not_forwarded(provider_caches_automatically;"
+        "->not_forwarded(provider_decides_caching;"
         " cache reads reported in usage.cache_read_input_tokens)"
     )
     assert "ignored" not in CACHE_CONTROL_NOT_FORWARDED_SUFFIX

--- a/exp/runtime/models/providers/streaming_requests_test.py
+++ b/exp/runtime/models/providers/streaming_requests_test.py
@@ -32,7 +32,10 @@ from exp.runtime.models.providers.anthropic_tool_compat import (
 )
 from exp.runtime.models.providers.base import GatewayWireProfile
 from exp.runtime.models.providers.bedrock_requests import converse_body
-from exp.runtime.models.providers.dialect_dispatch import THINKING_HISTORY_DROP_DISCLOSURE
+from exp.runtime.models.providers.dialect_dispatch import (
+    CACHE_CONTROL_NOT_FORWARDED_SUFFIX,
+    THINKING_HISTORY_DROP_DISCLOSURE,
+)
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
     ProviderParameterError,
@@ -1234,9 +1237,7 @@ def test_mixed_route_keeps_the_prompt_cache_marker_when_any_rung_is_anthropic() 
     # No rung can cache: dropped with disclosure.
     public_only, provider_only = route_generation_parameter_requests((fallback,), request)
     assert provider_only.provider_cache_control is None
-    assert (
-        "cache_control->not_forwarded(provider_decides_caching)" in public_only.ignored_parameters
-    )
+    assert f"cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}" in public_only.ignored_parameters
 
 
 def test_route_shaping_omits_parallel_control_when_tool_choice_disables_tools() -> None:
@@ -2599,7 +2600,7 @@ def test_tool_call_cache_hint_forwards_to_anthropic_and_discloses_elsewhere() ->
         request,
     )
     assert (
-        "messages.tool_calls.cache_control->not_forwarded(provider_decides_caching)"
+        f"messages.tool_calls.cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}"
         in public.ignored_parameters
     )
     anthropic_public, _provider = route_generation_parameter_requests(
@@ -3048,7 +3049,7 @@ def test_tool_annotations_and_top_carriers_forward_on_anthropic_and_disclose_els
     # rungs.
     assert set(mixed_public.ignored_parameters) == {
         "inference_geo",
-        "tools.cache_control->not_forwarded(provider_decides_caching)",
+        f"tools.cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}",
         "tools.eager_input_streaming",
         "tools.defer_loading",
         "tools.allowed_callers",
@@ -3294,7 +3295,7 @@ def test_block_cache_markers_reach_the_anthropic_wire_and_survive_mixed_routes()
     # 14,976 cached tokens billed at the cached rate beside this disclosure),
     # so the wording says what actually happens to the marker.
     assert (
-        "messages.content.cache_control->not_forwarded(provider_decides_caching)"
+        f"messages.content.cache_control{CACHE_CONTROL_NOT_FORWARDED_SUFFIX}"
         in foreign_public.ignored_parameters
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.51,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.52,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.51"
+version = "0.3.52"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Customer report (Spandana / Harbor, Claude Code over `/v1/messages` on hy4-preview via Tencent, 2026-09-11)

> 1. "Stream usage shape: `message_start.message.usage` is a stub: `input_tokens: 10, output_tokens: 1`, no cache fields. `message_delta.usage` has final input/output/cost but no `cache_read_input_tokens` / `cache_creation_input_tokens`. That is still not Anthropic's shape."
> 2. "cache_control listed as ignored while cache is billed: same prefix replay billed `cache_read_input_tokens: 256` and still disclosed `messages.content.cache_control->not_forwarded(provider_decides_caching)`."

## What changed

**Every Messages usage object carries Anthropic's four legs** (`message_start.message.usage`, `message_delta.usage`, the non-streamed body `usage`), always present, `0` when the provider reported none, in Anthropic's field order. Previously the cache legs were emitted only when nonzero, so an uncached turn read as "not Anthropic's shape" to a client that reads the legs by key (Claude Code, the official SDK accumulators).

| Anthropic field | source (normalized `Usage`, whose `input_tokens` is the folded total the ledger bills) |
|---|---|
| `input_tokens` | folded input minus cache reads minus cache writes (uncached input, saturating) |
| `cache_creation_input_tokens` | Anthropic-wire `cache_creation_input_tokens`, else `0` (only the Anthropic wire reports cache writes) |
| `cache_read_input_tokens` | Anthropic `cache_read_input_tokens`; OpenAI-compatible `prompt_tokens_details.cached_tokens` (Chat) / `input_tokens_details.cached_tokens` (Responses); Gemini `cachedContentTokenCount`; Bedrock `cacheReadInputTokens`; else `0` |
| `output_tokens` | provider output (reasoning folded where billed additively) |

Harbor's real turn on the Tencent rung (ledger: input 437, cached 256) now renders as `{"input_tokens":181,"cache_creation_input_tokens":0,"cache_read_input_tokens":256,"output_tokens":12}`.

**Exact wire shapes**

`message_start` on an OpenAI-wire rung (the pre-dispatch estimate; nothing is cached before dispatch, Anthropic's `output_tokens: 1` start placeholder):
```
event: message_start
data: {"type":"message_start","message":{"id":"msg_…","type":"message","role":"assistant","model":"hy4-preview","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":5260,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1}}}
```
`message_delta`, cached prefix replay (Harbor's 437/256 turn) and an uncached completion:
```
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":181,"cache_creation_input_tokens":0,"cache_read_input_tokens":256,"output_tokens":12}}
data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":437,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}}
```
Non-streamed body:
```
"usage": {"input_tokens": 181, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 256, "output_tokens": 12}
"usage": {"input_tokens": 437, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0, "output_tokens": 12}
```
(An Anthropic-wire rung's own start meters still outrank the estimate on `message_start`; the platform's `usage.cost` extension is added by the platform front and is unchanged.)

**The `input_tokens: 10` estimate.** The start-frame estimate and `count_tokens` were already one function (`counted_input_tokens` on the decoded Messages request), and it counts the system array (folded into the leading system turn), every turn's content blocks including `tool_use` / `tool_result`, and each tool definition. A 28 KB Claude Code-shaped body (system array, 12 tools, six turns) counts 5,260 on the served stream, equal to the `count_tokens` answer for the same body. The OpenAI-compatible dialect holds provider usage until its finish chunk, so the start frame on that wire is always the estimate; a two-digit start figure is therefore a two-digit prompt (Claude Code's own startup probes), not a stub. Both the unit count and the served stream are now pinned in the thousands so a decoder change that dropped system or tools would fail loudly rather than by tokenizer drift.

**Disclosure wording.** `CACHE_CONTROL_NOT_FORWARDED_SUFFIX` is now
```
->not_forwarded(provider_decides_caching; cache reads reported in usage.cache_read_input_tokens)
```
It rides in `x-experiential-ignored-parameters`, so the bare "not forwarded" beside a billed cache read was read as "caching is ignored". The wording stays provider-dependent (a generic OpenAI-compatible endpoint may never cache; Greptile's review point, taken) and names where whatever the provider does is reported. The literal is pinned in `dialect_dispatch_test.py`; the four `streaming_requests_test` sites read the constant; `docs/reference/gateway-architecture.md` documents both the wording and the four-leg usage contract.

**Not in this PR (follow-up), from the 2026-09-12 adversarial probe, finding B4:** `count_tokens` / the `message_start` estimate read 494 against 233 billed on a system + 1 tool + 3 turns prompt, while prose is within 2%. Cause: `TOOLS_PRESENT_TOKENS = 400` in `attempt_tokens.py`, the fixed tool-use system-prompt allowance sized to Anthropic's documented 264 to 395 tokens, applied to every wire. On an OpenAI-wire rung (hy4 via Tencent here) the chat template's tool overhead is ~150 tokens, so the estimate over-counts by a CONSTANT ~250 tokens whenever any tool is declared. It is not a 2x multiplier: on a real Claude Code turn (thousands of tokens of tools and history) it is a low single-digit percent, and compaction near the context ceiling is unaffected by a 250-token offset. The fix is a per-wire preamble constant chosen from the admitted route's leading rung (Anthropic wire keeps 400; OpenAI-compatible, Gemini, Bedrock get their own calibrated allowance), with `count_tokens` resolving the alias's rungs the same way admission does; it needs provider-count calibration data per wire before the constants are changed, so it is left out of this PR rather than guessed.

**Crate** `exp-gateway-native` 0.3.51 -> 0.3.52 (gate requirement for `.rs` changes); Messages parity goldens updated for the four-leg usage objects (the committed contract change is exactly the two added `0` legs and Anthropic's field order). The usage object lives in `encode_messages/usage.rs` with its tests in `tests_usage.rs` so both `encode_messages.rs` and `tests.rs` stay under the 999-line budget. No release cut, no platform pin bump.

## Test evidence

- `cargo test --no-default-features`: 289 passed; `cargo clippy --no-default-features -- -D warnings` and `cargo fmt --check` clean.
- New: `usage_carries_both_cache_legs_as_zero_when_the_provider_reports_none`, `usage_reports_openai_wire_cached_tokens_as_cache_reads` (Rust); `test_start_frame_estimate_counts_the_whole_claude_code_prompt` (served stream > 1,000 and == `count_tokens`), `test_uncached_completion_reports_both_cache_legs_as_zero` (stream + non-stream), `test_messages_estimate_counts_system_every_turn_and_the_tools` (unit; dropping system or tools lowers the count by their contribution), `test_cache_control_disclosure_names_where_cache_reads_show_up`.
- `native_messages_test.py` 36 passed, `native_bridge_test.py -k "rust or messages"` 29 passed, `streaming_requests_test.py` + `attempt_tokens_test.py` green.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`: clean. Full `uv run pytest -q`: 4,166 passed, 6 skipped before the line-budget split (the one failure was `repo_layout_test` on the two oversized Rust files, fixed in bb1e5194; that test and every touched suite re-run green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
