### PR TITLE
release: bump experiential to 0.7.68 (Messages usage legs + thinking depth fixes for Claude Code)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.67"
+version = "0.7.68"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.67"
+version = "0.7.68"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only (pyproject + uv.lock). Carries #920 (Anthropic usage legs including cache_read/cache_creation tokens on every frame, real pre-dispatch estimate, `cache_control` disclosure wording) and #921 (bare thinking resolves to the lane's default effort, image+thinking misattributed 400 fixed, `budget_tokens >= max_tokens` refused, max_tokens headroom rule, Greptile P1s addressed). Native crate exp-gateway-native 0.3.52 (bumped in #920). Release notes staged for `gh release create v0.7.68`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)