### PR TITLE
release: bump experiential to 0.7.70 (DeepSeek trailing-system fold, exp#929)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "experiential"
-version = "0.7.69"
+version = "0.7.70"
 description = "Build simulations and optimize model routing from agent traces."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ source = { directory = "exp/runtime/gateway/native" }
 
 [[package]]
 name = "experiential"
-version = "0.7.69"
+version = "0.7.70"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Version bump only (pyproject + uv.lock) for the release carrying exp#929: DeepSeek rungs fold a trailing system/developer turn into the user turn (the Claude Code empty-answer bug). `exp-gateway-native` stays 0.3.52.

Note: the companion PR #927 (typed failure on a billed empty stop + effort snap) is still open with a failing gate and carries its own `release/0.7.70` branch; once it lands it re-bumps to 0.7.71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)