### PR TITLE
providers: validate hosted Platform origin

### DIFF
--- a/exp/cli/auth.py
+++ b/exp/cli/auth.py
@@ -17,7 +17,7 @@ from exp.cli.providers.experiential_cloud import (
     read_hosted_key_fallback,
 )
 from exp.cli.providers.sync import sync_account_models
-from exp.cli.shared.options import ROOT_OPTION
+from exp.cli.shared.options import ROOT_OPTION, usage_error
 from exp.cli.shared.theme import EXP_THEME
 from exp.common.auth import ProviderAuthStore
 from exp.common.config import ARTIFACT_DIR
@@ -117,4 +117,5 @@ def run_login(
 
 def login(root: Path = ROOT_OPTION) -> None:
     """Open Platform login, save the credential, and synchronize account models."""
-    run_login(console=Console(theme=EXP_THEME), environment=os.environ, root=root)
+    with usage_error(ValueError):
+        run_login(console=Console(theme=EXP_THEME), environment=os.environ, root=root)

--- a/exp/cli/auth_test.py
+++ b/exp/cli/auth_test.py
@@ -47,6 +47,21 @@ class _AccountModelLister:
         )
 
 
+def test_login_command_reports_invalid_platform_origin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The command reports an invalid Platform override as actionable usage feedback."""
+    monkeypatch.setenv("EXP_PLATFORM_URL", "https://platform.preview.test:invalid")
+    monkeypatch.setattr(
+        auth,
+        "Console",
+        lambda **_kwargs: Console(file=io.StringIO(), force_terminal=True, no_color=True),
+    )
+
+    with pytest.raises(typer.BadParameter, match="EXP_PLATFORM_URL must use a valid port"):
+        auth.login(tmp_path)
+
+
 def test_login_persists_platform_key_in_the_shared_cloud_record(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/exp/cli/providers/experiential_cloud.py
+++ b/exp/cli/providers/experiential_cloud.py
@@ -12,6 +12,7 @@ a loopback callback to receive the new organization key.
 from __future__ import annotations
 
 import html
+import ipaddress
 import os
 import secrets
 import select
@@ -243,11 +244,55 @@ def hosted_platform_url(environment: Mapping[str, str] | None = None) -> str:
         environment: Optional process environment. ``None`` reads ``os.environ``.
 
     Returns:
-        ``EXP_PLATFORM_URL`` when non-empty, otherwise the production Platform origin.
+        A validated ``EXP_PLATFORM_URL`` origin, otherwise the production Platform origin.
+
+    Raises:
+        ValueError: The configured override is not a trusted Platform origin.
     """
     source: Mapping[str, str] = os.environ if environment is None else environment
     value = source.get(HOSTED_PLATFORM_URL_ENV, "").strip()
-    return value.rstrip("/") or HOSTED_PLATFORM_DEFAULT_URL
+    return _validated_platform_origin(value) if value else HOSTED_PLATFORM_DEFAULT_URL
+
+
+def _validated_platform_origin(value: str) -> str:
+    """Return one trusted browser origin from the Platform override.
+
+    Args:
+        value: Non-empty environment override after surrounding whitespace is removed.
+
+    Returns:
+        The normalized HTTPS origin, or an HTTP loopback origin for local development.
+
+    Raises:
+        ValueError: The value is not a credential-free trusted origin.
+    """
+    if "\\" in value or any(
+        character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value
+    ):
+        raise ValueError(f"{HOSTED_PLATFORM_URL_ENV} must not contain whitespace or controls")
+    parsed = urlparse(value)
+    hostname = parsed.hostname
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError(f"{HOSTED_PLATFORM_URL_ENV} must use a valid port") from exc
+    if parsed.scheme not in {"http", "https"} or hostname is None:
+        raise ValueError(f"{HOSTED_PLATFORM_URL_ENV} must be an absolute HTTP(S) origin")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"{HOSTED_PLATFORM_URL_ENV} must not embed credentials")
+    if parsed.params or parsed.query or parsed.fragment or parsed.path.strip("/"):
+        raise ValueError(f"{HOSTED_PLATFORM_URL_ENV} must not include a path, query, or fragment")
+    try:
+        loopback = ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        loopback = hostname.rstrip(".").lower() == "localhost"
+    if parsed.scheme != "https" and not loopback:
+        raise ValueError(f"{HOSTED_PLATFORM_URL_ENV} must use HTTPS unless it targets loopback")
+    normalized_host = hostname.lower()
+    if ":" in normalized_host:
+        normalized_host = f"[{normalized_host}]"
+    authority = normalized_host if port is None else f"{normalized_host}:{port}"
+    return f"{parsed.scheme}://{authority}"
 
 
 def hosted_platform_login(

--- a/exp/cli/providers/experiential_cloud_test.py
+++ b/exp/cli/providers/experiential_cloud_test.py
@@ -86,6 +86,32 @@ def test_platform_origin_defaults_to_production_and_strips_override_slashes() ->
         hosted_platform_url({HOSTED_PLATFORM_URL_ENV: "https://platform.preview.test///"})
         == "https://platform.preview.test"
     )
+    assert (
+        hosted_platform_url({HOSTED_PLATFORM_URL_ENV: "http://127.0.0.1:3000/"})
+        == "http://127.0.0.1:3000"
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "file:///tmp/platform.html",
+        "javascript:alert(1)",
+        "http://platform.preview.test",
+        "https://user:secret@platform.preview.test",
+        "https://platform.preview.test/cli/auth",
+        "https://platform.preview.test?tenant=a",
+        "https://platform.preview.test#approval",
+        "https://platform.preview.test:invalid",
+        "https://platform.preview.test\\@redirect.test",
+        "https://platform.preview.test/\x01redirect",
+        "https://platform.preview.test/\nredirect",
+    ],
+)
+def test_platform_origin_rejects_unsafe_overrides(value: str) -> None:
+    """Browser login rejects values that are not trusted Platform origins."""
+    with pytest.raises(ValueError, match=HOSTED_PLATFORM_URL_ENV):
+        hosted_platform_url({HOSTED_PLATFORM_URL_ENV: value})
 
 
 def test_browser_login_builds_the_platform_authorization_url(running_login: BrowserLogin) -> None:


### PR DESCRIPTION
## Why

`EXP_PLATFORM_URL` was treated as an arbitrary string and then used to construct the browser authorization URL and callback success-page destination. Values using `file:`, `javascript:`, remote plaintext HTTP, embedded credentials, paths, queries, fragments, invalid ports, backslashes, or control characters were not rejected.

Closes #933.

## What

- Validate non-empty Platform overrides as credential-free browser origins.
- Require HTTPS except for explicit IP loopback or `localhost` development origins.
- Reject paths, queries, fragments, invalid ports, backslashes, whitespace, and control characters.
- Normalize accepted hostnames and IPv6 authorities before browser URL construction.
- Cover production defaults, preview HTTPS, loopback HTTP, and unsafe override classes in the inline provider test module.
- Convert invalid overrides into actionable usage errors at the direct `exp login` command boundary.

## Validation

- `uv run --no-sync pytest -q exp/cli/auth_test.py exp/cli/providers/experiential_cloud_test.py`: 24 passed in 5.82s
- `uv run --no-sync ruff check .`: passed
- `uv run --no-sync ruff format --check .`: 844 files already formatted
- `uv run --no-sync ty check`: passed

## Non-goals

This change does not alter `EXP_GATEWAY_URL` or its provider API endpoint contract. It does not change the hosted login callback protocol or key handling.
