### PR TITLE
messages: bare thinking resolves to the lane's default effort; thinking coerces on every reasoning-capable rung instead of 400

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -393,7 +393,8 @@ configs outright, an `enabled` config translates to adaptive with the dropped
 because those models cannot turn thinking off; a bare `{type: enabled}` with no budget, which
 Claude Code sends, is legal at the gateway boundary: an Anthropic rung receives the gateway's
 derived budget (`thinking.budget_tokens->derived`, or `thinking->dropped(no_legal_budget)` when
-none fits under `max_tokens`) and an effort route reads it as the default depth), requires
+none fits under `max_tokens`) and an effort route reads it as the LANE's default depth: the
+rung's catalog `reasoning_default_effort`, medium when no rung pins one), requires
 `max_tokens`, validates `cache_control` (carrying it everywhere the Anthropic wire caches
 natively: `tool_use` blocks, tool definitions, the top-level automatic marker, and block-level
 markers on system and message text runs and on `tool_result` breakpoints all forward verbatim.
@@ -675,12 +676,23 @@ through `ignored_parameters`, logged, and counted in the `admission_parameter_co
 metric; every serving surface carries that list to the caller as a body-level
 `x-experiential-ignored-parameters` key (Chat chunk and completion, Responses envelope, and the
 Anthropic message on both `message_start` and the aggregated body), so a drop is never silent; nothing coercible keeps the first rung's own field-scoped rejection.
-The thinking vocabulary names the outcome, never a bare field: `thinking->reasoning_effort:<tier>`
-(the config was TRANSLATED onto the route's effort ladder and applies at that tier),
+The thinking vocabulary names the outcome, never a bare field:
+`thinking->reasoning_effort:<tier>(<source>)` (the config was TRANSLATED onto the route's effort
+ladder and applies at that tier; the source names what asked for it: `budget_tokens` for an
+explicit budget through the tier table, `lane_default` for a budget-less `enabled` or `adaptive`
+config read as the rung's catalog `reasoning_default_effort`, `gateway_default` for the same
+config on a route whose rungs pin no default (medium), `disabled` for the off switch),
 `thinking->dropped(superseded_by_effort)` (the caller's own `output_config.effort` or
-`reasoning.effort` already states the depth, which is what serves), and
-`thinking->dropped(unsupported_by_route)` (no rung can reason at any depth). A caller reading a
-bare `thinking` as "my depth was stripped" is the misreading this vocabulary exists to prevent.
+`reasoning.effort` already states the depth, which is what serves),
+`thinking->dropped(unsupported_by_route)` (no rung can reason at any depth), and
+`thinking->dropped(no_servable_tier)` (the route reasons, but no tier of its ladder serves this
+request beside its other controls, so the rung answers at its own default depth). The translation
+runs on every route with a non-Anthropic rung once every rung has declined the config verbatim, a
+mixed route included (its Anthropic rung, when it can honor the config, is kept by narrowing before
+this layer is consulted); only an all-Anthropic route leaves the config to Anthropic shaping. The
+named `thinking` rejection therefore never reaches a caller whose route carries a reasoning rung.
+A caller reading a bare `thinking` as "my depth was stripped" is the misreading this vocabulary
+exists to prevent.
 
 On the Messages stream, `message_start.message.usage` is a PRE-DISPATCH figure and
 `message_delta.usage` is the authoritative one. The start frame carries what the upstream already

--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -394,8 +394,13 @@ because those models cannot turn thinking off; a bare `{type: enabled}` with no 
 Claude Code sends, is legal at the gateway boundary: an Anthropic rung receives the gateway's
 derived budget (`thinking.budget_tokens->derived`, or `thinking->dropped(no_legal_budget)` when
 none fits under `max_tokens`) and an effort route reads it as the LANE's default depth: the
-rung's catalog `reasoning_default_effort`, medium when no rung pins one), requires
-`max_tokens`, validates `cache_control` (carrying it everywhere the Anthropic wire caches
+rung's catalog `reasoning_default_effort`, medium when no rung pins one; a budget at or above
+`max_tokens` is refused on `thinking.budget_tokens` at the boundary, Anthropic's own rule, while a
+budget under Anthropic's 1024 minimum is only a depth hint and is carried), requires
+`max_tokens` (a ceiling under 1024 with no reasoning signal of the caller's own, on a route whose
+every rung reasons by default and offers a `none` tier, dispatches at `reasoning_effort: none`
+disclosed as `reasoning_effort->none(max_tokens_headroom)`, so the reply is text rather than
+thinking cut off at the ceiling), validates `cache_control` (carrying it everywhere the Anthropic wire caches
 natively: `tool_use` blocks, tool definitions, the top-level automatic marker, and block-level
 markers on system and message text runs and on `tool_result` breakpoints all forward verbatim.
 Marked runs re-emit the caller's exact block structure while the flattened string stays the
@@ -676,6 +681,10 @@ through `ignored_parameters`, logged, and counted in the `admission_parameter_co
 metric; every serving surface carries that list to the caller as a body-level
 `x-experiential-ignored-parameters` key (Chat chunk and completion, Responses envelope, and the
 Anthropic message on both `message_start` and the aggregated body), so a drop is never silent; nothing coercible keeps the first rung's own field-scoped rejection.
+When a coercion APPLIES but none SERVES (every candidate dies one layer later, on a blocker
+unrelated to the coerced field), admission carries the unprobed coercion forward so the stage
+that actually refuses names the caller's remedy: an image on a text-only reasoning route is
+refused on `messages`, never as an unsupported `thinking` field that merely rode along.
 The thinking vocabulary names the outcome, never a bare field:
 `thinking->reasoning_effort:<tier>(<source>)` (the config was TRANSLATED onto the route's effort
 ladder and applies at that tier; the source names what asked for it: `budget_tokens` for an

--- a/exp/common/models/catalog.py
+++ b/exp/common/models/catalog.py
@@ -465,7 +465,13 @@ class GatewayDeploymentCapabilities(ContractModel):
     ordered set here because their supported values vary by model.
     """
     reasoning_default_effort: ReasoningEffort | None = None
-    """Explicit provider default used only when the wire requires this field."""
+    """The depth this deployment reasons at when the caller names none.
+
+    Emitted on a wire that requires an explicit effort, and read by Messages
+    admission as the depth a budget-less ``thinking`` config (``adaptive``, or
+    Claude Code's bare ``{type: enabled}``) asks for on an effort rung, so a
+    lane's think-mode depth is set here, not in code.
+    """
     reasoning_effort_required: bool = False
     """Whether this deployment requires an explicit reasoning effort on its wire."""
     reports_refusals: bool = False

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -378,7 +378,6 @@ def _decode(
     _validate_manifest(payload)
     request = validate_wire(payload, wire)
     _require_served_server_tool_types(request.tools)
-    _require_thinking_budget_below_max_tokens(request)
     forwarded_betas, dropped_beta_disclosures = _beta_tokens(anthropic_beta)
     messages: list[GatewayMessage] = []
     system_text = _system_text(request.system)
@@ -419,6 +418,7 @@ def _decode(
             else None
         ),
     )
+    _require_thinking_budget_below_max_tokens(channels.thinking_config, request.max_tokens)
     try:
         canonical = GatewayRequest(
             surface=GatewayApiSurface.MESSAGES,
@@ -604,7 +604,10 @@ def _marked_text_blocks(
     return tuple(rebuilt)
 
 
-def _require_thinking_budget_below_max_tokens(request: _MessagesRequest) -> None:
+def _require_thinking_budget_below_max_tokens(
+    thinking_config: JsonObject | None,
+    max_tokens: int | None,
+) -> None:
     """Refuse a thinking budget that leaves no room for the reply.
 
     Anthropic requires ``thinking.budget_tokens < max_tokens`` (its own 400 reads
@@ -617,16 +620,21 @@ def _require_thinking_budget_below_max_tokens(request: _MessagesRequest) -> None
     it with the derived legal budget (disclosed), and on an effort rung it is
     only a depth hint read through the tier table, so nothing about it can
     fail. A ``count_tokens`` body carries no ``max_tokens`` and is not checked.
+    The check reads the RESOLVED thinking channel, after reasoning-channel
+    precedence: a ``thinking`` config that an explicit ``reasoning`` effort
+    supersedes is discarded, and a discarded budget cannot starve anything.
 
     Args:
-        request: The validated wire request.
+        thinking_config: The thinking config the canonical request will carry.
+        max_tokens: The caller's reply ceiling, ``None`` for ``count_tokens``.
 
     Raises:
         OpenAIProtocolError: The budget is not below ``max_tokens``.
     """
-    if request.thinking is None or request.thinking.budget_tokens is None:
+    if thinking_config is None or max_tokens is None:
         return
-    if request.max_tokens is not None and request.thinking.budget_tokens >= request.max_tokens:
+    budget = thinking_config.get("budget_tokens")
+    if isinstance(budget, int) and not isinstance(budget, bool) and budget >= max_tokens:
         raise invalid_field(
             "thinking.budget_tokens",
             "thinking.budget_tokens must be below max_tokens so the reply has room after "

--- a/exp/runtime/anthropic_protocol/requests.py
+++ b/exp/runtime/anthropic_protocol/requests.py
@@ -378,6 +378,7 @@ def _decode(
     _validate_manifest(payload)
     request = validate_wire(payload, wire)
     _require_served_server_tool_types(request.tools)
+    _require_thinking_budget_below_max_tokens(request)
     forwarded_betas, dropped_beta_disclosures = _beta_tokens(anthropic_beta)
     messages: list[GatewayMessage] = []
     system_text = _system_text(request.system)
@@ -601,6 +602,36 @@ def _marked_text_blocks(
             entry["cache_control"] = block.cache_control.model_dump(mode="json", exclude_none=True)
         rebuilt.append(entry)
     return tuple(rebuilt)
+
+
+def _require_thinking_budget_below_max_tokens(request: _MessagesRequest) -> None:
+    """Refuse a thinking budget that leaves no room for the reply.
+
+    Anthropic requires ``thinking.budget_tokens < max_tokens`` (its own 400 reads
+    "max_tokens must be greater than thinking budget_tokens"), and the same
+    arithmetic holds on every route: a budget at or above the ceiling can only
+    end as thinking cut off at ``max_tokens`` with no text, so the request is
+    refused here, before a reservation or a provider round trip, exactly like
+    the sibling ``reasoning.max_tokens`` channel. A budget BELOW Anthropic's
+    1024 minimum is not refused: on an Anthropic rung route shaping replaces
+    it with the derived legal budget (disclosed), and on an effort rung it is
+    only a depth hint read through the tier table, so nothing about it can
+    fail. A ``count_tokens`` body carries no ``max_tokens`` and is not checked.
+
+    Args:
+        request: The validated wire request.
+
+    Raises:
+        OpenAIProtocolError: The budget is not below ``max_tokens``.
+    """
+    if request.thinking is None or request.thinking.budget_tokens is None:
+        return
+    if request.max_tokens is not None and request.thinking.budget_tokens >= request.max_tokens:
+        raise invalid_field(
+            "thinking.budget_tokens",
+            "thinking.budget_tokens must be below max_tokens so the reply has room after "
+            "thinking. Raise max_tokens or lower the budget.",
+        )
 
 
 def _stop_sequences(sequences: tuple[str, ...] | None) -> tuple[str, ...]:

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -1693,7 +1693,7 @@ def test_a_claude_code_thinking_request_serves_on_an_openai_route() -> None:
 
     coercion = coerce_generation_parameters((profile,), decoded.request)
     assert coercion is not None
-    assert coercion.disclosures == ("thinking->reasoning_effort:medium",)
+    assert coercion.disclosures == ("thinking->reasoning_effort:medium(budget_tokens)",)
     _public, provider = route_generation_parameter_requests((profile,), coercion.request)
     payload = dialect_stream_payload(profile, provider)
     assert payload["reasoning"] == {"effort": "medium"}

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -165,7 +165,7 @@ def test_output_config_is_carried_verbatim_and_maps_canonical_effort() -> None:
 def test_thinking_config_is_carried_verbatim() -> None:
     """The caller's thinking object survives byte-for-byte on the canonical request."""
     config: JsonObject = {"type": "enabled", "budget_tokens": 1024}
-    decoded = decode_messages(_body(thinking=config))
+    decoded = decode_messages(_body(max_tokens=4096, thinking=config))
     assert decoded.request.provider_thinking_config == config
     assert decode_messages(_body()).request.provider_thinking_config is None
 
@@ -1683,6 +1683,7 @@ def test_a_claude_code_thinking_request_serves_on_an_openai_route() -> None:
 
     decoded = decode_messages(
         _body(
+            max_tokens=16000,
             messages=[{"role": "user", "content": "hi"}],
             thinking={"type": "enabled", "budget_tokens": 8192},
         )
@@ -1904,6 +1905,7 @@ def test_openrouter_reasoning_wins_over_thinking_and_output_config_with_disclosu
     """
     decoded = decode_messages(
         _body(
+            max_tokens=4096,
             reasoning={"effort": "high"},
             thinking={"type": "enabled", "budget_tokens": 2048},
             output_config={"effort": "low", "format": {"type": "text"}},
@@ -2106,3 +2108,40 @@ def test_claude_code_beta_header_set_decodes_with_per_token_disclosures() -> Non
     assert decoded.request.reasoning_effort == "high"
     assert decoded.request.provider_thinking_config == {"type": "enabled"}
     assert [tool.name for tool in decoded.request.tools] == ["Bash"]
+
+
+def test_a_thinking_budget_at_or_above_max_tokens_is_refused_at_the_boundary() -> None:
+    """Anthropic's own rule, applied before any reservation or provider call.
+
+    A budget at or above ``max_tokens`` can only end as thinking cut off at the
+    ceiling with no text (Anthropic answers "max_tokens must be greater than
+    thinking budget_tokens"), so the gateway refuses it on ``thinking.budget_tokens``
+    like the sibling ``reasoning.max_tokens`` channel. A budget below Anthropic's
+    1024 minimum is NOT refused: an Anthropic rung replaces it with the derived
+    legal budget (disclosed) and an effort rung reads it as a depth hint, so it
+    is accepted and carried verbatim. ``count_tokens`` has no ceiling to check.
+    """
+    from exp.runtime.anthropic_protocol.requests import decode_messages_count_tokens
+
+    with pytest.raises(OpenAIProtocolError) as equal:
+        decode_messages(_body(max_tokens=4096, thinking={"type": "enabled", "budget_tokens": 4096}))
+    assert equal.value.status_code == 400
+    assert equal.value.detail.param == "thinking.budget_tokens"
+    assert "max_tokens" in equal.value.detail.message
+    with pytest.raises(OpenAIProtocolError) as above:
+        decode_messages(_body(max_tokens=256, thinking={"type": "enabled", "budget_tokens": 4096}))
+    assert above.value.detail.param == "thinking.budget_tokens"
+
+    small = decode_messages(
+        _body(max_tokens=4096, thinking={"type": "enabled", "budget_tokens": 100})
+    )
+    assert small.request.provider_thinking_config == {"type": "enabled", "budget_tokens": 100}
+
+    counted = decode_messages_count_tokens(
+        {
+            "model": "coding",
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "enabled", "budget_tokens": 4096},
+        }
+    )
+    assert counted.request.provider_thinking_config == {"type": "enabled", "budget_tokens": 4096}

--- a/exp/runtime/anthropic_protocol/requests_test.py
+++ b/exp/runtime/anthropic_protocol/requests_test.py
@@ -2145,3 +2145,30 @@ def test_a_thinking_budget_at_or_above_max_tokens_is_refused_at_the_boundary() -
         }
     )
     assert counted.request.provider_thinking_config == {"type": "enabled", "budget_tokens": 4096}
+
+
+def test_a_superseded_thinking_budget_is_never_refused() -> None:
+    """The refusal reads the RESOLVED channel: an explicit ``reasoning.effort``
+    discards the thinking config beside it, so its budget cannot starve the
+    reply and the request decodes at that effort with the supersession
+    disclosed. A ``reasoning.max_tokens`` budget is its own channel's check."""
+    decoded = decode_messages(
+        _body(
+            max_tokens=2048,
+            thinking={"type": "enabled", "budget_tokens": 4096},
+            reasoning={"effort": "high"},
+        )
+    )
+    assert decoded.request.reasoning_effort == "high"
+    assert decoded.request.provider_thinking_config is None
+    assert "thinking->dropped(superseded_by_reasoning)" in decoded.request.ignored_parameters
+
+    # reasoning: {enabled: false} resolves to a disabled config with no budget.
+    off = decode_messages(
+        _body(
+            max_tokens=2048,
+            thinking={"type": "enabled", "budget_tokens": 4096},
+            reasoning={"enabled": False},
+        )
+    )
+    assert off.request.provider_thinking_config == {"type": "disabled"}

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -156,12 +156,6 @@ def admitted_route_requests(
     coercion_disclosures: tuple[str, ...] = ()
     full_route = route
     full_wires = resolved_wires
-    headroom = reserve_thinking_headroom(
-        tuple(profile for profile, _client in resolved_wires), admitted_request
-    )
-    if headroom is not None:
-        admitted_request = headroom.request
-        coercion_disclosures = headroom.disclosures
 
     def candidate_serves(candidate: GatewayRequest) -> bool:
         return _candidate_serves(full_route, full_wires, candidate)
@@ -206,6 +200,17 @@ def admitted_route_requests(
         coercion_disclosures = (*coercion_disclosures, *coercion.disclosures)
     route = select_route_deployments(route, compatible_indexes)
     resolved_wires = tuple(resolved_wires[index] for index in compatible_indexes)
+    # The headroom rule reads the rungs that SURVIVED narrowing: a rung with
+    # no reasoning default (or no ``none`` tier) that narrowing has already
+    # removed must not veto the coercion for the default-on rung that will
+    # actually serve. Every surviving rung accepted the request verbatim and
+    # offers ``none``, so the coerced request narrows to the same set.
+    headroom = reserve_thinking_headroom(
+        tuple(profile for profile, _client in resolved_wires), admitted_request
+    )
+    if headroom is not None:
+        admitted_request = headroom.request
+        coercion_disclosures = (*coercion_disclosures, *headroom.disclosures)
     public_request, provider_request = route_generation_parameter_requests(
         tuple(profile for profile, _client in resolved_wires),
         admitted_request,

--- a/exp/runtime/gateway/native_admission.py
+++ b/exp/runtime/gateway/native_admission.py
@@ -46,6 +46,7 @@ from exp.runtime.models.providers.capability_policy import (
     coerce_route_rejections,
     coerce_strict_tool_schemas,
     coerce_structured_text_schema,
+    reserve_thinking_headroom,
 )
 from exp.runtime.models.providers.errors import (
     ProviderCapabilityError,
@@ -155,6 +156,12 @@ def admitted_route_requests(
     coercion_disclosures: tuple[str, ...] = ()
     full_route = route
     full_wires = resolved_wires
+    headroom = reserve_thinking_headroom(
+        tuple(profile for profile, _client in resolved_wires), admitted_request
+    )
+    if headroom is not None:
+        admitted_request = headroom.request
+        coercion_disclosures = headroom.disclosures
 
     def candidate_serves(candidate: GatewayRequest) -> bool:
         return _candidate_serves(full_route, full_wires, candidate)
@@ -174,13 +181,29 @@ def admitted_route_requests(
             admits=candidate_serves,
         )
         if coercion is None:
+            # No coercion SERVES, but one may still APPLY: the probe refused
+            # every candidate because the coerced request dies one layer
+            # later, on a blocker that has nothing to do with the coerced
+            # field. Re-raising the verbatim rejection here would name that
+            # field (an image on a text-only route read as "thinking is not
+            # supported by this model route", because shaping rejects the
+            # foreign-wire thinking config before preflight ever sees the
+            # image; 25 such 400s on 2026-09-11). Carry the unprobed
+            # coercion forward instead and let the stage that actually
+            # refuses it name the caller's remedy. Nothing is recorded for a
+            # request that never serves.
+            coercion = coerce_generation_parameters(
+                tuple(profile for profile, _client in resolved_wires),
+                admitted_request,
+            )
+        if coercion is None:
             raise
         compatible_indexes = compatible_generation_parameter_profile_indexes(
             tuple(profile for profile, _client in resolved_wires),
             coercion.request,
         )
         admitted_request = coercion.request
-        coercion_disclosures = coercion.disclosures
+        coercion_disclosures = (*coercion_disclosures, *coercion.disclosures)
     route = select_route_deployments(route, compatible_indexes)
     resolved_wires = tuple(resolved_wires[index] for index in compatible_indexes)
     public_request, provider_request = route_generation_parameter_requests(

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -814,7 +814,7 @@ def test_a_thinking_config_translates_through_admission_on_an_openai_route() -> 
     )
 
     assert tuple(item.deployment_id for item in narrowed.deployments) == ("gpt",)
-    assert "thinking->reasoning_effort:medium" in public.ignored_parameters
+    assert "thinking->reasoning_effort:medium(budget_tokens)" in public.ignored_parameters
     assert provider.provider_thinking_config is None
     assert provider.reasoning_effort == "medium"
     assert accounting.recorded == 1

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -1702,3 +1702,65 @@ def test_a_tiny_max_tokens_on_a_default_reasoning_lane_dispatches_without_thinki
     )
     assert provider.reasoning_effort is None
     assert public.ignored_parameters == ()
+
+
+def test_the_headroom_rule_reads_the_rungs_that_survive_narrowing() -> None:
+    """A rung with no reasoning default that narrowing removes (its output
+    ceiling is below the caller's ``max_tokens``) must not veto the headroom
+    coercion for the default-on rung that actually serves; and a surviving
+    rung without a default still does, because it already answers in text."""
+    plain = GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+    )
+    route = _mixed_route(
+        "maximize_availability",
+        (
+            _deployment("text-only", gateway=plain),
+            _deployment("hy4", provider="tencent", gateway=plain),
+        ),
+        GatewayApiSurface.MESSAGES,
+    )
+    client = cast(NativeWireClient, object())
+    hy4 = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://tokenhub.test/v1",
+        model_id="hy4-preview",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+        supported_reasoning_efforts=("none", "low", "medium", "high"),
+        reasoning_effort="high",
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        maximum_output_tokens=32,
+        maximum_output_tokens_parameter="max_tokens",
+        stream=True,
+        include_usage=True,
+    )
+
+    narrowed_out = GatewayWireProfile(
+        dialect="openai_compatible", url="https://plain.test/v1", maximum_output_tokens=16
+    )
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
+        route,
+        ((narrowed_out, client), (hy4, client)),
+        request,
+        accounting=cast(NativeAttemptAccounting, _AdmissionCoercionCounter()),
+        authorization=route.snapshot.authorization,
+    )
+    assert tuple(item.deployment_id for item in narrowed.deployments) == ("hy4",)
+    assert provider.reasoning_effort == "none"
+    assert "reasoning_effort->none(max_tokens_headroom)" in public.ignored_parameters
+
+    surviving = GatewayWireProfile(dialect="openai_compatible", url="https://plain.test/v1")
+    narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
+        route,
+        ((surviving, client), (hy4, client)),
+        request,
+        accounting=cast(NativeAttemptAccounting, _AdmissionCoercionCounter()),
+        authorization=route.snapshot.authorization,
+    )
+    assert len(narrowed.deployments) == 2
+    assert provider.reasoning_effort is None
+    assert public.ignored_parameters == ()

--- a/exp/runtime/gateway/native_admission_test.py
+++ b/exp/runtime/gateway/native_admission_test.py
@@ -1558,3 +1558,147 @@ class TestAffinityOrderedRungs:
         expiring.bind(b"fingerprint", "dep-house", ttl_seconds=600.0)
         clock[0] = 601.0
         assert expiring.bound_deployment(b"fingerprint") is None
+
+
+def test_an_image_refusal_is_never_blamed_on_the_thinking_field() -> None:
+    """A modality refusal names ``messages`` even when ``thinking`` rides along.
+
+    On a text-only reasoning route (hy4-preview's shape) an image block is
+    refused at capability preflight. Claude Code sends a ``thinking`` field on
+    every request, and route shaping rejects that field by name on a foreign
+    wire before preflight ever runs, so with no correction the caller read
+    "The parameter 'thinking' is not supported by this model route" for a
+    pasted screenshot (25 such 400s on 2026-09-11; removing thinking still
+    failed). The rejection the caller sees must be the one the coerced request
+    hits: the image, on ``messages``.
+    """
+    from exp.runtime.anthropic_protocol.requests import decode_messages
+    from exp.runtime.gateway.native_accounting import NativeAttemptAccounting
+
+    text_only = GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(
+            supports_streaming=True,
+            supports_streaming_tool_arguments=True,
+        )
+    )
+    route = _mixed_route(
+        "maximize_availability",
+        (_deployment("hy4", provider="tencent", gateway=text_only),),
+        GatewayApiSurface.MESSAGES,
+    )
+    client = cast(NativeWireClient, object())
+    wires = (
+        (
+            GatewayWireProfile(
+                dialect="openai_compatible",
+                url="https://tokenhub.test/v1",
+                model_id="hy4-preview",
+                supports_reasoning=True,
+                reasoning_wire_format="reasoning_effort",
+                supported_reasoning_efforts=("none", "low", "medium", "high"),
+                reasoning_effort="high",
+            ),
+            client,
+        ),
+    )
+    image_turn: JsonObject = {
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/png", "data": _TOOL_IMAGE_PNG},
+            },
+            {"type": "text", "text": "What is this?"},
+        ],
+    }
+    for thinking in ({"type": "disabled"}, {"type": "enabled"}, {"type": "adaptive"}):
+        body: JsonObject = {
+            "model": "hy4-preview",
+            "max_tokens": 48,
+            "thinking": thinking,
+            "messages": [image_turn],
+        }
+        request = decode_messages(body).request.model_copy(update={"include_usage": True})
+        with pytest.raises(ProviderCapabilityError) as refused:
+            admitted_route_requests(
+                route,
+                wires,
+                request,
+                accounting=cast(NativeAttemptAccounting, _AdmissionCoercionCounter()),
+                authorization=route.snapshot.authorization,
+            )
+        assert refused.value.capability == "image_input", thinking
+
+    # The control: the same body without thinking is refused the same way.
+    control = decode_messages(
+        {"model": "hy4-preview", "max_tokens": 48, "messages": [image_turn]}
+    ).request.model_copy(update={"include_usage": True})
+    with pytest.raises(ProviderCapabilityError) as refused:
+        admitted_route_requests(
+            route,
+            wires,
+            control,
+            accounting=cast(NativeAttemptAccounting, _AdmissionCoercionCounter()),
+            authorization=route.snapshot.authorization,
+        )
+    assert refused.value.capability == "image_input"
+
+
+def test_a_tiny_max_tokens_on_a_default_reasoning_lane_dispatches_without_thinking() -> None:
+    """Through the admit loop: hy4's shape at ``max_tokens: 32`` with no
+    reasoning signal dispatches at ``reasoning_effort: none`` with the headroom
+    disclosure recorded and counted, so the caller gets text instead of a
+    thinking block truncated at the ceiling."""
+    reasoning = GatewayDeploymentMetadata(
+        capabilities=GatewayDeploymentCapabilities(supports_streaming=True)
+    )
+    route = _mixed_route(
+        "maximize_availability",
+        (_deployment("hy4", provider="tencent", gateway=reasoning),),
+        GatewayApiSurface.MESSAGES,
+    )
+    client = cast(NativeWireClient, object())
+    wires = (
+        (
+            GatewayWireProfile(
+                dialect="openai_compatible",
+                url="https://tokenhub.test/v1",
+                model_id="hy4-preview",
+                supports_reasoning=True,
+                reasoning_wire_format="reasoning_effort",
+                supported_reasoning_efforts=("none", "low", "medium", "high"),
+                reasoning_effort="high",
+            ),
+            client,
+        ),
+    )
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+        maximum_output_tokens=32,
+        maximum_output_tokens_parameter="max_tokens",
+        stream=True,
+        include_usage=True,
+    )
+    accounting = _AdmissionCoercionCounter()
+    _narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
+        route,
+        wires,
+        request,
+        accounting=cast(NativeAttemptAccounting, accounting),
+        authorization=route.snapshot.authorization,
+    )
+    assert provider.reasoning_effort == "none"
+    assert "reasoning_effort->none(max_tokens_headroom)" in public.ignored_parameters
+    assert accounting.recorded == 1
+
+    roomy = request.model_copy(update={"maximum_output_tokens": 4096})
+    _narrowed, _wires_out, public, provider, _placement = admitted_route_requests(
+        route,
+        wires,
+        roomy,
+        accounting=cast(NativeAttemptAccounting, _AdmissionCoercionCounter()),
+        authorization=route.snapshot.authorization,
+    )
+    assert provider.reasoning_effort is None
+    assert public.ignored_parameters == ()

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -1364,7 +1364,10 @@ def test_replayed_thinking_history_serves_with_disclosure_on_a_foreign_route(
         headers={"x-api-key": engine.raw_key},
         json={
             **_messages_body("thinking-config-serves"),
-            "thinking": {"type": "enabled", "budget_tokens": 2048},
+            # Below the 64-token ceiling: a budget at or above max_tokens is
+            # refused at the boundary (Anthropic's own rule), while one under
+            # Anthropic's 1024 minimum is only a depth hint on this route.
+            "thinking": {"type": "enabled", "budget_tokens": 32},
         },
         timeout=10.0,
     )

--- a/exp/runtime/models/providers/base.py
+++ b/exp/runtime/models/providers/base.py
@@ -204,7 +204,10 @@ class GatewayWireProfile:
     """Exact provider field used to carry normalized reasoning effort."""
 
     reasoning_effort: str | None = None
-    """Optional provider default used when the wire requires an explicit effort."""
+    """The rung's catalog default depth (``reasoning_default_effort``).
+
+    Emitted when the wire requires an explicit effort, and the depth a
+    budget-less caller ``thinking`` config translates to on this rung."""
 
     supported_reasoning_efforts: tuple[ReasoningEffort, ...] = ()
     """Exact caller values declared by this deployment, in canonical order."""

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic import JsonValue
 
 from exp.common.core.artifacts import JsonObject
+from exp.common.models.model import ReasoningEffort
 from exp.runtime.gateway.contracts import (
     GatewayNamedToolChoice,
     GatewayRequest,
@@ -39,6 +40,7 @@ from exp.runtime.models.providers.generation_route_compat import (
 )
 from exp.runtime.models.providers.reasoning_compat import (
     MINIMUM_THINKING_BUDGET_TOKENS,
+    REASONING_EFFORTS,
     anthropic_adaptive_only_thinking,
     anthropic_budgeted_enabled_only,
     anthropic_thinking_budget_tokens,
@@ -87,9 +89,42 @@ THINKING_TRANSLATED_DISCLOSURE = "thinking.type->enabled"
 """Disclosure recorded when an adaptive thinking config is translated to a
 budgeted ``enabled`` config for a budgeted-enabled Anthropic route."""
 
+THINKING_NO_SERVABLE_TIER_DROP_DISCLOSURE = "thinking->dropped(no_servable_tier)"
+"""Disclosure recorded when the route CAN reason but no tier of its ladder
+serves this request end to end beside the caller's other controls, so the
+config drops and the rung answers at its own default depth. Distinct from
+``unsupported_by_route`` (no rung reasons at all) so a caller can tell "this
+model never thinks" from "this request could not state a depth"."""
+
 THINKING_EFFORT_DISCLOSURE_PREFIX = "thinking->reasoning_effort:"
 """Disclosure prefix recorded when a thinking config translates to the effort
-a non-Anthropic reasoning route speaks; the effective tier follows the colon."""
+a reasoning route speaks; the effective tier and the source that named it
+follow, rendered by :func:`thinking_effort_disclosure`."""
+
+ThinkingEffortSource = Literal["budget_tokens", "lane_default", "gateway_default", "disabled"]
+"""What named the depth a thinking config translated to.
+
+``budget_tokens``: the caller's own budget through the documented tier table.
+``lane_default``: a budget-less config (``adaptive``, or the bare ``enabled``
+Claude Code sends) read as the rung's catalog default depth
+(``reasoning_default_effort``). ``gateway_default``: the same config on a
+route whose rungs pin no default, so the provider-default analog (medium)
+stands in. ``disabled``: the explicit off switch.
+"""
+
+
+def thinking_effort_disclosure(tier: str, source: ThinkingEffortSource) -> str:
+    """Render ``thinking->reasoning_effort:<tier>(<source>)`` for one translation.
+
+    Args:
+        tier: The EFFECTIVE tier after the nearest-tier snap onto the ladder.
+        source: What asked for that depth (see :data:`ThinkingEffortSource`).
+
+    Returns:
+        The disclosure string admission records in ``ignored_parameters``.
+    """
+    return f"{THINKING_EFFORT_DISCLOSURE_PREFIX}{tier}({source})"
+
 
 THINKING_BUDGET_IGNORED_DISCLOSURE = "thinking.budget_tokens"
 """Disclosure recorded when a caller budget was illegal and a derived budget
@@ -201,38 +236,89 @@ def _coerce_adaptive_budget(
     return RequestCoercion(request=dropped, disclosures=disclosures)
 
 
+def _requested_thinking_tier(
+    profiles: Sequence[GatewayWireProfile],
+    config: Mapping[str, object],
+) -> tuple[ReasoningEffort, ThinkingEffortSource]:
+    """Resolve the depth one thinking config asks for on a route of effort rungs.
+
+    An explicit ``budget_tokens`` names the depth through the documented tier
+    table (:func:`thinking_config_reasoning_effort`). A budget-less config
+    (``adaptive``, or the bare ``enabled`` Claude Code sends in think mode)
+    asks the MODEL to pick its depth, and on an effort rung the model's own
+    depth is its catalog default (``reasoning_default_effort``, carried on the
+    wire profile as ``reasoning_effort``): the first rung in route order that
+    pins an active default it can serve names the tier, so an operator sets a
+    lane's think-mode depth by catalog, not by code. A route whose rungs pin no
+    default falls back to medium, the provider-default analog. A ``none``
+    default is not a depth (that rung reasons only when asked), so it is
+    skipped rather than reading an active config as no reasoning.
+
+    Args:
+        profiles: Ordered wire profiles for every live route deployment.
+        config: Verbatim caller ``thinking`` object.
+
+    Returns:
+        The requested tier and the source that named it.
+    """
+    if config.get("type") == "disabled":
+        return "none", "disabled"
+    budget = config.get("budget_tokens")
+    if isinstance(budget, int) and not isinstance(budget, bool):
+        return thinking_config_reasoning_effort(config), "budget_tokens"
+    for profile in profiles:
+        default = profile.reasoning_effort
+        if (
+            default is not None
+            and default in REASONING_EFFORTS
+            and default != "none"
+            and default in profile_reasoning_efforts(profile)
+        ):
+            # Membership in REASONING_EFFORTS is the runtime check the cast
+            # relies on; the profile field is a plain string.
+            return cast("ReasoningEffort", default), "lane_default"
+    return "medium", "gateway_default"
+
+
 def _coerce_thinking_to_effort(
     profiles: Sequence[GatewayWireProfile],
     request: GatewayRequest,
     *,
     admits: Callable[[GatewayRequest], bool] | None = None,
 ) -> RequestCoercion | None:
-    """Translate a thinking config for an all-non-Anthropic route.
+    """Translate a thinking config onto the route's effort ladder.
 
     Claude Code pins a ``thinking`` config on every model, so the named
     rejection at route shaping would make whole sessions unusable against
-    OpenAI-family reasoning models the provider itself serves fine. On a
-    route with NO Anthropic rung the config translates to the nearest effort
-    the route actually serves (the tier table in
-    :func:`thinking_config_reasoning_effort`, then nearest-first over the
-    route's ladder), disclosed as ``thinking->reasoning_effort:<tier>``.
-    The combined ladder is a union of per-rung ladders, so the naive nearest
-    tier may be served only by rungs that reject some other control;
-    candidates are therefore tried in nearness order (ties prefer the lower
-    tier) and the translation is the closest tier that survives full route
-    construction and the caller's admission probe, mirroring the
-    explicit-effort snap in :func:`coerce_generation_parameters`. A route
-    with no reasoning rung drops every reasoning signal with disclosure
-    instead. An explicit caller effort is the same channel already stated in
-    the route's own vocabulary, so it wins verbatim and the config drops
-    with one disclosure. Routes with an Anthropic rung are left alone:
-    narrowing already prefers the rung that honors the config verbatim, and
-    stealing that preference here would trade real thinking for a
-    translation. Replayed thinking blocks are signed provider state no
-    translation can carry, so their presence declines the coercion (and the
-    gateway never fabricates unsigned blocks on the response side: our own
-    decode routes replayed blocks to Anthropic-only routes, so a fabricated
-    block would wedge the caller's next turn).
+    reasoning models the provider itself serves fine through an effort. Once
+    every rung has declined the config verbatim (an all-non-Anthropic route
+    always does; a mixed route reaches here only when its Anthropic rung
+    declined too, for the config or for another control), the config
+    translates to the nearest effort the route actually serves, disclosed as
+    ``thinking->reasoning_effort:<tier>(<source>)``. The requested tier comes
+    from :func:`_requested_thinking_tier`: an explicit budget through the tier
+    table, a budget-less config from the lane's catalog default depth (medium
+    when no rung pins one). The combined ladder is a union of per-rung
+    ladders, so the naive nearest tier may be served only by rungs that reject
+    some other control; candidates are therefore tried in nearness order (ties
+    prefer the lower tier) and the translation is the closest tier that
+    survives full route construction and the caller's admission probe,
+    mirroring the explicit-effort snap in :func:`coerce_generation_parameters`.
+
+    Where no tier serves, the config DROPS with disclosure rather than
+    rejecting: the route's answer is then its own default behavior, stated
+    openly, which is the rule every first-party-pinned field follows here (a
+    zero-reasoning route drops a pinned effort the same way). A route with no
+    reasoning rung discloses ``unsupported_by_route``; a route that reasons
+    but cannot state any tier beside this request's other controls discloses
+    ``no_servable_tier``. The drop is offered only when the admission probe
+    accepts it, so a request whose real blocker is another control keeps that
+    rejection. An explicit caller effort is the same channel already stated in
+    the route's own vocabulary, so it wins verbatim and the config drops with
+    one disclosure. Replayed thinking blocks are signed provider state no
+    translation can carry; route shaping strips them from a foreign wire with
+    disclosure, so their presence never blocks the translation (and the
+    gateway never fabricates unsigned blocks on the response side).
 
     Args:
         profiles: Ordered wire profiles for every live route deployment.
@@ -243,15 +329,16 @@ def _coerce_thinking_to_effort(
 
     Returns:
         The disclosed translation or drop, or ``None`` when the request
-        carries no thinking config, the route has an Anthropic rung, or no
-        translatable tier serves the request end to end. Replayed Anthropic
-        thinking blocks no longer block the translation: route shaping strips
-        them from a foreign wire with disclosure.
+        carries no thinking config or no offered request passes the probe.
     """
     config = request.provider_thinking_config
     if config is None or not profiles:
         return None
-    if any(profile.dialect == "anthropic_messages" for profile in profiles):
+    if all(profile.dialect == "anthropic_messages" for profile in profiles):
+        # The config is native on every rung: shaping forwards, fills, or
+        # family-gates it itself and never raises the unsupported-parameter
+        # rejection, so whatever declined the request here lies elsewhere and
+        # a translation would replace real thinking for nothing.
         return None
 
     def admitted(coercion: RequestCoercion) -> RequestCoercion | None:
@@ -273,9 +360,9 @@ def _coerce_thinking_to_effort(
                 disclosures=(THINKING_SUPERSEDED_BY_EFFORT_DISCLOSURE,),
             )
         )
-    requested_tier = thinking_config_reasoning_effort(config)
+    requested_tier, source = _requested_thinking_tier(profiles, config)
     candidates = set(ladder)
-    if requested_tier == "none":
+    if source == "disabled":
         # A disabled config asked for NO reasoning; snapping it to an active
         # level would enable reasoning the caller explicitly turned off, so
         # only an exact 'none' translates and anything else takes the
@@ -305,35 +392,38 @@ def _coerce_thinking_to_effort(
             continue
         return RequestCoercion(
             request=translated_request,
-            disclosures=(f"{THINKING_EFFORT_DISCLOSURE_PREFIX}{candidate}",),
+            disclosures=(thinking_effort_disclosure(candidate, source),),
         )
-    if candidates:
-        # Active tiers exist but none serves this request end to end, so the
-        # original rejection stands: dropping the config here would silently
-        # disable reasoning the caller asked for.
-        return None
-    dropped, disclosures = _drop_thinking_and_effort(request)
+    dropped, disclosures = _drop_thinking_and_effort(
+        request,
+        disclosure=(
+            THINKING_NO_SERVABLE_TIER_DROP_DISCLOSURE if candidates else THINKING_DROP_DISCLOSURE
+        ),
+    )
     return admitted(RequestCoercion(request=dropped, disclosures=disclosures))
 
 
 def _drop_thinking_and_effort(
     request: GatewayRequest,
+    *,
+    disclosure: str = THINKING_DROP_DISCLOSURE,
 ) -> tuple[GatewayRequest, tuple[str, ...]]:
-    """Null the thinking config and effort channels for a route that cannot reason.
+    """Null the thinking config and effort channels for a route that cannot honor them.
 
     Shared drop for the routes that cannot honor a reasoning signal: the
     thinking config, the caller effort, and the Messages ``output_config.effort``
     channel all go, and a ``clear_thinking`` context edit rides on the thinking
-    config and is stripped with it. Every removal is disclosed. History thinking
-    blocks are NOT touched — Anthropic accepts replayed blocks without a live
-    thinking config.
+    config and is stripped with it. Every removal is disclosed; ``disclosure``
+    names why the config went (no reasoning rung, or no servable tier). History
+    thinking blocks are NOT touched: Anthropic accepts replayed blocks without a
+    live thinking config.
     """
     updates: dict[str, object] = {"provider_thinking_config": None}
     disclosures: list[str] = []
     if request.reasoning_effort is not None:
         updates["reasoning_effort"] = None
         disclosures.append(EFFORT_DROP_DISCLOSURE)
-    disclosures.append(THINKING_DROP_DISCLOSURE)
+    disclosures.append(disclosure)
     if request.provider_output_config is not None and "effort" in request.provider_output_config:
         remaining = {
             key: value for key, value in request.provider_output_config.items() if key != "effort"

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -24,6 +24,7 @@ from pydantic import JsonValue
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.model import ReasoningEffort
 from exp.runtime.gateway.contracts import (
+    GatewayApiSurface,
     GatewayNamedToolChoice,
     GatewayRequest,
     GatewayToolDefinition,
@@ -234,6 +235,63 @@ def _coerce_adaptive_budget(
     # cannot re-emit adaptive thinking through output_config.
     dropped, disclosures = _drop_thinking_and_effort(request)
     return RequestCoercion(request=dropped, disclosures=disclosures)
+
+
+THINKING_HEADROOM_DISCLOSURE = "reasoning_effort->none(max_tokens_headroom)"
+"""Disclosure recorded when default-on reasoning is turned off because the
+caller's ``max_tokens`` cannot hold any thinking (see
+:func:`reserve_thinking_headroom`)."""
+
+
+def reserve_thinking_headroom(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+) -> RequestCoercion | None:
+    """Turn default-on reasoning off when the caller's ceiling cannot hold thinking.
+
+    A lane that reasons by default (every rung pins an active catalog
+    ``reasoning_default_effort``) spends the caller's ``max_tokens`` on thinking
+    first, so a Messages request with a small ceiling and no reasoning signal
+    of its own ends as thinking cut off at ``max_tokens`` with no text at all
+    (hy4-preview at ``max_tokens: 32``, 48 such attempts in one day). Anthropic
+    refuses any ENABLED config whose budget cannot fit under the ceiling and
+    admits none below 1024 tokens, so a ceiling under that minimum is one no
+    caller could expect thinking to fit; rather than refuse (a client that
+    never asked for thinking has nothing to remove) the request dispatches at
+    ``reasoning_effort: none`` with disclosure and the model answers in text.
+    Only a route whose EVERY rung reasons by default AND offers a ``none``
+    tier is coerced: a rung without an active default already answers in
+    text, and a rung that cannot turn reasoning off (Anthropic's adaptive
+    generation) keeps its own behavior. A caller who stated any reasoning
+    signal (``thinking``, ``output_config.effort``, ``reasoning``) is never
+    second-guessed here.
+
+    Args:
+        profiles: Ordered wire profiles for every live route deployment.
+        request: Decoded public request before narrowing.
+
+    Returns:
+        The disclosed coercion, or ``None`` when the rule does not apply.
+    """
+    if request.surface != GatewayApiSurface.MESSAGES:
+        return None
+    if request.provider_thinking_config is not None or request.reasoning_effort is not None:
+        return None
+    if request.provider_output_config is not None and "effort" in request.provider_output_config:
+        return None
+    ceiling = request.maximum_output_tokens
+    if not profiles or ceiling is None or ceiling >= MINIMUM_THINKING_BUDGET_TOKENS:
+        return None
+    for profile in profiles:
+        default = profile.reasoning_effort
+        if default is None or default == "none" or default not in REASONING_EFFORTS:
+            return None
+        if "none" not in profile_reasoning_efforts(profile):
+            return None
+    return RequestCoercion(
+        request=request.model_copy(update={"reasoning_effort": "none"}),
+        disclosures=(THINKING_HEADROOM_DISCLOSURE,),
+    )
 
 
 def _requested_thinking_tier(

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
+import pytest
+
 from exp.common.core.artifacts import JsonObject
 from exp.common.models.model import ReasoningEffort
 from exp.runtime.gateway.contracts import (
@@ -18,6 +22,7 @@ from exp.runtime.models.providers.capability_policy import (
     coerce_generation_parameters,
     coerce_structured_text_schema,
 )
+from exp.runtime.models.providers.errors import ProviderParameterError
 from exp.runtime.models.providers.reasoning_compat import efforts_by_nearness
 
 
@@ -476,26 +481,35 @@ def test_disabled_thinking_drops_only_on_adaptive_only_anthropic_routes() -> Non
     assert coercion.disclosures == ("thinking.type->adaptive",)
     assert coercion.request.provider_thinking_config is None
 
-    # A rung that honors ``disabled`` verbatim leaves the config alone.
-    assert coerce_generation_parameters((budgeted, shim), request) is None
-    # No Anthropic rung at all: the thinking coercion serves the config as a
-    # disclosed drop (a disabled config on a non-reasoning route asks for
-    # exactly what the route already does).
+    # A rung that honors ``disabled`` verbatim is kept by NARROWING, before
+    # any coercion runs; the layer itself is reached only once that rung has
+    # declined too, and then serves the config as a disclosed drop onto the
+    # shim (a disabled config on a non-reasoning rung asks for exactly what
+    # the rung already does).
+    from exp.runtime.models.providers.generation_route_compat import (
+        compatible_generation_parameter_profile_indexes,
+    )
+
+    assert compatible_generation_parameter_profile_indexes((budgeted, shim), request) == (0,)
+    mixed_drop = coerce_generation_parameters((budgeted, shim), request)
+    assert mixed_drop is not None
+    assert mixed_drop.disclosures == ("thinking->dropped(unsupported_by_route)",)
+    # No Anthropic rung at all: the same disclosed drop.
     shim_only = coerce_generation_parameters((shim,), request)
     assert shim_only is not None
     assert "thinking->dropped(unsupported_by_route)" in shim_only.disclosures
     assert shim_only.request.provider_thinking_config is None
-    # Only a disabled config is coercible; other types keep their own path.
-    assert (
-        coerce_generation_parameters(
-            (adaptive_only, shim),
-            _request(
-                surface=GatewayApiSurface.MESSAGES,
-                provider_thinking_config={"type": "adaptive"},
-            ),
-        )
-        is None
+    # An adaptive config on the same mixed route is not a ``disabled`` drop;
+    # it takes the effort translation path instead.
+    adaptive_mixed = coerce_generation_parameters(
+        (adaptive_only, shim),
+        _request(
+            surface=GatewayApiSurface.MESSAGES,
+            provider_thinking_config={"type": "adaptive"},
+        ),
     )
+    assert adaptive_mixed is not None
+    assert adaptive_mixed.disclosures[0].startswith("thinking->reasoning_effort:")
     # The admission probe still gates the offer.
     assert (
         coerce_generation_parameters((adaptive_only, shim), request, admits=lambda _c: False)
@@ -766,19 +780,22 @@ def test_a_thinking_config_translates_to_an_effort_on_an_openai_route() -> None:
         route_generation_parameter_requests,
     )
 
-    for thinking, expected in (
-        ({"type": "enabled", "budget_tokens": 2048}, "low"),
-        ({"type": "enabled", "budget_tokens": 8192}, "medium"),
-        ({"type": "enabled", "budget_tokens": 32000}, "high"),
-        ({"type": "adaptive"}, "medium"),
-        ({"type": "disabled"}, "none"),
+    for thinking, expected, source in (
+        ({"type": "enabled", "budget_tokens": 2048}, "low", "budget_tokens"),
+        ({"type": "enabled", "budget_tokens": 8192}, "medium", "budget_tokens"),
+        ({"type": "enabled", "budget_tokens": 32000}, "high", "budget_tokens"),
+        # This profile pins no catalog default, so a budget-less config takes
+        # the gateway's medium fallback and says so.
+        ({"type": "adaptive"}, "medium", "gateway_default"),
+        ({"type": "enabled"}, "medium", "gateway_default"),
+        ({"type": "disabled"}, "none", "disabled"),
     ):
         profile = _openai_reasoning_profile()
         coercion = coerce_generation_parameters(
             (profile,), _messages_request(provider_thinking_config=thinking)
         )
         assert coercion is not None, thinking
-        assert coercion.disclosures == (f"thinking->reasoning_effort:{expected}",)
+        assert coercion.disclosures == (f"thinking->reasoning_effort:{expected}({source})",)
         assert coercion.request.provider_thinking_config is None
         assert coercion.request.reasoning_effort == expected
 
@@ -877,7 +894,7 @@ def test_the_thinking_translation_tries_farther_tiers_when_the_nearest_cannot_se
     )
 
     assert coercion is not None
-    assert coercion.disclosures == ("thinking->reasoning_effort:high",)
+    assert coercion.disclosures == ("thinking->reasoning_effort:high(budget_tokens)",)
     assert coercion.request.provider_thinking_config is None
     assert coercion.request.reasoning_effort == "high"
 
@@ -899,34 +916,58 @@ def test_a_disabled_thinking_config_never_snaps_to_an_active_effort() -> None:
         _messages_request(provider_thinking_config={"type": "disabled"}),
     )
     assert exact is not None
-    assert exact.disclosures == ("thinking->reasoning_effort:none",)
+    assert exact.disclosures == ("thinking->reasoning_effort:none(disabled)",)
     assert exact.request.reasoning_effort == "none"
 
 
-def test_the_thinking_coercion_leaves_anthropic_bearing_routes_alone() -> None:
-    """A route with any Anthropic rung keeps its verbatim-service preference:
-    narrowing already picks the rung that honors the config, so the coercion
-    declines rather than trading real thinking for a translation. Replayed
-    thinking blocks no longer decline it on a foreign-only route: route
-    shaping drops them there with disclosure, so the live config still
-    translates to the route's effort ladder."""
-    mixed = (
-        GatewayWireProfile(
-            dialect="anthropic_messages",
-            url="https://anthropic.test",
-            supports_reasoning=True,
-            reasoning_wire_format="anthropic_adaptive",
-        ),
-        _openai_reasoning_profile(),
-    )
-    assert (
-        coerce_generation_parameters(
-            mixed,
-            _messages_request(provider_thinking_config={"type": "enabled", "budget_tokens": 2048}),
-        )
-        is None
+def test_a_mixed_route_whose_anthropic_rung_declined_translates_onto_the_foreign_ladder() -> None:
+    """The coercion runs only after EVERY rung declined verbatim, so on a mixed
+    route the Anthropic rung that would have honored the config is already
+    out (here: its output ceiling is below the caller's ``max_tokens``), and
+    the foreign rung's named ``thinking`` rejection is what the caller would
+    otherwise see. The config translates onto the ladder the surviving rung
+    speaks instead; the caller is told the tier and what named it. Narrowing
+    preference is untouched: with an Anthropic rung that accepts the config,
+    admission never reaches this layer."""
+    from exp.runtime.models.providers.generation_route_compat import (
+        compatible_generation_parameter_profile_indexes,
     )
 
+    anthropic = GatewayWireProfile(
+        dialect="anthropic_messages",
+        url="https://anthropic.test",
+        model_id="claude-sonnet-4-6",
+        supports_reasoning=True,
+        reasoning_wire_format="anthropic_adaptive",
+        maximum_output_tokens=64,
+    )
+    mixed = (anthropic, _openai_reasoning_profile())
+    request = _messages_request(
+        provider_thinking_config={"type": "enabled", "budget_tokens": 2048},
+        maximum_output_tokens=256,
+    )
+    with pytest.raises(ProviderParameterError):
+        compatible_generation_parameter_profile_indexes(mixed, request)
+
+    coercion = coerce_generation_parameters(mixed, request)
+    assert coercion is not None
+    assert coercion.disclosures == ("thinking->reasoning_effort:low(budget_tokens)",)
+    assert coercion.request.reasoning_effort == "low"
+    assert coercion.request.provider_thinking_config is None
+    assert compatible_generation_parameter_profile_indexes(mixed, coercion.request) == (1,)
+
+    # An Anthropic rung that accepts the config verbatim narrows the route to
+    # itself before any coercion runs; the coercion layer is never consulted.
+    honoring = replace(anthropic, maximum_output_tokens=None)
+    assert compatible_generation_parameter_profile_indexes(
+        (honoring, _openai_reasoning_profile()), request
+    ) == (0,)
+
+
+def test_replayed_thinking_blocks_never_block_the_translation() -> None:
+    """Replayed thinking blocks are signed provider state route shaping drops
+    from a foreign wire with disclosure, so the live config still translates
+    to the route's effort ladder and the blocks stay on the request."""
     with_blocks = _messages_request(
         provider_thinking_config={"type": "enabled", "budget_tokens": 2048},
         messages=(
@@ -940,7 +981,7 @@ def test_the_thinking_coercion_leaves_anthropic_bearing_routes_alone() -> None:
     )
     coercion = coerce_generation_parameters((_openai_reasoning_profile(),), with_blocks)
     assert coercion is not None
-    assert coercion.disclosures == ("thinking->reasoning_effort:low",)
+    assert coercion.disclosures == ("thinking->reasoning_effort:low(budget_tokens)",)
     assert coercion.request.reasoning_effort == "low"
     # The signed blocks stay on the request; the foreign wire omits them.
     assert (
@@ -1032,6 +1073,7 @@ def _hy4_route() -> tuple[GatewayWireProfile, GatewayWireProfile]:
         supports_reasoning=True,
         reasoning_wire_format="reasoning",
         supported_reasoning_efforts=("none", "low", "high"),
+        reasoning_effort="high",
     )
     return tencent, openrouter
 
@@ -1039,26 +1081,128 @@ def _hy4_route() -> tuple[GatewayWireProfile, GatewayWireProfile]:
 def test_thinking_translates_to_an_effort_on_the_hy4_tencent_openrouter_route() -> None:
     """Claude Code's think-mode config lands on the hy4 ladders as a translation, never a strip.
 
-    Harbor runs Claude Code think-mode-high against hy4-preview served by a
-    Tencent rung (none/low/medium/high) then an OpenRouter rung (none/low/high).
-    A 32k budget must translate to ``high`` with the ``thinking->reasoning_effort``
-    disclosure; a bare enabled config (Claude Code omits the budget) is the
-    default depth; medium narrows onto the one rung that speaks it.
+    Harbor runs Claude Code think mode against hy4-preview served by a Tencent
+    rung (none/low/medium/high, catalog default high) then an OpenRouter rung
+    (none/low/high, catalog default high). A bare enabled config (Claude Code
+    omits the budget) and ``adaptive`` both ask the model for its own depth,
+    which on these rungs is the catalog default: HIGH, named as the lane
+    default. An explicit budget keeps the tier table: 32k is high, 8k is
+    medium (narrowing onto the one rung that speaks it) regardless of the
+    lane default.
     """
     route = _hy4_route()
-    for thinking, expected in (
-        ({"type": "enabled", "budget_tokens": 32000}, "high"),
-        ({"type": "enabled"}, "medium"),
-        ({"type": "enabled", "budget_tokens": 8192}, "medium"),
-        ({"type": "adaptive"}, "medium"),
+    for thinking, expected, source in (
+        ({"type": "enabled"}, "high", "lane_default"),
+        ({"type": "adaptive"}, "high", "lane_default"),
+        ({"type": "enabled", "budget_tokens": 32000}, "high", "budget_tokens"),
+        ({"type": "enabled", "budget_tokens": 8192}, "medium", "budget_tokens"),
+        ({"type": "enabled", "budget_tokens": 2048}, "low", "budget_tokens"),
     ):
         coercion = coerce_generation_parameters(
             route, _messages_request(provider_thinking_config=thinking)
         )
         assert coercion is not None, thinking
-        assert coercion.disclosures == (f"thinking->reasoning_effort:{expected}",), thinking
+        assert coercion.disclosures == (f"thinking->reasoning_effort:{expected}({source})",), (
+            thinking
+        )
         assert coercion.request.reasoning_effort == expected
         assert coercion.request.provider_thinking_config is None
+
+
+def test_bare_thinking_on_the_openrouter_failover_rung_alone_runs_at_its_lane_default() -> None:
+    """With the Tencent rung dead (skipped before admission), the OpenRouter
+    rung is the whole live route: a bare think-mode config must still coerce
+    onto its ladder at the catalog default (high), never 400 as an unsupported
+    parameter, and the coerced request reaches the OpenRouter payload as the
+    ``reasoning`` object."""
+    from exp.runtime.models.providers.streaming_requests import (
+        dialect_stream_payload,
+        route_generation_parameter_requests,
+    )
+
+    _tencent, openrouter = _hy4_route()
+    request = _messages_request(provider_thinking_config={"type": "enabled"})
+    with pytest.raises(ProviderParameterError, match="thinking"):
+        route_generation_parameter_requests((openrouter,), request)
+
+    coercion = coerce_generation_parameters((openrouter,), request)
+    assert coercion is not None
+    assert coercion.disclosures == ("thinking->reasoning_effort:high(lane_default)",)
+    assert coercion.request.reasoning_effort == "high"
+    _public, provider = route_generation_parameter_requests((openrouter,), coercion.request)
+    payload = dialect_stream_payload(openrouter, provider)
+    assert payload["reasoning"] == {"effort": "high"}
+    assert "thinking" not in payload
+
+
+def test_bare_thinking_skips_a_rung_whose_default_is_none_and_reads_the_next_lane_default() -> None:
+    """A ``none`` default is not a depth: the rung reasons only when asked, so
+    an active config reads the next rung's default rather than turning into
+    no reasoning. With no rung pinning an active default, medium stands in and
+    the disclosure says the gateway (not the lane) chose it."""
+    off_by_default = GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://off.test/v1",
+        model_id="off-by-default",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+        supported_reasoning_efforts=("none", "low", "high"),
+        reasoning_effort="none",
+    )
+    tencent, _openrouter = _hy4_route()
+    request = _messages_request(provider_thinking_config={"type": "enabled"})
+
+    coercion = coerce_generation_parameters((off_by_default, tencent), request)
+    assert coercion is not None
+    assert coercion.disclosures == ("thinking->reasoning_effort:high(lane_default)",)
+
+    alone = coerce_generation_parameters((off_by_default,), request)
+    assert alone is not None
+    # The gateway's medium fallback snaps onto this rung's ladder (low/high tie
+    # prefers the lower tier) and is named as the gateway's choice.
+    assert alone.disclosures == ("thinking->reasoning_effort:low(gateway_default)",)
+    assert alone.request.reasoning_effort == "low"
+
+
+def test_output_config_effort_low_beside_bare_thinking_wins_on_the_hy4_route() -> None:
+    """The caller's own effort supersedes the lane default: ``output_config.effort:
+    low`` beside a bare config dispatches at low with the named supersession,
+    not at the lane's high."""
+    coercion = coerce_generation_parameters(
+        _hy4_route(),
+        _messages_request(
+            provider_thinking_config={"type": "enabled"},
+            reasoning_effort="low",
+            provider_output_config={"effort": "low"},
+        ),
+    )
+    assert coercion is not None
+    assert coercion.request.reasoning_effort == "low"
+    assert coercion.request.provider_thinking_config is None
+    assert coercion.disclosures == ("thinking->dropped(superseded_by_effort)",)
+
+
+def test_a_reasoning_route_that_can_state_no_tier_drops_thinking_with_its_own_disclosure() -> None:
+    """A route that reasons but serves none of its tiers beside the request's
+    other controls drops the config as ``no_servable_tier``, distinct from the
+    no-reasoning route's ``unsupported_by_route``, so the caller can tell
+    "this model never thinks" from "this request could not state a depth".
+    The drop is offered only when the admission probe accepts it; a probe
+    that refuses it leaves the original rejection standing."""
+    rung = _openai_reasoning_profile(efforts=("low", "high"))
+    request = _messages_request(provider_thinking_config={"type": "enabled", "budget_tokens": 2048})
+
+    def refuse_every_effort(candidate: GatewayRequest) -> bool:
+        """Stand in for a downstream gate that admits only an effort-less request."""
+        return candidate.reasoning_effort is None
+
+    coercion = coerce_generation_parameters((rung,), request, admits=refuse_every_effort)
+    assert coercion is not None
+    assert coercion.disclosures == ("thinking->dropped(no_servable_tier)",)
+    assert coercion.request.provider_thinking_config is None
+    assert coercion.request.reasoning_effort is None
+
+    assert coerce_generation_parameters((rung,), request, admits=lambda _candidate: False) is None
 
 
 def test_output_config_effort_high_beside_thinking_keeps_high_on_the_hy4_route() -> None:

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -1218,3 +1218,89 @@ def test_output_config_effort_high_beside_thinking_keeps_high_on_the_hy4_route()
     assert coercion is not None
     assert coercion.request.reasoning_effort == "high"
     assert coercion.disclosures == ("thinking->dropped(superseded_by_effort)",)
+
+
+def test_default_on_reasoning_turns_off_when_max_tokens_cannot_hold_thinking() -> None:
+    """A tiny Messages ceiling on a lane that thinks by default dispatches at
+    ``none``, disclosed, instead of returning thinking cut off at ``max_tokens``
+    with no text. The rule reads only the catalog default and the ladder, and
+    never second-guesses a caller who stated a reasoning signal."""
+    from exp.runtime.models.providers.capability_policy import reserve_thinking_headroom
+
+    route = _hy4_route()
+    tiny = _messages_request(maximum_output_tokens=32)
+    coercion = reserve_thinking_headroom(route, tiny)
+    assert coercion is not None
+    assert coercion.disclosures == ("reasoning_effort->none(max_tokens_headroom)",)
+    assert coercion.request.reasoning_effort == "none"
+
+    # Anthropic's minimum budget is the threshold: a ceiling that could hold a
+    # legal budget is left to the lane's default.
+    assert reserve_thinking_headroom(route, _messages_request(maximum_output_tokens=1024)) is None
+    assert reserve_thinking_headroom(route, _messages_request()) is None
+    # A stated reasoning signal of any kind is the caller's decision.
+    assert (
+        reserve_thinking_headroom(
+            route, tiny.model_copy(update={"provider_thinking_config": {"type": "enabled"}})
+        )
+        is None
+    )
+    assert (
+        reserve_thinking_headroom(route, tiny.model_copy(update={"reasoning_effort": "low"}))
+        is None
+    )
+    assert (
+        reserve_thinking_headroom(
+            route, tiny.model_copy(update={"provider_output_config": {"effort": "low"}})
+        )
+        is None
+    )
+    # Chat Completions keeps the OpenAI-wire behavior (empty content, finish
+    # length) its callers expect.
+    assert (
+        reserve_thinking_headroom(
+            route, tiny.model_copy(update={"surface": GatewayApiSurface.CHAT_COMPLETIONS})
+        )
+        is None
+    )
+    # A rung with no active default already answers in text; a rung that
+    # cannot turn reasoning off keeps its own behavior.
+    tencent, openrouter = route
+    assert (
+        reserve_thinking_headroom((replace(tencent, reasoning_effort=None), openrouter), tiny)
+        is None
+    )
+    assert (
+        reserve_thinking_headroom(
+            (replace(tencent, supported_reasoning_efforts=("low", "medium", "high")), openrouter),
+            tiny,
+        )
+        is None
+    )
+
+
+def test_temperature_forwards_beside_a_translated_thinking_config_on_an_effort_rung() -> None:
+    """Anthropic refuses sampling controls beside an enabled thinking config;
+    an effort rung has no such rule, so the translated request carries the
+    caller's temperature to the provider untouched and nothing is disclosed
+    about it: a constraint of Anthropic's wire is not a constraint of the
+    route that serves the request."""
+    from exp.runtime.models.providers.streaming_requests import (
+        dialect_stream_payload,
+        route_generation_parameter_requests,
+    )
+
+    tencent, _openrouter = _hy4_route()
+    request = _messages_request(
+        provider_thinking_config={"type": "enabled", "budget_tokens": 2048},
+        temperature=0.3,
+        maximum_output_tokens=4096,
+    )
+    coercion = coerce_generation_parameters((tencent,), request)
+    assert coercion is not None
+    assert coercion.disclosures == ("thinking->reasoning_effort:low(budget_tokens)",)
+    public, provider = route_generation_parameter_requests((tencent,), coercion.request)
+    payload = dialect_stream_payload(tencent, provider)
+    assert payload["temperature"] == 0.3
+    assert payload["reasoning_effort"] == "low"
+    assert not any("temperature" in item for item in public.ignored_parameters)

--- a/exp/runtime/models/providers/reasoning_compat.py
+++ b/exp/runtime/models/providers/reasoning_compat.py
@@ -284,9 +284,11 @@ def thinking_config_reasoning_effort(config: Mapping[str, object]) -> ReasoningE
     ==================================  ========
 
     ``adaptive`` means the model picks its own depth, whose closest effort
-    analog is the provider default (medium, OpenAI's own default). Callers
-    must snap the returned tier to the route's supported ladder and disclose
-    the translation.
+    analog is the provider default (medium, OpenAI's own default); the
+    admission coercion resolves a budget-less config against the LANE's
+    catalog default first and consults this table only for an explicit
+    budget. Callers must snap the returned tier to the route's supported
+    ladder and disclose the translation.
 
     Args:
         config: Verbatim caller ``thinking`` object.


### PR DESCRIPTION
## Customer report (Spandana / Harbor, Claude Code over `/v1/messages` on hy4-preview)

> 3. "Think-mode depth: bare Claude Code thinking → medium, not Harbor high. `output_config.effort=high` or `reasoning.effort=high` supersedes thinking. If Harbor only sends `{type:"enabled"}`, hy4 will not run at high."

Also reported once (5:38 PM PT):

> "Failed: The parameter 'thinking' is not supported by this model route. Remove the field or choose a native Anthropic-only route."

The adversarial production probe of 2026-09-12 (`.local/adversarial-messages-probe-2026-09-12.md` in the platform repo) found the root cause of that second line (B1 below) and several neighbouring admission bugs; B1, D1 and D2 are fixed here, B2, B3 and D3 are documented with findings.

## What changes

**A. A budget-less `thinking` config resolves to the LANE's default depth.** `{type: "enabled"}` (Claude Code think mode) and `{type: "adaptive"}` ask the model to pick its depth; on an effort rung that is the catalog default, `GatewayDeploymentCapabilities.reasoning_default_effort` (carried on the wire profile as `reasoning_effort`). The first rung in route order that pins an active default it can serve names the tier; a route whose rungs pin none keeps the previous medium. An explicit `budget_tokens` keeps the tier table (≤4096 low, ≤16384 medium, >16384 high). `output_config.effort` / `reasoning.effort` keep superseding. A `none` default is not a depth and is skipped. The platform seed already carries `reasoning_default_effort: "high"` on BOTH hy4-preview rungs, so bare think-mode on hy4-preview dispatches at high once this ships, with no catalog change.

**B. `thinking` never 400s on a route with a reasoning rung.** The named rejection is raised at route shaping for any route with a non-Anthropic rung, by design (it is what lets the admit loop offer the translation). Three paths let it leak:

1. **B1, the customer incident: a modality refusal blamed on `thinking`.** An image block on text-only hy4 plus ANY `thinking` field (even `disabled`) returned "The parameter 'thinking' is not supported by this model route" (25 of the customer's 400s on 2026-09-11 05:47–06:01Z; without the field the same body correctly says "cannot accept image input (param: messages)"). Shaping rejected the foreign-wire config before preflight saw the image, the probed coercion found no candidate that SERVES, and the admit loop re-raised the verbatim rejection. Now, when no coercion serves but one applies, admission carries the unprobed coercion forward so the stage that actually refuses names the remedy: `messages`, capability `image_input`. Pinned end to end through `admitted_route_requests` for `disabled`, `enabled` and `adaptive`.
2. **Mixed route whose Anthropic rung declined.** The coercion returned `None` for any route with an Anthropic rung; now it runs on every route with a non-Anthropic rung once every rung declined verbatim (only an all-Anthropic route is left to Anthropic shaping). Narrowing preference is untouched: an honoring Anthropic rung is picked before this layer runs (pinned).
3. **A reasoning route where no ladder tier serves the request end to end.** Was `None` (the `thinking` 400). Now drops with `thinking->dropped(no_servable_tier)` when admission accepts the drop.

Rule followed (the one this module already applies to a pinned effort on a zero-reasoning route, owner decision 2026-09-01): a field a first-party client pins on every call is coerced or dropped with disclosure, never rejected by name. Only a route with NO reasoning rung drops as `unsupported_by_route`; no route 400s on `thinking` any more.

**D1. Tiny `max_tokens` on a default-reasoning lane no longer returns an empty reply.** hy4 thinks by default, so `max_tokens: 32` came back as one truncated `thinking` block, `stop_reason: max_tokens`, no text (48 attempts in 24h, ledger `incomplete`). Decision: coerce, never refuse. On the Messages surface, a ceiling under Anthropic's 1024 minimum thinking budget (one no caller could expect thinking to fit) with no reasoning signal of the caller's own, on a route whose EVERY rung reasons by default and offers a `none` tier, dispatches at `reasoning_effort: none` disclosed as `reasoning_effort->none(max_tokens_headroom)`. Anthropic's adaptive generation (no `none` tier) and Chat Completions (OpenAI-wire callers expect empty content + `length`) are untouched. A caller who stated `thinking`, `output_config.effort` or `reasoning` is never second-guessed.

**D2. Anthropic-invalid thinking combinations.** Decided per the coercion-vs-refusal rule and pinned:
- `budget_tokens >= max_tokens`: REFUSED at decode, 400 on `thinking.budget_tokens` ("must be below max_tokens so the reply has room after thinking"). It is Anthropic's own rule, the sibling `reasoning.max_tokens` channel already refuses the identical condition, and the request could only ever end as thinking cut off at the ceiling. Also saves the provider round trip Anthropic rungs were paying (`ledger_test` carries Anthropic's own "max_tokens must be greater than thinking budget_tokens").
- `budget_tokens < 1024`: ACCEPTED and carried. On an Anthropic rung shaping already replaces it with the derived legal budget (disclosed `thinking.budget_tokens`); on an effort rung it is only a depth hint through the tier table, and `thinking->reasoning_effort:low(budget_tokens)` IS the disclosure of how it was read.
- `thinking` + `temperature` / `top_k`: FORWARDED, nothing disclosed. Anthropic's "sampling only at effort none" is a constraint of Anthropic's wire (`sampling_requires_reasoning_none`, honored per rung); an effort rung that accepts both gets both. Pinned: temperature reaches the hy4 payload beside the translated effort.

## Decision table (Messages surface, route with at least one non-Anthropic rung)

| Input | Effective | Disclosure / error |
|---|---|---|
| `thinking: {type: enabled}` or `adaptive`, a rung pins `reasoning_default_effort` (hy4: high) | that default, snapped to the ladder | `thinking->reasoning_effort:high(lane_default)` |
| same, no rung pins an active default | medium, snapped | `thinking->reasoning_effort:medium(gateway_default)` |
| `budget_tokens: 8000` (any lane default) | medium | `thinking->reasoning_effort:medium(budget_tokens)` |
| `budget_tokens: 32000` | high | `thinking->reasoning_effort:high(budget_tokens)` |
| `budget_tokens: 100` (below Anthropic's minimum) | low | `thinking->reasoning_effort:low(budget_tokens)` |
| `budget_tokens >= max_tokens` | refused | 400 `invalid_request_error`, param `thinking.budget_tokens` |
| `thinking: {type: disabled}`, ladder has `none` | none | `thinking->reasoning_effort:none(disabled)` |
| `thinking: {type: disabled}`, ladder lacks `none` | route default (config dropped) | `thinking->dropped(unsupported_by_route)` |
| any thinking + `output_config.effort: low` (or `reasoning.effort`) | low | `thinking->dropped(superseded_by_effort)` |
| any thinking, no rung reasons | route default | `thinking->dropped(unsupported_by_route)` |
| active thinking, route reasons but no tier serves beside the other controls | rung default depth | `thinking->dropped(no_servable_tier)` |
| any thinking + image block on a text-only route | refused | 400, param `messages` (`image_input`), never `thinking` |
| no thinking field, `max_tokens < 1024`, every rung reasons by default with a `none` tier | none | `reasoning_effort->none(max_tokens_headroom)` |
| `thinking` + `temperature` on an effort rung | temperature forwarded | (nothing: no deviation) |

Every translation disclosure gains a `(<source>)` suffix (was `thinking->reasoning_effort:<tier>`); the platform's `llms.txt` copy documents the old shape and should follow in the pin bump.

## Findings documented, not fixed here

- **B2 (prefill + `thinking: disabled` → `content: []`, `end_turn`, 2 output tokens).** Not reproducible offline: the trailing assistant turn is encoded verbatim on the Chat wire, and two billed output tokens with a null `first_token_at` mean no text delta reached the gateway's decoder, so the provider emitted EOS (or only tokens its chat template renders as nothing) right after the prefill under `reasoning_effort: none`. Needs a live probe of TokenHub with the same body, outside the gateway, before any engine change.
- **B3 (`stop_sequences` fires but reports `end_turn` / `stop_sequence: null`).** On a Chat wire the provider cuts the text BEFORE the sequence and reports only `finish_reason: stop`, so the gateway cannot recover the matched string. Two candidate fixes, both needing a decision: (a) emulate stop sequences in the data plane for Messages-surface requests on Chat wires too (`STOP_SEQUENCE_EMULATED_DIALECTS` already does this for Responses; the relay's `StopSequenceGuard` reports the exact match; cost: the provider keeps generating until the relay stops reading), or (b) read a vLLM-style `choices[].stop_reason` string if TokenHub emits one (needs the raw frames). Not done blind.
- **D3 (thinking replays not integrity-checked; hy4 emits `signature: ""`).** The gateway never signs its own hy4 thinking output (the Hunyuan carrier rides `redacted_thinking`, which IS validated), so an empty signature on an unsigned block is honest; verifying a signature the gateway did not issue is not possible. Anthropic rungs forward the block and Anthropic verifies.
- When EVERY coercion is refused downstream and the coerced request also fails at narrowing, the first rung's first rejection is still what the caller sees (pre-existing attribution rule; B1 covers the preflight case, which is where the incident was).
- The OpenRouter `reasoning: {enabled: true}` channel still defaults to medium for a budget-less object (same lane-default rule applies; that module is under concurrent edit on another branch).

## Test evidence

- `capability_policy_test.py`: hy4 route bare/adaptive → `high(lane_default)`; 8192 → `medium(budget_tokens)`; `output_config.effort: low` → low + `superseded_by_effort`; OpenRouter failover rung alone → `high(lane_default)` and the payload carries `reasoning: {effort: high}`; `none` default skipped; mixed route translation with narrowing preference pinned; `no_servable_tier`; headroom rule and all its exclusions; temperature forwarded beside translated thinking.
- `native_admission_test.py`: B1 end to end (`disabled`/`enabled`/`adaptive` + image → `image_input`, plus the control); headroom rule through the admit loop (`max_tokens: 32` → `none` disclosed and counted; 4096 → untouched).
- `requests_test.py`: budget ≥ `max_tokens` → 400 `thinking.budget_tokens`; budget 100 carried; `count_tokens` unchecked.
- Full gates on `a6cadc5d` (the docs commit on top changes one markdown file): `ruff format` clean, `ruff check .` clean, `ty check` clean, `pytest -q` → 4173 passed, 6 skipped in 6m58s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
