### PR TITLE
gateway: print unknown setup key once

### DIFF
--- a/exp/cli/gateway/serve.py
+++ b/exp/cli/gateway/serve.py
@@ -486,7 +486,7 @@ def _emit_setup_unknown_recovery(
         markup=True,
     )
     _console.print(
-        f"Preserve this one-time gateway key: {setup.raw_key}",
+        "Preserve the one-time gateway key printed above.",
         markup=False,
     )
     _console.print(

--- a/exp/cli/gateway/serve_test.py
+++ b/exp/cli/gateway/serve_test.py
@@ -530,5 +530,6 @@ def test_first_run_unknown_setup_outcome_delivers_the_only_raw_key(
 
     transcript = output.getvalue()
     assert "export EXP_GATEWAY_KEY=exp_vk_unknown_secret" in transcript
-    assert "Preserve this one-time gateway key: exp_vk_unknown_secret" in transcript
+    assert transcript.count("exp_vk_unknown_secret") == 1
+    assert "Preserve the one-time gateway key printed above." in transcript
     assert "exp config gateway key issue default --key-id RECOVERY_KEY --json" in transcript


### PR DESCRIPTION
## Why

The unknown first-run setup recovery path printed the same one-time gateway key in both the
environment export and a later preservation sentence. Repeating a raw credential unnecessarily
increases its exposure in terminal scrollback and captured transcripts.

Closes #931

## What

- Keep `_emit_setup_credentials` as the only raw-key presenter.
- Make the recovery sentence refer to the one-time key printed above without repeating its value.
- Strengthen the existing unknown-outcome regression to assert that the exact secret occurs once.

## Validation

- `uv run --no-sync pytest -q exp/cli/gateway/serve_test.py -k 'not unbindable_port'`: passed,
  10 tests and 1 deselected
- `uv run --no-sync ruff check .`: passed
- `uv run --no-sync ruff format --check .`: passed, 844 files already formatted
- `uv run --no-sync ty check`: passed

The deselected existing test opens an IPv4 listener, which this restricted workspace prohibits
with `PermissionError: [Errno 1] Operation not permitted`. It does not exercise setup credential
presentation.

## Non-goals

This change does not alter key generation, storage, replacement, activation recovery, or the
successful first-run output path.
