### PR TITLE
gateway: a billed stop with no output fails the attempt instead of settling an empty success

### DIFF
--- a/docs/reference/gateway-architecture.md
+++ b/docs/reference/gateway-architecture.md
@@ -178,7 +178,13 @@ or tool-call semantic event commits the deployment, after which the gateway neve
 providers. Typed refusal fallback is disabled unless the active alias revision explicitly enables
 it. Opted-in refusal deltas are withheld only in a bounded in-memory buffer: a refusal-only terminal
 result can advance to the next certified deployment, while mixed semantic output or buffer overflow
-commits and flushes the original route. Provider-internal retry layers are disabled so every
+commits and flushes the original route. A `stop` that bills output or reasoning tokens yet carried no
+semantic event (a reasoning-only turn on a rung whose reasoning the gateway strips) is a typed
+`provider_internal` failure, not an empty success: it redials once, then takes the ladder, and on the
+last rung the caller receives that error rather than `content: []` with `end_turn`; a zero-token stop
+and a budget truncation before the first delta stay honest output-less answers. The Messages surface
+applies the same rule after commitment, when every committed event was one it cannot render.
+Provider-internal retry layers are disabled so every
 possible billable dispatch is visible to the gateway ledger.
 
 First-party CLI compatibility is capture-driven: the fields real Claude Code and Codex send by

--- a/exp/runtime/gateway/native/Cargo.lock
+++ b/exp/runtime/gateway/native/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.52"
+version = "0.3.53"
 dependencies = [
  "axum",
  "base64",

--- a/exp/runtime/gateway/native/Cargo.toml
+++ b/exp/runtime/gateway/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exp-gateway-native"
-version = "0.3.52"
+version = "0.3.53"
 edition = "2021"
 description = "Rust data plane for the Experiential local gateway (PoC), embedded as a PyO3 extension."
 license = "Apache-2.0"

--- a/exp/runtime/gateway/native/pyproject.toml
+++ b/exp/runtime/gateway/native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "exp-gateway-native"
-version = "0.3.52"
+version = "0.3.53"
 description = "Rust data plane for the Experiential local gateway (compiled extension module)."
 license = { file = "LICENSE" }
 requires-python = ">=3.12"

--- a/exp/runtime/gateway/native/src/encode_messages.rs
+++ b/exp/runtime/gateway/native/src/encode_messages.rs
@@ -331,6 +331,14 @@ impl MessagesSseEncoder {
         self.terminal
     }
 
+    /// Whether any content block has been scheduled so far: the route reads
+    /// this at a `Completed` terminal, because a committed stream whose only
+    /// events the surface cannot render (hidden reasoning on an unexposed
+    /// rung) would otherwise encode as `content: []` with `end_turn`.
+    pub fn has_content_blocks(&self) -> bool {
+        !self.blocks.is_empty()
+    }
+
     /// Encode one ordered normalized provider event into zero or more frames.
     pub fn feed(&mut self, event: &Event) -> Result<Vec<String>, PublicError> {
         if !self.started {
@@ -936,7 +944,9 @@ impl MessagesSseEncoder {
 mod aggregate;
 mod usage;
 
-pub use aggregate::{completed_messages_body, completed_messages_body_with_reasoning};
+pub use aggregate::{
+    completed_messages_body, completed_messages_body_with_reasoning, AggregatedMessage,
+};
 pub(crate) use usage::messages_usage;
 use usage::usage_object;
 

--- a/exp/runtime/gateway/native/src/errors.rs
+++ b/exp/runtime/gateway/native/src/errors.rs
@@ -233,6 +233,11 @@ const REFUSAL_MESSAGE: &str = "provider refused the request";
 /// including the executor's per-failure retry classification: whether the
 /// same deployment may be redialed and whether a later certified deployment
 /// may serve the request instead.
+/// Safe message of [`Failure::empty_completion`]; content-free and stable so
+/// the ledger and the public error name the same shape.
+pub const EMPTY_COMPLETION_MESSAGE: &str =
+    "provider completed the turn without any output; retry the request";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Failure {
     pub failure_class: FailureClass,
@@ -309,6 +314,18 @@ impl Failure {
             refusal_reason: Some(reason),
             ..Self::new(FailureClass::Refusal, &safe_message)
         }
+    }
+
+    /// The provider closed the turn as complete and billed output tokens
+    /// while sending nothing the caller can receive: no text, no tool call,
+    /// and no reasoning the surface renders (OpenRouter's DeepSeek rungs
+    /// answer a reasoning-only turn this way, live 2026-09-12). Nothing was
+    /// committed outward, so one bounded redial of the same deployment (the
+    /// empty answer is not deterministic) and then the ladder are both safe;
+    /// on the last rung the caller gets this message instead of an empty
+    /// success that bills tokens.
+    pub fn empty_completion() -> Self {
+        Self::new(FailureClass::ProviderInternal, EMPTY_COMPLETION_MESSAGE).with_retry(true, true)
     }
 
     /// Attach one already-validated provider parameter path.

--- a/exp/runtime/gateway/native/src/route_messages.rs
+++ b/exp/runtime/gateway/native/src/route_messages.rs
@@ -22,7 +22,8 @@ use crate::admission::{
 };
 use crate::encode::compact_json;
 use crate::encode_messages::{
-    anthropic_error_body, completed_messages_body_with_reasoning, MessagesSseEncoder,
+    anthropic_error_body, completed_messages_body_with_reasoning, AggregatedMessage,
+    MessagesSseEncoder,
 };
 use crate::errors::{Failure, FailureClass, PublicError};
 use crate::events::{Event, Usage};
@@ -35,7 +36,10 @@ use crate::respond::{
 use crate::route_chat::{seal_reasoning_candidate, seal_reasoning_events};
 use crate::server::AppState;
 use crate::settlement::AttemptGuard;
-use crate::waterfall::{acquire_attempt, CommittedAttempt, SettledAttempt, WaterfallContext, Won};
+use crate::waterfall::{
+    acquire_attempt, billed_empty_completion, CommittedAttempt, SettledAttempt, WaterfallContext,
+    Won,
+};
 
 /// Anthropic-enveloped variant of `error_response` for the Messages surface,
 /// mirroring `anthropic_error_response` in the python engine.
@@ -378,6 +382,23 @@ async fn respond_from_messages_events(
             .await;
         return messages_error_response(&error);
     }
+    if refusal_completed.is_none()
+        && aggregated_empty_completion(&events, &aggregated, usage.as_ref())
+    {
+        // Same guard as the live stream: a committed turn that rendered no
+        // block and billed for it is a failed attempt, never `content: []`.
+        let failure = Failure::empty_completion();
+        guard
+            .settle(
+                "failed",
+                aggregated.usage.as_ref().or(usage.as_ref()),
+                &aggregated.tool_names,
+                Some(&failure),
+                true,
+            )
+            .await;
+        return messages_error_response(&failure.public_error());
+    }
     let settled = if let Some(refusal) = &refusal_completed {
         // The caller saw the refusal output, so the public result completes;
         // the ledger still records the provider's typed refusal.
@@ -420,6 +441,25 @@ async fn respond_from_messages_events(
         return sse_body_response(&headers, body);
     }
     json_response(StatusCode::OK, &aggregated.body, &headers)
+}
+
+/// Whether an aggregated Messages turn is a billed empty completion: its
+/// terminal is `Completed`, its usage counts output, and no content block
+/// survived aggregation (every committed event was one this surface drops).
+fn aggregated_empty_completion(
+    events: &[Event],
+    aggregated: &AggregatedMessage,
+    usage: Option<&Usage>,
+) -> bool {
+    let Some(terminal) = events.iter().rev().find(|event| event.is_terminal()) else {
+        return false;
+    };
+    let content_empty = aggregated
+        .body
+        .get("content")
+        .and_then(Value::as_array)
+        .is_some_and(Vec::is_empty);
+    content_empty && billed_empty_completion(terminal, aggregated.usage.as_ref().or(usage))
 }
 
 fn encode_messages_sse(
@@ -680,6 +720,17 @@ async fn stream_messages(
                         Ok(Some(carrier)) => encoder.set_reasoning_content_carrier(carrier),
                         Ok(None) => {}
                         Err(failure) => fail_stream!(failure),
+                    }
+                    if !encoder.has_content_blocks()
+                        && billed_empty_completion(&event, usage.as_ref())
+                    {
+                        // The deployment committed on events this surface
+                        // cannot render (hidden reasoning on an unexposed
+                        // rung), so the caller would receive `content: []`
+                        // with `end_turn` and a bill: fail the attempt
+                        // instead. Post-commit, so no ladder; the typed
+                        // error is the answer.
+                        fail_stream!(Failure::empty_completion());
                     }
                 }
                 terminal = Some(event.clone());

--- a/exp/runtime/gateway/native/src/waterfall.rs
+++ b/exp/runtime/gateway/native/src/waterfall.rs
@@ -726,11 +726,27 @@ async fn run_attempt(
                         opened: true,
                     };
                 }
-                // A successful terminal with no semantic output: retain the
-                // output-less continuation while the attempt is still in
-                // flight, settle, then answer with the tracked usage ahead of
-                // the terminal so the encoders keep the client-visible token
-                // accounting.
+                if billed_empty_completion(&event, usage.as_ref()) {
+                    // A `stop` that billed output tokens yet carried no
+                    // semantic event is the provider's fault, not an answer
+                    // (a reasoning-only turn on a rung whose reasoning the
+                    // gateway strips): it takes the ladder like any other
+                    // pre-commit failure instead of settling an empty success.
+                    return AttemptEnd::Ladder {
+                        failure: Failure::empty_completion(),
+                        refusal_eligible: false,
+                        exhaustion_flush: Vec::new(),
+                        usage,
+                        tool_names,
+                        opened: true,
+                    };
+                }
+                // A successful terminal with no semantic output and nothing
+                // billed for it (a budget exhausted before the first delta,
+                // a zero-token stop): retain the output-less continuation
+                // while the attempt is still in flight, settle, then answer
+                // with the tracked usage ahead of the terminal so the
+                // encoders keep the client-visible token accounting.
                 let retention_failure = match &ctx.output_less_retention {
                     Some(argument) => ctx.bridge.call("remember", argument.clone()).await.err(),
                     None => None,
@@ -763,9 +779,77 @@ async fn run_attempt(
     }
 }
 
+/// Whether a successful terminal with no semantic output is a billed empty
+/// completion: the turn ended `Completed` (the provider's plain `stop`) while
+/// its reported usage counts at least one output or reasoning token. A budget
+/// truncation (`Incomplete`), a stop sequence, a paused turn, an unreported
+/// usage, or a zero-token stop are honest output-less endings and stay
+/// settled as they are; only a paid-for `stop` that delivered nothing fails.
+pub(crate) fn billed_empty_completion(terminal: &Event, usage: Option<&Usage>) -> bool {
+    if !matches!(terminal, Event::Completed) {
+        return false;
+    }
+    let Some(usage) = usage else {
+        return false;
+    };
+    usage.output_tokens.is_some_and(|tokens| tokens > 0)
+        || usage.reasoning_tokens.is_some_and(|tokens| tokens > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn usage(output_tokens: Option<u64>, reasoning_tokens: Option<u64>) -> Usage {
+        Usage {
+            input_tokens: Some(9),
+            output_tokens,
+            cached_input_tokens: None,
+            cache_creation_input_tokens: None,
+            reasoning_tokens,
+        }
+    }
+
+    #[test]
+    fn a_billed_stop_with_no_output_is_an_empty_completion() {
+        // The live OpenRouter DeepSeek shape: reasoning billed, nothing sent.
+        assert!(billed_empty_completion(
+            &Event::Completed,
+            Some(&usage(Some(147), Some(148)))
+        ));
+        // One EOS token and nothing else is still a paid-for empty answer.
+        assert!(billed_empty_completion(
+            &Event::Completed,
+            Some(&usage(Some(1), Some(0)))
+        ));
+        // A wire that reports thinking outside the output leg still counts it.
+        assert!(billed_empty_completion(
+            &Event::Completed,
+            Some(&usage(Some(0), Some(30)))
+        ));
+        let failure = Failure::empty_completion();
+        assert_eq!(failure.failure_class, FailureClass::ProviderInternal);
+        assert!(failure.retryable_same_deployment && failure.failover_eligible);
+    }
+
+    #[test]
+    fn honest_output_less_endings_are_not_empty_completions() {
+        // A zero-token stop is the provider saying nothing, not billing for it.
+        assert!(!billed_empty_completion(
+            &Event::Completed,
+            Some(&usage(Some(0), None))
+        ));
+        // No usage report proves nothing was spent.
+        assert!(!billed_empty_completion(&Event::Completed, None));
+        // Truncation, a stop sequence, and a paused turn keep their own shapes.
+        let billed = usage(Some(16), None);
+        assert!(!billed_empty_completion(&Event::Incomplete, Some(&billed)));
+        assert!(!billed_empty_completion(
+            &Event::StoppedAtSequence("END".to_string()),
+            Some(&billed)
+        ));
+        assert!(!billed_empty_completion(&Event::PausedTurn, Some(&billed)));
+    }
 
     fn wire(base: Option<f64>, slope: Option<f64>) -> DeploymentWire {
         DeploymentWire {

--- a/exp/runtime/gateway/tests/native_messages_test.py
+++ b/exp/runtime/gateway/tests/native_messages_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import sqlite3
 import subprocess
 import sys
 import textwrap
@@ -34,6 +35,7 @@ import pytest
 from exp.common.core.artifacts import JsonObject
 from exp.common.models import ModelCapabilities
 from exp.runtime.gateway.lifecycle_test import _configured_gateway
+from exp.runtime.gateway.management import GatewayManagement
 
 pytest.importorskip("exp_gateway_native")
 
@@ -136,6 +138,58 @@ def _terminal_frames(finish_reason: str, *, cached: bool = True) -> bytes:
         (
             _sse_frame({"choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}]}),
             _sse_frame({"choices": [], "usage": usage}),
+            b"data: [DONE]\n\n",
+        )
+    )
+
+
+def _reasoning_only_stop_frames() -> bytes:
+    """Encode the live OpenRouter DeepSeek reasoning-only turn (2026-09-12).
+
+    Hidden reasoning streams on OpenRouter's ``reasoning`` delta field, the
+    content stays empty, the choice finishes ``stop``, and usage bills the
+    reasoning as completion tokens. This unexposed rung strips the reasoning,
+    so nothing semantic reaches the caller while the tokens are billed.
+    """
+    return b"".join(
+        (
+            _sse_frame(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "", "reasoning": "Let me"},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse_frame(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "", "reasoning": " read the logs first."},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse_frame(
+                {"choices": [{"index": 0, "delta": {"content": ""}, "finish_reason": "stop"}]}
+            ),
+            _sse_frame(
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 9,
+                        "completion_tokens": 147,
+                        "total_tokens": 156,
+                        "prompt_tokens_details": {"cached_tokens": 2},
+                        "completion_tokens_details": {"reasoning_tokens": 148},
+                    },
+                }
+            ),
             b"data: [DONE]\n\n",
         )
     )
@@ -249,6 +303,8 @@ class _SseUpstream(BaseHTTPRequestHandler):
                 self.wfile.write(_terminal_frames("tool_calls"))
             elif prompt == "empty-token":
                 self.wfile.write(_zero_output_terminal_frames("stop"))
+            elif prompt == "reasoning-only-token":
+                self.wfile.write(_reasoning_only_stop_frames())
             elif prompt == "truncated-token":
                 self.wfile.write(_zero_output_terminal_frames("length"))
             elif prompt == "uncached-token":
@@ -1535,6 +1591,99 @@ def test_messages_stream_zero_output_keeps_real_input_tokens(
         "cache_read_input_tokens": 2,
         "output_tokens": 0,
     }
+
+
+_EMPTY_COMPLETION_MESSAGE = "provider completed the turn without any output; retry the request"
+
+
+def _latest_attempt_states(engine: _ServingEngine) -> list[tuple[int, str, str | None]]:
+    """Read the most recent request's settled attempt rows (ordinal, state, failure class).
+
+    An exhausted ladder answers with the bare Anthropic error envelope and no
+    request-id header, so the request is found as the newest accepted row.
+    """
+    database_path = GatewayManagement(engine.root).database_path
+    deadline = time.monotonic() + 10.0
+    while True:
+        with sqlite3.connect(database_path) as connection:
+            latest = connection.execute(
+                "SELECT request_id FROM gateway_requests ORDER BY accepted_at DESC, rowid DESC"
+                " LIMIT 1"
+            ).fetchone()
+            rows = (
+                connection.execute(
+                    "SELECT attempt_ordinal, state, failure_class FROM gateway_attempts"
+                    " WHERE request_id = ? ORDER BY attempt_ordinal",
+                    (latest[0],),
+                ).fetchall()
+                if latest is not None
+                else []
+            )
+        if rows and all(state not in {"dispatched", "running"} for _, state, _ in rows):
+            break
+        if time.monotonic() > deadline:
+            break
+        time.sleep(0.05)
+    return [(int(ordinal), str(state), failure) for ordinal, state, failure in rows]
+
+
+def test_messages_non_stream_billed_empty_stop_fails_instead_of_an_empty_end_turn(
+    engine: _ServingEngine,
+) -> None:
+    """A ``stop`` that billed reasoning yet rendered no block is a typed 502.
+
+    Production 2026-09-12 (deepseek-v4-flash via OpenRouter, Claude Code's
+    body): ``message_start`` then ``message_delta`` with ``end_turn``, zero
+    content blocks, and 42 to 750 billed output tokens, which Claude Code
+    reports as "[Your previous response had no visible output]". The single
+    rung here is redialed once (its bounded cap) and both dispatches settle
+    ``failed`` as ``provider_internal``; a route with a second rung would
+    fail over instead.
+    """
+    response = httpx.post(
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json=_messages_body("reasoning-only-token"),
+        timeout=30.0,
+    )
+    assert response.status_code == 502, response.text
+    body = response.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "api_error"
+    assert body["error"]["message"] == _EMPTY_COMPLETION_MESSAGE
+    assert _latest_attempt_states(engine) == [
+        (0, "failed", "provider_internal"),
+        (1, "failed", "provider_internal"),
+    ]
+
+
+def test_messages_stream_billed_empty_stop_is_refused_before_the_first_frame(
+    engine: _ServingEngine,
+) -> None:
+    """The streamed request never opens a stream that would end ``end_turn`` on nothing.
+
+    Nothing semantic was ever committed, so the exhausted ladder answers the
+    same typed error envelope as the non-streaming request instead of a
+    `message_start` followed by an empty `end_turn`.
+    """
+    with httpx.stream(
+        "POST",
+        f"{engine.base}/v1/messages",
+        headers={"x-api-key": engine.raw_key},
+        json=_messages_body("reasoning-only-token", stream=True),
+        timeout=30.0,
+    ) as response:
+        status = response.status_code
+        raw = b"".join(response.iter_bytes()).decode()
+    assert status == 502, raw
+    assert "message_start" not in raw
+    body = json.loads(raw)
+    assert body["type"] == "error"
+    assert body["error"]["message"] == _EMPTY_COMPLETION_MESSAGE
+    assert _latest_attempt_states(engine) == [
+        (0, "failed", "provider_internal"),
+        (1, "failed", "provider_internal"),
+    ]
 
 
 def test_replayed_thinking_history_serves_with_disclosure_on_a_foreign_route(

--- a/exp/runtime/gateway/tests/native_waterfall_test.py
+++ b/exp/runtime/gateway/tests/native_waterfall_test.py
@@ -133,14 +133,68 @@ def _terminal_frames(*, prompt_tokens: int = 2, completion_tokens: int = 2) -> b
     )
 
 
+def _reasoning_only_stop_frames() -> bytes:
+    """Encode the live OpenRouter DeepSeek reasoning-only turn (2026-09-12).
+
+    Hidden reasoning streams on OpenRouter's ``reasoning`` delta field, the
+    content stays empty, the choice finishes ``stop``, and usage bills the
+    reasoning as completion tokens; the gateway strips the reasoning on this
+    unexposed rung, so nothing semantic reaches the caller.
+    """
+    return b"".join(
+        (
+            _sse_frame(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "", "reasoning": "Let me"},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse_frame(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "", "reasoning": " read the logs first."},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+            _sse_frame(
+                {"choices": [{"index": 0, "delta": {"content": ""}, "finish_reason": "stop"}]}
+            ),
+            _sse_frame(
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 15613,
+                        "completion_tokens": 147,
+                        "total_tokens": 15760,
+                        "completion_tokens_details": {"reasoning_tokens": 148},
+                    },
+                }
+            ),
+            b"data: [DONE]\n\n",
+        )
+    )
+
+
 class _PrimaryUpstream(BaseHTTPRequestHandler):
     """The first certified deployment; behavior is selected by the prompt.
 
     ``always-500`` fails every dispatch, ``retry-then-succeed`` fails once
     per process then answers, ``refuse`` streams a refusal-only completion,
     ``silent-length`` exhausts the output budget with no content (a
-    thinking-only turn: ``finish_reason: length``, zero deltas), and anything
-    else streams a plain success.
+    thinking-only turn: ``finish_reason: length``, zero deltas),
+    ``silent-stop-then-succeed`` answers its first dispatch per process with
+    a billed reasoning-only ``stop`` (OpenRouter's DeepSeek shape: hidden
+    ``reasoning`` deltas, empty content, 147 completion tokens) and then a
+    plain success, and anything else streams a plain success.
     """
 
     retry_counts: dict[str, int] = {}
@@ -177,10 +231,19 @@ class _PrimaryUpstream(BaseHTTPRequestHandler):
                 self.send_response(500)
                 self.end_headers()
                 return
+        empty_stop = False
+        if prompt == "silent-stop-then-succeed":
+            with self.lock:
+                seen = self.retry_counts.get(prompt, 0)
+                self.retry_counts[prompt] = seen + 1
+            empty_stop = seen == 0
         self.send_response(200)
         self.send_header("content-type", "text/event-stream")
         self.end_headers()
         try:
+            if empty_stop:
+                self.wfile.write(_reasoning_only_stop_frames())
+                return
             if prompt == "silent-length":
                 self.wfile.write(
                     _sse_frame({"choices": [{"index": 0, "delta": {}, "finish_reason": "length"}]})
@@ -396,6 +459,41 @@ def test_transient_primary_failure_redials_the_same_deployment(
     assert response.headers["x-gateway-route-depth"] == "0"
     rows = _attempt_rows(engine, response.headers["x-request-id"])
     assert rows == [(0, 0, "failed"), (1, 0, "completed")]
+
+
+def test_billed_empty_stop_redials_instead_of_settling_an_empty_success(
+    engine: _ServingEngine,
+) -> None:
+    """A ``stop`` that billed reasoning but delivered nothing is a failed attempt.
+
+    Reproduced on production 2026-09-12 (deepseek-v4-flash via OpenRouter, 2 of
+    6 replays on both the Chat and Messages surfaces): the rung answered a
+    reasoning-only turn, the gateway stripped the hidden reasoning, and the
+    waterfall settled the output-less terminal as a completed empty answer
+    that billed 42 to 750 output tokens. The empty completion now takes the
+    ladder like any pre-commit failure: the primary is redialed and serves,
+    and the ledger names the empty attempt ``provider_internal``.
+    """
+    response = httpx.post(
+        f"{engine.base}/v1/chat/completions",
+        headers={"authorization": f"Bearer {engine.raw_key}"},
+        json=_chat_payload("silent-stop-then-succeed"),
+        timeout=30.0,
+    )
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["message"]["content"] == "from-primary"
+    assert response.headers["x-gateway-route-depth"] == "0"
+    request_id = response.headers["x-request-id"]
+    assert _attempt_rows(engine, request_id) == [(0, 0, "failed"), (1, 0, "completed")]
+    with sqlite3.connect(engine.database_path) as connection:
+        failed = connection.execute(
+            "SELECT failure_class, output_tokens FROM gateway_attempts"
+            " WHERE request_id = ? AND attempt_ordinal = 0",
+            (request_id,),
+        ).fetchone()
+    assert failed[0] == "provider_internal"
+    # The empty attempt keeps the tokens the provider billed for it.
+    assert failed[1] == 147
 
 
 def test_refusal_failover_withholds_the_refused_route(engine: _ServingEngine) -> None:
@@ -620,9 +718,9 @@ def test_ledger_conserves_every_admitted_request(engine: _ServingEngine) -> None
     )
     assert response.status_code == 200
     report = httpx.get(f"{engine.base}/usage.json", timeout=5.0).json()
-    # Seven scenario requests, the output-less continuation scenario's four
+    # Eight scenario requests, the output-less continuation scenario's four
     # (two first turns and their two continuations), and this probe.
-    assert report["totals"]["requests"] == 12
+    assert report["totals"]["requests"] == 13
     terminal_attempts = sum(int(count["attempts"]) for count in report["totals"]["terminal_counts"])
     with sqlite3.connect(engine.database_path) as connection:
         (total_attempts,) = connection.execute("SELECT count(*) FROM gateway_attempts").fetchone()
@@ -630,6 +728,6 @@ def test_ledger_conserves_every_admitted_request(engine: _ServingEngine) -> None
             "SELECT count(*) FROM gateway_attempts WHERE state IN ('dispatched', 'running')"
         ).fetchone()
     assert open_attempts == 0
-    # Twelve single-dispatch requests plus the four extra physical attempts the
-    # redial and failover scenarios spend.
-    assert terminal_attempts == total_attempts == 16
+    # Thirteen single-dispatch requests plus the five extra physical attempts
+    # the redial, empty-completion, and failover scenarios spend.
+    assert terminal_attempts == total_attempts == 18

--- a/exp/runtime/models/providers/capability_policy.py
+++ b/exp/runtime/models/providers/capability_policy.py
@@ -38,6 +38,7 @@ from exp.runtime.models.providers.generation_parameter_validation import (
 )
 from exp.runtime.models.providers.generation_route_compat import (
     compatible_generation_parameter_profile_indexes,
+    snap_effort_onto_route,
 )
 from exp.runtime.models.providers.reasoning_compat import (
     MINIMUM_THINKING_BUDGET_TOKENS,
@@ -412,9 +413,34 @@ def _coerce_thinking_to_effort(
         dropped, disclosures = _drop_thinking_and_effort(request)
         return admitted(RequestCoercion(request=dropped, disclosures=disclosures))
     if request.reasoning_effort is not None:
+        superseded = request.model_copy(update={"provider_thinking_config": None})
+        if request.reasoning_effort in ladder:
+            return admitted(
+                RequestCoercion(
+                    request=superseded,
+                    disclosures=(THINKING_SUPERSEDED_BY_EFFORT_DISCLOSURE,),
+                )
+            )
+        # The explicit effort is off the route's ladder, so superseding the
+        # config alone still leaves a request no rung admits. The two
+        # coercions compose here: the config drops and the effort snaps to
+        # the nearest level a rung serves, each disclosed. Left to the
+        # explicit-effort snap alone, the snapped candidate would still carry
+        # the thinking config every non-Anthropic rung rejects by name, and
+        # acceptance would depend on the VALUE (Claude Code's effort=high
+        # served, effort=medium refused on a [high, xhigh] rung).
+        snapped = snap_effort_onto_route(
+            profiles, superseded, request.reasoning_effort, ladder, admits=admits
+        )
+        if snapped is not None:
+            snapped_request, snap_disclosure = snapped
+            return RequestCoercion(
+                request=snapped_request,
+                disclosures=(THINKING_SUPERSEDED_BY_EFFORT_DISCLOSURE, snap_disclosure),
+            )
         return admitted(
             RequestCoercion(
-                request=request.model_copy(update={"provider_thinking_config": None}),
+                request=superseded,
                 disclosures=(THINKING_SUPERSEDED_BY_EFFORT_DISCLOSURE,),
             )
         )
@@ -589,31 +615,13 @@ def coerce_generation_parameters(
         # The effort itself is portable; the verbatim failure lies elsewhere
         # and a snap would change semantics for nothing.
         return None
-    # A heterogeneous waterfall can carry a nearby effort only on rungs that
-    # reject some other control, so candidates are tried in nearness order
-    # and the snap is the closest level that actually admits a rung.
-    for candidate in efforts_by_nearness(request.reasoning_effort, ladder):
-        snapped_request = request.model_copy(update={"reasoning_effort": candidate})
-        try:
-            indexes = compatible_generation_parameter_profile_indexes(profiles, snapped_request)
-            # Per-rung admission is not enough: the narrowed rung set changes
-            # with the candidate, and a route-wide gate (for example the
-            # homogeneous encrypted-reasoning channel) can reject a mixed set
-            # that a farther candidate would narrow past. Only a candidate
-            # that survives full route construction is a real snap.
-            route_generation_parameter_requests(
-                tuple(profiles[index] for index in indexes),
-                snapped_request,
-            )
-        except (ProviderParameterError, ProviderCapabilityError):
-            continue
-        if admits is not None and not admits(snapped_request):
-            continue
-        return RequestCoercion(
-            request=snapped_request,
-            disclosures=(f"reasoning_effort->{candidate}",),
-        )
-    return None
+    snapped = snap_effort_onto_route(
+        profiles, request, request.reasoning_effort, ladder, admits=admits
+    )
+    if snapped is None:
+        return None
+    snapped_request, snap_disclosure = snapped
+    return RequestCoercion(request=snapped_request, disclosures=(snap_disclosure,))
 
 
 def _coerce_disabled_thinking(

--- a/exp/runtime/models/providers/capability_policy_test.py
+++ b/exp/runtime/models/providers/capability_policy_test.py
@@ -1304,3 +1304,77 @@ def test_temperature_forwards_beside_a_translated_thinking_config_on_an_effort_r
     assert payload["temperature"] == 0.3
     assert payload["reasoning_effort"] == "low"
     assert not any("temperature" in item for item in public.ignored_parameters)
+
+
+def _ladder_profile(model_id: str, *efforts: ReasoningEffort) -> GatewayWireProfile:
+    """Build one OpenAI-compatible reasoning rung with an explicit effort ladder."""
+    return GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://provider.test",
+        model_id=model_id,
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+        supported_reasoning_efforts=tuple(efforts),
+    )
+
+
+def test_superseded_thinking_snaps_an_off_ladder_effort_onto_the_route() -> None:
+    """Claude Code's adaptive thinking beside an off-ladder effort composes both coercions.
+
+    The live deepseek-v4-flash route (2026-09-12) serves ``output_config.effort:
+    high`` (the config drops as superseded) but refused ``medium`` and ``low``
+    with the effort-unsupported 400: superseding alone left an effort no rung
+    served, and the explicit snap alone left a thinking config every rung
+    rejected. The two now compose into one disclosed coercion, and the snapped
+    effort lands on the Messages ``output_config`` channel as well.
+    """
+    route = (
+        _ladder_profile("deepseek-v4-flash", "high", "xhigh"),
+        GatewayWireProfile(
+            dialect="openai_compatible",
+            url="https://other.test",
+            model_id="deepseek-v4-flash",
+        ),
+    )
+    for requested in ("medium", "low"):
+        request = _messages_request(
+            reasoning_effort=requested,
+            provider_output_config={"effort": requested, "format": {"type": "text"}},
+            provider_thinking_config={"type": "adaptive"},
+        )
+        coercion = coerce_generation_parameters(route, request)
+        assert coercion is not None, requested
+        assert coercion.request.provider_thinking_config is None
+        assert coercion.request.reasoning_effort == "high"
+        assert coercion.request.provider_output_config == {
+            "effort": "high",
+            "format": {"type": "text"},
+        }
+        assert coercion.disclosures == (
+            "thinking->dropped(superseded_by_effort)",
+            "reasoning_effort->high",
+        )
+    # An on-ladder effort keeps the one-disclosure supersede it always had.
+    on_ladder = _messages_request(
+        reasoning_effort="high",
+        provider_output_config={"effort": "high"},
+        provider_thinking_config={"type": "adaptive"},
+    )
+    coercion = coerce_generation_parameters(route, on_ladder)
+    assert coercion is not None
+    assert coercion.request.reasoning_effort == "high"
+    assert coercion.request.provider_output_config == {"effort": "high"}
+    assert coercion.disclosures == ("thinking->dropped(superseded_by_effort)",)
+
+
+def test_effort_snap_carries_the_messages_output_config_channel() -> None:
+    """A snapped effort is rewritten on ``output_config`` too, never left stale."""
+    request = _messages_request(
+        reasoning_effort="xhigh",
+        provider_output_config={"effort": "xhigh"},
+    )
+    coercion = coerce_generation_parameters((_reasoning_profile("gpt-5.1"),), request)
+    assert coercion is not None
+    assert coercion.request.reasoning_effort == "high"
+    assert coercion.request.provider_output_config == {"effort": "high"}
+    assert coercion.disclosures == ("reasoning_effort->high",)

--- a/exp/runtime/models/providers/generation_route_compat.py
+++ b/exp/runtime/models/providers/generation_route_compat.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Collection, Sequence
 
 from exp.runtime.gateway.contracts import GatewayRequest
 from exp.runtime.models.providers.base import GatewayWireProfile
-from exp.runtime.models.providers.errors import ProviderParameterError
+from exp.runtime.models.providers.errors import ProviderCapabilityError, ProviderParameterError
+from exp.runtime.models.providers.reasoning_compat import efforts_by_nearness
 from exp.runtime.models.providers.streaming_requests import route_generation_parameter_requests
 
 
@@ -94,3 +95,64 @@ def _carries_exposed_reasoning(profile: GatewayWireProfile, request: GatewayRequ
         for message in request.messages
         for block in message.provider_reasoning
     )
+
+
+def request_with_reasoning_effort(request: GatewayRequest, effort: str) -> GatewayRequest:
+    """Return the request carrying ``effort`` on every channel that states one.
+
+    The Messages surface carries the caller's effort inside ``output_config``
+    as well as on ``reasoning_effort`` (decode maps the one onto the other), and
+    an Anthropic rung forwards that object verbatim, so a snapped effort must
+    land on both or the disclosed value and the dispatched one would differ.
+    """
+    updates: dict[str, object] = {"reasoning_effort": effort}
+    if request.provider_output_config is not None and "effort" in request.provider_output_config:
+        updates["provider_output_config"] = {**request.provider_output_config, "effort": effort}
+    return request.model_copy(update=updates)
+
+
+def snap_effort_onto_route(
+    profiles: Sequence[GatewayWireProfile],
+    request: GatewayRequest,
+    requested: str,
+    ladder: Collection[str],
+    *,
+    admits: Callable[[GatewayRequest], bool] | None,
+) -> tuple[GatewayRequest, str] | None:
+    """Snap one off-ladder effort to the nearest level a rung actually serves.
+
+    A heterogeneous waterfall can carry a nearby effort only on rungs that
+    reject some other control, so candidates are tried in nearness order and
+    the snap is the closest level that admits a rung. Per-rung admission is
+    not enough: the narrowed rung set changes with the candidate, and a
+    route-wide gate (for example the homogeneous encrypted-reasoning channel)
+    can reject a mixed set that a farther candidate would narrow past, so only
+    a candidate that survives full route construction and the caller's probe
+    is a real snap.
+
+    Args:
+        profiles: Ordered wire profiles for every live route deployment.
+        request: The request to snap; any thinking config it carries is what
+            the candidate rungs will be asked to accept.
+        requested: The caller's effort the snap measures nearness from.
+        ladder: Union of every rung's accepted efforts.
+        admits: Optional caller probe that must accept the candidate.
+
+    Returns:
+        The snapped request and its ``reasoning_effort->X`` disclosure, or
+        ``None`` when no candidate serves.
+    """
+    for candidate in efforts_by_nearness(requested, ladder):
+        snapped_request = request_with_reasoning_effort(request, candidate)
+        try:
+            indexes = compatible_generation_parameter_profile_indexes(profiles, snapped_request)
+            route_generation_parameter_requests(
+                tuple(profiles[index] for index in indexes),
+                snapped_request,
+            )
+        except (ProviderParameterError, ProviderCapabilityError):
+            continue
+        if admits is not None and not admits(snapped_request):
+            continue
+        return snapped_request, f"reasoning_effort->{candidate}"
+    return None

--- a/exp/runtime/models/providers/generation_route_compat_test.py
+++ b/exp/runtime/models/providers/generation_route_compat_test.py
@@ -1,0 +1,78 @@
+"""Tests for per-deployment generation-parameter route compatibility."""
+
+from __future__ import annotations
+
+from exp.common.models.model import ReasoningEffort
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.runtime.models.providers.base import GatewayWireProfile
+from exp.runtime.models.providers.generation_route_compat import (
+    request_with_reasoning_effort,
+    snap_effort_onto_route,
+)
+
+
+def _messages_request(**overrides: object) -> GatewayRequest:
+    """Build one Messages-surface request with overrides applied."""
+    request = GatewayRequest(
+        surface=GatewayApiSurface.MESSAGES,
+        messages=(GatewayMessage(role="user", content="go"),),
+    )
+    return request.model_copy(update=dict(overrides))
+
+
+def _ladder_profile(*efforts: ReasoningEffort) -> GatewayWireProfile:
+    """Build one OpenAI-compatible reasoning rung with an explicit effort ladder."""
+    return GatewayWireProfile(
+        dialect="openai_compatible",
+        url="https://provider.test",
+        model_id="deepseek-v4-flash",
+        supports_reasoning=True,
+        reasoning_wire_format="reasoning_effort",
+        supported_reasoning_efforts=tuple(efforts),
+    )
+
+
+def test_request_with_reasoning_effort_rewrites_every_effort_channel() -> None:
+    """The effort lands on ``reasoning_effort`` and on a stated ``output_config.effort``."""
+    both = request_with_reasoning_effort(
+        _messages_request(
+            reasoning_effort="medium",
+            provider_output_config={"effort": "medium", "format": {"type": "text"}},
+        ),
+        "high",
+    )
+    assert both.reasoning_effort == "high"
+    assert both.provider_output_config == {"effort": "high", "format": {"type": "text"}}
+    # An output_config without an effort key is left exactly as sent.
+    untouched = request_with_reasoning_effort(
+        _messages_request(reasoning_effort="medium", provider_output_config={"format": {}}),
+        "high",
+    )
+    assert untouched.reasoning_effort == "high"
+    assert untouched.provider_output_config == {"format": {}}
+
+
+def test_snap_effort_onto_route_takes_the_nearest_served_level() -> None:
+    """A [high, xhigh] rung serves ``medium`` as ``high`` (nearer) with one disclosure."""
+    route = (_ladder_profile("high", "xhigh"),)
+    request = _messages_request(
+        reasoning_effort="medium", provider_output_config={"effort": "medium"}
+    )
+    snapped = snap_effort_onto_route(route, request, "medium", {"high", "xhigh"}, admits=None)
+    assert snapped is not None
+    snapped_request, disclosure = snapped
+    assert snapped_request.reasoning_effort == "high"
+    assert snapped_request.provider_output_config == {"effort": "high"}
+    assert disclosure == "reasoning_effort->high"
+    # The caller's probe can veto a nearer candidate; the next one is offered.
+    farther = snap_effort_onto_route(
+        route,
+        request,
+        "medium",
+        {"high", "xhigh"},
+        admits=lambda candidate: candidate.reasoning_effort == "xhigh",
+    )
+    assert farther is not None
+    assert farther[0].reasoning_effort == "xhigh"
+    # No candidate that serves means no snap, never a guess.
+    assert snap_effort_onto_route(route, request, "medium", set(), admits=None) is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     # Cross-platform advisory locking for durable registries edited in place. Declared directly
     # because `exp.common.core.locks` imports it and Unix-only `fcntl` is not a portable boundary.
-    "exp-gateway-native>=0.3.52,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
+    "exp-gateway-native>=0.3.53,<0.4",  # compiled gateway data plane; checkouts build it via [tool.uv.sources]
     "filelock>=3.12",
     "typer>=0.16",
     "click>=8.2",  # pins no_args_is_help semantics: help + usage-error exit 2 (<8.2 exited 0)

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "exp-gateway-native"
-version = "0.3.52"
+version = "0.3.53"
 source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]


### PR DESCRIPTION
## Summary

A `stop` that bills output tokens but carries no semantic event is now a typed `provider_internal` failure that redials once and then takes the ladder, instead of settling as an empty success. The Messages surface applies the same rule after commitment, so `content: []` with `end_turn` and a bill can no longer be encoded. The Messages coercion for Claude Code's `thinking: adaptive` beside an off-ladder `output_config.effort` now composes the thinking drop with the effort snap, so acceptance no longer depends on the effort value.

## Root cause

Production 2026-09-12, `deepseek-v4-flash` through its OpenRouter rung, Claude Code's exact body (adaptive thinking + `output_config.effort: high` + 21 tools + a trailing mid-conversation `system` message). Replaying it against production with a fresh key on the demo org reproduced the empty answer on 2 of 6 streamed Messages calls (42 and 147 billed output tokens, both prompt-cache cold), 2 of 3 non-streamed Messages calls, and also on 2 of 6 Chat Completions calls (`finish_reason: stop`, empty content, one with 428 reasoning tokens and one with a single token). The failure is surface-neutral: the rung answers a reasoning-only turn (OpenRouter's `reasoning` delta field, empty `content`, `stop`), the rung is not exposure-stamped so the gateway strips the reasoning, and no semantic event reaches the waterfall, whose output-less branch settled the terminal as `completed` with the tracked usage. Hypothesis "tool_use block dropped" is ruled out: 15k tool-call attempts rendered on this rung on Messages in the last 7 days.

## Fix

- `waterfall.rs`: `billed_empty_completion` (terminal `Completed` and usage with output or reasoning tokens > 0) turns the output-less branch into `AttemptEnd::Ladder` with `Failure::empty_completion()` (`provider_internal`, retry same deployment, failover eligible). A zero-token stop, a `length` truncation before the first delta, a stop sequence, and a paused turn keep their honest output-less shape (the existing `empty-token` and `silent-length` cases pin this).
- `route_messages.rs`: after commitment, a `Completed` terminal with no scheduled block (`MessagesSseEncoder::has_content_blocks`) and billed usage fails the attempt with the same typed failure on the stream path, and the aggregated body's empty `content` does the same on the non-streaming path. This covers rungs whose reasoning IS relayed as `ReasoningContentDelta` (commits the deployment) but is not rendered on an unexposed Messages route.
- `capability_policy.py` / `generation_route_compat.py`: `_coerce_thinking_to_effort` superseded the adaptive config but kept an off-ladder effort verbatim, and the later explicit snap kept the thinking config, so neither round admitted. The snap now composes with the supersede (disclosed as `thinking->dropped(superseded_by_effort)` + `reasoning_effort->high`) and every snap rewrites `output_config.effort` alongside `reasoning_effort` (`request_with_reasoning_effort`). Production showed `effort: high` served and `medium`/`low` refused with the effort-unsupported 400 on the same route.
- Native crate 0.3.52 -> 0.3.53; parent floor bumped; docs updated.

## Tests (failing on the old build, passing now)

- `native_waterfall_test.py::test_billed_empty_stop_redials_instead_of_settling_an_empty_success`: Chat, primary answers the captured reasoning-only stop once; rows `[(0,0,failed),(1,0,completed)]`, failure class `provider_internal`, 147 output tokens kept on the failed attempt. Old build: `content: None`.
- `native_messages_test.py::test_messages_non_stream_billed_empty_stop_fails_instead_of_an_empty_end_turn` and `..._stream_billed_empty_stop_is_refused_before_the_first_frame`: single rung, both dispatches fail `provider_internal`, the caller gets the 502 Anthropic error envelope. Old build: `{"content":[],"stop_reason":"end_turn","usage":{"output_tokens":147}}` and the streamed `message_start`/`message_delta end_turn`/`message_stop` with zero blocks.
- `capability_policy_test.py::test_superseded_thinking_snaps_an_off_ladder_effort_onto_the_route`, `test_effort_snap_carries_the_messages_output_config_channel`; `generation_route_compat_test.py` (new, the module had none). Old code: effort stayed `medium`; `output_config.effort` stayed `xhigh`.
- Rust unit tests for `billed_empty_completion`; crate `cargo test --no-default-features` 291 passed, clippy `-D warnings` clean.

## Blast radius (production, read-only, last 7 days, deepseek-v4-flash openrouter rung, Messages)

1,798 completed no-tool attempts across 69 orgs report output_tokens <= reasoning_tokens + 1 (the empty-answer signature; 537,945 output tokens, 43,059,869 nano-USD settled, 2,666,177,725 nano-USD list value). This is an upper bound: the same usage signature also appears on 1,305 attempts that DID render tool calls, so OpenRouter's reasoning count is not a clean discriminator and no response capture exists for these orgs.

## Notes

- Finding (b): Chat Completions on this rung bills `reasoning_tokens` with no `reasoning_content` because none of the nine deepseek-v4-flash rungs carries `reasoning_output_exposed`; reasoning is stripped by design and the billing is correct.
- `provider_internal` counts toward the per-deployment health circuit, so a rung that answers empty repeatedly will be circuit-shed for a window; this is intended, and the redial keeps the caller on the preferred rung when the next answer is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
