### PR TITLE
Add regex guardrails with deterministic input and output redaction

### DIFF
--- a/docs/reference/gateway-guardrails.md
+++ b/docs/reference/gateway-guardrails.md
@@ -48,6 +48,10 @@ Capability kinds name the inspection job, not a vendor:
 
 Built-in adapter kinds:
 
+- `regex`: local RE2 matching and deterministic text replacement. Configure
+  custom expressions or the `email`, `credit_card`, and `api_key` built-in
+  families. Card candidates require a valid Luhn checksum. These rules find
+  specific patterns, not all personal information or every secret format.
 - `keyword`: coarse, test-oriented needle matching. Case-folded substrings of
   message text, completion text, or tool-call arguments. This is not a
   production prompt-injection or content-safety classifier.
@@ -57,6 +61,48 @@ Built-in adapter kinds:
   including a hosted PII redactor, by `adapter_id`.
 
 Other adapters may still be injected in code when composing a `GuardrailEngine`.
+
+### Regex rules
+
+For example, redact emails, card candidates, and an internal account format
+before provider dispatch and before delivering the completion:
+
+```json
+{
+  "adapters": [{
+    "adapter_id": "sensitive-patterns",
+    "kind": "regex",
+    "builtin_patterns": ["email", "credit_card"],
+    "patterns": ["ACCT-[0-9]{8}"],
+    "replacement": "[REDACTED]"
+  }],
+  "policies": [{
+    "policy_id": "redact-patterns",
+    "organization_id": "organization-one",
+    "identity_id": "identity-one",
+    "protected": true,
+    "checks": [
+      {"check_id": "redact-input", "capability": "pii", "stage": "input",
+       "action": "modify", "adapter_id": "sensitive-patterns", "timeout_ms": 250},
+      {"check_id": "redact-output", "capability": "pii", "stage": "output",
+       "action": "modify", "adapter_id": "sensitive-patterns", "timeout_ms": 250}
+    ]
+  }]
+}
+```
+
+`block` refuses a match instead of replacing it. Replacements are literal
+strings, not capture-group substitutions. Overlapping spans are combined
+before replacement. Zero-length matches do not flag text. Tool arguments are
+inspected but never rewritten: a flagged input tool argument under `modify`
+is refused, and output modifications with tool calls are blocked.
+
+RE2 does not support backreferences or look-around. Each custom pattern is
+limited to 1,024 UTF-8 bytes, with at most 32 patterns per adapter and 256 KiB
+of compile memory per expression. Each inspected text is limited to 1 MiB
+and 4,096 matches across its patterns. Exceeding these bounds is classifier
+uncertainty, governed by the policy's fail-closed setting. Use a model-backed
+PII detector for contextual entities such as names and addresses.
 
 Each check has an action (`allow`, `modify`, `block`, `error`), a per-check
 timeout, and an adapter identity. `modify` may rewrite request messages or

--- a/docs/reference/gateway-guardrails.md
+++ b/docs/reference/gateway-guardrails.md
@@ -50,7 +50,10 @@ Built-in adapter kinds:
 
 - `regex`: local RE2 matching and deterministic text replacement. Configure
   custom expressions or the `email`, `credit_card`, and `api_key` built-in
-  families. Card candidates require a valid Luhn checksum. These rules find
+  families. Card candidates require a valid Luhn checksum. Space- or hyphen-separated
+  digit groups are inspected for adjacent cards; overlapping valid spans are
+  redacted together. A valid card followed by another numeric group is still
+  redacted, while uninterrupted numbers longer than 19 digits are not split. These rules find
   specific patterns, not all personal information or every secret format.
 - `keyword`: coarse, test-oriented needle matching. Case-folded substrings of
   message text, completion text, or tool-call arguments. This is not a
@@ -100,7 +103,7 @@ is refused, and output modifications with tool calls are blocked.
 RE2 does not support backreferences or look-around. Each custom pattern is
 limited to 1,024 UTF-8 bytes, with at most 32 patterns per adapter and 256 KiB
 of compile memory per expression. Each inspected text is limited to 1 MiB
-and 4,096 matches across its patterns. Exceeding these bounds is classifier
+and 4,096 matches or card candidates across its patterns. Exceeding these bounds is classifier
 uncertainty, governed by the policy's fail-closed setting. Use a model-backed
 PII detector for contextual entities such as names and addresses.
 

--- a/exp/runtime/gateway/guardrails/config.py
+++ b/exp/runtime/gateway/guardrails/config.py
@@ -26,6 +26,7 @@ from exp.runtime.gateway.guardrails.http_json import (
     validate_classifier_url,
 )
 from exp.runtime.gateway.guardrails.preset import policy_from_authored
+from exp.runtime.gateway.guardrails.regex import RegexAdapterDocument, RegexClassifier
 from exp.runtime.gateway.guardrails.store import MappingGuardrailStore
 
 _CONFIG_NAME = "guardrails.json"
@@ -183,7 +184,9 @@ def _adapter(
         return _keyword_adapter(item)
     if kind == "http_json":
         return _http_json_adapter(item, http_client=http_client)
-    raise ValueError("adapter kind must be keyword or http_json")
+    if kind == "regex":
+        return RegexClassifier(RegexAdapterDocument.model_validate(item))
+    raise ValueError("adapter kind must be keyword, regex, or http_json")
 
 
 def _keyword_adapter(item: dict[str, object]) -> KeywordClassifier:

--- a/exp/runtime/gateway/guardrails/config_test.py
+++ b/exp/runtime/gateway/guardrails/config_test.py
@@ -150,8 +150,8 @@ def test_standard_preset_never_enables_a_global_policy() -> None:
 
 
 def test_unknown_adapter_kind_is_rejected() -> None:
-    """Built-in kinds are keyword and http_json; other kinds are injected in code."""
-    with pytest.raises(ValueError, match="keyword or http_json"):
+    """Unknown adapter kinds cannot become silently unconfigured checks."""
+    with pytest.raises(ValueError, match="keyword, regex, or http_json"):
         engine_from_document(
             {
                 "adapters": [{"adapter_id": "hosted", "kind": "hosted", "needles": ["x"]}],

--- a/exp/runtime/gateway/guardrails/regex.py
+++ b/exp/runtime/gateway/guardrails/regex.py
@@ -1,0 +1,195 @@
+"""Bounded RE2 detection with deterministic, in-memory text redaction."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from enum import StrEnum
+from typing import Literal, Protocol, cast
+
+import re2
+from pydantic import Field, model_validator
+
+from exp.common.core.artifacts import ArtifactId, ContractModel
+from exp.runtime.gateway.contracts import GatewayRequest
+from exp.runtime.gateway.guardrails.contracts import (
+    ClassifierVerdict,
+    GuardrailAction,
+    GuardrailCheck,
+    GuardrailCompletion,
+)
+
+
+class BuiltinPattern(StrEnum):
+    """Deterministic detector families; these do not cover contextual personal data."""
+
+    EMAIL = "email"
+    CREDIT_CARD = "credit_card"
+    API_KEY = "api_key"
+
+
+_BUILTINS = {
+    BuiltinPattern.EMAIL: r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+",
+    BuiltinPattern.CREDIT_CARD: r"\b[0-9](?:[ -]?[0-9]){12,18}\b",
+    BuiltinPattern.API_KEY: (
+        r"\b(?:sk-(?:proj-|ant-api[0-9]+-)?[A-Za-z0-9_-]{20,}"
+        r"|gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}"
+        r"|xpl_[A-Za-z0-9_-]{20,}|AKIA[A-Z0-9]{16})\b"
+    ),
+}
+_MAX_MATCHES = 4096
+_MAX_TEXT_BYTES = 1_048_576
+
+
+class RegexAdapterDocument(ContractModel):
+    """Author a local rule using custom RE2 expressions and optional built-in families.
+
+    All overlapping matches are replaced by one literal replacement. Capture
+    expansion is intentionally unavailable, so replacements cannot echo secrets.
+    """
+
+    adapter_id: ArtifactId
+    kind: Literal["regex"] = "regex"
+    patterns: tuple[str, ...] = Field(default=(), max_length=32)
+    builtin_patterns: tuple[BuiltinPattern, ...] = ()
+    replacement: str = Field(default="[REDACTED]", min_length=1, max_length=128)
+
+    @model_validator(mode="after")
+    def _validate_patterns(self) -> RegexAdapterDocument:
+        """Reject empty rules and excessive or duplicate pattern definitions."""
+        if not self.patterns and not self.builtin_patterns:
+            raise ValueError("regex requires patterns or builtin_patterns; add at least one")
+        if len(set(self.builtin_patterns)) != len(self.builtin_patterns):
+            raise ValueError("builtin_patterns must be unique; remove duplicate families")
+        if any(not pattern or len(pattern.encode("utf-8")) > 1024 for pattern in self.patterns):
+            raise ValueError("each regex pattern must contain 1 to 1024 UTF-8 bytes")
+        return self
+
+
+class _Match(Protocol):
+    """The RE2 match operations consumed at the untyped library boundary."""
+
+    def span(self) -> tuple[int, int]:
+        """Return Python string offsets for the matched text."""
+        ...
+
+
+class _Pattern(Protocol):
+    """The compiled RE2 operations consumed by this detector."""
+
+    def finditer(self, text: str) -> Iterator[_Match]:
+        """Iterate matches without materializing their text."""
+        ...
+
+
+def _compile(pattern: str) -> _Pattern:
+    """Compile with bounded RE2 memory and content-free validation failures."""
+    options = re2.Options()
+    options.max_mem = 262_144
+    options.log_errors = False
+    try:
+        # RE2 has no type annotations; Unicode span behavior is regression tested.
+        return cast(_Pattern, re2.compile(pattern, options=options))
+    except re2.error:
+        raise ValueError("invalid RE2 expression; check syntax and simplify the pattern") from None
+
+
+def _valid_card(text: str, start: int, end: int) -> bool:
+    """Validate a whole card candidate with Luhn, rejecting slices of longer numbers."""
+    if (start and text[start - 1].isdigit()) or (end < len(text) and text[end].isdigit()):
+        return False
+    if start >= 2 and text[start - 1] in " -" and text[start - 2].isdigit():
+        return False
+    if end + 1 < len(text) and text[end] in " -" and text[end + 1].isdigit():
+        return False
+    digits = [int(char) for char in text[start:end] if char in "0123456789"]
+    if not 13 <= len(digits) <= 19 or len(set(digits)) == 1:
+        return False
+    total = 0
+    for index, digit in enumerate(reversed(digits)):
+        doubled = digit * 2 if index % 2 else digit
+        total += doubled - 9 if doubled > 9 else doubled
+    return total % 10 == 0
+
+
+class RegexClassifier:
+    """Inspect text and tool arguments with compiled, bounded deterministic patterns."""
+
+    def __init__(self, document: RegexAdapterDocument) -> None:
+        """Compile the authored rule once, outside the gateway request path.
+
+        Args:
+            document: Validated expressions, built-in families, and literal replacement.
+        """
+        self._patterns = tuple(
+            [(_compile(pattern), False) for pattern in document.patterns]
+            + [
+                (_compile(_BUILTINS[kind]), kind is BuiltinPattern.CREDIT_CARD)
+                for kind in document.builtin_patterns
+            ]
+        )
+        self._replacement = document.replacement
+
+    def _redact(self, text: str) -> tuple[bool, str]:
+        """Union matched spans before replacement so overlapping rules cannot leak tails."""
+        if len(text.encode("utf-8")) > _MAX_TEXT_BYTES:
+            raise ValueError("regex subject exceeds the 1 MiB inspection limit")
+        spans: list[tuple[int, int]] = []
+        matches = 0
+        for pattern, is_card in self._patterns:
+            for match in pattern.finditer(text):
+                matches += 1
+                if matches > _MAX_MATCHES:
+                    raise ValueError("regex subject exceeds the match limit")
+                start, end = match.span()
+                if start == end:
+                    continue
+                if not is_card or _valid_card(text, start, end):
+                    spans.append((start, end))
+        if not spans:
+            return False, text
+        merged: list[tuple[int, int]] = []
+        for start, end in sorted(spans):
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(end, merged[-1][1]))
+            else:
+                merged.append((start, end))
+        pieces: list[str] = []
+        position = 0
+        for start, end in merged:
+            pieces.extend((text[position:start], self._replacement))
+            position = end
+        pieces.append(text[position:])
+        return True, "".join(pieces)
+
+    async def inspect_input(
+        self, *, request: GatewayRequest, check: GuardrailCheck
+    ) -> ClassifierVerdict:
+        """Redact message text; a match in tool arguments cannot be safely rewritten."""
+        messages = []
+        flagged = False
+        tool_match = False
+        for message in request.messages:
+            found, text = self._redact(message.content or "")
+            flagged |= found
+            messages.append(message.model_copy(update={"content": text}) if found else message)
+            for call in message.tool_calls:
+                found, _ = self._redact(call.arguments_json())
+                flagged |= found
+                tool_match |= found
+        if flagged and check.action is GuardrailAction.MODIFY and not tool_match:
+            return ClassifierVerdict(flagged=True, replacement_messages=tuple(messages))
+        # A flagged modify without replacement is refused by the engine, even
+        # under a fail-open policy. Tool arguments must never pass unredacted.
+        return ClassifierVerdict(flagged=flagged)
+
+    async def inspect_output(
+        self, *, completion: GuardrailCompletion, check: GuardrailCheck
+    ) -> ClassifierVerdict:
+        """Redact completion text; the engine blocks modifications of tool completions."""
+        flagged, text = self._redact(completion.text)
+        for call in completion.tool_calls:
+            found, _ = self._redact(call.arguments)
+            flagged |= found
+        if flagged and check.action is GuardrailAction.MODIFY:
+            return ClassifierVerdict(flagged=True, replacement_text=text)
+        return ClassifierVerdict(flagged=flagged)

--- a/exp/runtime/gateway/guardrails/regex.py
+++ b/exp/runtime/gateway/guardrails/regex.py
@@ -29,7 +29,7 @@ class BuiltinPattern(StrEnum):
 
 _BUILTINS = {
     BuiltinPattern.EMAIL: r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+",
-    BuiltinPattern.CREDIT_CARD: r"\b[0-9](?:[ -]?[0-9]){12,18}\b",
+    BuiltinPattern.CREDIT_CARD: r"\b[0-9](?:[ -]?[0-9]){12,}\b",
     BuiltinPattern.API_KEY: (
         r"\b(?:sk-(?:proj-|ant-api[0-9]+-)?[A-Za-z0-9_-]{20,}"
         r"|gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}"
@@ -93,15 +93,8 @@ def _compile(pattern: str) -> _Pattern:
         raise ValueError("invalid RE2 expression; check syntax and simplify the pattern") from None
 
 
-def _valid_card(text: str, start: int, end: int) -> bool:
-    """Validate a whole card candidate with Luhn, rejecting slices of longer numbers."""
-    if (start and text[start - 1].isdigit()) or (end < len(text) and text[end].isdigit()):
-        return False
-    if start >= 2 and text[start - 1] in " -" and text[start - 2].isdigit():
-        return False
-    if end + 1 < len(text) and text[end] in " -" and text[end + 1].isdigit():
-        return False
-    digits = [int(char) for char in text[start:end] if char in "0123456789"]
+def _valid_card(digits: list[int]) -> bool:
+    """Require a nonuniform 13 to 19 digit candidate with a valid Luhn checksum."""
     if not 13 <= len(digits) <= 19 or len(set(digits)) == 1:
         return False
     total = 0
@@ -109,6 +102,29 @@ def _valid_card(text: str, start: int, end: int) -> bool:
         doubled = digit * 2 if index % 2 else digit
         total += doubled - 9 if doubled > 9 else doubled
     return total % 10 == 0
+
+
+def _card_candidates(text: str, start: int, end: int) -> Iterator[tuple[int, int]]:
+    """Inspect card spans at digit-group boundaries, including adjacent cards.
+
+    Spaces and hyphens can separate cards or groups within a card. Check all
+    13 to 19 digit spans at those boundaries. Never split an uninterrupted
+    digit group into smaller candidates.
+    """
+    for first in range(start, end):
+        if text[first] not in "0123456789":
+            continue
+        if first > start and text[first - 1] in "0123456789":
+            continue
+        digits = 0
+        for last in range(first, min(end, first + 38)):
+            if text[last] not in "0123456789":
+                continue
+            digits += 1
+            if digits > 19:
+                break
+            if digits >= 13 and (last + 1 == end or text[last + 1] in " -"):
+                yield first, last + 1
 
 
 class RegexClassifier:
@@ -143,8 +159,16 @@ class RegexClassifier:
                 start, end = match.span()
                 if start == end:
                     continue
-                if not is_card or _valid_card(text, start, end):
+                if not is_card:
                     spans.append((start, end))
+                    continue
+                for first, last in _card_candidates(text, start, end):
+                    matches += 1
+                    if matches > _MAX_MATCHES:
+                        raise ValueError("regex subject exceeds the match limit")
+                    digits = [int(char) for char in text[first:last] if char in "0123456789"]
+                    if _valid_card(digits):
+                        spans.append((first, last))
         if not spans:
             return False, text
         merged: list[tuple[int, int]] = []

--- a/exp/runtime/gateway/guardrails/regex_test.py
+++ b/exp/runtime/gateway/guardrails/regex_test.py
@@ -1,0 +1,218 @@
+"""Deterministic rule detection and redaction through the real policy engine."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from exp.common.core.artifacts import JsonObject
+from exp.common.models.model import ToolCall
+from exp.runtime.gateway.contracts import GatewayApiSurface, GatewayMessage, GatewayRequest
+from exp.runtime.gateway.guardrails.config import engine_from_document
+from exp.runtime.gateway.guardrails.contracts import (
+    GuardrailCompletion,
+    GuardrailRejected,
+    GuardrailToolCall,
+)
+from exp.runtime.gateway.guardrails.regex import (
+    BuiltinPattern,
+    RegexAdapterDocument,
+    RegexClassifier,
+)
+
+
+def _document(adapter: JsonObject, *, action: str = "modify") -> JsonObject:
+    """Bind a regex rule to both stages of one protected identity."""
+    return {
+        "adapters": [{"kind": "regex", "adapter_id": "patterns", **adapter}],
+        "policies": [
+            {
+                "policy_id": "redact",
+                "organization_id": "org",
+                "identity_id": "identity",
+                "protected": True,
+                "checks": [
+                    {
+                        "check_id": stage,
+                        "capability": "pii",
+                        "stage": stage,
+                        "action": action,
+                        "adapter_id": "patterns",
+                        "timeout_ms": 500,
+                    }
+                    for stage in ("input", "output")
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("Contact alice@example.com today", "Contact [REDACTED] today"),
+        ("日本語 😀 alice@example.com fin", "日本語 😀 [REDACTED] fin"),
+        ("alice@example.com and bob@example.org", "[REDACTED] and [REDACTED]"),
+        ("No personal information", "No personal information"),
+    ],
+)
+def test_email_redaction_preserves_surrounding_text_on_both_stages(
+    content: str, expected: str
+) -> None:
+    """Real input/output chains preserve Unicode and only replace detected spans."""
+    engine = engine_from_document(_document({"builtin_patterns": ["email"]}))
+    policy = engine.policy_for("org", "identity")
+    assert policy is not None
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(GatewayMessage(role="user", content=content),),
+    )
+    result = asyncio.run(
+        engine.enforce_input(policy=policy, request=request, deadline_monotonic=1e12)
+    )
+    assert result.messages[0].content == expected
+    assert request.messages[0].content == content
+    output = asyncio.run(
+        engine.enforce_output(
+            policy=policy, completion=GuardrailCompletion(text=content), deadline_monotonic=1e12
+        )
+    )
+    assert output.text == expected
+    assert engine.policy_for("org", "other") is None
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("4111 1111 1111 1111", "[REDACTED]"),
+        ("4111-1111-1111-1111", "[REDACTED]"),
+        ("4111111111111111", "[REDACTED]"),
+        ("4111111111111112", "4111111111111112"),
+        ("0000000000000000", "0000000000000000"),
+        ("141111111111111111111", "141111111111111111111"),
+        ("4111 1111 1111 1111 0000", "4111 1111 1111 1111 0000"),
+    ],
+)
+def test_card_candidates_require_luhn(text: str, expected: str) -> None:
+    """Invalid card candidates remain untouched; valid formatted numbers redact."""
+    classifier = RegexClassifier(
+        RegexAdapterDocument(adapter_id="cards", builtin_patterns=(BuiltinPattern.CREDIT_CARD,))
+    )
+    assert classifier._redact(text)[1] == expected
+
+
+def test_overlapping_patterns_redact_the_union_and_replacement_is_literal() -> None:
+    """Two matching slices cannot leave a secret suffix; backreferences are never expanded."""
+    classifier = RegexClassifier(
+        RegexAdapterDocument(adapter_id="custom", patterns=("abc", "cde"), replacement=r"\1")
+    )
+    assert classifier._redact("xabcdey") == (True, r"x\1y")
+
+
+@pytest.mark.parametrize("pattern", ["(", r"(a)\1", r"(?<=a)b"])
+def test_invalid_or_unsupported_re2_patterns_are_rejected_without_echo(pattern: str) -> None:
+    """Customer patterns never enter parser error logs or exception text."""
+    with pytest.raises(ValueError, match="invalid RE2 expression"):
+        engine_from_document(_document({"patterns": [pattern]}))
+
+
+@pytest.mark.parametrize(
+    "adapter",
+    [{}, {"patterns": [""]}, {"patterns": ["a" * 1025]}, {"builtin_patterns": ["email", "email"]}],
+)
+def test_invalid_rule_configuration_cannot_be_activated(adapter: JsonObject) -> None:
+    """Empty or oversized rules fail while loading, before traffic is admitted."""
+    with pytest.raises(ValueError):
+        engine_from_document(_document(adapter))
+
+
+def test_adversarial_backtracking_pattern_completes_with_linear_engine() -> None:
+    """A classic exponential backtracking subject uses RE2's bounded matcher."""
+    classifier = RegexClassifier(RegexAdapterDocument(adapter_id="custom", patterns=(r"(a+)+$",)))
+    text = "a" * 100_000 + "!"
+    assert classifier._redact(text) == (False, text)
+
+
+def test_block_action_refuses_match_and_allows_clean_input() -> None:
+    """A custom content rule can block instead of modifying the request."""
+    engine = engine_from_document(_document({"patterns": [r"internal-[0-9]+"]}, action="block"))
+    policy = engine.policy_for("org", "identity")
+    assert policy is not None
+    for text in ("internal-123", "public documentation"):
+        request = GatewayRequest(
+            surface=GatewayApiSurface.CHAT_COMPLETIONS,
+            messages=(GatewayMessage(role="user", content=text),),
+        )
+        if text.startswith("internal"):
+            with pytest.raises(GuardrailRejected):
+                asyncio.run(
+                    engine.enforce_input(policy=policy, request=request, deadline_monotonic=1e12)
+                )
+        else:
+            assert (
+                asyncio.run(
+                    engine.enforce_input(policy=policy, request=request, deadline_monotonic=1e12)
+                )
+                == request
+            )
+
+
+def test_tool_completion_is_blocked_instead_of_rewritten() -> None:
+    """Redaction never passes sensitive tool arguments to the caller."""
+    engine = engine_from_document(_document({"builtin_patterns": ["email"]}))
+    policy = engine.policy_for("org", "identity")
+    assert policy is not None
+    completion = GuardrailCompletion(
+        tool_calls=(
+            GuardrailToolCall(
+                call_id="call", name="send", arguments='{"email":"alice@example.com"}'
+            ),
+        )
+    )
+    with pytest.raises(GuardrailRejected):
+        asyncio.run(
+            engine.enforce_output(policy=policy, completion=completion, deadline_monotonic=1e12)
+        )
+
+
+def test_api_key_family_redacts_known_prefixes() -> None:
+    """Built-in token families preserve text outside complete token matches."""
+    classifier = RegexClassifier(
+        RegexAdapterDocument(adapter_id="keys", builtin_patterns=(BuiltinPattern.API_KEY,))
+    )
+    for token in ("sk-proj-" + "a" * 40, "ghp_" + "b" * 36, "xpl_" + "c" * 32):
+        assert classifier._redact("token: " + token) == (True, "token: [REDACTED]")
+
+
+def test_match_explosion_is_bounded() -> None:
+    """Very dense custom matches cannot accumulate unbounded span lists."""
+    classifier = RegexClassifier(RegexAdapterDocument(adapter_id="dense", patterns=("a",)))
+    with pytest.raises(ValueError, match="match limit"):
+        classifier._redact("a" * 5000)
+
+
+@pytest.mark.parametrize("protected", [True, False])
+def test_input_tool_arguments_never_escape_a_redaction_rule(protected: bool) -> None:
+    """Known sensitive tool content is refused even when uncertainty is fail-open."""
+    engine = engine_from_document(_document({"builtin_patterns": ["email"]}))
+    policy = engine.policy_for("org", "identity")
+    assert policy is not None
+    policy = policy.model_copy(update={"protected": protected})
+    request = GatewayRequest(
+        surface=GatewayApiSurface.CHAT_COMPLETIONS,
+        messages=(
+            GatewayMessage(
+                role="assistant",
+                tool_calls=(
+                    ToolCall(
+                        call_id="call",
+                        name="lookup",
+                        arguments={"email": "alice@example.com"},
+                    ),
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(GuardrailRejected):
+        asyncio.run(engine.enforce_input(policy=policy, request=request, deadline_monotonic=1e12))

--- a/exp/runtime/gateway/guardrails/regex_test.py
+++ b/exp/runtime/gateway/guardrails/regex_test.py
@@ -55,13 +55,14 @@ def _document(adapter: JsonObject, *, action: str = "modify") -> JsonObject:
         ("日本語 😀 alice@example.com fin", "日本語 😀 [REDACTED] fin"),
         ("alice@example.com and bob@example.org", "[REDACTED] and [REDACTED]"),
         ("No personal information", "No personal information"),
+        ("Cards: 4111111111111111 5555555555554444", "Cards: [REDACTED] [REDACTED]"),
     ],
 )
-def test_email_redaction_preserves_surrounding_text_on_both_stages(
+def test_builtin_redaction_preserves_surrounding_text_on_both_stages(
     content: str, expected: str
 ) -> None:
     """Real input/output chains preserve Unicode and only replace detected spans."""
-    engine = engine_from_document(_document({"builtin_patterns": ["email"]}))
+    engine = engine_from_document(_document({"builtin_patterns": ["email", "credit_card"]}))
     policy = engine.policy_for("org", "identity")
     assert policy is not None
     request = GatewayRequest(
@@ -88,10 +89,14 @@ def test_email_redaction_preserves_surrounding_text_on_both_stages(
         ("4111 1111 1111 1111", "[REDACTED]"),
         ("4111-1111-1111-1111", "[REDACTED]"),
         ("4111111111111111", "[REDACTED]"),
+        ("4111111111111111 5555555555554444", "[REDACTED] [REDACTED]"),
+        ("4111 1111 1111 1111 5555 5555 5555 4444", "[REDACTED]"),
+        ("4111-1111-1111-1111 378282246310005", "[REDACTED] [REDACTED]"),
+        ("4111111111111111, 5555555555554444", "[REDACTED], [REDACTED]"),
         ("4111111111111112", "4111111111111112"),
         ("0000000000000000", "0000000000000000"),
         ("141111111111111111111", "141111111111111111111"),
-        ("4111 1111 1111 1111 0000", "4111 1111 1111 1111 0000"),
+        ("4111 1111 1111 1111 0000", "[REDACTED] 0000"),
     ],
 )
 def test_card_candidates_require_luhn(text: str, expected: str) -> None:
@@ -216,3 +221,12 @@ def test_input_tool_arguments_never_escape_a_redaction_rule(protected: bool) -> 
     )
     with pytest.raises(GuardrailRejected):
         asyncio.run(engine.enforce_input(policy=policy, request=request, deadline_monotonic=1e12))
+
+
+def test_card_candidate_work_is_bounded() -> None:
+    """A long ambiguous run cannot force unlimited candidate validation."""
+    classifier = RegexClassifier(
+        RegexAdapterDocument(adapter_id="cards", builtin_patterns=(BuiltinPattern.CREDIT_CARD,))
+    )
+    with pytest.raises(ValueError, match="match limit"):
+        classifier._redact("4111 " * 5000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     # Realistic input-token estimates for per-attempt reservations (free-tier windows and the
     # paid worst-case ceiling) count the prompt with the o200k BPE instead of a byte bound.
     "tiktoken>=0.9,<1",
+    "google-re2>=1.1,<2",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -535,43 +535,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -651,6 +651,7 @@ dependencies = [
     { name = "exp-gateway-native" },
     { name = "filelock" },
     { name = "google-auth" },
+    { name = "google-re2" },
     { name = "httpx" },
     { name = "numpy" },
     { name = "openai" },
@@ -689,6 +690,7 @@ requires-dist = [
     { name = "experiential", extras = ["sft"], marker = "extra == 'dev'" },
     { name = "filelock", specifier = ">=3.12" },
     { name = "google-auth", specifier = ">=2.35,<3" },
+    { name = "google-re2", specifier = ">=1.1,<2" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.7,<2" },
     { name = "numpy", specifier = ">=1.26" },
@@ -832,6 +834,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
+]
+
+[[package]]
+name = "google-re2"
+version = "1.1.20251105"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/60/805c654ba53d685513df955ee745f71920fe8e6a284faf0f9b9dc19b659c/google_re2-1.1.20251105.tar.gz", hash = "sha256:1db14a292ee8303b91e91e7c37e05ac17d3c467f29416c79ac70a78be3e65bda", size = 11676, upload-time = "2025-11-05T14:58:07.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/20/73b487538e9107c2fd96aed737e3f3890dfce3e292622e4ffb2f9c810ee5/google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b30f09b4d63249c72e65ccae4cbf6b331b48c22fc7cb439f1d85f347b9d07ceb", size = 485591, upload-time = "2025-11-05T14:57:20.961Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9a/ca3a993bdb5dc6d5b2616b9657b2872a83d1827f8bd3ab50cd629eb751c7/google_re2-1.1.20251105-1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:9a77892c524b8bdf3d47d7cad1cc2ac3a0108bdd65007ef4c02888fa46baf8ee", size = 518780, upload-time = "2025-11-05T14:57:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/df/37/b2e367987371514253ec9e514637f457deaacb7acc1c900814f3a6421e0f/google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a3ac51b28cbf25c100dfd8849212d878d7005d1d4a7e129a10789043c56b6021", size = 486966, upload-time = "2025-11-05T14:57:24.575Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/1db6742943c0ac254bfb7d8a37a5d3f73f016a65cfa1f84fe3a0451820f6/google_re2-1.1.20251105-1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:9f7158afc9825ac2654c6561aea94a1f7edb5b5b88e6e3639bb80bb817d102ac", size = 520225, upload-time = "2025-11-05T14:57:26.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0a/0747c92dbebe2c09a26bd7386d372b5c5a9926236b4f3d69bb8f15db05cb/google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:5320da07dc3b7ac7f407514f42ac17d67e771ac7c7562d449571185e6fb601b2", size = 482943, upload-time = "2025-11-05T14:57:27.353Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/6bfc6838bb6cb561824ac03deeab2bd11d5d9a93505f536c8fa2f6bd46c4/google_re2-1.1.20251105-1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:5a4e5785bc30d52ce655d805b07ad2d8a4905429a5f690ae9c2f1caa76665709", size = 510384, upload-time = "2025-11-05T14:57:29.139Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0a/6add090c917ee39f6f0be753037cafceb3bad904b424efc155fb38082635/google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b7a3b90f747130310d4b3b8e19ebb845d0d97c1deb63b36f76c7242dacbd736", size = 572446, upload-time = "2025-11-05T14:57:30.495Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1c/8b1ccbeade96a21435d55b5185cd6d9b2ceab5a9af998a4d9099e0540759/google_re2-1.1.20251105-1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:809c5fa5d08279413b29c2e2c5c528e85cd94a0e0fd897db595a0c09eeee2782", size = 591348, upload-time = "2025-11-05T14:57:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/62/cf/7bdd7a1ae7828b613011da808eafec4da3132f43c3be6af5e0bd670ebe8b/google_re2-1.1.20251105-1-cp312-cp312-win32.whl", hash = "sha256:d8424e63a9ec0fe5bde03d97876b2431f8a746af33eb475fa1ae39144bd05b2a", size = 433787, upload-time = "2025-11-05T14:57:33.071Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e9/5dd951c35acaabfe87c67228b9af2cdcd7779d9167edbe6b9094b8a8e529/google_re2-1.1.20251105-1-cp312-cp312-win_amd64.whl", hash = "sha256:062313c309f93dfeb6966372f4c446580e98879133ec155522eea8aaf568a5cd", size = 491726, upload-time = "2025-11-05T14:57:34.39Z" },
+    { url = "https://files.pythonhosted.org/packages/60/8d/c1afd29fc2cb475fd4c634f3d3c8099c0efb662362c10b27a9eaf11c9357/google_re2-1.1.20251105-1-cp312-cp312-win_arm64.whl", hash = "sha256:558f144b26a9555ae4e9467cc3aa3299a8ce13217f328b21ae326ca0633be19b", size = 642673, upload-time = "2025-11-05T14:57:35.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/c441722196598fc3de0f654606ad9975a968c71dc27f516b5a4c9ebb94fd/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:9f3cf610e857a7d6f02916cf2b7fc159a5429b8bcb23164500d46e5e233f2924", size = 485549, upload-time = "2025-11-05T14:57:36.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/87/cf588255e5ada1dfb555cc96de35be78438bb0b6faba64df5fe91cecc224/google_re2-1.1.20251105-1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a21c2807bf4d5d00f206a4ecb3b043aad674e28c451b697b740280f608872078", size = 518840, upload-time = "2025-11-05T14:57:38.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/39/da66e4ca9be0c51546efc6fb39cf1683c4be8245d8199cb54a9808e8d5fa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8314144eefeee7b88b742081c2038418f677e63901039ca9dbfbc0c5bb6d2911", size = 487037, upload-time = "2025-11-05T14:57:39.467Z" },
+    { url = "https://files.pythonhosted.org/packages/75/dd/24ba65692dd58dca6ff178428551f4e9b776d1489a1251f5c8539e598baa/google_re2-1.1.20251105-1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:28a46be978e53c772139d0f5c9ba69f53563fcdd4225407e4d34d51208b828f1", size = 520285, upload-time = "2025-11-05T14:57:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/61/12/cfdbb92bed24af6474970a75a26145c424f98cfbcc633fdd185985f0efe0/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:83292e23963aa1b219d5f64a65365b0880448a6a060276027b55270bc5b18c7e", size = 482981, upload-time = "2025-11-05T14:57:41.928Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bf/5fc32ded9279e69a87b88d7261e7e77e2e26325d4e27ca1303a3215e430a/google_re2-1.1.20251105-1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:1920b15dc9b1bdfeca5aa2c60900373c6f27cd1056d53cd299456ea5540a6fff", size = 510366, upload-time = "2025-11-05T14:57:43.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/71/f927ddc7aef1b8d7ccc8a649c335d311f29f3dea658209e30e37720e4891/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b1458d9ca588124cd61aa1bf5388a216e1247e7d474f8e5e1530498044f5c87", size = 572390, upload-time = "2025-11-05T14:57:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8c/23075e589038284c9487f41cde531d35873f9da622fb4ac7d1d97bd9086e/google_re2-1.1.20251105-1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a52cb204e49d20cdbb66faf394d57f476e96c39c23a328442ab0194fc6bd1a2b", size = 591386, upload-time = "2025-11-05T14:57:45.713Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/858453ef689f6b9895cd02b466836a9d1a6e4ba535d1a275b01bf73baa1d/google_re2-1.1.20251105-1-cp313-cp313-win32.whl", hash = "sha256:67c5c73d7ebcf3f0e0a3b528b41bd8c6c04900f1598aebf05bbdf15a06cf5f9a", size = 433807, upload-time = "2025-11-05T14:57:46.92Z" },
+    { url = "https://files.pythonhosted.org/packages/08/24/6ea87fe682e115ffd296e91eb5c5a266349d1ee8414ce8ece3f99ec1ac84/google_re2-1.1.20251105-1-cp313-cp313-win_amd64.whl", hash = "sha256:0bcba63ad3ea8926fb0c71bb5044e33d405bb9395f5b5444393cd5f28f0bf6d3", size = 491734, upload-time = "2025-11-05T14:57:48.304Z" },
+    { url = "https://files.pythonhosted.org/packages/34/85/32ba71b06f3cf5f9856ae95b3d6463b971742453631a5ae2c5be338ea377/google_re2-1.1.20251105-1-cp313-cp313-win_arm64.whl", hash = "sha256:64ee189ea857f2126c5e42073cfa9b03e9f4cbaf073edbedb575059074841aa0", size = 642654, upload-time = "2025-11-05T14:57:49.602Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7f/7eb238bdcd06182b5f427afd305cf413b7cf4ea71047308bbf35912cf923/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:cc151cf6a585d9ebe711da32b23683fcff40f78db8c8587c7f4b209ef4658809", size = 484719, upload-time = "2025-11-05T14:57:51.326Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/62/eed28eab67f939f4b9383c47b1db11638ade6ac30785c15cb960de85ba43/google_re2-1.1.20251105-1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7e2186d2c90488c1e11895343941f35ca2f58e9ba6c6b034fd531abe22ef77cc", size = 517698, upload-time = "2025-11-05T14:57:52.597Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/16/a1e6768513f788bf9c67a1cfe379ef34a793983eee46e4b653e42b558b78/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:41be22359c3dceb582937739b4365dd8e279de24ad0a5b10e653503abaff2ed7", size = 486421, upload-time = "2025-11-05T14:57:53.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fc/7a97ffd36d451e5a8bfaff2f9022b14807795d588f98227ff96e8da99856/google_re2-1.1.20251105-1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:f3168d7bbac247c862ea85b2f3c011d3a04bedcb6892b37f14d488f4133b206e", size = 519037, upload-time = "2025-11-05T14:57:55.078Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ee/8b6f7d94bb689dafdf60de8dd8f8f6296ad40d4d15c933fcda4da7a3a06b/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:79ce664038194a31bbcf422137f9607ae3d9946a5cff98cf0efbeb7f9411e64b", size = 483373, upload-time = "2025-11-05T14:57:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a6/16a09e03d1de128f821869e4252688c21319f5017d9209f4d0e71ea5c951/google_re2-1.1.20251105-1-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:0476b07421b8882b279d5ceb5b760c15c62d581ded95274697fc1227e3869ee6", size = 510167, upload-time = "2025-11-05T14:57:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/9d/213dce5de401527369fb5af11096b18c06001d9eb71f3318fe5eba1ec706/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85feec3161ffdc12f6b144e37a2f91f80b771c72ffadde60191e89a49f6d7e81", size = 573176, upload-time = "2025-11-05T14:57:59.211Z" },
+    { url = "https://files.pythonhosted.org/packages/03/be/a8def96aa4a80b233e105767d22e3de961dcde5a04f0a05cb4f3ddb4df78/google_re2-1.1.20251105-1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7bfaa2cf55daf0c5c650e68526bb20b61e37d7f3ae53f6893013acc1c91c116", size = 591483, upload-time = "2025-11-05T14:58:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ea/144bbc4b9359da89aec07b4c2a91a6bfe7119914885386577c665b07bb01/google_re2-1.1.20251105-1-cp314-cp314-win32.whl", hash = "sha256:214c1accdc60fff9ce1bf812b157147ca361844f496ed9e0d5f357b0e562ced8", size = 433773, upload-time = "2025-11-05T14:58:01.594Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/74e301211699f1b650ba7690a3e4e52146ac4266fcd62f3ea0a945b9eda4/google_re2-1.1.20251105-1-cp314-cp314-win_amd64.whl", hash = "sha256:6d4d5fdadd329a2ed193463899d00ef2fd126172f36a4c01c9def271f19801b6", size = 491893, upload-time = "2025-11-05T14:58:02.969Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/4adcfcb9c95e3d064c9f7aaf6cb3a4fc842d86115014b9d4094db4d465b5/google_re2-1.1.20251105-1-cp314-cp314-win_arm64.whl", hash = "sha256:1d27f3a2a947ec1f721d0f14f661108acfd4f4d34f357ce28db951cc036656e5", size = 643093, upload-time = "2025-11-05T14:58:05.761Z" },
 ]
 
 [[package]]
@@ -1480,7 +1523,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1519,7 +1562,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1531,7 +1574,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1561,9 +1604,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1575,7 +1618,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
## Behavior

Identity policies can now bind a local `regex` adapter to block or redact matched input and output text. Rules accept custom RE2 expressions and built-in email, Luhn-validated credit-card, and known API-key pattern families. For example, `Contact alice@example.com` becomes `Contact [REDACTED]` before dispatch and delivery.

Expressions compile before requests with bounded memory. Matches use Unicode character offsets and overlapping spans are combined before literal replacement. Sensitive tool arguments are refused when modification is requested, preserving the engine's no-tool-rewrite contract. Adjacent cards are detected at digit-group boundaries, and overlapping checksum-valid spans are combined. No inspected content is retained by the adapter. These deterministic families do not claim contextual PII or universal secret detection.

## Validation

- Full Python suite before the adjacent-card fix: 4209 passed, 6 skipped.
- After the adjacent-card fix, all 171 guardrail tests pass. Detector tests cover both engine stages, Unicode, overlap, invalid cards, malicious backtracking expressions, match bounds, and tool arguments under both fail-closed and fail-open policies.
- Full Ruff, format, and ty checks pass.
- Windows and Linux resolved dependency trees were compared against the base: the only added dependency is google-re2. CUDA remains Linux-only through the existing torch edge.

This is the first engine delivery for managed Platform guardrails. Hosted model inference, branding judges, Platform configuration, and the end-to-end demo are subsequent work in the same task. No merge or production deployment is requested.
