### PR TITLE
messages: a tool continuation closed by a mid-conversation system reminder replays its reasoning carrier

### DIFF
--- a/exp/runtime/gateway/native_bridge_test.py
+++ b/exp/runtime/gateway/native_bridge_test.py
@@ -5625,6 +5625,101 @@ def test_hunyuan_tool_turn_redacted_carrier_round_trips_on_messages(tmp_path: Pa
         _admit(control, raw_key, json.dumps(tampered), surface="messages")
 
 
+def test_claude_code_tool_continuation_with_trailing_system_reminder_serves_on_messages(
+    tmp_path: Path,
+) -> None:
+    """Claude Code's exact replay of a gateway tool turn is admitted, carrier and all.
+
+    Claude Code 2.1 (``mid-conversation-system`` beta) replays the tool turn's
+    blocks as ``[thinking, text, redacted_thinking, tool_use]`` and closes the
+    continuation with a ``system`` message carrying its token budget AFTER the
+    ``tool_result`` turn. The window after the last user turn therefore ends on
+    ``system``; every carrier-bound call has its result, so the carrier unseals,
+    pins the issuing rung, and the reminder forwards in place. Harbor's hy4
+    rollouts died on this shape at their first thinking turn (965 refusals in
+    seven hours on 2026-09-12).
+    """
+    _manager, raw_key = _configured_gateway(
+        tmp_path,
+        base_url="https://tokenhub-intl.tencentcloudmaas.com/v1",
+        capabilities=ModelCapabilities(supports_tools=True, reasoning_output_exposed=True),
+    )
+    control = NativeControlPlane(
+        load_gateway_components(tmp_path, environment={"TEST_PROVIDER_KEY": "k"})
+    )
+    initial = _admit_started(control, raw_key, _chat_body())
+    hidden = "I should read the file first."
+    sealed = json.loads(
+        control.seal_reasoning_content(
+            json.dumps(
+                {
+                    "request_id": initial["request_id"],
+                    "route_depth": initial["route_depth"],
+                    "route_sha256": initial["hunyuan_reasoning_route_sha256"],
+                    "content": hidden,
+                    "assistant_content": "Reading the file.",
+                    "tool_calls": [{"call_id": "toolu_01", "name": "Read", "raw_arguments": "{}"}],
+                }
+            )
+        )
+    )["carrier"]
+    control.settle(
+        json.dumps(
+            {
+                "request_id": initial["request_id"],
+                "attempt_id": initial["attempt_id"],
+                "outcome": "completed",
+                "usage": {"input_tokens": 3, "output_tokens": 2},
+                "tool_names": ["Read"],
+                "failure": None,
+            }
+        )
+    )
+    body = _messages_body(
+        [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": hidden, "signature": ""},
+                    {"type": "text", "text": "Reading the file."},
+                    {"type": "redacted_thinking", "data": sealed},
+                    {"type": "tool_use", "id": "toolu_01", "name": "Read", "input": {}},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "done"}],
+            },
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "<total_tokens>100</total_tokens>",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+        ]
+    )
+    continued = _admit(control, raw_key, body, surface="messages")
+    assert continued["route_reason"] == "reasoning_continuation"
+    messages = _payload_messages(continued)
+    assert messages[1]["reasoning_content"] == hidden
+    assert messages[1]["content"] == "Reading the file."
+    assert messages[2] == {"role": "tool", "content": "done", "tool_call_id": "toolu_01"}
+    assert messages[3] == {"role": "system", "content": "<total_tokens>100</total_tokens>"}
+
+    # Dropping the tool result leaves the carrier-bound call unanswered: the
+    # continuation is refused however the caller closes the request.
+    unanswered = json.loads(body)
+    del unanswered["messages"][2]
+    with pytest.raises(NativeBridgeError) as refused:
+        _admit(control, raw_key, json.dumps(unanswered), surface="messages")
+    assert "complete tool results" in refused.value.public_error_json
+
+
 def test_anthropic_signed_thinking_drops_with_disclosure_on_a_foreign_route(
     tmp_path: Path,
 ) -> None:

--- a/exp/runtime/models/providers/fireworks.py
+++ b/exp/runtime/models/providers/fireworks.py
@@ -123,6 +123,13 @@ def _require_complete_tool_results(messages: Sequence[GatewayMessage]) -> None:
     A provider answers some tool rounds without reasoning, so an active window mixes
     carrier-bearing turns with plain ones. Every tool call in the window is tracked for
     result identity, while completion is required only of the rounds that carry state.
+
+    The window is everything after the latest user turn, so it can also hold
+    mid-conversation ``system`` and ``developer`` messages: Claude Code closes a
+    tool continuation with a trailing system reminder (its token budget) after the
+    ``tool_result`` turn. Those messages neither call tools nor answer them, so the
+    walk passes over them; a continuation is complete when every carrier-bound call
+    has its one result, whatever message the caller ends the request on.
     """
     pending: set[str] = set()
     window_call_ids: set[str] = set()
@@ -147,7 +154,5 @@ def _require_complete_tool_results(messages: Sequence[GatewayMessage]) -> None:
                 )
             pending.discard(call_id)
             completed_call_ids.add(call_id)
-    if pending or not messages or messages[-1].role != "tool":
-        raise _reasoning_parameter_error(
-            "reasoning_content can replay only in a completed tool continuation."
-        )
+    if pending:
+        raise _reasoning_parameter_error("reasoning_content tool calls need complete tool results.")

--- a/exp/runtime/models/providers/fireworks_test.py
+++ b/exp/runtime/models/providers/fireworks_test.py
@@ -226,3 +226,61 @@ def test_active_reasoning_rejects_duplicate_tool_results() -> None:
 
     with pytest.raises(ProviderParameterError, match="exactly one result"):
         prepare_gateway_reasoning_history(messages, route_sha256=_ROUTE_SHA256)
+
+
+def test_active_reasoning_accepts_a_trailing_mid_conversation_system_message() -> None:
+    """Claude Code's tool continuation ends on a system reminder, not on the tool result.
+
+    Claude Code (``mid-conversation-system`` beta) appends a ``system`` message
+    carrying its token budget after the ``tool_result`` turn, so the window after
+    the last user turn ends on ``system``. Every carrier-bound call has its result,
+    so the carrier replays; requiring the request to END on a tool message refused
+    the very continuation the gateway issued the carrier for.
+    """
+    messages = (
+        GatewayMessage(role="user", content="Use a tool"),
+        _assistant(),
+        GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+        GatewayMessage(role="system", content="<total_tokens>100</total_tokens>"),
+    )
+
+    prepared, active = prepare_gateway_reasoning_history(messages, route_sha256=_ROUTE_SHA256)
+
+    assert active
+    assert prepared[1].provider_reasoning != ()
+    assert prepared[3].role == "system"
+
+
+def test_active_reasoning_accepts_system_reminders_between_completed_rounds() -> None:
+    """A system reminder after each completed round leaves every carrier active."""
+    messages = (
+        GatewayMessage(role="user", content="Use a tool"),
+        _assistant(call_id="call-one"),
+        GatewayMessage(role="tool", content="done", tool_call_id="call-one"),
+        GatewayMessage(role="system", content="<total_tokens>200</total_tokens>"),
+        _assistant(call_id="call-two"),
+        GatewayMessage(role="tool", content="done", tool_call_id="call-two"),
+        GatewayMessage(role="system", content="<total_tokens>100</total_tokens>"),
+    )
+
+    prepared, active = prepare_gateway_reasoning_history(messages, route_sha256=_ROUTE_SHA256)
+
+    assert active
+    assert prepared[1].provider_reasoning != ()
+    assert prepared[4].provider_reasoning != ()
+
+
+def test_active_reasoning_rejects_a_carrier_turn_whose_results_never_arrive() -> None:
+    """A request ending on an unanswered carrier-bound turn is still refused.
+
+    The trailing-role rule is gone; the completion rule is what protects the
+    provider from resuming a tool round that has no results, whatever follows it.
+    """
+    messages = (
+        GatewayMessage(role="user", content="Use a tool"),
+        _assistant(),
+        GatewayMessage(role="system", content="<total_tokens>100</total_tokens>"),
+    )
+
+    with pytest.raises(ProviderParameterError, match="complete tool results"):
+        prepare_gateway_reasoning_history(messages, route_sha256=_ROUTE_SHA256)


### PR DESCRIPTION
## Problem

Harbor's hy4 rollouts on the Explabs fallback (Claude Code protocol, `/v1/messages`) died at their first thinking turn with

```
400 reasoning_content can replay only in a completed tool continuation. (param: messages.reasoning_content)
```

Production: 965 `gateway_requests` rows for org Akhara AI on alias `hy4-preview` between 2026-09-12 08:39Z and 15:44Z, `terminal_failure_class=invalid_request`, zero attempt rows (the refusal is raised while the upstream payload is built).

## Root cause

Driving the real Claude Code 2.1.269 against a mock Messages server that emits a thinking block, a tool_use and the gateway's `redacted_thinking` carrier shows the exact replay:

```
user            [text, text]
assistant       [thinking(signature ""), text, redacted_thinking(carrier), tool_use]
user            [tool_result]
system          [text "<total_tokens>…" cache_control]     <- mid-conversation-system beta
```

Claude Code closes every tool continuation with a trailing `system` reminder carrying its token budget. Flattened, the window after the last user turn ends on `system`, and `_require_complete_tool_results` demanded `messages[-1].role == "tool"`. Every carrier-bound call had its result; the rule refused the continuation the gateway had issued the carrier for. Every other Claude Code shape (tool_result plus trailing text reminder, parallel results, interrupted loops, a plain thinking turn followed by a tool loop) already passed.

## Fix

`prepare_gateway_reasoning_history` now requires only that every carrier-bound tool call in the active window has exactly one result. Mid-conversation `system`/`developer` messages neither call tools nor answer them and are passed over by the walk.

Security properties kept, unchanged:
- carrier authenticity: AEAD under the per-provider domain-separated key, deployment pin, issuing-turn digest (assistant text + tool calls), history-prefix digest;
- one carrier per assistant tool turn on the issuing rung only (cross-route replay still a 400);
- unique tool-call ids in the window, exactly one result per call, no duplicate results;
- an assistant turn after an unanswered carrier-bound call, or a request that ends with one unanswered, is still refused (`reasoning_content tool calls need complete tool results.`).

What changed: a completed round may be followed by anything the caller sends (system reminder, developer note, prefilled assistant text); the provider decides what it accepts, the gateway no longer refuses text it itself emitted.

## Tests (red then green)

- `fireworks_test.py`: Claude Code's trailing system reminder replays the carrier; system reminders between completed rounds keep every carrier active; a carrier turn whose results never arrive is still refused.
- `native_bridge_test.py`: served Messages admission with Claude Code's exact block order and trailing `system` message unseals the carrier (`route_reason == reasoning_continuation`, `reasoning_content` forwarded, tool result and system reminder forwarded in place); dropping the tool result is refused.

All four new tests fail on `main` with the customer's string and pass here. `ruff check`, `ruff format --check`, `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
