### PR TITLE
release: bump experiential to 0.7.69

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.68"
+version = "0.7.69"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.68"
+version = "0.7.69"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only (pyproject + uv.lock) for the v0.7.69 release: #925 (Messages tool continuation closed by a Claude Code mid-conversation system reminder replays its Hunyuan reasoning carrier instead of a 400). Native crate unchanged at 0.3.52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)